### PR TITLE
Dont stop npc scripts after warp.

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -4116,7 +4116,7 @@ will be seen to everyone around but not in chat window.
 
 ---------------------------------------
 
-*warp "<map name>",<x>,<y>;
+*warp "<map name>",<x>,<y>{,<flag>};
 
 This command will take the invoking character to the specified map, and if 
 wanted, specified coordinates too, but these can be random.
@@ -4138,6 +4138,10 @@ There are also three special 'map names' you can use:
 
 "Random" will warp the player randomly on the current map.
 "Save" and "SavePoint" will warp the player back to their save point.
+
+If flag parameter is set to 0, after player warped will be not stopped
+currend running npc script. Running script after warp can be issue for
+Gravity client if warp to other maps.
 
 ---------------------------------------
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -9215,14 +9215,16 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd) {
 		clif->updatestatus(sd,SP_DEX);
 		clif->updatestatus(sd,SP_LUK);
 
-		// abort currently running script
-		sd->state.using_fake_npc = 0;
-		sd->state.menu_or_input = 0;
-		sd->npc_menu = 0;
-
-		if(sd->npc_id)
-			npc->event_dequeue(sd);
-
+		if (sd->state.warp_clean) {
+			// abort currently running script
+			sd->state.using_fake_npc = 0;
+			sd->state.menu_or_input = 0;
+			sd->npc_menu = 0;
+			if(sd->npc_id)
+				npc->event_dequeue(sd);
+		} else {
+			sd->state.warp_clean = 1;
+		}
 		if( sd->guild && ( battle_config.guild_notice_changemap == 2 || ( battle_config.guild_notice_changemap == 1 && sd->state.changemap ) ) )
 			clif->guild_notice(sd,sd->guild);
 	}

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -651,6 +651,7 @@ int pc_setnewpc(struct map_session_data *sd, int account_id, int char_id, int lo
 	sd->canlog_tick  = timer->gettick();
 	//Required to prevent homunculus copuing a base speed of 0.
 	sd->battle_status.speed = sd->base_status.speed = DEFAULT_WALK_SPEED;
+	sd->state.warp_clean = 1;
 	return 0;
 }
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -206,6 +206,7 @@ struct map_session_data {
 		unsigned int itemcheck : 1;
 		unsigned int standalone : 1;/* [Ind/Hercules <3] */
 		unsigned int loggingout : 1;
+		unsigned int warp_clean : 1;
 	} state;
 	struct {
 		unsigned char no_weapon_damage, no_magic_damage, no_misc_damage;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -5763,6 +5763,7 @@ BUILDIN(warp)
 {
 	int ret;
 	int x,y;
+	int warp_clean = 1;
 	const char* str;
 	TBL_PC* sd;
 
@@ -5774,6 +5775,11 @@ BUILDIN(warp)
 	x = script_getnum(st,3);
 	y = script_getnum(st,4);
 
+	if (script_hasdata(st, 5)) {
+		warp_clean = script_getnum(st, 5);
+	}
+
+	sd->state.warp_clean = warp_clean;
 	if(strcmp(str,"Random")==0)
 		ret = pc->randomwarp(sd,CLR_TELEPORT);
 	else if(strcmp(str,"SavePoint")==0 || strcmp(str,"Save")==0)
@@ -19855,7 +19861,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(jobchange,"i?"),
 		BUILDIN_DEF(jobname,"i"),
 		BUILDIN_DEF(input,"r??"),
-		BUILDIN_DEF(warp,"sii"),
+		BUILDIN_DEF(warp,"sii?"),
 		BUILDIN_DEF(areawarp,"siiiisii??"),
 		BUILDIN_DEF(warpchar,"siii"), // [LuzZza]
 		BUILDIN_DEF(warpparty,"siii?"), // [Fredzilla] [Paradox924X]


### PR DESCRIPTION
At old times if npc what talking with player or player itself went in long distance or in other map, npc script terminated with error. Now it will not terminate after changes some months ago.

Current warp issue. If start talking with npc and warp, all npc related variables will be set to 0. And player cant continue talking to npc. This patch fix this issue.

More about issue and example code here: http://herc.ws/board/topic/10242-invalid-menu-selection-on-npc-after-warp/

Old patch what add this cleanup: https://github.com/HerculesWS/Hercules/commit/9babdbcbb4209a6ae861550eb662ac810d7ad886.

@MishimaHaruna what you can say?
