### PR TITLE
Added option for song timers behaviour. Fixes bug 8265

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -127,6 +127,13 @@ traps_setting: 0
 //     one hydra out)
 summon_flora_setting: 3
 
+// When songs are canceled, terminated or the character goes out of the
+// area of effect, there's an additional effect that lasts for 20 seconds
+// Should that time be reset for each song?
+// 0: No, you must recast the song AFTER those 20 seconds to have the effect again (Aegis)
+// 1: Yes, recasting songs reset the 20 seconds timer (eathena)
+song_timer_reset: 0
+
 // Whether placed down skills will check walls (Note 1)
 // (Makes it so that Storm Gust/Lord of Vermillion/etc when cast next to a wall, won't hit on the other side) 
 skill_wall_check: yes

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -6733,6 +6733,7 @@ static const struct battle_data {
 	{ "mail_show_status",                   &battle_config.mail_show_status,                0,      0,      2,              },
 	{ "client_limit_unit_lv",               &battle_config.client_limit_unit_lv,            0,      0,      BL_ALL,         },
 	{ "client_emblem_max_blank_percent",    &battle_config.client_emblem_max_blank_percent, 100,    0,      100,            },
+	{ "song_timer_reset",                   &battle_config.song_timer_reset,                0,      0,      1,              },
 	// BattleGround Settings
 	{ "bg_update_interval",                 &battle_config.bg_update_interval,              1000,   100,    INT_MAX,        },
 	{ "bg_flee_penalty",                    &battle_config.bg_flee_penalty,                 20,     0,      INT_MAX,        },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -169,6 +169,7 @@ struct Battle_Config {
 	int emergency_call;
 	int guild_aura;
 	int pc_invincible_time;
+	int song_timer_reset;
 	
 	int pet_catch_rate;
 	int pet_rename;


### PR DESCRIPTION
- Fixes bug 8265: http://hercules.ws/board/tracker/issue-8265-bragis-poem-overlapped-20-seconds-effect/
- Added setting in /conf/battle/skill.conf song_timer_reset: switch between official behaviour (songs don't reset time from prior songs) or eathena (every song resets the timer)
