### PR TITLE
Added Explosive_Kunai and Makibishi to Boonji NPC

### DIFF
--- a/npc/merchants/shops.txt
+++ b/npc/merchants/shops.txt
@@ -269,6 +269,8 @@ OnInit:
 	sellitem Flash_Shuriken;
 	sellitem Sharp_Leaf_Shuriken;
 	sellitem Thorn_Needle_Shuriken;
+	sellitem Explosive_Kunai;
+	sellitem Makibishi;
 }
 
 que_ng,73,26,5	trader	Boonray#nin	4_M_01,{


### PR DESCRIPTION
Not sure if they  were added somewhere already, but on rAthena they were on Boonji NPC last time I checked.
Also i think i made a mistake on the pull request >.> the Merge Pull Request #1 commit was included for some reason, I didn't know how to select, I had to update my fork before i did this. Sorry, first timer here : (
