### PR TITLE
Fixes CR_DEVOTION and MG_STONECURSE behaviour, hiding behaviour.

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -6360,7 +6360,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 
 				if (tsc->data[SC_STONE]) {
 					status_change_end(bl, SC_STONE, INVALID_TIMER);
-					if (sd) clif->skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
+					clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
 					break;
 				}
 				if (sc_start4(src,bl,SC_STONE,(skill_lv*4+20)+brate,

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -1790,16 +1790,8 @@ int status_check_skilluse(struct block_list *src, struct block_list *target, uin
 	hide_flag = flag?OPTION_HIDE:(OPTION_HIDE|OPTION_CLOAK|OPTION_CHASEWALK);
 
 	//You cannot hide from ground skills.
-	if( skill->get_ele(skill_id,1) == ELE_EARTH ) //TODO: Need Skill Lv here :/
+	if( skill->get_ele(skill_id,1) == ELE_EARTH && skill_id != MG_STONECURSE)
 		hide_flag &= ~OPTION_HIDE;
-	else {
-		switch ( skill_id ) {
-			case MO_ABSORBSPIRITS: // it works when already casted and target suddenly hides.
-			case SA_DISPELL:
-				hide_flag &= ~OPTION_HIDE;
-				break;
-		}
-	}
 
 	switch( target->type ) {
 		case BL_PC: {
@@ -1810,6 +1802,7 @@ int status_check_skilluse(struct block_list *src, struct block_list *target, uin
 					return 0;
 				if( tsc ) {
 					if (tsc->option&hide_flag && !is_boss &&
+						!(flag&1 && skill->get_nk(skill_id)&NK_NO_DAMAGE) && // Buff/debuff skills that started casting before hiding still applies
 						((sd->special_state.perfect_hiding || !is_detect) ||
 						(tsc->data[SC_CLOAKINGEXCEED] && is_detect)))
 						return 0;

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1241,6 +1241,17 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 			casttime = -1;
 		temp = 1;
 	break;
+	case CR_DEVOTION:
+		if (sd)	{
+			int i = 0, count = min(skill_lv, 5);
+			ARR_FIND(0, count, i, sd->devotion[i] == target_id);
+			if (i == count) {
+				ARR_FIND(0, count, i, sd->devotion[i] == 0);
+					if(i == count)
+						return 0; // Can't cast on other characters when limit is reached
+			}
+		}
+	break;
 	case SR_GATEOFHELL:
 	case SR_TIGERCANNON:
 		if (sc && sc->data[SC_COMBOATTACK] &&


### PR DESCRIPTION
Fixed CR_DEVOTION to not be casted on other characters while the limit is already reached. Follow-up: e7be72538ea9c203bfd7a976d82e268e04303ca4

MG_STONECURSE now correctly displays effect when terminating SC_STONE. No longer works on hidden characters. Bug report http://hercules.ws/board/tracker/issue-7958-stone-curse/

Hiding no longer prevents skills from working if they were casted before hiding and are not intended to inflict damage (buff/de-buff skills). Tested on aegis. Thanks to Haruna.
