### PR TITLE
Quest Bubbles (Actually Works Finally)

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -7886,7 +7886,7 @@ that fails, the command returns an empty string instead.
 =========================
 ---------------------------------------
 
-*questinfo <Quest ID>, <Icon>{, <Job Class>};
+*questinfo <Quest ID>, <Icon> {, <Map Mark Color>{, <Job Class>}};
 
 This is esentially a combination of checkquest and showevent. Use this only
 in an OnInit label. For the Quest ID, specify the quest ID that you want
@@ -7904,6 +7904,14 @@ No Icon		: QTYPE_NONE
 Warg		: QTYPE_WARG
 Warg Face	: QTYPE_WARG2 (Only for packetver >= 20120410)
 
+Map Mark Color, when used, creates a mark in the user's mini map on the position of the NPC,
+the available color values are:
+
+0 - No Marker
+1 - Yellow Marker
+2 - Green Marker
+3 - Purple Marker
+
 When a user shows up on a map, each NPC is checked for questinfo that has been set.
 If questinfo is present, it will check if the quest has been started, if it has not, the bubble will appear.
 
@@ -7916,7 +7924,7 @@ izlude,100,100,4	script	Test	844,{
 	close;
 
 	OnInit:
-		questinfo 1001, QTYPE_QUEST, Job_Novice;
+		questinfo 1001, QTYPE_QUEST, 0, Job_Novice;
 		end;
 }
 
@@ -7975,10 +7983,11 @@ If parameter "HUNTING" is supplied:
 
 ---------------------------------------
 
-*showevent <icon>;
+*showevent <icon>{,<mark color>}
 
-Show a colored mark in the mini-map like "viewpoint" and an emotion on top 
-of a NPC. This is used to indicate that a NPC has a quest or an event to 
+Show an emotion on top of a NPC, and optionally,
+a colored mark in the mini-map like "viewpoint".
+This is used to indicate that a NPC has a quest or an event to 
 a certain player. 
 
 Available Icons:
@@ -7992,6 +8001,12 @@ Remove Icon	: QTYPE_NONE
 ? Event Icon	: QTYPE_EVENT2
 Warg		: QTYPE_WARG
 Warg Face	: QTYPE_WARG2 (Only for packetver >= 20120410)
