### PR TITLE
Fix compilation without memory manager.

### DIFF
--- a/src/common/console.c
+++ b/src/common/console.c
@@ -112,7 +112,9 @@ CPCMD_C(ers_report,server) {
  * Displays memory usage
  **/
 CPCMD_C(mem_report,server) {
+#ifdef USE_MEMMGR
 	memmgr_report(line?atoi(line):0);
+#endif
 }
 
 /**

--- a/src/common/malloc.c
+++ b/src/common/malloc.c
@@ -822,8 +822,10 @@ void malloc_final (void) {
 }
 
 void malloc_init (void) {
+#ifdef USE_MEMMGR
 	memmgr_usage_bytes_t = 0;
 	memmgr_usage_bytes = 0;
+#endif
 #if defined(DMALLOC) && defined(CYGWIN)
 	// http://dmalloc.com/docs/latest/online/dmalloc_19.html
 	dmalloc_debug_setup(getenv("DMALLOC_OPTIONS"));


### PR DESCRIPTION
configure example: ./configure --enable-manager=no
