### PR TITLE
Devotion statuses fixed. Cleaned some warnings. Unit range shortened!

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1733,7 +1733,7 @@ int skill_counter_additional_effect(struct block_list* src, struct block_list *b
 		case LG_HESPERUSLIT:
 			if ( sc && sc->data[SC_FORCEOFVANGUARD] && sc->data[SC_BANDING] && sc->data[SC_BANDING]->val2 > 6 ) {
 					char i;
-					for( i = 0; i < sc->data[SC_FORCEOFVANGUARD]->val3; i++ && sc->fv_counter <= sc->data[SC_FORCEOFVANGUARD]->val3 )
+					for( i = 0; i < sc->data[SC_FORCEOFVANGUARD]->val3 && sc->fv_counter <= sc->data[SC_FORCEOFVANGUARD]->val3 ; i++)
 					clif->millenniumshield(bl, sc->fv_counter++);
 				}
 				break;
@@ -1768,15 +1768,12 @@ int skill_counter_additional_effect(struct block_list* src, struct block_list *b
 		if( attack_type&BF_MAGIC ) {
 			sp += sd->bonus.magic_sp_gain_value;
 			hp += sd->bonus.magic_hp_gain_value;
-			if( skill_id == WZ_WATERBALL ) {// (bugreport:5303)
-				struct status_change *sc = NULL;
-				if( ( sc = status->get_sc(src) ) ) {
-					if( sc->data[SC_SOULLINK]
-					 && sc->data[SC_SOULLINK]->val2 == SL_WIZARD
-					 && sc->data[SC_SOULLINK]->val3 == WZ_WATERBALL
-					)
-						sc->data[SC_SOULLINK]->val3 = 0; //Clear bounced spell check.
-				}
+			if( skill_id == WZ_WATERBALL ) {// (bugreport:5303) 
+				if( sc->data[SC_SOULLINK]
+				  && sc->data[SC_SOULLINK]->val2 == SL_WIZARD
+				  && sc->data[SC_SOULLINK]->val3 == WZ_WATERBALL
+				)
+					sc->data[SC_SOULLINK]->val3 = 0; //Clear bounced spell check.
 			}
 		}
 		if( hp || sp ) {
@@ -11866,7 +11863,7 @@ int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *bl, int6
 			if( md && md->class_ == MOBID_EMPERIUM )
 				break;
 #endif
-			if( sg->src_id == bl->id && !(tsc && tsc->data[SC_SOULLINK] && tsc->data[SC_SOULLINK]->val2 == SL_BARDDANCER)
+			if( (sg->src_id == bl->id && !(tsc && tsc->data[SC_SOULLINK] && tsc->data[SC_SOULLINK]->val2 == SL_BARDDANCER))
 			  || (!(battle_config.song_timer_reset) && tsc && tsc->data[type] && tsc->data[type]->val4 == 1))
 				break;
 			heal = skill->calc_heal(ss,bl,sg->skill_id, sg->skill_lv, true);

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -316,7 +316,7 @@ int unit_walktoxy_timer(int tid, int64 tick, int id, intptr_t data) {
 				unit->attack(bl, tbl->id, ud->state.attack_continue);
 			}
 		} else { //Update chase-path
-			unit->walktobl(bl, tbl, ud->chaserange, ud->state.walk_easy|(ud->state.attack_continue?2:0));
+			unit->walktobl(bl, tbl, ud->chaserange, ud->state.walk_easy|(ud->state.attack_continue? 1 : 0));
 			return 0;
 		}
 	} else {


### PR DESCRIPTION
- Now SC_AUTOGUARD and SC_REFLECTSHIELD won't have effect if the devotion range is too big. Bug report http://hercules.ws/board/tracker/issue-8345-about-devotion-status-tra/
- Cleaned some warnings
- Due to the exploit of some client edits and with the feedback of some users, I can say it's safe to change back the range extra cell to 1. Thanks Juvia, KeyWorld.
