### PR TITLE
Fixed 2 bugs in Sealed Shrine

### DIFF
--- a/npc/instances/SealedShrine.txt
+++ b/npc/instances/SealedShrine.txt
@@ -437,7 +437,7 @@ OnInstanceInit:
 	// Pick one "true" Gravestone and 12 "false" Gravestones.
 	.@true = rand(1,13);
 	for (.@i = 1; .@i<13; ++.@i) {
-		disablenpc instance_npcname("Gravestone#1F_1"+((.@i == .@true)?"F":"T"));
+		disablenpc instance_npcname("Gravestone#1F_"+.@i+((.@i == .@true)?"F":"T"));
 	}
 	disablenpc instance_npcname("ins_baphomet_lotto");
 	end;
@@ -445,7 +445,7 @@ OnInstanceInit:
 
 1@cata,3,2,0	script	ins_baphomet_lotto2	-1,{
 OnEnable:
-	for (.@i = 1; .@i < 12; ++.@i)
+	for (.@i = 1; .@i <= 12; ++.@i)
 		enablenpc instance_npcname("Bobbing Torch#"+.@i);
 	end;
 }


### PR DESCRIPTION
Fixed trying to disable wrong NPCs.
Fixed not enabling all Bobbing Torches.

Both bugs were (re)introduced in cd95d1cadacc9b506e08d4cbe52a4a0ce2a59df3