### PR TITLE
Fixed a bug in Lv4 Weapon Quest dialog

### DIFF
--- a/npc/quests/lvl4_weapon_quest.txt
+++ b/npc/quests/lvl4_weapon_quest.txt
@@ -2807,13 +2807,13 @@ niflheim,187,280,3	script	Hein#lv4	4_M_NFDEADMAN,{
 		mes "[Hein]";
 		mes "Ready? This is";
 		mes "what I wrote down...";
-		if (.@npchand == 1) {
+		if (.@npchand1 == 1) {
 			mes "Scissors";
 		}
-		else if (.@npchand == 2) {
+		else if (.@npchand1 == 2) {
 			mes "Rock";
 		}
-		else if (.@npchand == 3) {
+		else if (.@npchand1 == 3) {
 			mes "Paper";
 		}
 		if (.@npchand2 == 1) {


### PR DESCRIPTION
Dialog with rolled rock/paper/scissors didn't appear because of variable typo.
An ancient one. Discovered by Aafemt.