### PR TITLE
Fixed @changesex issues on PACKETVERs that don't support per-character sex

### DIFF
--- a/src/char/char.h
+++ b/src/char/char.h
@@ -166,6 +166,7 @@ struct char_interface {
 	int (*mmo_char_tosql) (int char_id, struct mmo_charstatus* p);
 	int (*memitemdata_to_sql) (const struct item items[], int max, int id, int tableswitch);
 	int (*inventory_to_sql) (const struct item items[], int max, int id);
+	int (*mmo_gender) (const struct char_session_data *sd, const struct mmo_charstatus *p, char sex);
 	int (*mmo_chars_fromsql) (struct char_session_data* sd, uint8* buf);
 	int (*mmo_char_fromsql) (int char_id, struct mmo_charstatus* p, bool load_everything);
 	int (*mmo_char_sql_init) (void);
@@ -233,6 +234,7 @@ struct char_interface {
 	void (*ban) (int account_id, int char_id, time_t *unban_time, short year, short month, short day, short hour, short minute, short second);
 	void (*unban) (int char_id, int *result);
 	void (*ask_name_ack) (int fd, int acc, const char* name, int type, int result);
+	int (*changecharsex) (int char_id, int sex);
 	void (*parse_frommap_change_account) (int fd);
 	void (*parse_frommap_fame_list) (int fd);
 	void (*parse_frommap_divorce_char) (int fd);

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -6431,7 +6431,7 @@ ACMD(changesex)
 	// to avoid any problem with equipment and invalid sex, equipment is unequipped.
 	for( i=0; i<EQI_MAX; i++ )
 		if( sd->equip_index[i] >= 0 ) pc->unequipitem(sd, sd->equip_index[i], 3);
-	chrif->changesex(sd);
+	chrif->changesex(sd, true);
 	return true;
 }
 

--- a/src/map/chrif.h
+++ b/src/map/chrif.h
@@ -103,7 +103,7 @@ struct chrif_interface {
 	bool (*char_reset_offline) (void);
 	bool (*send_users_tochar) (void);
 	bool (*char_online) (struct map_session_data *sd);
-	bool (*changesex) (struct map_session_data *sd);
+	bool (*changesex) (struct map_session_data *sd, bool change_account);
 	//int (*chardisconnect) (struct map_session_data *sd); // FIXME: Commented out in clif.c, function does not exist
 	bool (*divorce) (int partner_id1, int partner_id2);
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11244,7 +11244,7 @@ BUILDIN(changesex)
 	TBL_PC *sd = prepareChangeSex(st);
 	if (sd == NULL)
 		return false;
-	chrif->changesex(sd);
+	chrif->changesex(sd, true);
 	return true;
 }
 
@@ -11256,12 +11256,7 @@ BUILDIN(changecharsex)
 	TBL_PC *sd = prepareChangeSex(st);
 	if (sd == NULL)
 		return false;
-	if (sd->status.sex == 99)
-		sd->status.sex = 0;
-	sd->status.sex = sd->status.sex ? 0 : 1;
-	chrif->save(sd, 0);
-	if (sd->fd)
-		clif->authfail_fd(sd->fd, 15);
+	chrif->changesex(sd, false);
 	return true;
 }
 


### PR DESCRIPTION
- Fixes bugreport:8504
  http://hercules.ws/board/tracker/issue-8504-changesex/
- Existing database entries with an incorrect per-character sex will be
  fixed automatically when the character logs in to match the account's
  sex, if the PACKETVER doesn't support per-character sex.

Although I have tested this on a live server for some time, I'd prefer to have someone review it, in case I missed to handle some cases. Thank you.