### PR TITLE
subnet.conf overhaul

### DIFF
--- a/conf/network.conf
+++ b/conf/network.conf
@@ -1,0 +1,37 @@
+// Network configuration file
+
+/*
+ * List here any LAN subnets this server is in.
+ * Example:
+ * - char- (or map-) server's IP in LAN is 192.168.0.10
+ * - Public IP is 198.51.100.37
+ * If the list contains "192.168.0.10:255.255.255.0", any clients connecting
+ * from the same 192.168.0.0/24 network will be presented with the LAN IP
+ * (192.168.0.10) in the server list, rather than the public IP (198.51.100.37).
+ */
+lan_subnets: (
+	"127.0.0.1:255.0.0.0",
+	// "192.168.1.1:255.255.255.0",
+)
+
+/*
+ * List here any IP ranges a char- or map-server can connect from.
+ * A wildcard of "0.0.0.0:0.0.0.0" means that server connections are allowed
+ * from ANY IP. (not recommended).
+ */
+allowed: (
+	"0.0.0.0:0.0.0.0",
+	// "127.0.0.1:255.0.0.0",
+)
+
+/*
+ * List here any IP ranges a char- or map-server can connect from. These ranges
+ * will also be excluded from the automatic ipban in casee of password failure.
+ * Any entry present in this list is also automatically included in the
+ * allowed IP list.
+ * Note: This may be a security threat. Only edit this list if you know what
+ * you are doing.
+ */
+trusted: (
+	"127.0.0.1:255.0.0.0",
+)

--- a/conf/subnet.conf
+++ b/conf/subnet.conf
@@ -1,7 +1,0 @@
-// Subnet support file
-// Format is:
-// subnet: net-submask:char_ip:map_ip
-// you can add more than one subnet 
-
-subnet: 255.0.0.0:127.0.0.1:127.0.0.1
-subnet: 0.0.0.0:127.0.0.1:127.0.0.1

