### PR TITLE
Fix a warning when loading instance duplicates (#812)

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -142,15 +142,11 @@ void mvptomb_create(struct mob_data *md, char *killer, time_t time)
 	if ( md->tomb_nid )
 		mob->mvptomb_destroy(md);
 
-	nd = npc->create_npc(md->bl.m, md->bl.x, md->bl.y);
+	nd = npc->create_npc(md->bl.m, md->bl.x, md->bl.y, md->ud.dir, MOB_TOMB);
 	md->tomb_nid = nd->bl.id;
-	nd->dir = md->ud.dir;
-	nd->bl.type = BL_NPC;
 
 	safestrncpy(nd->name, msg_txt(856), sizeof(nd->name)); // "Tomb"
 
-	nd->class_ = 565;
-	nd->speed = 200;
 	nd->subtype = TOMB;
 
 	nd->u.tomb.md = md;
@@ -165,7 +161,6 @@ void mvptomb_create(struct mob_data *md, char *killer, time_t time)
 	map->addblock(&nd->bl);
 	status->set_viewdata(&nd->bl, nd->class_);
 	clif->spawn(&nd->bl);
-
 }
 
 void mvptomb_destroy(struct mob_data *md) {

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -142,12 +142,10 @@ void mvptomb_create(struct mob_data *md, char *killer, time_t time)
 	if ( md->tomb_nid )
 		mob->mvptomb_destroy(md);
 
-	nd = npc->create_npc(md->bl.m, md->bl.x, md->bl.y, md->ud.dir, MOB_TOMB);
+	nd = npc->create_npc(TOMB, md->bl.m, md->bl.x, md->bl.y, md->ud.dir, MOB_TOMB);
 	md->tomb_nid = nd->bl.id;
 
 	safestrncpy(nd->name, msg_txt(856), sizeof(nd->name)); // "Tomb"
-
-	nd->subtype = TOMB;
 
 	nd->u.tomb.md = md;
 	nd->u.tomb.kill_time = time;

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -231,7 +231,7 @@ struct npc_interface {
 	void (*parsename) (struct npc_data *nd, const char *name, const char *start, const char *buffer, const char *filepath);
 	int (*parseview) (const char *w4, const char *start, const char *buffer, const char *filepath);
 	bool (*viewisid) (const char *viewid);
-	struct npc_data *(*create_npc) (int m, int x, int y, uint8 dir, int16 class_);
+	struct npc_data *(*create_npc) (enum npc_subtype subtype, int m, int x, int y, uint8 dir, int16 class_);
 	struct npc_data* (*add_warp) (char *name, short from_mapid, short from_x, short from_y, short xs, short ys, unsigned short to_mapindex, short to_x, short to_y);
 	const char* (*parse_warp) (char *w1, char *w2, char *w3, char *w4, const char *start, const char *buffer, const char *filepath, int *retval);
 	const char* (*parse_shop) (char *w1, char *w2, char *w3, char *w4, const char *start, const char *buffer, const char *filepath, int *retval);

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -70,7 +70,7 @@ struct npc_data {
 	unsigned short stat_point;
 
 	struct npc_parse *chatdb;
-	char* path;/* path dir */
+	const char *path; ///< Source path reference
 	enum npc_subtype subtype;
 	int src_id;
 	union {
@@ -225,6 +225,8 @@ struct npc_interface {
 	void (*clearsrcfile) (void);
 	void (*addsrcfile) (const char *name);
 	void (*delsrcfile) (const char *name);
+	const char *(*retainpathreference) (const char *filepath);
+	void (*releasepathreference) (const char *filepath);
 	void (*parsename) (struct npc_data *nd, const char *name, const char *start, const char *buffer, const char *filepath);
 	int (*parseview) (const char *w4, const char *start, const char *buffer, const char *filepath);
 	bool (*viewisid) (const char *viewid);

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -240,6 +240,9 @@ struct npc_interface {
 	const char* (*skip_script) (const char *start, const char *buffer, const char *filepath, int *retval);
 	const char* (*parse_script) (char *w1, char *w2, char *w3, char *w4, const char *start, const char *buffer, const char *filepath, int options, int *retval);
 	void (*add_to_location) (struct npc_data *nd);
+	bool (*duplicate_script_sub) (struct npc_data *nd, const struct npc_data *snd, int xs, int ys, int options);
+	bool (*duplicate_shop_sub) (struct npc_data *nd, const struct npc_data *snd, int xs, int ys, int options);
+	bool (*duplicate_warp_sub) (struct npc_data *nd, const struct npc_data *snd, int xs, int ys, int options);
 	bool (*duplicate_sub) (struct npc_data *nd, const struct npc_data *snd, int xs, int ys, int options);
 	const char* (*parse_duplicate) (char* w1, char* w2, char* w3, char* w4, const char* start, const char* buffer, const char* filepath, int options, int *retval);
 	int (*duplicate4instance) (struct npc_data *snd, int16 m);

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -111,6 +111,7 @@ struct npc_data {
 enum actor_classes {
 	WARP_CLASS = 45,
 	HIDDEN_WARP_CLASS = 139,
+	MOB_TOMB = 565,
 	WARP_DEBUG_CLASS = 722,
 	FLAG_CLASS = 722,
 	INVISIBLE_CLASS = 32767,
@@ -230,7 +231,7 @@ struct npc_interface {
 	void (*parsename) (struct npc_data *nd, const char *name, const char *start, const char *buffer, const char *filepath);
 	int (*parseview) (const char *w4, const char *start, const char *buffer, const char *filepath);
 	bool (*viewisid) (const char *viewid);
-	struct npc_data* (*create_npc) (int m, int x, int y);
+	struct npc_data *(*create_npc) (int m, int x, int y, uint8 dir, int16 class_);
 	struct npc_data* (*add_warp) (char *name, short from_mapid, short from_x, short from_y, short xs, short ys, unsigned short to_mapindex, short to_x, short to_y);
 	const char* (*parse_warp) (char *w1, char *w2, char *w3, char *w4, const char *start, const char *buffer, const char *filepath, int *retval);
 	const char* (*parse_shop) (char *w1, char *w2, char *w3, char *w4, const char *start, const char *buffer, const char *filepath, int *retval);
@@ -238,7 +239,7 @@ struct npc_interface {
 	void (*convertlabel_db) (struct npc_label_list *label_list, const char *filepath);
 	const char* (*skip_script) (const char *start, const char *buffer, const char *filepath, int *retval);
 	const char* (*parse_script) (char *w1, char *w2, char *w3, char *w4, const char *start, const char *buffer, const char *filepath, int options, int *retval);
-	bool (*duplicate_sub) (struct npc_data *nd, const struct npc_data *snd, int class_, int dir, int xs, int ys, int options);
+	bool (*duplicate_sub) (struct npc_data *nd, const struct npc_data *snd, int xs, int ys, int options);
 	const char* (*parse_duplicate) (char* w1, char* w2, char* w3, char* w4, const char* start, const char* buffer, const char* filepath, int options, int *retval);
 	int (*duplicate4instance) (struct npc_data *snd, int16 m);
 	void (*setcells) (struct npc_data *nd);

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -238,6 +238,7 @@ struct npc_interface {
 	void (*convertlabel_db) (struct npc_label_list *label_list, const char *filepath);
 	const char* (*skip_script) (const char *start, const char *buffer, const char *filepath, int *retval);
 	const char* (*parse_script) (char *w1, char *w2, char *w3, char *w4, const char *start, const char *buffer, const char *filepath, int options, int *retval);
+	bool (*duplicate_sub) (struct npc_data *nd, const struct npc_data *snd, int class_, int dir, int xs, int ys, int options);
 	const char* (*parse_duplicate) (char* w1, char* w2, char* w3, char* w4, const char* start, const char* buffer, const char* filepath, int options, int *retval);
 	int (*duplicate4instance) (struct npc_data *snd, int16 m);
 	void (*setcells) (struct npc_data *nd);

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -239,6 +239,7 @@ struct npc_interface {
 	void (*convertlabel_db) (struct npc_label_list *label_list, const char *filepath);
 	const char* (*skip_script) (const char *start, const char *buffer, const char *filepath, int *retval);
 	const char* (*parse_script) (char *w1, char *w2, char *w3, char *w4, const char *start, const char *buffer, const char *filepath, int options, int *retval);
+	void (*add_to_location) (struct npc_data *nd);
 	bool (*duplicate_sub) (struct npc_data *nd, const struct npc_data *snd, int xs, int ys, int options);
 	const char* (*parse_duplicate) (char* w1, char* w2, char* w3, char* w4, const char* start, const char* buffer, const char* filepath, int options, int *retval);
 	int (*duplicate4instance) (struct npc_data *snd, int16 m);


### PR DESCRIPTION
This changes the way duplicates are created when they're needed in an instance.

Previously, duplicates were created through an opportunely forged fake script line, parsed as if it was a normal duplicate NPC loaded from a script. Now, it's done without formatting and parsing a script line.

This fixes #812.