### PR TITLE
Skip calling autotrade (@at) guildmembers with GD_EMERGENCYCALL

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -7888,6 +7888,8 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 					if ((dstsd = g->member[i].sd) != NULL && sd != dstsd && !dstsd->state.autotrade && !pc_isdead(dstsd)) {
 						if (map->list[dstsd->bl.m].flag.nowarp && !map_flag_gvg2(dstsd->bl.m))
 							continue;
+						if (status->isdead(&dstsd->bl) || dstsd->state.autotrade > 0) // Don't summon autotrade characters
+							continue;
 						if(map->getcell(src->m,src->x+dx[j],src->y+dy[j],CELL_CHKNOREACH))
 							dx[j] = dy[j] = 0;
 						pc->setpos(dstsd, map_id2index(src->m), src->x+dx[j], src->y+dy[j], CLR_RESPAWN);


### PR DESCRIPTION
GD_EMERGENCYCALL should skip players in autotrade state.