--- a/src/char/char.h
+++ b/src/char/char.h
@@ -145,7 +145,7 @@ struct char_interface {
 	int new_display;
 
 	char *CHAR_CONF_NAME;
-	char *LAN_CONF_NAME;
+	char *NET_CONF_NAME; ///< Network config filename
 	char *SQL_CONF_NAME;
 	char *INTER_CONF_NAME;
 
@@ -256,7 +256,7 @@ struct char_interface {
 	int (*parse_frommap) (int fd);
 	int (*search_mapserver) (unsigned short map, uint32 ip, uint16 port);
 	int (*mapif_init) (int fd);
-	int (*lan_subnetcheck) (uint32 ip);
+	uint32 (*lan_subnet_check) (uint32 ip);
 	void (*delete2_ack) (int fd, int char_id, uint32 result, time_t delete_date);
 	void (*delete2_accept_actual_ack) (int fd, int char_id, uint32 result);
 	void (*delete2_accept_ack) (int fd, int char_id, uint32 result);
@@ -305,7 +305,6 @@ struct char_interface {
 	int (*check_connect_login_server) (int tid, int64 tick, int id, intptr_t data);
 	int (*online_data_cleanup_sub) (DBKey key, DBData *data, va_list ap);
 	int (*online_data_cleanup) (int tid, int64 tick, int id, intptr_t data);
-	int (*lan_config_read) (const char *lancfgName);
 	void (*sql_config_read) (const char* cfgName);
 	void (*config_dispatch) (char *w1, char *w2);
 	int (*config_read) (const char* cfgName);

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -6,6 +6,7 @@
 #define COMMON_SOCKET_H
 
 #include "common/cbasetypes.h"
+#include "common/conf.h"
 
 #ifdef WIN32
 #	include "common/winapi.h"
@@ -105,6 +106,12 @@ struct hSockOpt {
 	unsigned int setTimeo : 1;
 };
 
+/// Subnet/IP range in the IP/Mask format.
+struct s_subnet {
+	uint32 ip;
+	uint32 mask;
+};
+
 /// Use a shortlist of sockets instead of iterating all sessions for sockets
 /// that have data to send or need eof handling.
 /// Adapted to use a static array instead of a linked list.
@@ -132,6 +139,14 @@ struct socket_interface {
 	/* */
 	uint32 addr_[16];   // ip addresses of local host (host byte order)
 	int naddr_;   // # of ip addresses
+
+	struct s_subnet *lan_subnet; ///< LAN subnets array
+	int lan_subnet_count;        ///< LAN subnets count
+	struct s_subnet *trusted_ip; ///< Trusted IP ranges array
+	int trusted_ip_count;        ///< Trusted IP ranges count
+	struct s_subnet *allowed_ip; ///< Allowed server IP ranges array
+	int allowed_ip_count;        ///< Allowed server IP ranges count
+
 	/* */
 	void (*init) (void);
 	void (*final) (void);
@@ -165,6 +180,12 @@ struct socket_interface {
 	int (*getips) (uint32* ips, int max);
 	/* */
 	void (*set_eof) (int fd);
+
+	uint32 (*lan_subnet_check) (uint32 ip, struct s_subnet *info);
+	bool (*allowed_ip_check) (uint32 ip);
+	bool (*trusted_ip_check) (uint32 ip);
+	int (*net_config_read_sub) (config_setting_t *t, struct s_subnet **list, int *count, const char *filename, const char *groupname);
+	void (*net_config_read) (const char *filename);
 };
 
 struct socket_interface *sockt;

--- a/src/login/login.c
+++ b/src/login/login.c
@@ -12,6 +12,7 @@
 #include "login/loginlog.h"
 #include "common/HPM.h"
 #include "common/cbasetypes.h"
+#include "common/conf.h"
 #include "common/core.h"
 #include "common/db.h"
 #include "common/malloc.h"
@@ -238,65 +239,17 @@ bool login_check_password(const char* md5key, int passwdenc, const char* passwd,
 	}
 }
 
-//--------------------------------------------
-// Test to know if an IP come from LAN or WAN.
-//--------------------------------------------
-int login_lan_subnetcheck(uint32 ip)
+
+/**
+ * Checks whether the given IP comes from LAN or WAN.
+ *
+ * @param ip IP address to check.
+ * @retval 0 if it is a WAN IP.
+ * @return the appropriate LAN server address to send, if it is a LAN IP.
+ */
+uint32 login_lan_subnet_check(uint32 ip)
 {
-	int i;
-	ARR_FIND( 0, login_config.subnet_count, i, (login_config.subnet[i].char_ip & login_config.subnet[i].mask) == (ip & login_config.subnet[i].mask) );
-	return ( i < login_config.subnet_count ) ? login_config.subnet[i].char_ip : 0;
-}
-
-//----------------------------------
-// Reading LAN Support configuration
-//----------------------------------
-int login_lan_config_read(const char *lancfgName)
-{
-	FILE *fp;
-	int line_num = 0;
-	char line[1024], w1[64], w2[64], w3[64], w4[64];
-
-	nullpo_ret(lancfgName);
-	if((fp = fopen(lancfgName, "r")) == NULL) {
-		ShowWarning("LAN Support configuration file is not found: %s\n", lancfgName);
-		return 1;
-	}
-
-	while(fgets(line, sizeof(line), fp))
-	{
-		line_num++;
-		if ((line[0] == '/' && line[1] == '/') || line[0] == '\n' || line[1] == '\n')
-			continue;
-
-		if (sscanf(line, "%63[^:]: %63[^:]:%63[^:]:%63[^\r\n]", w1, w2, w3, w4) != 4) {
-			ShowWarning("Error syntax of configuration file %s in line %d.\n", lancfgName, line_num);
-			continue;
-		}
-
-		if( strcmpi(w1, "subnet") == 0 )
-		{
-			login_config.subnet[login_config.subnet_count].mask = str2ip(w2);
-			login_config.subnet[login_config.subnet_count].char_ip = str2ip(w3);
-			login_config.subnet[login_config.subnet_count].map_ip = str2ip(w4);
-
-			if( (login_config.subnet[login_config.subnet_count].char_ip
-			     & login_config.subnet[login_config.subnet_count].mask) != (login_config.subnet[login_config.subnet_count].map_ip
-			     & login_config.subnet[login_config.subnet_count].mask) )
-			{
-				ShowError("%s: Configuration Error: The char server (%s) and map server (%s) belong to different subnetworks!\n", lancfgName, w3, w4);
-				continue;
-			}
-
-			login_config.subnet_count++;
-		}
-	}
-
-	if( login_config.subnet_count > 1 ) /* only useful if there is more than 1 available */
-		ShowStatus("Read information about %d subnetworks.\n", login_config.subnet_count);
-
-	fclose(fp);
-	return 0;
+	return sockt->lan_subnet_check(ip, NULL);
 }
 
 void login_fromchar_auth_ack(int fd, int account_id, uint32 login_id1, uint32 login_id2, uint8 sex, int request_id, struct login_auth_node* node)
@@ -1233,7 +1186,6 @@ void login_auth_ok(struct login_session_data* sd)
 	int fd = 0;
 	uint32 ip;
 	uint8 server_num, n;
-	uint32 subnet_char_ip;
 	struct login_auth_node* node;
 	int i;
 
@@ -1308,12 +1260,13 @@ void login_auth_ok(struct login_session_data* sd)
 	memset(WFIFOP(fd,20), 0, 24);
 	WFIFOW(fd,44) = 0; // unknown
 	WFIFOB(fd,46) = sex_str2num(sd->sex);
-	for( i = 0, n = 0; i < ARRAYLENGTH(server); ++i )
-	{
+	for (i = 0, n = 0; i < ARRAYLENGTH(server); ++i) {
+		uint32 subnet_char_ip;
+
 		if( !session_isValid(server[i].fd) )
 			continue;
 
-		subnet_char_ip = login->lan_subnetcheck(ip); // Advanced subnet check [LuzZza]
+		subnet_char_ip = login->lan_subnet_check(ip);
 		WFIFOL(fd,47+n*32) = htonl((subnet_char_ip) ? subnet_char_ip : server[i].ip);
 		WFIFOW(fd,47+n*32+4) = ntows(htons(server[i].port)); // [!] LE byte order here [!]
 		memcpy(WFIFOP(fd,47+n*32+6), server[i].name, 20);
@@ -1393,7 +1346,7 @@ void login_auth_failed(struct login_session_data* sd, int result)
 		login_log(ip, sd->userid, result, error); // FIXME: result can be 100, conflicting with the value 100 we use for successful login...
 	}
 
-	if( result == 1 && login_config.dynamic_pass_failure_ban )
+	if (result == 1 && login_config.dynamic_pass_failure_ban && !sockt->trusted_ip_check(ip))
 		ipban_log(ip); // log failed password attempt
 
 #if PACKETVER >= 20120000 /* not sure when this started */
@@ -1590,7 +1543,7 @@ void login_parse_request_connection(int fd, struct login_session_data* sd, const
 		sd->account_id >= 0 &&
 		sd->account_id < ARRAYLENGTH(server) &&
 		!session_isValid(server[sd->account_id].fd) &&
-		login->lan_subnetcheck(ipl))
+		sockt->allowed_ip_check(ipl))
 	{
 		ShowStatus("Connection of the char-server '%s' accepted.\n", server_name);
 		safestrncpy(server[sd->account_id].name, server_name, sizeof(server[sd->account_id].name));
@@ -1637,7 +1590,7 @@ int login_parse_login(int fd)
 	if( sd == NULL )
 	{
 		// Perform ip-ban check
-		if( login_config.ipban && ipban_check(ipl) )
+		if (login_config.ipban && !sockt->trusted_ip_check(ipl) && ipban_check(ipl))
 		{
 			ShowStatus("Connection refused: IP isn't authorized (deny/allow, ip: %s).\n", ip);
 			login_log(ipl, "unknown", -3, "ip banned");
@@ -1759,7 +1712,6 @@ void login_set_defaults()
 
 	login_config.client_hash_check = 0;
 	login_config.client_hash_nodes = NULL;
-	login_config.subnet_count = 0;
 }
 
 //-----------------------------------
@@ -1929,7 +1881,7 @@ int do_final(void) {
 	HPM_login_do_final();
 
 	aFree(login->LOGIN_CONF_NAME);
-	aFree(login->LAN_CONF_NAME);
+	aFree(login->NET_CONF_NAME);
 
 	HPM->event(HPET_POST_FINAL);
 
@@ -1984,15 +1936,15 @@ static CMDLINEARG(loginconfig)
 	return true;
 }
 /**
- * --lan-config handler
+ * --net-config handler
  *
  * Overrides the default subnet configuration file.
  * @see cmdline->exec
  */
-static CMDLINEARG(lanconfig)
+static CMDLINEARG(netconfig)
 {
-	aFree(login->LAN_CONF_NAME);
-	login->LAN_CONF_NAME = aStrdup(params);
+	aFree(login->NET_CONF_NAME);
+	login->NET_CONF_NAME = aStrdup(params);
 	return true;
 }
 /**
@@ -2001,7 +1953,7 @@ static CMDLINEARG(lanconfig)
 void cmdline_args_init_local(void)
 {
 	CMDLINEARG_DEF2(login-config, loginconfig, "Alternative login-server configuration.", CMDLINE_OPT_PARAM);
-	CMDLINEARG_DEF2(lan-config, lanconfig, "Alternative subnet configuration.", CMDLINE_OPT_PARAM);
+	CMDLINEARG_DEF2(net-config, netconfig, "Alternative subnet configuration.", CMDLINE_OPT_PARAM);
 }
 
 //------------------------------
@@ -2025,7 +1977,7 @@ int do_init(int argc, char** argv)
 	login_set_defaults();
 
 	login->LOGIN_CONF_NAME = aStrdup("conf/login-server.conf");
-	login->LAN_CONF_NAME   = aStrdup("conf/subnet.conf");
+	login->NET_CONF_NAME   = aStrdup("conf/network.conf");
 
 	HPM_login_do_init();
 	HPM->symbol_defaults_sub = login_hp_symbols;
@@ -2035,7 +1987,7 @@ int do_init(int argc, char** argv)
 
 	cmdline->exec(argc, argv, CMDLINE_OPT_NORMAL);
 	login_config_read(login->LOGIN_CONF_NAME);
-	login->lan_config_read(login->LAN_CONF_NAME);
+	sockt->net_config_read(login->NET_CONF_NAME);
 
 	for( i = 0; i < ARRAYLENGTH(server); ++i )
 		chrif_server_init(i);
@@ -2112,8 +2064,7 @@ void login_defaults(void) {
 	login->sync_ip_addresses = login_sync_ip_addresses;
 	login->check_encrypted = login_check_encrypted;
 	login->check_password = login_check_password;
-	login->lan_subnetcheck = login_lan_subnetcheck;
-	login->lan_config_read = login_lan_config_read;
+	login->lan_subnet_check = login_lan_subnet_check;
 
 	login->fromchar_auth_ack = login_fromchar_auth_ack;
 	login->fromchar_accinfo = login_fromchar_accinfo;
@@ -2159,5 +2110,5 @@ void login_defaults(void) {
 	login->send_coding_key = login_send_coding_key;
 
 	login->LOGIN_CONF_NAME = NULL;
-	login->LAN_CONF_NAME = NULL;
+	login->NET_CONF_NAME = NULL;
 }

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -101,14 +101,6 @@ struct Login_Config {
 
 	int client_hash_check;                          ///< flags for checking client md5
 	struct client_hash_node *client_hash_nodes;     ///< linked list containg md5 hash for each gm group
-
-	/// Advanced subnet check [LuzZza]
-	struct s_subnet {
-		uint32 mask;
-		uint32 char_ip;
-		uint32 map_ip;
-	} subnet[16];
-	int subnet_count;
 };
 
 struct login_auth_node {
@@ -163,8 +155,7 @@ struct login_interface {
 	int (*sync_ip_addresses) (int tid, int64 tick, int id, intptr_t data);
 	bool (*check_encrypted) (const char* str1, const char* str2, const char* passwd);
 	bool (*check_password) (const char* md5key, int passwdenc, const char* passwd, const char* refpass);
-	int (*lan_subnetcheck) (uint32 ip);
-	int (*lan_config_read) (const char *lancfgName);
+	uint32 (*lan_subnet_check) (uint32 ip);
 	void (*fromchar_accinfo) (int fd, int account_id, int u_fd, int u_aid, int u_group, int map_fd, struct mmo_account *acc);
 	void (*fromchar_account) (int fd, int account_id, struct mmo_account *acc);
 	void (*fromchar_account_update_other) (int account_id, unsigned int state);
@@ -207,7 +198,7 @@ struct login_interface {
 	void (*parse_request_connection) (int fd, struct login_session_data* sd, const char *ip, uint32 ipl);
 	int (*parse_login) (int fd);
 	char *LOGIN_CONF_NAME;
-	char *LAN_CONF_NAME;
+	char *NET_CONF_NAME; ///< Network configuration filename
 };
 
 struct login_interface *login;


### PR DESCRIPTION
The subnet.conf system has been rewritten to offer greater flexibility, and to fix some issues that appeared with 838321a36c79e71117320154c9b611c99e93af03.

It is now possible to enter, separately, LAN subnets:
- `lan_subnets`: This is essentially the same feature present in the old subnet.conf. Each entry in this list defines a (LAN, private) subnet the server is in. Clients connecting from the same subnet, will be redirected to the LAN IP rather than the default public IP. The format has been simplified, and it only requires one IP and one subnet mask (as opposed to a character and a map server IP).
- `allowed`: Allowed IPs are IP ranges a server (char to login or map to char) can connect from. Any attempt to connect as a server from an IP not included here, will fail. For convenience, a wildcard range (matching all possible IP addresses) has been provided (`0.0.0.0:0.0.0.0`), but it is very advisable to edit it to a more restrictive set.
- `trusted`: Trusted IPs are IP ranges excluded from the IPban checks. This may be useful, for example, to exclude the server's own IP from ipbans, in case of false positives. Any IP ranges added to this list are also implicitly included in the allowed IP ranges.