### PR TITLE
Corrected search order in itemdb_searchname

### DIFF
--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -75,7 +75,7 @@ struct item_data* itemdb_searchname(const char *str) {
 			return item;
 
 		//Second priority to Client displayed name.
-		if( strcasecmp(item->jname,str) == 0 )
+		if( item2 != 0 && strcasecmp(item->jname,str) == 0 )
 			item2 = item;
 	}
 


### PR DESCRIPTION
It’ll now return the first result, rather than the last due to item2
being overwritten as it searches through the array.