### PR TITLE
- Fixing battle->calc_cardfix applying target's cards twice on PvP/Cart ...

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -629,7 +629,7 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 				else if( cardfix != 1000 )
 					damage = damage * cardfix / 1000;
 
-		}else if( tsd && !(nk&NK_NO_CARDFIX_DEF) ){
+		}else if( tsd && !(nk&NK_NO_CARDFIX_DEF)  && !(left&2 )){
 			if( !(nk&NK_NO_ELEFIX) )
 			{
 				int ele_fix = tsd->subele[s_ele];


### PR DESCRIPTION
battle->calc_cardfix was missing a check for flag 2, making it reduct damage twice (As it gets run once for sd and one for tsd). This addresses the issue. 
(Crosses fingers this pull goes in fine)
