### PR TITLE
Questlog fixes

### DIFF
--- a/src/char/int_quest.c
+++ b/src/char/int_quest.c
@@ -19,45 +19,76 @@
 #include <string.h>
 #include <stdlib.h>
 
-//Load entire questlog for a character
-int mapif_quests_fromsql(int char_id, struct quest questlog[])
-{
-	int i;
+/**
+ * Loads the entire questlog for a character.
+ *
+ * @param char_id Character ID
+ * @param count   Pointer to return the number of found entries.
+ * @return Array of found entries. It has *count entries, and it is care of the
+ *         caller to aFree() it afterwards.
+ */
+struct quest *mapif_quests_fromsql(int char_id, int *count) {
+	struct quest *questlog = NULL;
 	struct quest tmp_quest;
-	SqlStmt * stmt;
+	SqlStmt *stmt;
+
+	if (!count)
+		return NULL;
 
 	stmt = SQL->StmtMalloc(sql_handle);
-	if( stmt == NULL )
-	{
+	if (stmt == NULL) {
 		SqlStmt_ShowDebug(stmt);
 		return 0;
 	}
 
 	memset(&tmp_quest, 0, sizeof(struct quest));
 
-	if( SQL_ERROR == SQL->StmtPrepare(stmt, "SELECT `quest_id`, `state`, `time`, `count1`, `count2`, `count3` FROM `%s` WHERE `char_id`=? LIMIT %d", quest_db, MAX_QUEST_DB)
-	||	SQL_ERROR == SQL->StmtBindParam(stmt, 0, SQLDT_INT, &char_id, 0)
-	||	SQL_ERROR == SQL->StmtExecute(stmt)
-	||	SQL_ERROR == SQL->StmtBindColumn(stmt, 0, SQLDT_INT,    &tmp_quest.quest_id, 0, NULL, NULL)
-	||	SQL_ERROR == SQL->StmtBindColumn(stmt, 1, SQLDT_INT,    &tmp_quest.state, 0, NULL, NULL)
-	||	SQL_ERROR == SQL->StmtBindColumn(stmt, 2, SQLDT_UINT,   &tmp_quest.time, 0, NULL, NULL)
-	||	SQL_ERROR == SQL->StmtBindColumn(stmt, 3, SQLDT_INT,    &tmp_quest.count[0], 0, NULL, NULL)
-	||	SQL_ERROR == SQL->StmtBindColumn(stmt, 4, SQLDT_INT,    &tmp_quest.count[1], 0, NULL, NULL)
-	||	SQL_ERROR == SQL->StmtBindColumn(stmt, 5, SQLDT_INT,    &tmp_quest.count[2], 0, NULL, NULL) )
+	if (SQL_ERROR == SQL->StmtPrepare(stmt, "SELECT `quest_id`, `state`, `time`, `count1`, `count2`, `count3` FROM `%s` WHERE `char_id`=?", quest_db)
+	 || SQL_ERROR == SQL->StmtBindParam(stmt, 0, SQLDT_INT, &char_id, 0)
+	 || SQL_ERROR == SQL->StmtExecute(stmt)
+	 || SQL_ERROR == SQL->StmtBindColumn(stmt, 0, SQLDT_INT,  &tmp_quest.quest_id, 0, NULL, NULL)
+	 || SQL_ERROR == SQL->StmtBindColumn(stmt, 1, SQLDT_INT,  &tmp_quest.state,    0, NULL, NULL)
+	 || SQL_ERROR == SQL->StmtBindColumn(stmt, 2, SQLDT_UINT, &tmp_quest.time,     0, NULL, NULL)
+	 || SQL_ERROR == SQL->StmtBindColumn(stmt, 3, SQLDT_INT,  &tmp_quest.count[0], 0, NULL, NULL)
+	 || SQL_ERROR == SQL->StmtBindColumn(stmt, 4, SQLDT_INT,  &tmp_quest.count[1], 0, NULL, NULL)
+	 || SQL_ERROR == SQL->StmtBindColumn(stmt, 5, SQLDT_INT,  &tmp_quest.count[2], 0, NULL, NULL)
+	) {
 		SqlStmt_ShowDebug(stmt);
+		SQL->StmtFree(stmt);
+		*count = 0;
+		return NULL;
+	}
 
-	for( i = 0; i < MAX_QUEST_DB && SQL_SUCCESS == SQL->StmtNextRow(stmt); ++i )
-		memcpy(&questlog[i], &tmp_quest, sizeof(tmp_quest));
+	*count = (int)SQL->NumRows(sql_handle);
+	if (*count > 0) {
+		int i = 0;
+		questlog = (struct quest *)aCalloc(*count, sizeof(struct quest));
+
+		while (SQL_SUCCESS == SQL->StmtNextRow(stmt)) {
+			if (i >= *count) // Sanity check, should never happen
+				break;
+			memcpy(&questlog[i++], &tmp_quest, sizeof(tmp_quest));
+		}
+		if (i < *count) {
+			// Should never. Compact array
+			*count = i;
+			questlog = aRealloc(questlog, sizeof(struct quest)*i);
+		}
+	}
 
 	SQL->StmtFree(stmt);
-	return i;
+	return questlog;
 }
 
-//Delete a quest
-bool mapif_quest_delete(int char_id, int quest_id)
-{
-	if ( SQL_ERROR == SQL->Query(sql_handle, "DELETE FROM `%s` WHERE `quest_id` = '%d' AND `char_id` = '%d'", quest_db, quest_id, char_id) )
-	{
+/**
+ * Deletes a quest from a character's questlog.
+ *
+ * @param char_id  Character ID
+ * @param quest_id Quest ID
+ * @return false in case of errors, true otherwise
+ */
+bool mapif_quest_delete(int char_id, int quest_id) {
+	if (SQL_ERROR == SQL->Query(sql_handle, "DELETE FROM `%s` WHERE `quest_id` = '%d' AND `char_id` = '%d'", quest_db, quest_id, char_id)) {
 		Sql_ShowDebug(sql_handle);
 		return false;
 	}
@@ -65,11 +96,18 @@ bool mapif_quest_delete(int char_id, int quest_id)
 	return true;
 }
 
-//Add a quest to a questlog
-bool mapif_quest_add(int char_id, struct quest qd)
-{
-	if ( SQL_ERROR == SQL->Query(sql_handle, "INSERT INTO `%s`(`quest_id`, `char_id`, `state`, `time`, `count1`, `count2`, `count3`) VALUES ('%d', '%d', '%d','%d', '%d', '%d', '%d')", quest_db, qd.quest_id, char_id, qd.state, qd.time, qd.count[0], qd.count[1], qd.count[2]) ) 
-	{
+/**
+ * Adds a quest to a character's questlog.
+ *
+ * @param char_id Character ID
+ * @param qd      Quest data
+ * @return false in case of errors, true otherwise
+ */
+bool mapif_quest_add(int char_id, struct quest qd) {
+	if (SQL_ERROR == SQL->Query(sql_handle, "INSERT INTO `%s`(`quest_id`, `char_id`, `state`, `time`, `count1`, `count2`, `count3`) "
+	                                        "VALUES ('%d', '%d', '%d','%d', '%d', '%d', '%d')",
+	                            quest_db, qd.quest_id, char_id, qd.state, qd.time, qd.count[0], qd.count[1], qd.count[2])
+	) {
 		Sql_ShowDebug(sql_handle);
 		return false;
 	}
@@ -77,11 +115,18 @@ bool mapif_quest_add(int char_id, struct quest qd)
 	return true;
 }
 
-//Update a questlog
-bool mapif_quest_update(int char_id, struct quest qd)
-{
-	if ( SQL_ERROR == SQL->Query(sql_handle, "UPDATE `%s` SET `state`='%d', `count1`='%d', `count2`='%d', `count3`='%d' WHERE `quest_id` = '%d' AND `char_id` = '%d'", quest_db, qd.state, qd.count[0], qd.count[1], qd.count[2], qd.quest_id, char_id) ) 
-	{
+/**
+ * Updates a quest in a character's questlog.
+ *
+ * @param char_id Character ID
+ * @param qd      Quest data
+ * @return false in case of errors, true otherwise
+ */
+bool mapif_quest_update(int char_id, struct quest qd) {
+	if (SQL_ERROR == SQL->Query(sql_handle, "UPDATE `%s` SET `state`='%d', `count1`='%d', `count2`='%d', `count3`='%d' "
+	                                        "WHERE `quest_id` = '%d' AND `char_id` = '%d'",
+	                            quest_db, qd.state, qd.count[0], qd.count[1], qd.count[2], qd.quest_id, char_id)
+	) {
 		Sql_ShowDebug(sql_handle);
 		return false;
 	}
@@ -89,42 +134,52 @@ bool mapif_quest_update(int char_id, struct quest qd)
 	return true;
 }
 
-//Save quests
-int mapif_parse_quest_save(int fd)
-{
-	int i, j, k, num2, num1 = (RFIFOW(fd,2)-8)/sizeof(struct quest);
+/**
+ * Handles the save request from mapserver for a character's questlog.
+ *
+ * Received quests are saved, and an ack is sent back to the map server.
+ *
+ * @see inter_parse_frommap
+ */
+int mapif_parse_quest_save(int fd) {
+	int i, j, k, old_n, new_n = (RFIFOW(fd,2)-8)/sizeof(struct quest);
 	int char_id = RFIFOL(fd,4);
-	struct quest qd1[MAX_QUEST_DB],qd2[MAX_QUEST_DB];
+	struct quest *old_qd = NULL, *new_qd = NULL;
 	bool success = true;
 
-	memset(qd1, 0, sizeof(qd1));
-	memset(qd2, 0, sizeof(qd2));
-	if( num1 ) memcpy(&qd1, RFIFOP(fd,8), RFIFOW(fd,2)-8);
-	num2 = mapif_quests_fromsql(char_id, qd2);
+	if (new_n)
+		new_qd = (struct quest*)RFIFOP(fd,8);
 
-	for( i = 0; i < num1; i++ )
-	{
-		ARR_FIND( 0, num2, j, qd1[i].quest_id == qd2[j].quest_id );
-		if( j < num2 ) // Update existed quests
-		{	// Only states and counts are changable.
-			ARR_FIND( 0, MAX_QUEST_OBJECTIVES, k, qd1[i].count[k] != qd2[j].count[k] );
-			if( k != MAX_QUEST_OBJECTIVES || qd1[i].state != qd2[j].state )
-				success &= mapif_quest_update(char_id, qd1[i]);
+	old_qd = mapif_quests_fromsql(char_id, &old_n);
 
-			if( j < (--num2) )
-			{
-				memmove(&qd2[j],&qd2[j+1],sizeof(struct quest)*(num2-j));
-				memset(&qd2[num2], 0, sizeof(struct quest));
+	for (i = 0; i < new_n; i++) {
+		ARR_FIND( 0, old_n, j, new_qd[i].quest_id == old_qd[j].quest_id );
+		if (j < old_n) {
+			// Update existing quests
+
+			// Only states and counts are changable.
+			ARR_FIND( 0, MAX_QUEST_OBJECTIVES, k, new_qd[i].count[k] != old_qd[j].count[k] );
+			if (k != MAX_QUEST_OBJECTIVES || new_qd[i].state != old_qd[j].state)
+				success &= mapif_quest_update(char_id, new_qd[i]);
+
+			if (j < (--old_n)) {
+				// Compact array
+				memmove(&old_qd[j],&old_qd[j+1],sizeof(struct quest)*(old_n-j));
+				memset(&old_qd[old_n], 0, sizeof(struct quest));
 			}
-
+		} else {
+			// Add new quests
+			success &= mapif_quest_add(char_id, new_qd[i]);
 		}
-		else // Add new quests
-			success &= mapif_quest_add(char_id, qd1[i]);
 	}
 
-	for( i = 0; i < num2; i++ ) // Quests not in qd1 but in qd2 are to be erased.
-		success &= mapif_quest_delete(char_id, qd2[i].quest_id);
+	for (i = 0; i < old_n; i++) // Quests not in new_qd but in old_qd are to be erased.
+		success &= mapif_quest_delete(char_id, old_qd[i].quest_id);
 
+	if (old_qd)
+		aFree(old_qd);
+
+	// Send ack
 	WFIFOHEAD(fd,7);
 	WFIFOW(fd,0) = 0x3861;
 	WFIFOL(fd,2) = char_id;
@@ -134,48 +189,42 @@ int mapif_parse_quest_save(int fd)
 	return 0;
 }
 
-//Send questlog to map server
-int mapif_parse_quest_load(int fd)
-{
+/**
+ * Sends questlog to the map server
+ *
+ * Note: Completed quests (state == Q_COMPLETE) are guaranteed to be sent last
+ * and the map server relies on this behavior (once the first Q_COMPLETE quest,
+ * all of them are considered to be Q_COMPLETE)
+ *
+ * @see inter_parse_frommap
+ */
+int mapif_parse_quest_load(int fd) {
 	int char_id = RFIFOL(fd,2);
-	struct quest tmp_questlog[MAX_QUEST_DB];
-	int num_quests, i, num_complete = 0;
-	int complete[MAX_QUEST_DB];
+	struct quest *tmp_questlog = NULL;
+	int num_quests;
 
-	memset(tmp_questlog, 0, sizeof(tmp_questlog));
-	memset(complete, 0, sizeof(complete));
-
-	num_quests = mapif_quests_fromsql(char_id, tmp_questlog);
+	tmp_questlog = mapif_quests_fromsql(char_id, &num_quests);
 
 	WFIFOHEAD(fd,num_quests*sizeof(struct quest)+8);
 	WFIFOW(fd,0) = 0x3860;
 	WFIFOW(fd,2) = num_quests*sizeof(struct quest)+8;
 	WFIFOL(fd,4) = char_id;
 
-	//Active and inactive quests
-	for( i = 0; i < num_quests; i++ )
-	{
-		if( tmp_questlog[i].state == Q_COMPLETE )
-		{
-			complete[num_complete++] = i;
-			continue;
-		}
-		memcpy(WFIFOP(fd,(i-num_complete)*sizeof(struct quest)+8), &tmp_questlog[i], sizeof(struct quest));
-	}
-
-	// Completed quests
-	for( i = num_quests - num_complete; i < num_quests; i++ )
-		memcpy(WFIFOP(fd,i*sizeof(struct quest)+8), &tmp_questlog[complete[i-num_quests+num_complete]], sizeof(struct quest));
+	if (num_quests > 0)
+		memcpy(WFIFOP(fd,8), tmp_questlog, sizeof(struct quest)*num_quests);
 
 	WFIFOSET(fd,num_quests*sizeof(struct quest)+8);
 
 	return 0;
 }
 
-int inter_quest_parse_frommap(int fd)
-{
-	switch(RFIFOW(fd,0))
-	{
+/**
+ * Parses questlog related packets from the map server.
+ *
+ * @see inter_parse_frommap
+ */
+int inter_quest_parse_frommap(int fd) {
+	switch(RFIFOW(fd,0)) {
 		case 0x3060: mapif_parse_quest_load(fd); break;
 		case 0x3061: mapif_parse_quest_save(fd); break;
 		default:

--- a/src/char/int_quest.h
+++ b/src/char/int_quest.h
@@ -4,9 +4,6 @@
 #ifndef _QUEST_H_
 #define _QUEST_H_
 
-/*questlog system*/
-struct quest;
-
 int inter_quest_parse_frommap(int fd);
 
 #endif

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -119,7 +119,6 @@
 #define MAX_GUILDSKILL	15      // Increased max guild skills because of new skills [Sara-chan]
 #define MAX_GUILDLEVEL 50
 #define MAX_GUARDIANS 8         // Local max per castle. [Skotlex]
-#define MAX_QUEST_DB 2670       // Max quests that the server will load
 #define MAX_QUEST_OBJECTIVES 3  // Max quest objectives for a quest
 #define MAX_START_ITEMS 32	    // Max number of items allowed to be given to a char whenever it's created. [mkbu95]
 
@@ -202,14 +201,19 @@ enum item_types {
 };
 
 
-// Questlog system [Kevin] [Inkfish]
-typedef enum quest_state { Q_INACTIVE, Q_ACTIVE, Q_COMPLETE } quest_state;
+// Questlog states
+enum quest_state {
+	Q_INACTIVE, ///< Inactive quest (the user can toggle between active and inactive quests)
+	Q_ACTIVE,   ///< Active quest
+	Q_COMPLETE, ///< Completed quest
+};
 
+/// Questlog entry
 struct quest {
-	int quest_id;
-	unsigned int time;
-	int count[MAX_QUEST_OBJECTIVES];
-	quest_state state;
+	int quest_id;                    ///< Quest ID
+	unsigned int time;               ///< Expiration time
+	int count[MAX_QUEST_OBJECTIVES]; ///< Kill counters of each quest objective
+	enum quest_state state;          ///< Current quest state
 };
 
 struct item {

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -15635,8 +15635,7 @@ void clif_parse_PartyTick(int fd, struct map_session_data* sd)
 
 /// Sends list of all quest states (ZC_ALL_QUEST_LIST).
 /// 02b1 <packet len>.W <num>.L { <quest id>.L <active>.B }*num
-void clif_quest_send_list(struct map_session_data * sd)
-{
+void clif_quest_send_list(struct map_session_data *sd) {
 	int fd = sd->fd;
 	int i;
 	int len = sd->avail_quests*5+8;
@@ -15657,8 +15656,7 @@ void clif_quest_send_list(struct map_session_data * sd)
 
 /// Sends list of all quest missions (ZC_ALL_QUEST_MISSION).
 /// 02b2 <packet len>.W <num>.L { <quest id>.L <start time>.L <expire time>.L <mobs>.W { <mob id>.L <mob count>.W <mob name>.24B }*3 }*num
-void clif_quest_send_mission(struct map_session_data * sd)
-{
+void clif_quest_send_mission(struct map_session_data *sd) {
 	int fd = sd->fd;
 	int i, j;
 	int len = sd->avail_quests*104+8;
@@ -15670,17 +15668,17 @@ void clif_quest_send_mission(struct map_session_data * sd)
 	WFIFOL(fd, 4) = sd->avail_quests;
 
 	for( i = 0; i < sd->avail_quests; i++ ) {
+		struct quest_db *qi = quest->db(sd->quest_log[i].quest_id);
 		WFIFOL(fd, i*104+8) = sd->quest_log[i].quest_id;
-		WFIFOL(fd, i*104+12) = sd->quest_log[i].time - quest->db[sd->quest_index[i]].time;
+		WFIFOL(fd, i*104+12) = sd->quest_log[i].time - qi->time;
 		WFIFOL(fd, i*104+16) = sd->quest_log[i].time;
-		WFIFOW(fd, i*104+20) = quest->db[sd->quest_index[i]].num_objectives;
+		WFIFOW(fd, i*104+20) = qi->num_objectives;
 
-		for( j = 0 ; j < quest->db[sd->quest_index[i]].num_objectives; j++ )
-		{
-			WFIFOL(fd, i*104+22+j*30) = quest->db[sd->quest_index[i]].mob[j];
+		for( j = 0 ; j < qi->num_objectives; j++ ) {
+			WFIFOL(fd, i*104+22+j*30) = qi->mob[j];
 			WFIFOW(fd, i*104+26+j*30) = sd->quest_log[i].count[j];
-			monster = mob->db(quest->db[sd->quest_index[i]].mob[j]);
-			memcpy(WFIFOP(fd, i*104+28+j*30), monster?monster->jname:"NULL", NAME_LENGTH);
+			monster = mob->db(qi->mob[j]);
+			memcpy(WFIFOP(fd, i*104+28+j*30), monster->jname, NAME_LENGTH);
 		}
 	}
 
@@ -15690,25 +15688,25 @@ void clif_quest_send_mission(struct map_session_data * sd)
 
 /// Notification about a new quest (ZC_ADD_QUEST).
 /// 02b3 <quest id>.L <active>.B <start time>.L <expire time>.L <mobs>.W { <mob id>.L <mob count>.W <mob name>.24B }*3
-void clif_quest_add(struct map_session_data * sd, struct quest * qd, int index)
-{
+void clif_quest_add(struct map_session_data *sd, struct quest *qd) {
 	int fd = sd->fd;
 	int i;
 	struct mob_db *monster;
+	struct quest_db *qi = quest->db(qd->quest_id);
 
 	WFIFOHEAD(fd, packet_len(0x2b3));
 	WFIFOW(fd, 0) = 0x2b3;
 	WFIFOL(fd, 2) = qd->quest_id;
 	WFIFOB(fd, 6) = qd->state;
-	WFIFOB(fd, 7) = qd->time - quest->db[index].time;
+	WFIFOB(fd, 7) = qd->time - qi->time;
 	WFIFOL(fd, 11) = qd->time;
-	WFIFOW(fd, 15) = quest->db[index].num_objectives;
+	WFIFOW(fd, 15) = qi->num_objectives;
 
-	for( i = 0; i < quest->db[index].num_objectives; i++ ) {
-		WFIFOL(fd, i*30+17) = quest->db[index].mob[i];
+	for( i = 0; i < qi->num_objectives; i++ ) {
+		WFIFOL(fd, i*30+17) = qi->mob[i];
 		WFIFOW(fd, i*30+21) = qd->count[i];
-		monster = mob->db(quest->db[index].mob[i]);
-		memcpy(WFIFOP(fd, i*30+23), monster?monster->jname:"NULL", NAME_LENGTH);
+		monster = mob->db(qi->mob[i]);
+		memcpy(WFIFOP(fd, i*30+23), monster->jname, NAME_LENGTH);
 	}
 
 	WFIFOSET(fd, packet_len(0x2b3));
@@ -15717,8 +15715,7 @@ void clif_quest_add(struct map_session_data * sd, struct quest * qd, int index)
 
 /// Notification about a quest being removed (ZC_DEL_QUEST).
 /// 02b4 <quest id>.L
-void clif_quest_delete(struct map_session_data * sd, int quest_id)
-{
+void clif_quest_delete(struct map_session_data *sd, int quest_id) {
 	int fd = sd->fd;
 
 	WFIFOHEAD(fd, packet_len(0x2b4));
@@ -15730,21 +15727,21 @@ void clif_quest_delete(struct map_session_data * sd, int quest_id)
 
 /// Notification of an update to the hunting mission counter (ZC_UPDATE_MISSION_HUNT).
 /// 02b5 <packet len>.W <mobs>.W { <quest id>.L <mob id>.L <total count>.W <current count>.W }*3
-void clif_quest_update_objective(struct map_session_data * sd, struct quest * qd, int index)
-{
+void clif_quest_update_objective(struct map_session_data *sd, struct quest *qd) {
 	int fd = sd->fd;
 	int i;
-	int len = quest->db[index].num_objectives*12+6;
+	struct quest_db *qi = quest->db(qd->quest_id);
+	int len = qi->num_objectives*12+6;
 
 	WFIFOHEAD(fd, len);
 	WFIFOW(fd, 0) = 0x2b5;
 	WFIFOW(fd, 2) = len;
-	WFIFOW(fd, 4) = quest->db[index].num_objectives;
+	WFIFOW(fd, 4) = qi->num_objectives;
 
-	for( i = 0; i < quest->db[index].num_objectives; i++ ) {
+	for( i = 0; i < qi->num_objectives; i++ ) {
 		WFIFOL(fd, i*12+6) = qd->quest_id;
-		WFIFOL(fd, i*12+10) = quest->db[index].mob[i];
-		WFIFOW(fd, i*12+14) = quest->db[index].count[i];
+		WFIFOL(fd, i*12+10) = qi->mob[i];
+		WFIFOW(fd, i*12+14) = qi->count[i];
 		WFIFOW(fd, i*12+16) = qd->count[i];
 	}
 
@@ -15754,16 +15751,14 @@ void clif_quest_update_objective(struct map_session_data * sd, struct quest * qd
 
 /// Request to change the state of a quest (CZ_ACTIVE_QUEST).
 /// 02b6 <quest id>.L <active>.B
-void clif_parse_questStateAck(int fd, struct map_session_data * sd)
-{
+void clif_parse_questStateAck(int fd, struct map_session_data *sd) {
 	quest->update_status(sd, RFIFOL(fd,2), RFIFOB(fd,6)?Q_ACTIVE:Q_INACTIVE);
 }
 
 
 /// Notification about the change of a quest state (ZC_ACTIVE_QUEST).
 /// 02b7 <quest id>.L <active>.B
-void clif_quest_update_status(struct map_session_data * sd, int quest_id, bool active)
-{
+void clif_quest_update_status(struct map_session_data *sd, int quest_id, bool active) {
 	int fd = sd->fd;
 
 	WFIFOHEAD(fd, packet_len(0x2b7));

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -923,12 +923,12 @@ struct clif_interface {
 	int (*hom_food) (struct map_session_data *sd,int foodid,int fail);
 	void (*send_homdata) (struct map_session_data *sd, int state, int param);
 	/* questlog-related */
-	void (*quest_send_list) (struct map_session_data * sd);
-	void (*quest_send_mission) (struct map_session_data * sd);
-	void (*quest_add) (struct map_session_data * sd, struct quest * qd, int index);
-	void (*quest_delete) (struct map_session_data * sd, int quest_id);
-	void (*quest_update_status) (struct map_session_data * sd, int quest_id, bool active);
-	void (*quest_update_objective) (struct map_session_data * sd, struct quest * qd, int index);
+	void (*quest_send_list) (struct map_session_data *sd);
+	void (*quest_send_mission) (struct map_session_data *sd);
+	void (*quest_add) (struct map_session_data *sd, struct quest *qd);
+	void (*quest_delete) (struct map_session_data *sd, int quest_id);
+	void (*quest_update_status) (struct map_session_data *sd, int quest_id, bool active);
+	void (*quest_update_objective) (struct map_session_data *sd, struct quest *qd);
 	void (*quest_show_event) (struct map_session_data *sd, struct block_list *bl, short state, short color);
 	/* mail-related */
 	void (*mail_window) (int fd, int flag);

--- a/src/map/intif.c
+++ b/src/map/intif.c
@@ -1311,50 +1311,79 @@ QUESTLOG SYSTEM FUNCTIONS
 
 ***************************************/
 
-int intif_request_questlog(TBL_PC *sd)
-{
+/**
+ * Requests a character's quest log entries to the inter server.
+ *
+ * @param sd Character's data
+ */
+void intif_request_questlog(TBL_PC *sd) {
 	WFIFOHEAD(inter_fd,6);
 	WFIFOW(inter_fd,0) = 0x3060;
 	WFIFOL(inter_fd,2) = sd->status.char_id;
 	WFIFOSET(inter_fd,6);
-	return 0;
 }
 
+/**
+ * Parses the received quest log entries for a character from the inter server.
+ *
+ * Received in reply to the requests made by intif_request_questlog.
+ *
+ * @see intif_parse
+ */
 void intif_parse_QuestLog(int fd) {
-	int char_id = RFIFOL(fd, 4);
-	int i;
-	TBL_PC * sd = map->charid2sd(char_id);
+	int char_id = RFIFOL(fd, 4), num_received = (RFIFOW(fd, 2)-8)/sizeof(struct quest);
+	TBL_PC *sd = map->charid2sd(char_id);
 
-	//User not online anymore
-	if(!sd)
+	if (!sd) // User not online anymore
 		return;
 
-	sd->avail_quests = sd->num_quests = (RFIFOW(fd, 2)-8)/sizeof(struct quest);
-
-	memset(&sd->quest_log, 0, sizeof(sd->quest_log));
-
-	for( i = 0; i < sd->num_quests; i++ )
-	{
-		memcpy(&sd->quest_log[i], RFIFOP(fd, i*sizeof(struct quest)+8), sizeof(struct quest));
-
-		sd->quest_index[i] = quest->search_db(sd->quest_log[i].quest_id);
-
-		if( sd->quest_index[i] < 0 )
-		{
-			ShowError("intif_parse_QuestLog: quest %d not found in DB.\n",sd->quest_log[i].quest_id);
-			sd->avail_quests--;
-			sd->num_quests--;
-			i--;
-			continue;
+	if (num_received == 0) {
+		if (sd->quest_log) {
+			aFree(sd->quest_log);
+			sd->quest_log = NULL;
+		}
+		sd->num_quests = sd->avail_quests = 0;
+	} else {
+		struct quest *received = (struct quest *)RFIFOP(fd, 8);
+		int i, k = num_received;
+		if (sd->quest_log) {
+			RECREATE(sd->quest_log, struct quest, num_received);
+		} else {
+			CREATE(sd->quest_log, struct quest, num_received);
 		}
 
-		if( sd->quest_log[i].state == Q_COMPLETE )
-			sd->avail_quests--;
+		for (i = 0; i < num_received; i++) {
+			if( quest->db(received[i].quest_id) == &quest->dummy ) {
+				ShowError("intif_parse_QuestLog: quest %d not found in DB.\n", received[i].quest_id);
+				continue;
+			}
+			if (received->state != Q_COMPLETE) {
+				// Insert at the beginning
+				memcpy(&sd->quest_log[sd->avail_quests++], &received[i], sizeof(struct quest));
+			} else {
+				// Insert at the end
+				memcpy(&sd->quest_log[--k], &received[i], sizeof(struct quest));
+			}
+			sd->num_quests++;
+		}
+		if (sd->avail_quests < k) {
+			// sd->avail_quests and k didn't meet in the middle: some entries were skipped
+			if (k < num_received) // Move the entries at the end to fill the gap
+				memmove(&sd->quest_log[k], &sd->quest_log[sd->avail_quests], sizeof(struct quest)*(num_received - k));
+			sd->quest_log = aRealloc(sd->quest_log, sizeof(struct quest)*sd->num_quests);
+		}
 	}
 
 	quest->pc_login(sd);
 }
 
+/**
+ * Parses the quest log save ack for a character from the inter server.
+ *
+ * Received in reply to the requests made by intif_quest_save.
+ *
+ * @see intif_parse
+ */
 void intif_parse_QuestSave(int fd) {
 	int cid = RFIFOL(fd, 2);
 	TBL_PC *sd = map->id2sd(cid);
@@ -1365,21 +1394,24 @@ void intif_parse_QuestSave(int fd) {
 		sd->save_quest = false;
 }
 
-int intif_quest_save(TBL_PC *sd)
-{
-	int len;
+/**
+ * Requests to the inter server to save a character's quest log entries.
+ *
+ * @param sd Character's data
+ * @return 0 in case of success, nonzero otherwise
+ */
+int intif_quest_save(TBL_PC *sd) {
+	int len = sizeof(struct quest)*sd->num_quests + 8;
 
 	if(intif->CheckForCharServer())
-		return 0;
-
-	len = sizeof(struct quest)*sd->num_quests + 8;
+		return 1;
 
 	WFIFOHEAD(inter_fd, len);
 	WFIFOW(inter_fd,0) = 0x3061;
 	WFIFOW(inter_fd,2) = len;
 	WFIFOL(inter_fd,4) = sd->status.char_id;
 	if( sd->num_quests )
-		memcpy(WFIFOP(inter_fd,8), &sd->quest_log, sizeof(struct quest)*sd->num_quests);
+		memcpy(WFIFOP(inter_fd,8), sd->quest_log, sizeof(struct quest)*sd->num_quests);
 	WFIFOSET(inter_fd,  len);
 
 	return 0;

--- a/src/map/intif.h
+++ b/src/map/intif.h
@@ -85,7 +85,7 @@ struct intif_interface {
 	int (*homunculus_requestsave) (int account_id, struct s_homunculus* sh);
 	int (*homunculus_requestdelete) (int homun_id);
 	/******QUEST SYTEM*******/
-	int (*request_questlog) (struct map_session_data * sd);
+	void (*request_questlog) (struct map_session_data * sd);
 	int (*quest_save) (struct map_session_data * sd);
 	// MERCENARY SYSTEM
 	int (*mercenary_create) (struct s_mercenary *merc);

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -5116,6 +5116,7 @@ void do_final(void)
 	ircbot->final();/* before clif. */
 	clif->final();
 	npc->final();
+	quest->final();
 	script->final();
 	itemdb->final();
 	instance->final();

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1136,7 +1136,12 @@ bool pc_authok(struct map_session_data *sd, int login_id2, time_t expiration_tim
 	for( i = 0; i < 3; i++ )
 		sd->hate_mob[i] = -1;
 
-    //warp player
+	sd->quest_log = NULL;
+	sd->num_quests = 0;
+	sd->avail_quests = 0;
+	sd->save_quest = false;
+
+	//warp player
 	if ((i=pc->setpos(sd,sd->status.last_point.map, sd->status.last_point.x, sd->status.last_point.y, CLR_OUTSIGHT)) != 0) {
 		ShowError ("Last_point_map %s - id %d not found (error code %d)\n", mapindex_id2name(sd->status.last_point.map), sd->status.last_point.map, i);
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -438,12 +438,11 @@ struct map_session_data {
 		bool changed; // if true, should sync with charserver on next mailbox request
 	} mail;
 
-	//Quest log system [Kevin] [Inkfish]
-	int num_quests;
-	int avail_quests;
-	int quest_index[MAX_QUEST_DB];
-	struct quest quest_log[MAX_QUEST_DB];
-	bool save_quest;
+	// Quest log system
+	int num_quests;          ///< Number of entries in quest_log
+	int avail_quests;        ///< Number of Q_ACTIVE and Q_INACTIVE entries in quest log (index of the first Q_COMPLETE entry)
+	struct quest *quest_log; ///< Quest log entries (note: Q_COMPLETE quests follow the first <avail_quests>th enties
+	bool save_quest;         ///< Whether the quest_log entries were modified and are waitin to be saved
 
 	// temporary debug [flaviojs]
 	const char* debug_file;

--- a/src/map/quest.c
+++ b/src/map/quest.c
@@ -35,20 +35,25 @@
 
 struct quest_interface quest_s;
 
-int quest_search_db(int quest_id)
-{
-	int i;
-
-	ARR_FIND(0, MAX_QUEST_DB,i,quest_id == quest->db[i].id);
-	if( i == MAX_QUEST_DB )
-		return -1;
-
-	return i;
+/**
+ * Searches a quest by ID.
+ *
+ * @param quest_id ID to lookup
+ * @return Quest entry (equals to &quest->dummy if the ID is invalid)
+ */
+struct quest_db *quest_db(int quest_id) {
+	if (quest_id < 0 || quest_id > MAX_QUEST_DB || quest->db_data[quest_id] == NULL)
+		return &quest->dummy;
+	return quest->db_data[quest_id];
 }
 
-//Send quest info on login
-int quest_pc_login(TBL_PC * sd)
-{
+/**
+ * Sends quest info to the player on login.
+ *
+ * @param sd Player's data
+ * @return 0 in case of success, nonzero otherwise (i.e. the player has no quests)
+ */
+int quest_pc_login(TBL_PC *sd) {
 	int i;
 
 	if(sd->avail_quests == 0)
@@ -57,100 +62,109 @@ int quest_pc_login(TBL_PC * sd)
 	clif->quest_send_list(sd);
 	clif->quest_send_mission(sd);
 	for( i = 0; i < sd->avail_quests; i++ ) {
-		clif->quest_update_objective(sd, &sd->quest_log[i], sd->quest_index[i]);
+		// TODO[Haru]: is this necessary? Does quest_send_mission not take care of this?
+		clif->quest_update_objective(sd, &sd->quest_log[i]);
 	}
 
 	return 0;
 }
 
-int quest_add(TBL_PC * sd, int quest_id)
-{
+/**
+ * Adds a quest to the player's list.
+ *
+ * New quest will be added as Q_ACTIVE.
+ *
+ * @param sd       Player's data
+ * @param quest_id ID of the quest to add.
+ * @return 0 in case of success, nonzero otherwise
+ */
+int quest_add(TBL_PC *sd, int quest_id) {
+	int n;
+	struct quest_db *qi = quest->db(quest_id);
 
-	int i, j;
-
-	if( sd->num_quests >= MAX_QUEST_DB )
-	{
-		ShowError("quest_add: Character %d has got all the quests.(max quests: %d)\n", sd->status.char_id, MAX_QUEST_DB);
-		return 1;
-	}
-
-	if( quest->check(sd, quest_id, HAVEQUEST) >= 0 )
-	{
-		ShowError("quest_add: Character %d already has quest %d.\n", sd->status.char_id, quest_id);
-		return -1;
-	}
-
-	if( (j = quest->search_db(quest_id)) < 0 )
-	{
+	if( qi == &quest->dummy ) {
 		ShowError("quest_add: quest %d not found in DB.\n", quest_id);
 		return -1;
 	}
 
-	i = sd->avail_quests;
-	memmove(&sd->quest_log[i+1], &sd->quest_log[i], sizeof(struct quest)*(sd->num_quests-sd->avail_quests));
-	memmove(sd->quest_index+i+1, sd->quest_index+i, sizeof(int)*(sd->num_quests-sd->avail_quests));
+	if( quest->check(sd, quest_id, HAVEQUEST) >= 0 ) {
+		ShowError("quest_add: Character %d already has quest %d.\n", sd->status.char_id, quest_id);
+		return -1;
+	}
 
-	memset(&sd->quest_log[i], 0, sizeof(struct quest));
-	sd->quest_log[i].quest_id = quest->db[j].id;
-	if( quest->db[j].time )
-		sd->quest_log[i].time = (unsigned int)(time(NULL) + quest->db[j].time);
-	sd->quest_log[i].state = Q_ACTIVE;
+	n = sd->avail_quests; // Insertion point
 
-	sd->quest_index[i] = j;
 	sd->num_quests++;
 	sd->avail_quests++;
+	RECREATE(sd->quest_log, struct quest, sd->num_quests);
+
+	if( sd->avail_quests != sd->num_quests ) {
+		// The character has some completed quests, make room before them so that they will stay at the end of the array
+		memmove(&sd->quest_log[n+1], &sd->quest_log[n], sizeof(struct quest)*(sd->num_quests-sd->avail_quests));
+	}
+
+	memset(&sd->quest_log[n], 0, sizeof(struct quest));
+
+	sd->quest_log[n].quest_id = qi->id;
+	if( qi->time )
+		sd->quest_log[n].time = (unsigned int)(time(NULL) + qi->time);
+	sd->quest_log[n].state = Q_ACTIVE;
+
 	sd->save_quest = true;
 
-	clif->quest_add(sd, &sd->quest_log[i], sd->quest_index[i]);
-	clif->quest_update_objective(sd, &sd->quest_log[i], sd->quest_index[i]);
+	clif->quest_add(sd, &sd->quest_log[n]);
+	clif->quest_update_objective(sd, &sd->quest_log[n]);
+
 	if( map->save_settings&64 )
 		chrif->save(sd,0);
 
 	return 0;
 }
 
-int quest_change(TBL_PC * sd, int qid1, int qid2)
-{
+/**
+ * Replaces a quest in a player's list with another one.
+ *
+ * @param sd   Player's data
+ * @param qid1 Current quest to replace
+ * @param qid2 New quest to add
+ * @return 0 in case of success, nonzero otherwise
+ */
+int quest_change(TBL_PC *sd, int qid1, int qid2) {
+	int i;
+	struct quest_db *qi = quest->db(qid2);
 
-	int i, j;
+	if( qi == &quest->dummy ) {
+		ShowError("quest_change: quest %d not found in DB.\n", qid2);
+		return -1;
+	}
 
-	if( quest->check(sd, qid2, HAVEQUEST) >= 0 )
-	{
+	if( quest->check(sd, qid2, HAVEQUEST) >= 0 ) {
 		ShowError("quest_change: Character %d already has quest %d.\n", sd->status.char_id, qid2);
 		return -1;
 	}
 
-	if( quest->check(sd, qid1, HAVEQUEST) < 0 )
-	{
+	if( quest->check(sd, qid1, HAVEQUEST) < 0 ) {
 		ShowError("quest_change: Character %d doesn't have quest %d.\n", sd->status.char_id, qid1);
 		return -1;
 	}
 
-	if( (j = quest->search_db(qid2)) < 0 )
-	{
-		ShowError("quest_change: quest %d not found in DB.\n",qid2);
-		return -1;
-	}
-
 	ARR_FIND(0, sd->avail_quests, i, sd->quest_log[i].quest_id == qid1);
-	if(i == sd->avail_quests)
-	{
-		ShowError("quest_change: Character %d has completed quests %d.\n", sd->status.char_id, qid1);
+	if( i == sd->avail_quests ) {
+		ShowError("quest_change: Character %d has completed quest %d.\n", sd->status.char_id, qid1);
 		return -1;
 	}
 
 	memset(&sd->quest_log[i], 0, sizeof(struct quest));
-	sd->quest_log[i].quest_id = quest->db[j].id;
-	if( quest->db[j].time )
-		sd->quest_log[i].time = (unsigned int)(time(NULL) + quest->db[j].time);
+	sd->quest_log[i].quest_id = qi->id;
+	if( qi->time )
+		sd->quest_log[i].time = (unsigned int)(time(NULL) + qi->time);
 	sd->quest_log[i].state = Q_ACTIVE;
 
-	sd->quest_index[i] = j;
 	sd->save_quest = true;
 
 	clif->quest_delete(sd, qid1);
-	clif->quest_add(sd, &sd->quest_log[i], sd->quest_index[i]);
-	clif->quest_update_objective(sd, &sd->quest_log[i], sd->quest_index[i]);
+	clif->quest_add(sd, &sd->quest_log[i]);
+	clif->quest_update_objective(sd, &sd->quest_log[i]);
 
 	if( map->save_settings&64 )
 		chrif->save(sd,0);
@@ -158,27 +172,37 @@ int quest_change(TBL_PC * sd, int qid1, int qid2)
 	return 0;
 }
 
-int quest_delete(TBL_PC * sd, int quest_id)
-{
+/**
+ * Removes a quest from a player's list
+ *
+ * @param sd       Player's data
+ * @param quest_id ID of the quest to remove
+ * @return 0 in case of success, nonzero otherwise
+ */
+int quest_delete(TBL_PC *sd, int quest_id) {
 	int i;
 
 	//Search for quest
 	ARR_FIND(0, sd->num_quests, i, sd->quest_log[i].quest_id == quest_id);
-	if(i == sd->num_quests)
-	{
+
+	if(i == sd->num_quests) {
 		ShowError("quest_delete: Character %d doesn't have quest %d.\n", sd->status.char_id, quest_id);
 		return -1;
 	}
 
 	if( sd->quest_log[i].state != Q_COMPLETE )
 		sd->avail_quests--;
-	if( sd->num_quests-- < MAX_QUEST_DB && sd->quest_log[i+1].quest_id )
-	{
+
+	if( i < --sd->num_quests ) {
+		// Compact the array
 		memmove(&sd->quest_log[i], &sd->quest_log[i+1], sizeof(struct quest)*(sd->num_quests-i));
-		memmove(sd->quest_index+i, sd->quest_index+i+1, sizeof(int)*(sd->num_quests-i));
 	}
-	memset(&sd->quest_log[sd->num_quests], 0, sizeof(struct quest));
-	sd->quest_index[sd->num_quests] = 0;
+	if( sd->num_quests == 0 ) {
+		aFree(sd->quest_log);
+		sd->quest_log = NULL;
+	} else {
+		RECREATE(sd->quest_log, struct quest, sd->num_quests);
+	}
 	sd->save_quest = true;
 
 	clif->quest_delete(sd, quest_id);
@@ -189,8 +213,16 @@ int quest_delete(TBL_PC * sd, int quest_id)
 	return 0;
 }
 
+/**
+ * Map iterator subroutine to update quest objectives for a party after killing a monster.
+ *
+ * @see map_foreachinrange
+ * @param ap Argument list, expecting:
+ *           int Party ID
+ *           int Mob ID
+ */
 int quest_update_objective_sub(struct block_list *bl, va_list ap) {
-	struct map_session_data * sd;
+	struct map_session_data *sd;
 	int mob_id, party_id;
 
 	nullpo_ret(bl);
@@ -210,28 +242,48 @@ int quest_update_objective_sub(struct block_list *bl, va_list ap) {
 }
 
 
-void quest_update_objective(TBL_PC * sd, int mob_id) {
+/**
+ * Updates the quest objectives for a character after killing a monster.
+ *
+ * @param sd     Character's data
+ * @param mob_id Monster ID
+ */
+void quest_update_objective(TBL_PC *sd, int mob_id) {
 	int i,j;
 
 	for( i = 0; i < sd->avail_quests; i++ ) {
-		if( sd->quest_log[i].state != Q_ACTIVE )
+		struct quest_db *qi = NULL;
+
+		if( sd->quest_log[i].state != Q_ACTIVE ) // Skip inactive quests
 			continue;
 
-		for( j = 0; j < MAX_QUEST_OBJECTIVES; j++ )
-			if( quest->db[sd->quest_index[i]].mob[j] == mob_id && sd->quest_log[i].count[j] < quest->db[sd->quest_index[i]].count[j] )  {
+		qi = quest->db(sd->quest_log[i].quest_id);
+
+		for( j = 0; j < qi->num_objectives; j++ ) {
+			if( qi->mob[j] == mob_id && sd->quest_log[i].count[j] < qi->count[j] )  {
 				sd->quest_log[i].count[j]++;
 				sd->save_quest = true;
-				clif->quest_update_objective(sd,&sd->quest_log[i],sd->quest_index[i]);
+				clif->quest_update_objective(sd, &sd->quest_log[i]);
 			}
+		}
 	}
 }
 
-int quest_update_status(TBL_PC * sd, int quest_id, quest_state qs) {
+/**
+ * Updates a quest's state.
+ *
+ * Only status of active and inactive quests can be updated. Completed quests can't (for now). [Inkfish]
+ *
+ * @param sd       Character's data
+ * @param quest_id Quest ID to update
+ * @param qs       New quest state
+ * @return 0 in case of success, nonzero otherwise
+ */
+int quest_update_status(TBL_PC *sd, int quest_id, enum quest_state qs) {
 	int i;
 
-	//Only status of active and inactive quests can be updated. Completed quests can't (for now). [Inkfish]
 	ARR_FIND(0, sd->avail_quests, i, sd->quest_log[i].quest_id == quest_id);
-	if(i == sd->avail_quests) {
+	if( i == sd->avail_quests ) {
 		ShowError("quest_update_status: Character %d doesn't have quest %d.\n", sd->status.char_id, quest_id);
 		return -1;
 	}
@@ -240,11 +292,13 @@ int quest_update_status(TBL_PC * sd, int quest_id, quest_state qs) {
 	sd->save_quest = true;
 
 	if( qs < Q_COMPLETE ) {
-		clif->quest_update_status(sd, quest_id, (bool)qs);
+		clif->quest_update_status(sd, quest_id, qs == Q_ACTIVE ? true : false);
 		return 0;
 	}
 
-	if( i != (--sd->avail_quests) ) {
+	// The quest is complete, so it needs to be moved to the completed quests block at the end of the array.
+
+	if( i < (--sd->avail_quests) ) {
 		struct quest tmp_quest;
 		memcpy(&tmp_quest, &sd->quest_log[i],sizeof(struct quest));
 		memcpy(&sd->quest_log[i], &sd->quest_log[sd->avail_quests],sizeof(struct quest));
@@ -259,7 +313,22 @@ int quest_update_status(TBL_PC * sd, int quest_id, quest_state qs) {
 	return 0;
 }
 
-int quest_check(TBL_PC * sd, int quest_id, quest_check_type type) {
+/**
+ * Queries quest information for a character.
+ *
+ * @param sd       Character's data
+ * @param quest_id Quest ID
+ * @param type     Check type
+ * @return -1 if the quest was not found, otherwise it depends on the type:
+ *         HAVEQUEST: The quest's state
+ *         PLAYTIME:  2 if the quest's timeout has expired
+ *                    1 if the quest was completed
+ *                    0 otherwise
+ *         HUNTING:   2 if the quest has not been marked as completed yet, and its objectives have been fulfilled
+ *                    1 if the quest's timeout has expired
+ *                    0 otherwise
+ */
+int quest_check(TBL_PC *sd, int quest_id, enum quest_check_type type) {
 	int i;
 
 	ARR_FIND(0, sd->num_quests, i, sd->quest_log[i].quest_id == quest_id);
@@ -271,18 +340,17 @@ int quest_check(TBL_PC * sd, int quest_id, quest_check_type type) {
 			return sd->quest_log[i].state;
 		case PLAYTIME:
 			return (sd->quest_log[i].time < (unsigned int)time(NULL) ? 2 : sd->quest_log[i].state == Q_COMPLETE ? 1 : 0);
-		case HUNTING: {
-				if( sd->quest_log[i].state == 0 || sd->quest_log[i].state == 1 ) {
-					int j;
-					ARR_FIND(0, MAX_QUEST_OBJECTIVES, j, sd->quest_log[i].count[j] < quest->db[sd->quest_index[i]].count[j]);
-					if( j == MAX_QUEST_OBJECTIVES )
-						return 2;
-					if( sd->quest_log[i].time < (unsigned int)time(NULL) )
-						return 1;
-					return 0;
-				} else
-					return 0;
+		case HUNTING:
+			if( sd->quest_log[i].state == Q_INACTIVE || sd->quest_log[i].state == Q_ACTIVE ) {
+				int j;
+				struct quest_db *qi = quest->db(sd->quest_log[i].quest_id);
+				ARR_FIND(0, MAX_QUEST_OBJECTIVES, j, sd->quest_log[i].count[j] < qi->count[j]);
+				if( j == MAX_QUEST_OBJECTIVES )
+					return 2;
+				if( sd->quest_log[i].time < (unsigned int)time(NULL) )
+					return 1;
 			}
+			return 0;
 		default:
 			ShowError("quest_check_quest: Unknown parameter %d",type);
 			break;
@@ -291,66 +359,133 @@ int quest_check(TBL_PC * sd, int quest_id, quest_check_type type) {
 	return -1;
 }
 
+/**
+ * Loads quests from the quest db.
+ *
+ * @return Number of loaded quests, or -1 if the file couldn't be read.
+ */
 int quest_read_db(void) {
+	// TODO[Haru] This duplicates some sv_readdb functionalities, and it would be
+	// nice if it could be replaced by it. The reason why it wasn't is probably
+	// because we need to accept commas (which is also used as delimiter) in the
+	// last field (quest name), and sv_readdb isn't capable of doing so.
 	FILE *fp;
 	char line[1024];
-	int i,j,k = 0;
-	char *str[20],*p,*np;
+	int i, count = 0;
+	char *str[20], *p, *np;
+	struct quest_db entry;
 
 	sprintf(line, "%s/quest_db.txt", map->db_path);
-	if( (fp=fopen(line,"r"))==NULL ){
+	if ((fp=fopen(line,"r"))==NULL) {
 		ShowError("can't read %s\n", line);
 		return -1;
 	}
-	
-	while(fgets(line, sizeof(line), fp)) {
-		if (k == MAX_QUEST_DB) {
-			ShowError("quest_read_db: Too many entries specified in %s/quest_db.txt!\n", map->db_path);
-			break;
-		}
-		
-		if(line[0]=='/' && line[1]=='/')
+
+	while (fgets(line, sizeof(line), fp)) {
+		if (line[0]=='/' && line[1]=='/')
 			continue;
 		memset(str,0,sizeof(str));
 
-		for( j = 0, p = line; j < 8; j++ ) {
-			if( ( np = strchr(p,',') ) != NULL ) {
-				str[j] = p;
+		for (i = 0, p = line; i < 8; i++) {
+			if (( np = strchr(p,',') ) != NULL) {
+				str[i] = p;
 				*np = 0;
 				p = np + 1;
-			}
-			else if (str[0] == NULL)
-				continue;
-			else {
+			} else if (str[0] == NULL) {
+				break;
+			} else {
 				ShowError("quest_read_db: insufficient columns in line %s\n", line);
 				continue;
 			}
 		}
-		if(str[0]==NULL)
+		if (str[0] == NULL)
 			continue;
 
-		memset(&quest->db[k], 0, sizeof(quest->db[0]));
+		memset(&entry, 0, sizeof(entry));
 
-		quest->db[k].id = atoi(str[0]);
-		quest->db[k].time = atoi(str[1]);
-		
-		for( i = 0; i < MAX_QUEST_OBJECTIVES; i++ ) {
-			quest->db[k].mob[i] = atoi(str[2*i+2]);
-			quest->db[k].count[i] = atoi(str[2*i+3]);
+		entry.id = atoi(str[0]);
 
-			if( !quest->db[k].mob[i] || !quest->db[k].count[i] )
+		if (entry.id < 0 || entry.id >= MAX_QUEST_DB) {
+			ShowError("quest_read_db: Invalid quest ID '%d' in line '%s' (min: 0, max: %d.)\n", entry.id, line, MAX_QUEST_DB);
+			continue;
+		}
+
+		entry.time = atoi(str[1]);
+
+		for (i = 0; i < MAX_QUEST_OBJECTIVES; i++) {
+			entry.mob[i] = atoi(str[2*i+2]);
+			entry.count[i] = atoi(str[2*i+3]);
+
+			if (!entry.mob[i] || !entry.count[i])
 				break;
 		}
-		
-		quest->db[k].num_objectives = i;
 
-		k++;
+		entry.num_objectives = i;
+
+		if (quest->db_data[entry.id] == NULL)
+			quest->db_data[entry.id] = aMalloc(sizeof(struct quest_db));
+
+		memcpy(quest->db_data[entry.id], &entry, sizeof(struct quest_db));
+		count++;
 	}
 	fclose(fp);
-	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", k, "quest_db.txt");
+	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, "quest_db.txt");
 	return 0;
 }
 
+/**
+ * Map iterator to ensures a player has no invalid quest log entries.
+ *
+ * Any entries that are no longer in the db are removed.
+ *
+ * @see map->foreachpc
+ * @param ap Ignored
+ */
+int quest_reload_check_sub(struct map_session_data *sd, va_list ap) {
+	int i, j;
+
+	nullpo_ret(sd);
+
+	j = 0;
+	for (i = 0; i < sd->num_quests; i++) {
+		struct quest_db *qi = quest->db(sd->quest_log[i].quest_id);
+		if (qi == &quest->dummy) { // Remove no longer existing entries
+			if (sd->quest_log[i].state != Q_COMPLETE) // And inform the client if necessary
+				clif->quest_delete(sd, sd->quest_log[i].quest_id);
+			continue;
+		}
+		if (i != j) {
+			// Move entries if there's a gap to fill
+			memcpy(&sd->quest_log[j], &sd->quest_log[i], sizeof(struct quest));
+		}
+		j++;
+	}
+	sd->num_quests = 0;
+	ARR_FIND(sd->avail_quests, 0, j, sd->quest_log[j].state != Q_COMPLETE);
+	sd->avail_quests = j+1;
+
+	return 1;
+}
+
+/**
+ * Clears the quest database for shutdown or reload.
+ */
+void quest_clear_db(void) {
+	int i;
+
+	for (i = 0; i < MAX_QUEST_DB; i++) {
+		if (quest->db_data[i]) {
+			aFree(quest->db_data[i]);
+			quest->db_data[i] = NULL;
+		}
+	}
+}
+
+/**
+ * Initializes the quest interface.
+ *
+ * @param minimal Run in minimal mode (skips most of the loading)
+ */
 void do_init_quest(bool minimal) {
 	if (minimal)
 		return;
@@ -358,20 +493,39 @@ void do_init_quest(bool minimal) {
 	quest->read_db();
 }
 
-void do_reload_quest(void) {
-	memset(&quest->db, 0, sizeof(quest->db));
-	quest->read_db();
+/**
+ * Finalizes the quest interface before shutdown.
+ */
+void do_final_quest(void) {
+	quest->clear();
 }
 
+/**
+ * Reloads the quest database.
+ */
+void do_reload_quest(void) {
+	quest->clear();
+
+	quest->read_db();
+
+	// Update quest data for players, to ensure no entries about removed quests are left over.
+	map->foreachpc(&quest_reload_check_sub);
+}
+
+/**
+ * Initializes default values for the quest interface.
+ */
 void quest_defaults(void) {
 	quest = &quest_s;
-	
+
 	memset(&quest->db, 0, sizeof(quest->db));
+	memset(&quest->dummy, 0, sizeof(quest->dummy));
 	/* */
 	quest->init = do_init_quest;
+	quest->final = do_final_quest;
 	quest->reload = do_reload_quest;
 	/* */
-	quest->search_db = quest_search_db;
+	quest->db = quest_db;
 	quest->pc_login = quest_pc_login;
 	quest->add = quest_add;
 	quest->change = quest_change;
@@ -380,5 +534,6 @@ void quest_defaults(void) {
 	quest->update_objective = quest_update_objective;
 	quest->update_status = quest_update_status;
 	quest->check = quest_check;
+	quest->clear = quest_clear_db;
 	quest->read_db = quest_read_db;
 }

--- a/src/map/quest.h
+++ b/src/map/quest.h
@@ -5,7 +5,9 @@
 #ifndef _QUEST_H_
 #define _QUEST_H_
 
-struct s_quest_db {
+#define MAX_QUEST_DB (60355+1) // Highest quest ID + 1
+
+struct quest_db {
 	int id;
 	unsigned int time;
 	int mob[MAX_QUEST_OBJECTIVES];
@@ -14,23 +16,31 @@ struct s_quest_db {
 	//char name[NAME_LENGTH];
 };
 
-typedef enum quest_check_type { HAVEQUEST, PLAYTIME, HUNTING } quest_check_type;
+// Questlog check types
+enum quest_check_type {
+	HAVEQUEST, ///< Query the state of the given quest
+	PLAYTIME,  ///< Check if the given quest has been completed or has yet to expire
+	HUNTING,   ///< Check if the given hunting quest's requirements have been met
+};
 
 struct quest_interface {
-	struct s_quest_db db[MAX_QUEST_DB];
+	struct quest_db *db_data[MAX_QUEST_DB]; ///< Quest database
+	struct quest_db dummy;                  ///< Dummy entry for invalid quest lookups
 	/* */
 	void (*init) (bool minimal);
+	void (*final) (void);
 	void (*reload) (void);
 	/* */
-	int (*search_db) (int quest_id);
+	struct quest_db *(*db) (int quest_id);
 	int (*pc_login) (TBL_PC *sd);
 	int (*add) (TBL_PC *sd, int quest_id);
 	int (*change) (TBL_PC *sd, int qid1, int qid2);
 	int (*delete) (TBL_PC *sd, int quest_id);
 	int (*update_objective_sub) (struct block_list *bl, va_list ap);
 	void (*update_objective) (TBL_PC *sd, int mob_id);
-	int (*update_status) (TBL_PC *sd, int quest_id, quest_state qs);
-	int (*check) (TBL_PC *sd, int quest_id, quest_check_type type);
+	int (*update_status) (TBL_PC *sd, int quest_id, enum quest_state qs);
+	int (*check) (TBL_PC *sd, int quest_id, enum quest_check_type type);
+	void (*clear) (void);
 	int (*read_db) (void);
 };
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -15889,20 +15889,20 @@ BUILDIN(questinfo)
 	return true;
 }
 
-BUILDIN(setquest)
-{
+BUILDIN(setquest) {
 	struct map_session_data *sd = script->rid2sd(st);
 	unsigned short i;
-	
-	if (!sd)
-		return false;
+	int quest_id;
+	nullpo_retr(false,sd);
 
-	quest->add(sd, script_getnum(st, 2));
+	quest_id = script_getnum(st, 2);
+
+	quest->add(sd, quest_id);
 
 	// If questinfo is set, remove quest bubble once quest is set.
 	for(i = 0; i < map->list[sd->bl.m].qi_count; i++) {
 		struct questinfo *qi = &map->list[sd->bl.m].qi_data[i];
-		if( qi->quest_id == script_getnum(st, 2) ) {
+		if( qi->quest_id == quest_id ) {
 #if PACKETVER >= 20120410
 			clif->quest_show_event(sd, &qi->nd->bl, 9999, 0);
 #else
@@ -15914,8 +15914,7 @@ BUILDIN(setquest)
 	return true;
 }
 
-BUILDIN(erasequest)
-{
+BUILDIN(erasequest) {
 	struct map_session_data *sd = script->rid2sd(st);
 	nullpo_retr(false,sd);
 	
@@ -15923,8 +15922,7 @@ BUILDIN(erasequest)
 	return true;
 }
 
-BUILDIN(completequest)
-{
+BUILDIN(completequest) {
 	struct map_session_data *sd = script->rid2sd(st);
 	nullpo_retr(false,sd);
 	
@@ -15932,8 +15930,7 @@ BUILDIN(completequest)
 	return true;
 }
 
-BUILDIN(changequest)
-{
+BUILDIN(changequest) {
 	struct map_session_data *sd = script->rid2sd(st);
 	nullpo_retr(false,sd);
 	
@@ -15941,15 +15938,14 @@ BUILDIN(changequest)
 	return true;
 }
 
-BUILDIN(checkquest)
-{
+BUILDIN(checkquest) {
 	struct map_session_data *sd = script->rid2sd(st);
-	quest_check_type type = HAVEQUEST;
+	enum quest_check_type type = HAVEQUEST;
 	
 	nullpo_retr(false,sd);
 	
 	if( script_hasdata(st, 3) )
-		type = (quest_check_type)script_getnum(st, 3);
+		type = (enum quest_check_type)script_getnum(st, 3);
 	
 	script_pushint(st, quest->check(sd, script_getnum(st, 2), type));
 	

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -2393,6 +2393,11 @@ int unit_free(struct block_list *bl, clr_type clrtype) {
 				aFree(sd->queues);
 				sd->queues = NULL;
 			}
+			if( sd->quest_log != NULL ) {
+				aFree(sd->quest_log);
+				sd->quest_log = NULL;
+				sd->num_quests = sd->avail_quests = 0;
+			}
 			
 			for( k = 0; k < sd->hdatac; k++ ) {
 				if( sd->hdata[k]->flag.free ) {


### PR DESCRIPTION
I'm submitting this as a pull request so that it can get some review.
- Improved memory usage of the quest log system. (saves up to 75kB per
  online character). Fixes issue #133.
- Fixed various issues with quest entries disappearing from characters
  without an apparent reason, or monster kill counters getting stuck -
  the issues were caused by a de-synchronization between the two
  parallel questlog arrays in map_session_data.
- Added some code documentation.
- Thanks to Ind.

Signed-off-by: Haru haru@dotalux.com
