### PR TITLE
Extra parameter for script command resetstatus.

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5438,11 +5438,22 @@ official rebirth scripts.
 
 ---------------------------------------
 
-*resetstatus;
+*resetstatus {<type>}; 
 
 This is a character reset command, which will reset the stats on the 
 invoking character and give back all the stat points used to raise them 
 previously. Nothing will happen to any other numbers about the character.
+Return the amount of statuspoint gained from reset.
+
+Valid type parameter are:
+	 0 - All (default)
+	// must disable battle_config.use_statpoint_table
+	13 - bSTR
+	14 - bAGI
+	15 - bVIT
+	16 - bINT
+	17 - bDEX
+	18 - bLUK
 
 Used in reset NPC's (duh!).
 

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -1388,7 +1388,7 @@ ACMD(baselevelup)
 		for (i = 0; i > -level; i--)
 			status_point += pc->gets_status_point(sd->status.base_level + i - 1);
 		if (sd->status.status_point < status_point)
-			pc->resetstate(sd);
+			pc->resetstate(sd,0);
 		if (sd->status.status_point < status_point)
 			sd->status.status_point = 0;
 		else
@@ -6257,7 +6257,7 @@ ACMD(users)
  *
  *------------------------------------------*/
 ACMD(reset) {
-	pc->resetstate(sd);
+	pc->resetstate(sd,0);
 	pc->resetskill(sd, PCRESETSKILL_RESYNC);
 	safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,208), sd->status.name); // '%s' skill and stats points reseted!
 	clif->message(fd, atcmd_output);
@@ -8002,7 +8002,7 @@ ACMD(allowks)
 
 ACMD(resetstat)
 {
-	pc->resetstate(sd);
+	pc->resetstate(sd,0);
 	safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,207), sd->status.name);
 	clif->message(fd, atcmd_output);
 	return true;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -7173,66 +7173,89 @@ int pc_resetlvl(struct map_session_data* sd,int type)
 /*==========================================
  * /resetstate
  *------------------------------------------*/
