### PR TITLE
Fix - Do not allow players to attack while sitting

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10101,7 +10101,7 @@ void clif_parse_ActionRequest_sub(struct map_session_data *sd, int action_type, 
 				return;
 			}
 			
-			if( pc_cant_act(sd) || sd->sc.option&OPTION_HIDE )
+			if( pc_cant_act(sd) || pc_issit(sd) || sd->sc.option&OPTION_HIDE )
 				return;
 
 			if( sd->sc.option&OPTION_COSTUME )


### PR DESCRIPTION
While working on roBrowser I figured out there is no check server-side to block a players to do a _regular_ attack while sitting.

![sit-bug](https://cloud.githubusercontent.com/assets/4102403/2707667/f980e84a-c4a3-11e3-87b2-5fa610b6d0b2.jpg)

The attack do not reset the "sit" stat, so you can't walk or do skill but you'll keep your awesome double hp/sp regeneration.
It can be abused (specially by long range players) to regenerate while attacking monsters.
