### PR TITLE
wrong HPM parsing of packets of variable length, when the size is not equal declared size.

### DIFF
--- a/src/common/HPM.c
+++ b/src/common/HPM.c
@@ -512,7 +512,7 @@ unsigned char hplugins_parse_packets(int fd, enum HPluginPacketHookingPoints poi
 		short length;
 		
 		if( (length = packet->len) == -1 ) {
-			if( (length = RFIFOW(fd, 2)) < (int)RFIFOREST(fd) )
+			if( (length = RFIFOW(fd, 2)) > (int)RFIFOREST(fd) )
 			   return 2;
 		}
 		


### PR DESCRIPTION
When working with packets with variable length (defined with -1 length) in HPM,
we are leaving these in stack when the size of packet exceeds declared size due to this line forcing server to cycle forever for this fd.
This was probably meant as if( packet_declared_size > packet_actual_size ) do_not_parse_it_yet,
but was doing the opposite.
