### PR TITLE
Channel banning characters with a space in their name

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -9045,11 +9045,17 @@ ACMD(channel) {
 			return false;
 		}
 		
-		if( sub2[0] == '\0' || ( pl_sd = iMap->nick2sd(sub2) ) == NULL ) {
-			sprintf(atcmd_output, msg_txt(1434), sub2);// Player '%s' was not found
-			clif->message(fd, atcmd_output);
-			return false;
+		if (!message || !*message || sscanf(message, "%s %s %24[^\n]", key, sub1, sub2) < 1) {
+		        sprintf(atcmd_output, msg_txt(1434), sub2);// Player '%s' was not found
+		         clif->message(fd, atcmd_output);
+		         return false;
 		}
+
+		if( sub2[0] == '\0' || ( pl_sd = map_nick2sd(sub2) ) == NULL ) {
+		         sprintf(atcmd_output, msg_txt(1434), sub2);// Player '%s' was not found
+		         clif->message(fd, atcmd_output);
+		         return false;
+		 }
 		
 		if( pc_has_permission(pl_sd, PC_PERM_HCHSYS_ADMIN) ) {
 			clif->message(fd, msg_txt(1464)); // Ban failed, not possible to ban this user.


### PR DESCRIPTION
Due to how the sub's are scanned, "a name" doesnt become sub2, instead "a" does, meaning the characters can't be banned.
This would rescan the command parameters and make nick everything between after channel name up to 23 characters. 
