### PR TITLE
Add new config to allow player vend/chat room nearby hidden npc (#834)

### DIFF
--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -148,6 +148,9 @@ idle_no_autoloot: 0
 // Default: 3 (0: disabled).
 min_npc_vendchat_distance: 3
 
+// Can players vend/chat room nearby hidden npc? (Ie: FAKE_NPC/HIDDEN_WARP_NPC)
+vendchat_near_hiddennpc: no
+
 // Super Novice's fury is enabled to increments of 10%, such as at 10.0%, 20.0% - 80.0%, 90.0%
 // Changing snovice_call_type config to 1 enables its use at 0%, for maxed super novices.
 // default: 0

--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -148,7 +148,8 @@ idle_no_autoloot: 0
 // Default: 3 (0: disabled).
 min_npc_vendchat_distance: 3
 
-// Can players vend/chat room nearby hidden npc? (Ie: FAKE_NPC/HIDDEN_WARP_NPC)
+// If min_npc_vendchat_distance is enabled,
+// can players vend/chat room nearby hidden npc? (Ie: FAKE_NPC/HIDDEN_WARP_NPC)
 vendchat_near_hiddennpc: no
 
 // Super Novice's fury is enabled to increments of 10%, such as at 10.0%, 20.0% - 80.0%, 90.0%

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7103,6 +7103,7 @@ static const struct battle_data {
 	{ "mvp_tomb_enabled",                   &battle_config.mvp_tomb_enabled,                1,      0,      1               },
 	{ "feature.atcommand_suggestions",      &battle_config.atcommand_suggestions_enabled,   0,      0,      1               },
 	{ "min_npc_vendchat_distance",          &battle_config.min_npc_vendchat_distance,       3,      0,      100             },
+	{ "vendchat_near_hiddennpc",            &battle_config.vendchat_near_hiddennpc,         0,      0,      1               },
 	{ "atcommand_mobinfo_type",             &battle_config.atcommand_mobinfo_type,          0,      0,      1               },
 	{ "homunculus_max_level",               &battle_config.hom_max_level,                   99,     0,      MAX_LEVEL,      },
 	{ "homunculus_S_max_level",             &battle_config.hom_S_max_level,                 150,    0,      MAX_LEVEL,      },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -471,6 +471,7 @@ struct Battle_Config {
 
 	int atcommand_suggestions_enabled;
 	int min_npc_vendchat_distance;
+	int vendchat_near_hiddennpc;
 	int atcommand_mobinfo_type;
 
 	int mob_size_influence; // Enable modifications on earned experience, drop rates and monster status depending on monster size. [mkbu95]

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -137,7 +137,7 @@ int npc_isnear_sub(struct block_list* bl, va_list args) {
 	if( nd->option & (OPTION_HIDE|OPTION_INVISIBLE) )
 		return 0;
 
-	if( battle_config.vendchat_near_hiddennpc && ( nd->class_ == -1 || nd->class_ == 139 ) )
+	if( battle_config.vendchat_near_hiddennpc && ( nd->class_ == FAKE_NPC || nd->class_ == HIDDEN_WARP_CLASS ) )
 		return 0;
 
 	return 1;
@@ -4646,7 +4646,7 @@ int do_init_npc(bool minimal) {
 	npc->fake_nd = (struct npc_data *)aCalloc(1,sizeof(struct npc_data));
 	npc->fake_nd->bl.m = -1;
 	npc->fake_nd->bl.id = npc->get_new_npc_id();
-	npc->fake_nd->class_ = -1;
+	npc->fake_nd->class_ = FAKE_NPC;
 	npc->fake_nd->speed = 200;
 	strcpy(npc->fake_nd->name,"FAKE_NPC");
 	memcpy(npc->fake_nd->exname, npc->fake_nd->name, 9);

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -137,6 +137,9 @@ int npc_isnear_sub(struct block_list* bl, va_list args) {
 	if( nd->option & (OPTION_HIDE|OPTION_INVISIBLE) )
 		return 0;
 
+	if( battle_config.vendchat_near_hiddennpc && ( nd->class_ == -1 || nd->class_ == 139 ) )
+		return 0;
+
 	return 1;
 }
 

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -109,6 +109,7 @@ struct npc_data {
 #define START_NPC_NUM 110000000
 
 enum actor_classes {
+	FAKE_NPC = -1,
 	WARP_CLASS = 45,
 	HIDDEN_WARP_CLASS = 139,
 	WARP_DEBUG_CLASS = 722,


### PR DESCRIPTION
tested with
```
prontera,145,187,5	script	test1	-1,{}
prontera,155,187,5	script	test2	HIDDEN_NPC,{}
prontera,165,187,5	script	test3	HIDDEN_WARP_NPC,{}
```
apparently when using -1 with coordinates, the server doesn't throw error