### PR TITLE
Fix for "Solo at Sphinx Dungeon!" Quest

### DIFF
--- a/db/quest_db.conf
+++ b/db/quest_db.conf
@@ -99,7 +99,7 @@ quest_db: (
 	Name: "Solo at Sphinx Dungeon!"
 	Targets: (
 	{
-		MobId: 2687
+		MobId: 1178
 		Count: 20
 	},
 	)


### PR DESCRIPTION
Solo at Sphinx Dungeon Quest should require Zerom to be hunted.