-int pc_resetstate(struct map_session_data* sd)
+/*==========================================
+* /resetstate
+*------------------------------------------*/
+int pc_resetstate(struct map_session_data* sd, int type)
 {
 	nullpo_ret(sd);
+	int add = 0;
 
-	if (battle_config.use_statpoint_table) {
-		// New statpoint table used here - Dexity
-		if (sd->status.base_level > MAX_LEVEL) {
-			//pc->statp[] goes out of bounds, can't reset!
-			ShowError("pc_resetstate: Can't reset stats of %d:%d, the base level (%d) is greater than the max level supported (%d)\n",
-				sd->status.account_id, sd->status.char_id, sd->status.base_level, MAX_LEVEL);
-			return 0;
+	if (type == 0) {
+		if (battle_config.use_statpoint_table) {
+			// New statpoint table used here - Dexity
+			if (sd->status.base_level > MAX_LEVEL) {
+				//pc->statp[] goes out of bounds, can't reset!
+				ShowError("pc_resetstate: Can't reset stats of %d:%d, the base level (%d) is greater than the max level supported (%d)\n",
+					sd->status.account_id, sd->status.char_id, sd->status.base_level, MAX_LEVEL);
+				return 0;
+			}
+
+			add = pc->statp[sd->status.base_level] + ((sd->class_&JOBL_UPPER) ? 52 : 0); // extra 52+48=100 stat points
+			sd->status.status_point = add;
+		}
+		else
+		{
+			add += pc->need_status_point(sd, SP_STR, 1 - pc->getstat(sd, SP_STR));
+			add += pc->need_status_point(sd, SP_AGI, 1 - pc->getstat(sd, SP_AGI));
+			add += pc->need_status_point(sd, SP_VIT, 1 - pc->getstat(sd, SP_VIT));
+			add += pc->need_status_point(sd, SP_INT, 1 - pc->getstat(sd, SP_INT));
+			add += pc->need_status_point(sd, SP_DEX, 1 - pc->getstat(sd, SP_DEX));
+			add += pc->need_status_point(sd, SP_LUK, 1 - pc->getstat(sd, SP_LUK));
+
+			sd->status.status_point += add;
 		}
 
-		sd->status.status_point = pc->statp[sd->status.base_level] + ((sd->class_&JOBL_UPPER) ? 52 : 0); // extra 52+48=100 stat points
+		pc->setstat(sd, SP_STR, 1);
+		pc->setstat(sd, SP_AGI, 1);
+		pc->setstat(sd, SP_VIT, 1);
+		pc->setstat(sd, SP_INT, 1);
+		pc->setstat(sd, SP_DEX, 1);
+		pc->setstat(sd, SP_LUK, 1);
+
+		clif->updatestatus(sd, SP_STR);
+		clif->updatestatus(sd, SP_AGI);
+		clif->updatestatus(sd, SP_VIT);
+		clif->updatestatus(sd, SP_INT);
+		clif->updatestatus(sd, SP_DEX);
+		clif->updatestatus(sd, SP_LUK);
+
+		clif->updatestatus(sd, SP_USTR); // Updates needed stat points - Valaris
+		clif->updatestatus(sd, SP_UAGI);
+		clif->updatestatus(sd, SP_UVIT);
+		clif->updatestatus(sd, SP_UINT);
+		clif->updatestatus(sd, SP_UDEX);
+		clif->updatestatus(sd, SP_ULUK); // End Addition
 	}
-	else
-	{
-		int add=0;
-		add += pc->need_status_point(sd, SP_STR, 1-pc->getstat(sd, SP_STR));
-		add += pc->need_status_point(sd, SP_AGI, 1-pc->getstat(sd, SP_AGI));
-		add += pc->need_status_point(sd, SP_VIT, 1-pc->getstat(sd, SP_VIT));
-		add += pc->need_status_point(sd, SP_INT, 1-pc->getstat(sd, SP_INT));
-		add += pc->need_status_point(sd, SP_DEX, 1-pc->getstat(sd, SP_DEX));
-		add += pc->need_status_point(sd, SP_LUK, 1-pc->getstat(sd, SP_LUK));
+	else if (battle_config.use_statpoint_table) {
+		ShowError("pc_resetstate: 'type' reset failed if battle_config.use_statpoint_table is enabled.\n");
+		return 0;
+	}
+	else if (type < SP_STR || type > SP_LUK) {
+		ShowError("pc_resetstate: Invalid type (%d).\n", type);
+		return 0;
+	}
+	else {
+		add = pc->need_status_point(sd, type, 1 - pc->getstat(sd, type));
+		sd->status.status_point += add;
 
-		sd->status.status_point+=add;
+		pc->setstat(sd, type, 1);
+
+		clif->updatestatus(sd, type);
+		clif->updatestatus(sd, type + 19); // 19 adjust enum value.
 	}
 
-	pc->setstat(sd, SP_STR, 1);
-	pc->setstat(sd, SP_AGI, 1);
-	pc->setstat(sd, SP_VIT, 1);
-	pc->setstat(sd, SP_INT, 1);
-	pc->setstat(sd, SP_DEX, 1);
-	pc->setstat(sd, SP_LUK, 1);
+	clif->updatestatus(sd, SP_STATUSPOINT);
 
-	clif->updatestatus(sd,SP_STR);
-	clif->updatestatus(sd,SP_AGI);
-	clif->updatestatus(sd,SP_VIT);
-	clif->updatestatus(sd,SP_INT);
-	clif->updatestatus(sd,SP_DEX);
-	clif->updatestatus(sd,SP_LUK);
-
-	clif->updatestatus(sd,SP_USTR); // Updates needed stat points - Valaris
-	clif->updatestatus(sd,SP_UAGI);
-	clif->updatestatus(sd,SP_UVIT);
-	clif->updatestatus(sd,SP_UINT);
-	clif->updatestatus(sd,SP_UDEX);
-	clif->updatestatus(sd,SP_ULUK); // End Addition
-
-	clif->updatestatus(sd,SP_STATUSPOINT);
-
-	if( sd->mission_mobid ) { //bugreport:2200
+	if (sd->mission_mobid) { //bugreport:2200
 		sd->mission_mobid = 0;
 		sd->mission_count = 0;
-		pc_setglobalreg(sd,script->add_str("TK_MISSION_ID"), 0);
+		pc_setglobalreg(sd, script->add_str("TK_MISSION_ID"), 0);
 	}
 
-	status_calc_pc(sd,SCO_NONE);
+	status_calc_pc(sd, SCO_NONE);
 
-	return 1;
+	return add;
 }
 
 /*==========================================
@@ -8431,7 +8454,7 @@ int pc_jobchange(struct map_session_data *sd,int job, int upper)
 	if (sd->status.base_level > pc->maxbaselv(sd)) {
 		sd->status.base_level = pc->maxbaselv(sd);
 		sd->status.base_exp=0;
-		pc->resetstate(sd);
+		pc->resetstate(sd,0);
 		clif->updatestatus(sd,SP_STATUSPOINT);
 		clif->updatestatus(sd,SP_BASELEVEL);
 		clif->updatestatus(sd,SP_BASEEXP);

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -911,7 +911,7 @@ END_ZEROED_BLOCK; /* End */
 	int (*skillup) (struct map_session_data *sd,uint16 skill_id);
 	int (*allskillup) (struct map_session_data *sd);
 	int (*resetlvl) (struct map_session_data *sd,int type);
-	int (*resetstate) (struct map_session_data *sd);
+	int (*resetstate) (struct map_session_data *sd, int type);
 	int (*resetskill) (struct map_session_data *sd, int flag);
 	int (*resetfeel) (struct map_session_data *sd);
 	int (*resethate) (struct map_session_data *sd);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11139,15 +11139,25 @@ BUILDIN(resetlvl)
 	return true;
 }
 /*==========================================
- * Reset a player status point
- *------------------------------------------*/
+* Reset a player status point
+* @type:
+*	0 = All
+*	bStr,bAgi,bInt,bVit,bDex,bLuk
+* Return total status point gained.
+*------------------------------------------*/
 BUILDIN(resetstatus)
 {
 	TBL_PC *sd;
-	sd=script->rid2sd(st);
-	if( sd == NULL )
+	int type = 0;
+
+	sd = script->rid2sd(st);
+	if (sd == NULL)
 		return false;
-	pc->resetstate(sd);
+
+	if (script_hasdata(st, 2))
+		type = script_getnum(st, 2);
+
+	script_pushint(st, pc->resetstate(sd, type));
 	return true;
 }
 
@@ -20011,7 +20021,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF2(catchpet,"pet","i"),
 		BUILDIN_DEF2(birthpet,"bpet",""),
 		BUILDIN_DEF(resetlvl,"i"),
-		BUILDIN_DEF(resetstatus,""),
+		BUILDIN_DEF(resetstatus,"?"),
 		BUILDIN_DEF(resetskill,""),
 		BUILDIN_DEF(skillpointcount,""),
 		BUILDIN_DEF(changebase,"i?"),

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -53332,15 +53332,15 @@ int HP_pc_resetlvl(struct map_session_data *sd, int type) {
 	}
 	return retVal___;
 }
-int HP_pc_resetstate(struct map_session_data *sd) {
+int HP_pc_resetstate(struct map_session_data *sd,int type) {
 	int hIndex = 0;
 	int retVal___ = 0;
 	if( HPMHooks.count.HP_pc_resetstate_pre ) {
-		int (*preHookFunc) (struct map_session_data *sd);
+		int (*preHookFunc) (struct map_session_data *sd,int *type);
 		*HPMforce_return = false;
 		for(hIndex = 0; hIndex < HPMHooks.count.HP_pc_resetstate_pre; hIndex++ ) {
 			preHookFunc = HPMHooks.list.HP_pc_resetstate_pre[hIndex].func;
-			retVal___ = preHookFunc(sd);
+			retVal___ = preHookFunc(sd, &type);
 		}
 		if( *HPMforce_return ) {
 			*HPMforce_return = false;
@@ -53348,13 +53348,13 @@ int HP_pc_resetstate(struct map_session_data *sd) {
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.pc.resetstate(sd);
+		retVal___ = HPMHooks.source.pc.resetstate(sd, type);
 	}
 	if( HPMHooks.count.HP_pc_resetstate_post ) {
-		int (*postHookFunc) (int retVal___, struct map_session_data *sd);
+		int (*postHookFunc) (int retVal___, struct map_session_data *sd, int *type);
 		for(hIndex = 0; hIndex < HPMHooks.count.HP_pc_resetstate_post; hIndex++ ) {
 			postHookFunc = HPMHooks.list.HP_pc_resetstate_post[hIndex].func;
-			retVal___ = postHookFunc(retVal___, sd);
+			retVal___ = postHookFunc(retVal___, sd, &type);
 		}
 	}
 	return retVal___;


### PR DESCRIPTION
Support extra 'type' parameters.
Required to disable battle_config.use_statpoint_table, to avoid status
point abuse.

Sample NPC for testing.
http://pastebin.com/raw.php?i=qxBLumHR

```
prontera,155,171,5  script  Reset#sample    861,{
    mes "Reset which status ?";
    .@i = select( "All","STR","AGI","VIT","INT","DEX","LUK" ) - 1;
    if ( .@i )
        .@i += 12;
    .@value = resetstatus(.@i);
    mes "Gained "+F_InsertComma( .@value )+" status points.";
    close;
}
```

> Edit by Haru -- inlined the code snippet here (as it's very short), to make it future proof
