### PR TITLE
Fixed Bug #8248

### DIFF
--- a/npc/custom/jobmaster.txt
+++ b/npc/custom/jobmaster.txt
@@ -158,6 +158,10 @@ function Job_Menu {
 			jobchange .@newjob;
 			if (.@newjob == Job_Novice_High)
 				resetlvl(1);
+			if (.@newjob == Job_Baby) {
+				resetlvl(4);
+				SkillPoint = 0;
+			}
 			specialeffect2 EF_ANGEL2;
 			specialeffect2 EF_ELECTRIC;
 			if (.platinum)


### PR DESCRIPTION
http://hercules.ws/board/tracker/issue-8248-job-master-bug/
- Job Master now properly resets Novice Basic Skill upon job change into Baby Novice.
- Sparkles and thanks to @Ridley8819 for pointing out the issue.
