### PR TITLE
Fix some issues with the @help command.

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -1519,7 +1519,7 @@ ACMD(help) {
 	}
 
 	// Display help contents
-	clif->message(fd, tinfo->help);
+	clif->messageln(fd, tinfo->help);
 	return true;
 }
 
@@ -10105,8 +10105,8 @@ void atcommand_config_read(const char* config_filename) {
 				if( commandinfo->help == NULL ) {
 					const char *str = libconfig->setting_get_string(command);
 					size_t len = strlen(str);
-					commandinfo->help = aMalloc( len * sizeof(char) );
-					safestrncpy(commandinfo->help, str, len);
+					commandinfo->help = aMalloc(len + 1);
+					safestrncpy(commandinfo->help, str, len + 1);
 				}
 			}
 		}


### PR DESCRIPTION
Fix help messages being trimmed due to an incorrect length value.
Fix help messages formatting: use clif_displaymessage2 to properly display newlines.