### PR TITLE
Corrected SC_WARMER. Other cleanups

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -12116,7 +12116,7 @@ int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *bl, int6
 			break;
 
 		case UNT_WARMER:
-			if( bl->type == BL_PC && !battle->check_undead(tstatus->race, tstatus->def_ele) && tstatus->race != RC_DEMON ) {
+			{	// It has effect on everything, including monsters, undead property and demon
 				int hp = 0;
 				if( ssc && ssc->data[SC_HEATER_OPTION] )
 					hp = tstatus->max_hp * 3 * sg->skill_lv / 100;
@@ -12128,10 +12128,9 @@ int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *bl, int6
 				if( tsc && tsc->data[SC_AKAITSUKI] && hp )
 					hp = ~hp + 1;
 				status->heal(bl, hp, 0, 0);
-				sc_start(ss, bl, SC_WARMER, 100, sg->skill_lv, skill->get_time2(sg->skill_id,sg->skill_lv));
+				sc_start(ss, bl, type, 100, sg->skill_lv, sg->interval + 100);
 			}
 			break;
-
 		case UNT_FIRE_INSIGNIA:
 		case UNT_WATER_INSIGNIA:
 		case UNT_WIND_INSIGNIA:
@@ -12239,10 +12238,8 @@ int skill_unit_onout(struct skill_unit *src, struct block_list *bl, int64 tick) 
 	switch(sg->unit_id){
 		case UNT_SAFETYWALL:
 		case UNT_PNEUMA:
-		case UNT_EPICLESIS://Arch Bishop
 		case UNT_NEUTRALBARRIER:
 		case UNT_STEALTHFIELD:
-		case UNT_WARMER:
 			if (sce)
 				status_change_end(bl, type, INVALID_TIMER);
 			break;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -677,7 +677,6 @@ void initChangeTables(void) {
 	set_sc_with_vfx( SO_DIAMONDDUST       , SC_COLD      , SI_COLD   , SCB_NONE ); // it does show the snow icon on mobs but doesn't affect it.
 	set_sc( SO_CLOUD_KILL        , SC_POISON          , SI_CLOUDKILL       , SCB_NONE );
 	set_sc( SO_STRIKING          , SC_STRIKING        , SI_STRIKING        , SCB_WATK|SCB_CRI );
-	set_sc( SO_WARMER            , SC_WARMER          , SI_WARMER          , SCB_NONE );
 	set_sc( SO_VACUUM_EXTREME    , SC_VACUUM_EXTREME  , SI_VACUUM_EXTREME  , SCB_NONE );
 	set_sc( SO_ARRULLO           , SC_DEEP_SLEEP       , SI_DEEPSLEEP       , SCB_NONE );
 	set_sc( SO_FIRE_INSIGNIA     , SC_FIRE_INSIGNIA   , SI_FIRE_INSIGNIA   , SCB_MATK | SCB_BATK | SCB_WATK | SCB_ATK_ELE | SCB_REGEN );

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -1185,7 +1185,7 @@ enum si_type {
 	SI_ECHOSONG                              = 443,
 	SI_HARMONIZE                             = 444,
 	SI_STRIKING                              = 445,
-	SI_WARMER                                = 446,
+	//SI_WARMER                              = 446,
 	SI_MOONLITSERENADE                       = 447,
 	SI_SATURDAYNIGHTFEVER                    = 448,
 	SI_SITDOWN_FORCE                         = 449,


### PR DESCRIPTION
-Fixes bug 8044: http://hercules.ws/board/tracker/issue-8044-sorcerer-warmer/ TODO: Fix skill_unit_onout to work for skill_unit_timer_sub_onplace too.
-Cleaned some skill_unit_onout cases never reached.
-Removed icon for SC_WARMER.
