### PR TITLE
Fixes damage missing. Snap dodging bug.

### DIFF
--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -146,3 +146,7 @@ autospell_check_range: no
 // If both the attacker and the target are on the same tile, should the target be knocked back to the left?
 // Official behavior is "yes", setting this to "no" will knock the target back behind the attacker.
 knockback_left: yes
+
+// Should the target be able of dodging damage by snapping away to the edge of the screen?
+// Official behavior is "no"
+snap_dodge: no

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -169,7 +169,6 @@ struct Battle_Config {
 	int emergency_call;
 	int guild_aura;
 	int pc_invincible_time;
-	int song_timer_reset;
 	
 	int pet_catch_rate;
 	int pet_rename;
@@ -475,6 +474,9 @@ struct Battle_Config {
 	int case_sensitive_aegisnames;
 	int guild_castle_invite;
 	int guild_castle_expulsion;
+
+	int song_timer_reset; // [csnv]
+	int snap_dodge; // Enable or disable dodging damage snapping away [csnv]
 };
 
 extern struct Battle_Config battle_config;


### PR DESCRIPTION
- Fixes damage miss on out of range Devotion. Follow-up: 964b47351ef2156423f6e0a68bfd3361283936c1
- Fixes snap dodge bug. Added setting snap_dodge to return to old behavior. Bug report: http://hercules.ws/board/tracker/issue-3510-snap-dodge-bug/
