### PR TITLE
Command line arguments handling overhaul

### DIFF
--- a/src/char/char.c
+++ b/src/char/char.c
@@ -50,10 +50,6 @@
 #endif
 
 // private declarations
-#define CHAR_CONF_NAME "conf/char-server.conf"
-#define LAN_CONF_NAME  "conf/subnet.conf"
-#define SQL_CONF_NAME  "conf/inter-server.conf"
-
 char char_db[256] = "char";
 char scdata_db[256] = "sc_data";
 char cart_db[256] = "cart_inventory";
@@ -5707,6 +5703,11 @@ int do_final(void) {
 		if( chr->server[i].map )
 			aFree(chr->server[i].map);
 
+	aFree(chr->CHAR_CONF_NAME);
+	aFree(chr->LAN_CONF_NAME);
+	aFree(chr->SQL_CONF_NAME);
+	aFree(chr->INTER_CONF_NAME);
+
 	HPM->event(HPET_POST_FINAL);
 
 	ShowStatus("Finished.\n");
@@ -5763,45 +5764,80 @@ void char_hp_symbols(void) {
 	HPM->share(inter->sql_handle, "sql_handle");
 }
 
+/**
+ * --char-config handler
+ *
+ * Overrides the default char configuration file.
+ * @see cmdline->exec
+ */
+static CMDLINEARG(charconfig)
+{
+	aFree(chr->CHAR_CONF_NAME);
+	chr->CHAR_CONF_NAME = aStrdup(params);
+	return true;
+}
+/**
+ * --inter-config handler
+ *
+ * Overrides the default inter-server configuration file.
+ * @see cmdline->exec
+ */
+static CMDLINEARG(interconfig)
+{
+	aFree(chr->INTER_CONF_NAME);
+	chr->INTER_CONF_NAME = aStrdup(params);
+	return true;
+}
+/**
+ * --lan-config handler
+ *
+ * Overrides the default subnet configuration file.
+ * @see cmdline->exec
+ */
+static CMDLINEARG(lanconfig)
+{
+	aFree(chr->LAN_CONF_NAME);
+	chr->LAN_CONF_NAME = aStrdup(params);
+	return true;
+}
+/**
+ * Initializes the command line arguments handlers.
+ */
+void cmdline_args_init_local(void)
+{
+	CMDLINEARG_DEF2(char-config, charconfig, "Alternative char-server configuration.", CMDLINE_OPT_PARAM);
+	CMDLINEARG_DEF2(inter-config, interconfig, "Alternative inter-server configuration.", CMDLINE_OPT_PARAM);
+	CMDLINEARG_DEF2(lan-config, lanconfig, "Alternative subnet configuration.", CMDLINE_OPT_PARAM);
+}
+
 int do_init(int argc, char **argv) {
 	int i;
 	memset(&skillid2idx, 0, sizeof(skillid2idx));
 
 	char_load_defaults();
 
+	chr->CHAR_CONF_NAME = aStrdup("conf/char-server.conf");
+	chr->LAN_CONF_NAME = aStrdup("conf/subnet.conf");
+	chr->SQL_CONF_NAME = aStrdup("conf/inter-server.conf");
+	chr->INTER_CONF_NAME = aStrdup("conf/inter-server.conf");
+
 	for(i = 0; i < MAX_MAP_SERVERS; i++ )
 		chr->server[i].map = NULL;
 
 	HPM_char_do_init();
 	HPM->symbol_defaults_sub = char_hp_symbols;
-#if 0
-	/* TODO: Move to common code */
-	for( i = 1; i < argc; i++ ) {
-		const char* arg = argv[i];
-		if( strcmp(arg, "--load-plugin") == 0 ) {
-			if( map->arg_next_value(arg, i, argc, true) ) {
-				RECREATE(load_extras, char *, ++load_extras_count);
-				load_extras[load_extras_count-1] = argv[++i];
-			}
-		}
-	}
-	HPM->config_read((const char * const *)load_extras, load_extras_count);
-	if (load_extras) {
-		aFree(load_extras);
-		load_extras = NULL;
-		load_extras_count = 0;
-	}
-#endif
-	HPM->config_read(NULL, 0);
+	cmdline->exec(argc, argv, CMDLINE_OPT_PREINIT);
+	HPM->config_read();
 	HPM->event(HPET_PRE_INIT);
 
 	//Read map indexes
 	mapindex->init();
 	start_point.map = mapindex->name2id("new_zone01");
 
-	chr->config_read((argc < 2) ? CHAR_CONF_NAME : argv[1]);
-	chr->lan_config_read((argc > 3) ? argv[3] : LAN_CONF_NAME);
-	chr->sql_config_read(SQL_CONF_NAME);
+	cmdline->exec(argc, argv, CMDLINE_OPT_NORMAL);
+	chr->config_read(chr->CHAR_CONF_NAME);
+	chr->lan_config_read(chr->LAN_CONF_NAME);
+	chr->sql_config_read(chr->SQL_CONF_NAME);
 
 	if (strcmp(chr->userid, "s1")==0 && strcmp(chr->passwd, "p1")==0) {
 		ShowWarning("Using the default user/password s1/p1 is NOT RECOMMENDED.\n");
@@ -5809,7 +5845,7 @@ int do_init(int argc, char **argv) {
 		ShowNotice("And then change the user/password to use in conf/char-server.conf (or conf/import/char_conf.txt)\n");
 	}
 
-	inter->init_sql((argc > 2) ? argv[2] : inter_cfgName); // inter server configuration
+	inter->init_sql(chr->INTER_CONF_NAME); // inter server configuration
 
 	auth_db = idb_alloc(DB_OPT_RELEASE_DATA);
 	chr->online_char_db = idb_alloc(DB_OPT_RELEASE_DATA);

--- a/src/char/char.h
+++ b/src/char/char.h
@@ -144,6 +144,11 @@ struct char_interface {
 	int server_type;
 	int new_display;
 
+	char *CHAR_CONF_NAME;
+	char *LAN_CONF_NAME;
+	char *SQL_CONF_NAME;
+	char *INTER_CONF_NAME;
+
 	int (*waiting_disconnect) (int tid, int64 tick, int id, intptr_t data);
 	int (*delete_char_sql) (int char_id);
 	DBData (*create_online_char_data) (DBKey key, va_list args);

--- a/src/char/inter.h
+++ b/src/char/inter.h
@@ -11,8 +11,6 @@
 
 struct accreg;
 
-#define inter_cfgName "conf/inter-server.conf"
-
 #ifdef HERCULES_CORE
 extern unsigned int party_share_level;
 

--- a/src/common/HPM.h
+++ b/src/common/HPM.h
@@ -82,14 +82,6 @@ struct HPMFileNameCache {
 	char *name;
 };
 
-struct HPMArgData {
-	unsigned int pluginID;
-	char *name;/* e.g. "--my-arg","-v","--whatever" */
-	void (*help) (void);/* to display when --help is used */
-	void (*func) (char *param);/* NULL when no param is available */
-	bool has_param;/* because of the weird "--arg<space>param" instead of the "--arg=param" */
-};
-
 struct HPDataOperationStorage {
 	void **HPDataSRCPtr;
 	unsigned int *hdatac;
@@ -123,8 +115,9 @@ struct HPM_interface {
 	/* config listen */
 	struct HPConfListenStorage *confs[HPCT_MAX];
 	unsigned int confsc[HPCT_MAX];
-	/* --command-line */
-	DBMap *arg_db;
+	/** Plugins requested through the command line */
+	char **cmdline_plugins;
+	int cmdline_plugins_count;
 	/* funcs */
 	void (*init) (void);
 	void (*final) (void);
@@ -137,16 +130,13 @@ struct HPM_interface {
 	void *(*import_symbol) (char *name, unsigned int pID);
 	void (*share) (void *, char *);
 	void (*symbol_defaults) (void);
-	void (*config_read) (const char * const *extra_plugins, int extra_plugins_count);
+	void (*config_read) (void);
 	bool (*populate) (struct hplugin *plugin,const char *filename);
 	void (*symbol_defaults_sub) (void);//TODO drop
 	char *(*pid2name) (unsigned int pid);
 	unsigned char (*parse_packets) (int fd, enum HPluginPacketHookingPoints point);
 	void (*load_sub) (struct hplugin *plugin);
 	bool (*addhook_sub) (enum HPluginHookType type, const char *target, void *hook, unsigned int pID);
-	bool (*parse_arg) (const char *arg, int* index, char *argv[], bool param);
-	void (*arg_help) (void);
-	int (*arg_db_clear_sub) (DBKey key, DBData *data, va_list args);
 	void (*grabHPData) (struct HPDataOperationStorage *ret, enum HPluginDataTypes type, void *ptr);
 	/* for server-specific HPData e.g. map_session_data */
 	bool (*grabHPDataSub) (struct HPDataOperationStorage *ret, enum HPluginDataTypes type, void *ptr);
@@ -157,6 +147,8 @@ struct HPM_interface {
 	void (*datacheck_init) (const struct s_HPMDataCheck *src, unsigned int length, int version);
 	void (*datacheck_final) (void);
 };
+
+CMDLINEARG(loadplugin);
 
 struct HPM_interface *HPM;
 

--- a/src/common/HPMi.h
+++ b/src/common/HPMi.h
@@ -104,7 +104,7 @@ enum HPluginConfType {
 #define hookStop() (HPMi->HookStop(__func__,HPMi->pid))
 #define hookStopped() (HPMi->HookStopped())
 
-#define addArg(name,param,func,help) (HPMi->addArg(HPMi->pid,(name),(param),(func),(help)))
+#define addArg(name, param,func,help) (HPMi->addArg(HPMi->pid,(name),(param),(cmdline_arg_ ## func),(help)))
 /* HPData handy redirects */
 /* session[] */
 #define addToSession(ptr,data,index,autofree) (HPMi->addToHPData(HPDT_SESSION,HPMi->pid,(ptr),(data),(index),(autofree)))
@@ -214,7 +214,7 @@ HPExport struct HPMi_interface {
 	void (*HookStop) (const char *func, unsigned int pID);
 	bool (*HookStopped) (void);
 	/* program --arg/-a */
-	bool (*addArg) (unsigned int pluginID, char *name, bool has_param,void (*func) (char *param),void (*help) (void));
+	bool (*addArg) (unsigned int pluginID, char *name, bool has_param, CmdlineExecFunc func, const char *help);
 	/* battle-config recv param */
 	bool (*addConf) (unsigned int pluginID, enum HPluginConfType type, char *name, void (*func) (const char *val));
 	/* pc group permission */

--- a/src/common/core.h
+++ b/src/common/core.h
@@ -5,6 +5,7 @@
 #ifndef COMMON_CORE_H
 #define COMMON_CORE_H
 
+#include "../common/cbasetypes.h"
 #include "../common/db.h"
 #include "../common/mmo.h"
 
@@ -39,6 +40,7 @@ extern char *SERVER_NAME;
 
 enum server_types SERVER_TYPE;
 
+extern void cmdline_args_init_local(void);
 extern int do_init(int,char**);
 extern void set_server_type(void);
 extern void do_abort(void);
@@ -47,6 +49,48 @@ extern int do_final(void);
 /// Called when a terminate signal is received. (Ctrl+C pressed)
 /// If NULL, runflag is set to CORE_ST_STOP instead.
 extern void (*shutdown_callback)(void);
+#endif // HERCULES_CORE
+
+/// Options for command line argument handlers.
+enum cmdline_options {
+	CMDLINE_OPT_NORMAL         = 0x0, ///< No special options.
+	CMDLINE_OPT_PARAM          = 0x1, ///< An additional value parameter is expected.
+	CMDLINE_OPT_SILENT         = 0x2, ///< If this command-line argument is passed, the server won't print any messages.
+	CMDLINE_OPT_PREINIT        = 0x4, ///< This command-line argument is executed before initializing the HPM.
+};
+typedef bool (*CmdlineExecFunc)(const char *name, const char *params);
+struct CmdlineArgData {
+	unsigned int pluginID; ///< Plugin ID (HPM_PID_CORE if used by the core)
+	unsigned int options;  ///< Command line argument options (@see enum cmdline_options)
+	char *name;            ///< Command-line argument (i.e. "--my-arg", "--version", "--whatever")
+	char shortname;        ///< Short form (i.e. "-v") - only store the 'v' part.
+	CmdlineExecFunc func;  ///< Function to call
+	char *help;            ///< Help message
+};
+
+struct cmdline_interface {
+	struct CmdlineArgData *args_data;
+	int args_data_count;
+
+	void (*init) (void);
+	void (*final) (void);
+	bool (*arg_add) (unsigned int pluginID, const char *name, char shortname, CmdlineExecFunc func, const char *help, unsigned int options);
+	int (*exec) (int argc, char **argv, unsigned int options);
+	bool (*arg_next_value) (const char *name, int current_arg, int argc);
+	const char *(*arg_source) (struct CmdlineArgData *arg);
+};
+
+struct cmdline_interface *cmdline;
+
+#define CMDLINEARG(x) bool cmdline_arg_ ## x (const char *name, const char *params)
+#ifdef HERCULES_CORE
+/// Special plugin ID assigned to the Hercules core
+#define HPM_PID_CORE ((unsigned int)-1)
+
+#define CMDLINEARG_DEF(name, shortname, help, options) cmdline->arg_add(HPM_PID_CORE, "--" EXPAND_AND_QUOTE(name), shortname, cmdline_arg_ ## name, help, options)
+#define CMDLINEARG_DEF2(name, funcname, help, options) cmdline->arg_add(HPM_PID_CORE, "--" EXPAND_AND_QUOTE(name), '\0', cmdline_arg_ ## funcname, help, options)
+
+void cmdline_defaults(void);
 #endif // HERCULES_CORE
 
 #endif /* COMMON_CORE_H */

--- a/src/common/malloc.c
+++ b/src/common/malloc.c
@@ -769,12 +769,24 @@ void memmgr_report (int extra) {
 
 }
 
-static void memmgr_init (void)
+/**
+ * Initializes the Memory Manager.
+ */
+static void memmgr_init(void)
+{
+#ifdef LOG_MEMMGR
+	memset(hash_unfill, 0, sizeof(hash_unfill));
+#endif /* LOG_MEMMGR */
+}
+
+/**
+ * Prints initialization messages from the Memory Manager.
+ */
+static void memmgr_init_messages(void)
 {
 #ifdef LOG_MEMMGR
 	sprintf(memmer_logfile, "log/%s.leaks", SERVER_NAME);
 	ShowStatus("Memory manager initialized: "CL_WHITE"%s"CL_RESET"\n", memmer_logfile);
-	memset(hash_unfill, 0, sizeof(hash_unfill));
 #endif /* LOG_MEMMGR */
 }
 #endif /* USE_MEMMGR */
@@ -821,7 +833,22 @@ void malloc_final (void) {
 		iMalloc->post_shutdown();
 }
 
-void malloc_init (void) {
+/**
+ * Prints initialization status messages.
+ *
+ * This is separated from malloc_init() in order to be run after giving the
+ * chance to other modules to initialize, in case they want to silence any
+ * status messages, but at the same time require malloc.
+ */
+void malloc_init_messages(void)
+{
+#ifdef USE_MEMMGR
+	memmgr_init_messages();
+#endif
+}
+
+void malloc_init(void)
+{
 #ifdef USE_MEMMGR
 	memmgr_usage_bytes_t = 0;
 	memmgr_usage_bytes = 0;
@@ -836,7 +863,7 @@ void malloc_init (void) {
 	GC_INIT();
 #endif
 #ifdef USE_MEMMGR
-	memmgr_init ();
+	memmgr_init();
 #endif
 }
 
@@ -865,4 +892,5 @@ void malloc_defaults(void) {
 	iMalloc->free     = aFree_;
 #endif
 	iMalloc->post_shutdown = NULL;
+	iMalloc->init_messages = malloc_init_messages;
 }

--- a/src/common/malloc.h
+++ b/src/common/malloc.h
@@ -59,12 +59,6 @@
 
 ////////////////////////////////////////////////
 
-//void malloc_memory_check(void);
-//bool malloc_verify_ptr(void* ptr);
-//size_t malloc_usage (void);
-//void malloc_init (void);
-//void malloc_final (void);
-
 #ifdef HERCULES_CORE
 void malloc_defaults(void);
 
@@ -87,6 +81,7 @@ struct malloc_interface {
 	size_t (*usage) (void);
 	/* */
 	void (*post_shutdown) (void);
+	void (*init_messages) (void);
 };
 
 struct malloc_interface *iMalloc;

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -18,9 +18,6 @@ enum E_LOGINSERVER_ST
 	LOGINSERVER_ST_LAST
 };
 
-#define LOGIN_CONF_NAME "conf/login-server.conf"
-#define LAN_CONF_NAME "conf/subnet.conf"
-
 // supported encryption types: 1- passwordencrypt, 2- passwordencrypt2, 3- both
 #define PASSWORDENC 3
 #define PASSWD_LEN (32+1) // 23+1 for plaintext, 32+1 for md5-ed passwords
@@ -200,6 +197,8 @@ struct login_interface {
 	void (*char_server_connection_status) (int fd, struct login_session_data* sd, uint8 status);
 	void (*parse_request_connection) (int fd, struct login_session_data* sd, const char *ip);
 	int (*parse_login) (int fd);
+	char *LOGIN_CONF_NAME;
+	char *LAN_CONF_NAME;
 };
 
 struct login_interface *login;

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -3628,7 +3628,7 @@ ACMD(reloadscript) {
 	mapit->free(iter);
 
 	flush_fifos();
-	map->reloadnpc(true, NULL, 0); // reload config files seeking for npcs
+	map->reloadnpc(true); // reload config files seeking for npcs
 	script->reload();
 	npc->reload();
 

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -812,7 +812,13 @@ struct map_cache_map_info {
 struct map_interface {
 
 	/* vars */
-	bool minimal;
+	bool minimal;     ///< Starts the server in minimal initialization mode.
+	bool scriptcheck; ///< Starts the server in script-check mode.
+
+	/** Additional scripts requested through the command-line */
+	char **extra_scripts;
+	int extra_scripts_count;
+
 	int retval;
 	int count;
 
@@ -1005,7 +1011,7 @@ struct map_interface {
 	struct mob_data * (*getmob_boss) (int16 m);
 	struct mob_data * (*id2boss) (int id);
 	// reload config file looking only for npcs
-	void (*reloadnpc) (bool clear, const char * const *extra_scripts, int extra_scripts_count);
+	void (*reloadnpc) (bool clear);
 
 	int (*check_dir) (int s_dir,int t_dir);
 	uint8 (*calc_dir) (struct block_list *src,int16 x,int16 y);
@@ -1068,9 +1074,6 @@ struct map_interface {
 	int (*nick_db_final) (DBKey key, DBData *data, va_list args);
 	int (*cleanup_db_sub) (DBKey key, DBData *data, va_list va);
 	int (*abort_sub) (struct map_session_data *sd, va_list ap);
-	void (*helpscreen) (bool do_exit);
-	void (*versionscreen) (bool do_exit);
-	bool (*arg_next_value) (const char *option, int i, int argc, bool must);
 	void (*update_cell_bl) (struct block_list *bl, bool increase);
 	int (*get_new_bonus_id) (void);
 	void (*add_questinfo) (int m, struct questinfo *qi);

--- a/src/plugins/db2sql.c
+++ b/src/plugins/db2sql.c
@@ -348,8 +348,10 @@ void do_db2sql(void) {
 CPCMD(db2sql) {
 	do_db2sql();
 }
-void db2sql_arg(char *param) {
+CMDLINEARG(db2sql)
+{
 	map->minimal = torun = true;
+	return true;
 }
 HPExport void server_preinit (void) {
 	SQL = GET_SYMBOL("SQL");
@@ -360,7 +362,7 @@ HPExport void server_preinit (void) {
 	libconfig = GET_SYMBOL("libconfig");
 	StrBuf = GET_SYMBOL("StrBuf");
 
-	addArg("--db2sql",false,db2sql_arg,NULL);
+	addArg("--db2sql",false,db2sql,NULL);
 }
 HPExport void plugin_init (void) {
 	addCPCommand("server:tools:db2sql",db2sql);

--- a/src/tool/mapcache.c
+++ b/src/tool/mapcache.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "../common/cbasetypes.h"
+#include "../common/core.h"
 #include "../common/grfio.h"
 #include "../common/malloc.h"
 #include "../common/mmo.h"
@@ -23,9 +24,9 @@
 
 #define NO_WATER 1000000
 
-char grf_list_file[256] = "conf/grf-files.txt";
-char map_list_file[256] = "db/map_index.txt";
-char map_cache_file[256];
+char *grf_list_file;
+char *map_list_file;
+char *map_cache_file;
 int rebuild = 0;
 
 FILE *map_cache_fp;
@@ -184,25 +185,67 @@ char *remove_extension(char *mapname)
 	return mapname;
 }
 
-// Processes command-line arguments
-void process_args(int argc, char *argv[])
+/**
+ * --grf-list handler
+ *
+ * Overrides the default grf list filename.
+ * @see cmdline->exec
+ */
+static CMDLINEARG(grflist)
 {
-	int i;
+	aFree(grf_list_file);
+	grf_list_file = aStrdup(params);
+	return true;
+}
 
-	for(i = 0; i < argc; i++) {
-		if(strcmp(argv[i], "-grf") == 0) {
-			if(++i < argc)
-				safestrncpy(grf_list_file, argv[i], sizeof(grf_list_file));
-		} else if(strcmp(argv[i], "-list") == 0) {
-			if(++i < argc)
-				safestrncpy(map_list_file, argv[i], sizeof(map_list_file));
-		} else if(strcmp(argv[i], "-cache") == 0) {
-			if(++i < argc)
-				safestrncpy(map_cache_file, argv[i], sizeof(map_cache_file));
-		} else if(strcmp(argv[i], "-rebuild") == 0)
-			rebuild = 1;
-	}
+/**
+ * --map-list handler
+ *
+ * Overrides the default map list filename.
+ * @see cmdline->exec
+ */
+static CMDLINEARG(maplist)
+{
+	aFree(map_list_file);
+	map_list_file = aStrdup(params);
+	return true;
+}
 
+/**
+ * --map-cache handler
+ *
+ * Overrides the default map cache filename.
+ * @see cmdline->exec
+ */
+static CMDLINEARG(mapcache)
+{
+	aFree(map_cache_file);
+	map_cache_file = aStrdup(params);
+	return true;
+}
+
+/**
+ * --rebuild handler
+ *
+ * Forces a rebuild of the mapcache, rather than only adding missing maps.
+ * @see cmdline->exec
+ */
+static CMDLINEARG(rebuild)
+{
+	rebuild = 1;
+	return true;
+}
+
+/**
+ * Defines the local command line arguments
+ */
+void cmdline_args_init_local(void)
+{
+	CMDLINEARG_DEF2(grf-list, grflist, "Alternative grf list file", CMDLINE_OPT_NORMAL|CMDLINE_OPT_PARAM);
+	CMDLINEARG_DEF2(map-list, maplist, "Alternative map list file", CMDLINE_OPT_NORMAL|CMDLINE_OPT_PARAM);
+	CMDLINEARG_DEF2(map-cache, mapcache, "Alternative map cache file", CMDLINE_OPT_NORMAL|CMDLINE_OPT_PARAM);
+	CMDLINEARG_DEF2(rebuild, rebuild, "Forces a rebuild of the map cache, rather than only adding missing maps", CMDLINE_OPT_NORMAL);
+	
 }
 
 int do_init(int argc, char** argv)
@@ -212,17 +255,13 @@ int do_init(int argc, char** argv)
 	struct map_data map;
 	char name[MAP_NAME_LENGTH_EXT];
 
+	grf_list_file = aStrdup("conf/grf-files.txt");
+	map_list_file = aStrdup("db/map_index.txt");
 	/* setup pre-defined, #define-dependant */
-	sprintf(map_cache_file,"db/%s/map_cache.dat",
-#ifdef RENEWAL
-			"re"
-#else
-			"pre-re"
-#endif
-			);
+	map_cache_file = aStrdup("db/"DBPATH"map_cache.dat");
 
-	// Process the command-line arguments
-	process_args(argc, argv);
+	cmdline->exec(argc, argv, CMDLINE_OPT_PREINIT);
+	cmdline->exec(argc, argv, CMDLINE_OPT_NORMAL);
 
 	ShowStatus("Initializing grfio with %s\n", grf_list_file);
 	grfio_init(grf_list_file);
@@ -302,9 +341,14 @@ int do_init(int argc, char** argv)
 
 	ShowInfo("%d maps now in cache\n", header.map_count);
 
+	aFree(grf_list_file);
+	aFree(map_list_file);
+	aFree(map_cache_file);
+
 	return 0;
 }
 
-void do_final(void)
+int do_final(void)
 {
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- login_server, char_server, map_server as well as the tools (mapcache)
  now have a common command line arguments handling mechanism.
- All of them now accept `--help` (`-h`), `--version` (`-v`) and
  `--load-plugin`.
- login_server now accepts `--login-config` and `--lan-config` instead
  of relying on positional arguments to override those files. The old
  syntax will no longer work, please update your custom startup scripts.
- char_server now accepts `--char-config`, `--inter-config`,
  `--lan-config` instead of relying on positional arguments. The old
  syntax will no longer work, please update your custom startup scripts.
- mapcache now accepts `--grf-list`, `--map-list`, `--map-cache`,
  `--rebuild` in place of, respectively, `-grf`, `-list`, `-cache`,
  `-rebuild`.
- A new macro `CMDLINEARG()` is provided, to help defining new command
  line argument handlers (i.e. in plugins). the `addArg()` call is still
  required, but its syntax has changed. The `help` argument is now of type
  `const char *` rather than a function pointer, and it is supposed to
  contain the message to show in the `--help` screen. Pass `NULL` if no
  help message is desired.

Signed-off-by: Haru <haru@dotalux.com>