+
+Mark Color:
+0 - No Mark
+1 - Yellow Mark
+2 - Green Mark
+3 - Purple Mark
 
 ----------------------------------------
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -9631,28 +9631,19 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd) {
 		skill->unit_move(&sd->bl,timer->gettick(),1);
 	
 	// NPC Quest / Event Icon Check [Kisuka]
-	#if PACKETVER >= 20090218
-		for(i = 0; i < map->list[sd->bl.m].npc_num; i++) {
-			TBL_NPC *nd = map->list[sd->bl.m].npc[i];
-
-			// Make sure NPC exists and is not a warp
-			if(nd != NULL)
-			{
-				// Check if NPC has quest attached to it
-				if(nd->quest.quest_id > 0)
-					if(quest->check(sd, nd->quest.quest_id, HAVEQUEST) == -1)	// Check if quest is not started
-						// Check if quest is job-specific, check is user is said job class.
-						if(nd->quest.hasJob == true)
-						{
-							if(sd->class_ == nd->quest.job)
-								clif->quest_show_event(sd, &nd->bl, nd->quest.icon, 0);
-						}
-						else {
-							clif->quest_show_event(sd, &nd->bl, nd->quest.icon, 0);
-						}
+#if PACKETVER >= 20090218
+	for(i = 0; i < map->list[sd->bl.m].qi_count; i++) {
+		struct questinfo *qi = &map->list[sd->bl.m].qi_data[i];
+		if( quest->check(sd, qi->quest_id, HAVEQUEST) == -1 ) {// Check if quest is not started
+			if( qi->hasJob ) { // Check if quest is job-specific, check is user is said job class.
+				if( sd->class_ == qi->job )
+					clif->quest_show_event(sd, &qi->nd->bl, qi->icon, qi->color);
+			} else {
+				clif->quest_show_event(sd, &qi->nd->bl, qi->icon, qi->color);
 			}
 		}
-	#endif
+	}
+#endif
 }
 
 

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -242,6 +242,13 @@ int instance_add_map(const char *name, int instance_id, bool usebasename, const 
 		}
 	}
 	
+	//Mimic questinfo
+	if( map->list[m].qi_count ) {
+		map->list[im].qi_count = map->list[m].qi_count;
+		CREATE( map->list[im].qi_data, struct questinfo, map->list[im].qi_count );
+		memcpy( map->list[im].qi_data, map->list[m].qi_data, map->list[im].qi_count * sizeof(struct questinfo) );
+	}
+	
 	map->list[im].m = im;
 	map->list[im].instance_id = instance_id;
 	map->list[im].instance_src_map = m;
@@ -442,6 +449,9 @@ void instance_del_map(int16 m) {
 		if( map->list[m].zone_mf )
 			aFree(map->list[m].zone_mf);
 	}
+	
+	if( map->list[m].qi_data )
+		aFree(map->list[m].qi_data);
 	
 	// Remove from instance
 	for( i = 0; i < instance->list[map->list[m].instance_id].num_map; i++ ) {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -557,6 +557,17 @@ struct map_drop_list {
 	int drop_per;
 };
 
+
+struct questinfo {
+	struct npc_data *nd;
+	unsigned short icon;
+	unsigned char color;
+	int quest_id;
+	bool hasJob;
+	unsigned short job;/* perhaps a mapid mask would be most flexible? */
+};
+
+
 struct map_data {
 	char name[MAP_NAME_LENGTH];
 	uint16 index; // The map index used by the mapindex* functions.
@@ -690,6 +701,10 @@ struct map_data {
 	int (*getcellp)(struct map_data* m,int16 x,int16 y,cell_chk cellchk);
 	void (*setcell) (int16 m, int16 x, int16 y, cell_t cell, bool flag);
 	char *cellPos;
+	
+	/* ShowEvent Data Cache */
+	struct questinfo *qi_data;
+	unsigned short qi_count;
 };
 
 /// Stores information about a remote map (for multi-mapserver setups).
@@ -1029,6 +1044,8 @@ struct map_interface {
 	void (*addblcell) (struct block_list *bl);
 	void (*delblcell) (struct block_list *bl);
 	int (*get_new_bonus_id) (void);
+	void (*add_questinfo) (int m, struct questinfo *qi);
+	bool (*remove_questinfo) (int m, struct npc_data *nd);
 };
 
 struct map_interface *map;

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -1790,6 +1790,9 @@ int npc_unload(struct npc_data* nd, bool single) {
 			aFree(nd->path);/* remove now that no other instances exist */
 		}
 	}
+	
+	if( single && nd->bl.m != -1 )
+		map->remove_questinfo(nd->bl.m,nd);
 
 	if( (nd->subtype == SHOP || nd->subtype == CASHSHOP) && nd->src_id == 0) //src check for duplicate shops [Orcao]
 		aFree(nd->u.shop.shop_item);

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -48,12 +48,6 @@ struct npc_data {
 	char* path;/* path dir */
 	enum npc_subtype subtype;
 	int src_id;
-	struct {
-		int icon;
-		int quest_id;
-		bool hasJob;
-		int job;
-	} quest;
 	union {
 		struct {
 			struct script_code *script;


### PR DESCRIPTION
This has been broken / not properly implemented since eAthena. Finally got fed up with it and implemented it how it should work.

Includes support if client is below packetver 20120410, as the IDs are different.

Completely removes type part of the bubbles, as 0 is always passed.

Using questinfo in an OnInit allows you to attach a quest to a specific NPC. When a player shows up on a map, it will check if any NPC on the map has a quest attached to it. If it does, it will check if the player has started the quest, if they haven't it will show the icon.

Keep in mind: the part that shows the icon on the mini-map is broken in current clients, show it won't currently show on the mini map. We may need further investigation into this part. A work around would be to just use compass packet in the mean time.
