### PR TITLE
Fix for bugreport:7218 in rAthena

### DIFF
--- a/src/char/int_auction.c
+++ b/src/char/int_auction.c
@@ -224,7 +224,7 @@ void inter_auctions_fromsql(void)
 
 		for( i = 0; i < MAX_SLOTS; i++ )
 		{
-			Sql_GetData(sql_handle, 14 + i, &data, NULL);
+			Sql_GetData(sql_handle, 15 + i, &data, NULL);
 			item->card[i] = atoi(data);
 		}
 


### PR DESCRIPTION
It actually fixes this:
http://rathena.org/board/tracker/issue-7218-rev17086-the-card0-of-equip-can-not-be-load-from-auction/
