### PR TITLE
Fixed a bug in Einbech "Oridecon/Mineral Quest"

### DIFF
--- a/npc/quests/quests_ein.txt
+++ b/npc/quests/quests_ein.txt
@@ -385,7 +385,7 @@ einbech,97,167,5	script	Cavitar	4_M_EINOLD,{
 								switch(select("Sure~!:No, thanks.")) {
 								case 1:
 									Zeny -= 1000;
-									++$einamanoama;
+									++$ein_amano;
 									ein_gear1 = 1;
 									mes "[Cavitar]";
 									mes "Great...!";


### PR DESCRIPTION
Because of some very old typo, this quest could never reach Minerals exchange dialog.

To save current server's progress, it's a good idea to rename `$einamanoama` to `$ein_amano` at **`mapreg`** table and make sure it's not > 60.