### PR TITLE
Additional Status Calculation for Plugins.

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2149,6 +2149,11 @@ unsigned int status_base_pc_maxsp(struct map_session_data* sd, struct status_dat
 	return (unsigned int)cap_value(val,0,UINT_MAX);
 }
 
+void status_calc_pc_additional(struct map_session_data* sd, enum e_status_calc_opt opt) {
+	/* Just used for Plugin to give bonuses. */
+	return;
+}
+
 //Calculates player data from scratch without counting SC adjustments.
 //Should be invoked whenever players raise stats, learn passive skills or change equipment.
 int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt) {
@@ -2530,6 +2535,8 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt) {
 		if( data && data->script )
 			script->run(data->script,0,sd->bl.id,0);
 	}
+	
+	status->calc_pc_additional(sd, opt);
 
 	if( sd->pd ) { // Pet Bonus
 		struct pet_data *pd = sd->pd;
@@ -12319,6 +12326,7 @@ void status_defaults(void) {
 	status->calc_mob_ = status_calc_mob_;
 	status->calc_pet_ = status_calc_pet_;
 	status->calc_pc_ = status_calc_pc_;
+	status->calc_pc_additional = status_calc_pc_additional;
 	status->calc_homunculus_ = status_calc_homunculus_;
 	status->calc_mercenary_ = status_calc_mercenary_;
 	status->calc_elemental_ = status_calc_elemental_;

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -2055,6 +2055,7 @@ struct status_interface {
 	int (*calc_mob_) (struct mob_data* md, enum e_status_calc_opt opt);
 	int (*calc_pet_) (struct pet_data* pd, enum e_status_calc_opt opt);
 	int (*calc_pc_) (struct map_session_data* sd, enum e_status_calc_opt opt);
+	void (*calc_pc_additional) (struct map_session_data* sd, enum e_status_calc_opt opt);
 	int (*calc_homunculus_) (struct homun_data *hd, enum e_status_calc_opt opt);
 	int (*calc_mercenary_) (struct mercenary_data *md, enum e_status_calc_opt opt);
 	int (*calc_elemental_) (struct elemental_data *ed, enum e_status_calc_opt opt);


### PR DESCRIPTION
So that One can invoke bonuses from plugin(by script->run)
since bonuses like bInt and bStr won't work directly, and needs to be in between status_calc_pc.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/HerculesWS/Hercules/pull/464%23issuecomment-76389663%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23issuecomment-77407786%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23issuecomment-77408165%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25882561%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25882595%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25882609%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25925869%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25925901%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25931874%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25936604%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25940832%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25941005%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25941110%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25943310%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25944172%22%2C%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25997389%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23issuecomment-76389663%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40MishimaHaruna%20%40shennetsind%20can%20you%20review%20it%3F%3F%22%2C%20%22created_at%22%3A%20%222015-02-27T12%3A49%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2889931%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dastgir%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hai%20I%27ll%20leave%20comments%20in%20the%20code%22%2C%20%22created_at%22%3A%20%222015-03-05T17%3A23%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1774501%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shennetsind%22%7D%7D%2C%20%7B%22body%22%3A%20%22on%20a%20second%20thought%2C%20I%27ll%20leave%20my%20comments%20in%20here%20and%20I%27ll%20mark%20what%20i%20mean%20in%20the%20code.%5Cr%5CnI%20think%20this%20would%20be%20best%20as%20a%20check%2C%20rather%20than%20defining%20and%20pointing%20to%20a%20useless%20function.%5Cr%5Cni.e.%20no%20assigning%2C%20no%20pointless%20function%2C%20.h%20stays%20as%20is.%20I%27ll%20demonstrate%20by%20commenting%20in%20the%20code%22%2C%20%22created_at%22%3A%20%222015-03-05T17%3A25%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1774501%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shennetsind%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a6ceeb41d3daf30b1ce8f9c5e5b629977ca80964%20src/map/status.c%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25882595%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22refering%20to%20my%20comment%2C%20this%20would%20be%20a%20if%28%20status-%3Ecalc_pc_additional%20%29%20status-%3Ecalc_pc_additional%28sd%2Copt%29%3B%22%2C%20%22created_at%22%3A%20%222015-03-05T17%3A25%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1774501%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shennetsind%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20calc_pc_additional%20is%20not%20defined%20so%20won%27t%20it%20error%3F%22%2C%20%22created_at%22%3A%20%222015-03-06T04%3A59%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2889931%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dastgir%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20declared%20in%20the%20.h%20file%2C%20so%20it%20will%20work.%20And%20even%20if%20it%20is%20never%20initialized%2C%20the%20C%20specs%20guarantee%20that%20it%20is%20initialized%20to%200%20/%20NULL.%20%28although%2C%20it%20might%20be%20a%20good%20idea%20to%20explicitly%20initialize%20it%20to%20NULL%20in%20%60status_defaults%60%2C%20for%20documentation%20purposes%2C%20rather%20than%20just%20removing%20the%20line%29%5Cr%5Cn%5Cr%5Cnedit%3A%20I%20forgot%20to%20mention%20%27the%20C%20specs%20guarantee%20that%20it%20is%20initialized%20to%200%20/%20NULL%27%20is%20because%20it%27s%20a%20global%20variable.%22%2C%20%22created_at%22%3A%20%222015-03-06T08%3A47%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4590397%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/MishimaHaruna%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/map/status.c%3AL2264-2272%22%7D%2C%20%22Pull%20a6ceeb41d3daf30b1ce8f9c5e5b629977ca80964%20src/map/status.c%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25882561%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22refering%20to%20my%20comment%2C%20this%20block%20would%20be%20gone.%22%2C%20%22created_at%22%3A%20%222015-03-05T17%3A25%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1774501%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shennetsind%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/map/status.c%3AL2149-2160%22%7D%2C%20%22Pull%20a6ceeb41d3daf30b1ce8f9c5e5b629977ca80964%20src/map/status.c%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/HerculesWS/Hercules/pull/464%23discussion_r25882609%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22refering%20to%20my%20comment%2C%20this%20line%20would%20be%20gone.%22%2C%20%22created_at%22%3A%20%222015-03-05T17%3A26%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1774501%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shennetsind%22%7D%7D%2C%20%7B%22body%22%3A%20%22How%20would%20we%20be%20able%20to%20hook%20if%20its%20gone%3F%3F%22%2C%20%22created_at%22%3A%20%222015-03-06T04%3A58%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2889931%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dastgir%22%7D%7D%2C%20%7B%22body%22%3A%20%22good%20point%2C%20didn%27t%20think%20of%20hooks%2C%20in%20that%20case%20the%20pointless%20function%20should%20remain%2C%20and%20in%20status_calc_pc%20you%27d%20have%20this%3A%5Cr%5Cn%60%60%60%5Cr%5Cnif%28%20status-%3Ecalc_pc_additional%20%21%3D%20status_calc_pc_additional%20%29%20status-%3Ecalc_pc_additional%28sd%2Copt%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cnhowever%20I%27m%20unsure%20about%20the%20benefits%20of%20hooking%20to%20a%20pointless%20function.%22%2C%20%22created_at%22%3A%20%222015-03-06T10%3A29%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1774501%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shennetsind%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20you%27re%20right%20o.o%20the%20hook%20stub%20would...crash%20when%20it%20calls%20the%20original%20function%3F%5Cr%5CnWe%20could%20modify%20it%20so%20that%20it%20always%20check%20the%20function%20pointer%20before%20calling%20it%2C%20if%20it%27s%20worth%20it.%22%2C%20%22created_at%22%3A%20%222015-03-06T12%3A07%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4590397%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/MishimaHaruna%22%7D%7D%2C%20%7B%22body%22%3A%20%22Instead%20of%20increasing%20%28very%20very%20very%20little%20time%20by%20checking%29%2C%20why%20not%20the%20current%20method%20used%3F%3F%22%2C%20%22created_at%22%3A%20%222015-03-06T12%3A12%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2889931%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dastgir%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%2C%20we%20do%20have%20this%20kind%20of%20method%20for%20other%20things%2C%20such%20as%20reading%20additional%20field%20of%20item%20db%20by%20plugin%2C%20etc...%22%2C%20%22created_at%22%3A%20%222015-03-06T12%3A15%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2889931%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dastgir%22%7D%7D%2C%20%7B%22body%22%3A%20%22getting%20into%20another%20function%20has%20a%20overhead%20that%20beats%20a%20comparison%27s%20overhead%20by%20many%20fold%20%28the%20reason%20it%20is%20being%20brought%20up%20is%20because%20the%20function%20does%20nothing%29.%20Haruna%20brings%20an%20interesting%20point%2C%20current%20hook%20implementation%20would%20crash%22%2C%20%22created_at%22%3A%20%222015-03-06T13%3A12%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1774501%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shennetsind%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20what%20can%20be%20done%3F%22%2C%20%22created_at%22%3A%20%222015-03-06T13%3A33%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2889931%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dastgir%22%7D%7D%2C%20%7B%22body%22%3A%20%22Even%20we%20add%20this%2C%20codes%20put%20into%20it%20will%20not%20work%20properly...bonuses%20inside%20%27status_calc_pc_%27%20is%20arrange%20sequentially...so%20adding%20custom%20bonuses%20some%20won%27t%20work....%20%22%2C%20%22created_at%22%3A%20%222015-03-07T16%3A50%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3251821%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/malufett%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/map/status.c%3AL12326-12333%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/HerculesWS/Hercules/pull/464#issuecomment-76389663'>General Comment</a></b>
- <a href='https://github.com/dastgir'><img border=0 src='https://avatars.githubusercontent.com/u/2889931?v=3' height=16 width=16'></a> @MishimaHaruna @shennetsind can you review it??
- <a href='https://github.com/shennetsind'><img border=0 src='https://avatars.githubusercontent.com/u/1774501?v=3' height=16 width=16'></a> Hai I'll leave comments in the code
- <a href='https://github.com/shennetsind'><img border=0 src='https://avatars.githubusercontent.com/u/1774501?v=3' height=16 width=16'></a> on a second thought, I'll leave my comments in here and I'll mark what i mean in the code.
I think this would be best as a check, rather than defining and pointing to a useless function.
i.e. no assigning, no pointless function, .h stays as is. I'll demonstrate by commenting in the code
- [ ] <a href='#crh-comment-Pull a6ceeb41d3daf30b1ce8f9c5e5b629977ca80964 src/map/status.c 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/HerculesWS/Hercules/pull/464#discussion_r25882561'>File: src/map/status.c:L2149-2160</a></b>
- <a href='https://github.com/shennetsind'><img border=0 src='https://avatars.githubusercontent.com/u/1774501?v=3' height=16 width=16'></a> refering to my comment, this block would be gone.
- [ ] <a href='#crh-comment-Pull a6ceeb41d3daf30b1ce8f9c5e5b629977ca80964 src/map/status.c 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/HerculesWS/Hercules/pull/464#discussion_r25882595'>File: src/map/status.c:L2264-2272</a></b>
- <a href='https://github.com/shennetsind'><img border=0 src='https://avatars.githubusercontent.com/u/1774501?v=3' height=16 width=16'></a> refering to my comment, this would be a if( status->calc_pc_additional ) status->calc_pc_additional(sd,opt);
- <a href='https://github.com/dastgir'><img border=0 src='https://avatars.githubusercontent.com/u/2889931?v=3' height=16 width=16'></a> But calc_pc_additional is not defined so won't it error?
- <a href='https://github.com/MishimaHaruna'><img border=0 src='https://avatars.githubusercontent.com/u/4590397?v=3' height=16 width=16'></a> It is declared in the .h file, so it will work. And even if it is never initialized, the C specs guarantee that it is initialized to 0 / NULL. (although, it might be a good idea to explicitly initialize it to NULL in `status_defaults`, for documentation purposes, rather than just removing the line)
edit: I forgot to mention 'the C specs guarantee that it is initialized to 0 / NULL' is because it's a global variable.
- [ ] <a href='#crh-comment-Pull a6ceeb41d3daf30b1ce8f9c5e5b629977ca80964 src/map/status.c 25'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/HerculesWS/Hercules/pull/464#discussion_r25882609'>File: src/map/status.c:L12326-12333</a></b>
- <a href='https://github.com/shennetsind'><img border=0 src='https://avatars.githubusercontent.com/u/1774501?v=3' height=16 width=16'></a> refering to my comment, this line would be gone.
- <a href='https://github.com/dastgir'><img border=0 src='https://avatars.githubusercontent.com/u/2889931?v=3' height=16 width=16'></a> How would we be able to hook if its gone??
- <a href='https://github.com/shennetsind'><img border=0 src='https://avatars.githubusercontent.com/u/1774501?v=3' height=16 width=16'></a> good point, didn't think of hooks, in that case the pointless function should remain, and in status_calc_pc you'd have this:
```
if( status->calc_pc_additional != status_calc_pc_additional ) status->calc_pc_additional(sd,opt);
```
however I'm unsure about the benefits of hooking to a pointless function.
- <a href='https://github.com/MishimaHaruna'><img border=0 src='https://avatars.githubusercontent.com/u/4590397?v=3' height=16 width=16'></a> Ah, you're right o.o the hook stub would...crash when it calls the original function?
We could modify it so that it always check the function pointer before calling it, if it's worth it.
- <a href='https://github.com/dastgir'><img border=0 src='https://avatars.githubusercontent.com/u/2889931?v=3' height=16 width=16'></a> Instead of increasing (very very very little time by checking), why not the current method used??
- <a href='https://github.com/dastgir'><img border=0 src='https://avatars.githubusercontent.com/u/2889931?v=3' height=16 width=16'></a> Also, we do have this kind of method for other things, such as reading additional field of item db by plugin, etc...
- <a href='https://github.com/shennetsind'><img border=0 src='https://avatars.githubusercontent.com/u/1774501?v=3' height=16 width=16'></a> getting into another function has a overhead that beats a comparison's overhead by many fold (the reason it is being brought up is because the function does nothing). Haruna brings an interesting point, current hook implementation would crash
- <a href='https://github.com/dastgir'><img border=0 src='https://avatars.githubusercontent.com/u/2889931?v=3' height=16 width=16'></a> So what can be done?
- <a href='https://github.com/malufett'><img border=0 src='https://avatars.githubusercontent.com/u/3251821?v=3' height=16 width=16'></a> Even we add this, codes put into it will not work properly...bonuses inside 'status_calc_pc_' is arrange sequentially...so adding custom bonuses some won't work....


<a href='https://www.codereviewhub.com/HerculesWS/Hercules/pull/464?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/HerculesWS/Hercules/pull/464?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/HerculesWS/Hercules/pull/464'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>