### PR TITLE
Add new *pcblock script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6184,12 +6184,15 @@ Examples:
 
 ---------------------------------------
 
-*pcblockmove(<id>, <option>)
+*pcblockmove(<account id>, <option>)
 
-Prevents the given ID from moving when the optionis true , and false
-enables the ID to move again. The ID can either be the GID of a
-monster/NPC or account ID of a character, and will run for the attached
-player if zero is supplied.
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    @ /!\ This command is deprecated @
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+Prevents the player from moving when the option != 0, and 0 enables the 
+player to move again. The player has to be the account ID of a character,
+and will run for the attached player if zero is supplied.
 
 Examples:
 
@@ -6199,6 +6202,53 @@ Examples:
 // Enables the current char to move again.
 	pcblockmove(getcharid(CHAR_ID_ACCOUNT), false);
 
+---------------------------------------
+
+*setpcblock(<type>,<option>)
+*checkpcblock()
+
+Prevents the player from doing the following action.
+
+For setpcblock, when the <option> is true(1) will block them, and false(0)
+will allow those actions again.
+
+The checkpcblock command returned value is a bit mask of the currently
+enabled block flags (or PCBLOCK_NONE when none is set).
+
+The <type> listed are a bit mask of the following:
+	PCBLOCK_NONE (only used by checkpcblock)
+	PCBLOCK_MOVE
+	PCBLOCK_ATTACK
+	PCBLOCK_SKILL
+	PCBLOCK_USEITEM
+	PCBLOCK_CHAT
+	PCBLOCK_IMMUNE
+	PCBLOCK_SITSTAND
+	PCBLOCK_COMMANDS
+
+Examples:
+
+// Make the current attached player invulnerable, same as @monsterignore
+	setpcblock(PCBLOCK_IMMUNE, true);
+
+// Prevents the current char from attacking or using skills
+	setpcblock(PCBLOCK_ATTACK|PCBLOCK_SKILL, true);
+
+// Re-enables attack, skills and item use
+	setpcblock(PCBLOCK_ATTACK|PCBLOCK_SKILL|PCBLOCK_ITEM, false);
+
+// checkpcblock related checks
+	if ((checkpcblock() & PCBLOCK_IMMUNE) != 0)
+		mes "You are invulnerable!";
+
+	if ((checkpcblock() & (PCBLOCK_MOVE|PCBLOCK_SITSTAND)) == (PCBLOCK_MOVE|PCBLOCK_SITSTAND))
+		mes "You can't walk or sit";
+
+	if ((checkpcblock() & (PCBLOCK_ATTACK|PCBLOCK_SKILL)) == PCBLOCK_NONE)
+		mes "You can attack and use skills";
+
+	if ((checkpcblock() & PCBLOCK_CHAT) == PCBLOCK_NONE)
+		mes "You can't chat";
 
 ---------------------------------------
 //=====================================

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -7522,11 +7522,11 @@ ACMD(sizeguild)
  *------------------------------------------*/
 ACMD(monsterignore)
 {
-	if (!sd->state.monster_ignore) {
-		sd->state.monster_ignore = 1;
+	if (!sd->block_action.immune) {
+		sd->block_action.immune = 1;
 		clif->message(sd->fd, msg_fd(fd,1305)); // You are now immune to attacks.
 	} else {
-		sd->state.monster_ignore = 0;
+		sd->block_action.immune = 0;
 		clif->message(sd->fd, msg_fd(fd,1306)); // Returned to normal state.
 	}
 
@@ -10090,6 +10090,8 @@ bool atcommand_exec(const int fd, struct map_session_data *sd, const char *messa
 			return false;
 		}
 	}
+	if (sd->block_action.commands) // *pcblock script command
+		return false;
 
 	if (*message == atcommand->char_symbol)
 		is_atcommand = false;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -6649,7 +6649,7 @@ int battle_check_target( struct block_list *src, struct block_list *target,int f
 			if (t_bl == s_bl)
 				break;
 
-			if( sd->state.monster_ignore && flag&BCT_ENEMY )
+			if (sd->block_action.immune && flag&BCT_ENEMY)
 				return 0; // Global immunity only to Attacks
 			if (sd->status.karma && s_bl->type == BL_PC && BL_UCCAST(BL_PC, s_bl)->status.karma)
 				state |= BCT_ENEMY; // Characters with bad karma may fight amongst them

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10488,6 +10488,9 @@ void clif_parse_ActionRequest_sub(struct map_session_data *sd, int action_type, 
 				return;
 			}
 
+			if (sd->block_action.sitstand) // *pcblock script command
+				break;
+
 			if (sd->ud.skilltimer != INVALID_TIMER || (sd->sc.opt1 && sd->sc.opt1 != OPT1_BURNING ))
 				break;
 
@@ -10514,6 +10517,9 @@ void clif_parse_ActionRequest_sub(struct map_session_data *sd, int action_type, 
 				clif->standing(&sd->bl);
 				return;
 			}
+
+			if (sd->block_action.sitstand) // *pcblock script command
+				break;
 
 			pc->update_idle_time(sd, BCIDLE_SIT);
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -5162,6 +5162,9 @@ int pc_useitem(struct map_session_data *sd,int n) {
 	if( sd->status.inventory[n].nameid <= 0 || sd->status.inventory[n].amount <= 0 )
 		return 0;
 
+	if (sd->block_action.useitem) // *pcblock script command
+		return 0;
+
 	if( !pc->isUseitem(sd,n) )
 		return 0;
 
@@ -9321,7 +9324,8 @@ bool pc_can_attack( struct map_session_data *sd, int target_id ) {
 		(sd->sc.data[SC_SIREN] && sd->sc.data[SC_SIREN]->val2 == target_id) ||
 		sd->sc.data[SC_BLADESTOP] ||
 		sd->sc.data[SC_DEEP_SLEEP] ||
-		sd->sc.data[SC_FALLENEMPIRE] )
+		sd->sc.data[SC_FALLENEMPIRE] ||
+		sd->block_action.attack)
 			return false;
 
 	return true;
@@ -9337,7 +9341,8 @@ bool pc_can_talk( struct map_session_data *sd ) {
 
 	if( sd->sc.data[SC_BERSERK] ||
 		(sd->sc.data[SC_DEEP_SLEEP] && sd->sc.data[SC_DEEP_SLEEP]->val2) ||
-		pc_ismuted(&sd->sc, MANNER_NOCHAT) )
+		pc_ismuted(&sd->sc, MANNER_NOCHAT) ||
+		sd->block_action.chat)
 		return false;
 
 	return true;

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -201,10 +201,8 @@ struct map_session_data {
 		unsigned int noask :1; // [LuzZza]
 		unsigned int trading :1; //[Skotlex] is 1 only after a trade has started.
 		unsigned int deal_locked :2; //1: Clicked on OK. 2: Clicked on TRADE
-		unsigned int monster_ignore :1; // for monsters to ignore a character [Valaris] [zzo]
 		unsigned int size :2; // for tiny/large types
 		unsigned int night :1; //Holds whether or not the player currently has the SI_NIGHT effect on. [Skotlex]
-		unsigned int blockedmove :1;
 		unsigned int using_fake_npc :1;
 		unsigned int rewarp :1; //Signals that a player should warp as soon as he is done loading a map. [Skotlex]
 		unsigned int killer : 1;
@@ -621,6 +619,16 @@ END_ZEROED_BLOCK;
 	// HatEffect
 	VECTOR_DECL(int) hatEffectId;
 
+	struct {
+		unsigned move     : 1;
+		unsigned attack   : 1;
+		unsigned skill    : 1;
+		unsigned useitem  : 1;
+		unsigned chat     : 1;
+		unsigned immune   : 1;
+		unsigned sitstand : 1;
+		unsigned commands : 1;
+	} block_action;
 };
 
 #define EQP_WEAPON EQP_HAND_R

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18062,9 +18062,88 @@ BUILDIN(pcblockmove) {
 	else
 		sd = script->rid2sd(st);
 
-	if (sd != NULL)
-		sd->state.blockedmove = flag > 0;
+	if (!sd)
+		return true;
 
+	if (flag)
+		sd->block_action.move = 1;
+	else
+		sd->block_action.move = 0;
+
+	return true;
+}
+
+BUILDIN(setpcblock)
+{
+	struct map_session_data *sd = script->rid2sd(st);
+	enum pcblock_action_flag type = script_getnum(st, 2);
+	int state = (script_getnum(st, 3) > 0) ? 1 : 0;
+
+	if (sd == NULL)
+		return true;
+
+	if ((type & PCBLOCK_MOVE) != 0)
+		sd->block_action.move = state;
+
+	if ((type & PCBLOCK_ATTACK) != 0)
+		sd->block_action.attack = state;
+
+	if ((type & PCBLOCK_SKILL) != 0)
+		sd->block_action.skill = state;
+
+	if ((type & PCBLOCK_USEITEM) != 0)
+		sd->block_action.useitem = state;
+
+	if ((type & PCBLOCK_CHAT) != 0)
+		sd->block_action.chat = state;
+
+	if ((type & PCBLOCK_IMMUNE) != 0)
+		sd->block_action.immune = state;
+
+	if ((type & PCBLOCK_SITSTAND) != 0) 
+		sd->block_action.sitstand = state;
+
+	if ((type & PCBLOCK_COMMANDS) != 0)
+		sd->block_action.commands = state;
+
+	return true;
+}
+
+BUILDIN(checkpcblock)
+{
+	struct map_session_data *sd = script->rid2sd(st);
+	int retval = PCBLOCK_NONE;
+
+	if (sd == NULL) {
+		script_pushint(st, PCBLOCK_NONE);
+		return true;
+	}
+
+	if (sd->block_action.move != 0)
+		retval |= PCBLOCK_MOVE;
+
+	if (sd->block_action.attack != 0)
+		retval |= PCBLOCK_ATTACK;
+
+	if (sd->block_action.skill != 0)
+		retval |= PCBLOCK_SKILL;
+
+	if (sd->block_action.useitem != 0)
+		retval |= PCBLOCK_USEITEM;
+
+	if (sd->block_action.chat != 0)
+		retval |= PCBLOCK_CHAT;
+
+	if (sd->block_action.immune != 0)
+		retval |= PCBLOCK_IMMUNE;
+
+	if (sd->block_action.sitstand != 0)
+		retval |= PCBLOCK_SITSTAND;
+
+	if (sd->block_action.commands != 0)
+		retval |= PCBLOCK_COMMANDS;
+
+	script_pushint(st, retval);
 	return true;
 }
 
@@ -24520,7 +24599,9 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(rid2name,"i"),
 		BUILDIN_DEF(pcfollow,"ii"),
 		BUILDIN_DEF(pcstopfollow,"i"),
-		BUILDIN_DEF(pcblockmove,"ii"),
+		BUILDIN_DEF_DEPRECATED(pcblockmove,"ii"), // Deprecated 2018-05-04
+		BUILDIN_DEF(setpcblock, "ii"),
+		BUILDIN_DEF(checkpcblock, ""),
 		// <--- [zBuffer] List of player cont commands
 		// [zBuffer] List of mob control commands --->
 		BUILDIN_DEF(getunittype,"i"),
@@ -25093,6 +25174,17 @@ void script_hardcoded_constants(void)
 	script->set_constant("MST_AROUND3", MST_AROUND3, false, false);
 	script->set_constant("MST_AROUND4", MST_AROUND4, false, false);
 	script->set_constant("MST_AROUND", MST_AROUND , false, false);
+ 
+	script->constdb_comment("pc block constants, use with *setpcblock* and *checkpcblock*");
+	script->set_constant("PCBLOCK_NONE",     PCBLOCK_NONE,     false, false);
+	script->set_constant("PCBLOCK_MOVE",     PCBLOCK_MOVE,     false, false);
+	script->set_constant("PCBLOCK_ATTACK",   PCBLOCK_ATTACK,   false, false);
+	script->set_constant("PCBLOCK_SKILL",    PCBLOCK_SKILL,    false, false);
+	script->set_constant("PCBLOCK_USEITEM",  PCBLOCK_USEITEM,  false, false);
+	script->set_constant("PCBLOCK_CHAT",     PCBLOCK_CHAT,     false, false);
+	script->set_constant("PCBLOCK_IMMUNE",   PCBLOCK_IMMUNE,   false, false);
+	script->set_constant("PCBLOCK_SITSTAND", PCBLOCK_SITSTAND, false, false);
+	script->set_constant("PCBLOCK_COMMANDS", PCBLOCK_COMMANDS, false, false);
 
 	script->constdb_comment("Renewal");
 #ifdef RENEWAL

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -454,6 +454,22 @@ enum script_iteminfo_types {
 };
 
 /**
+ * Player blocking actions related flags.
+ */
+enum pcblock_action_flag {
+	PCBLOCK_NONE     = 0x00,
+	PCBLOCK_MOVE     = 0x01,
+	PCBLOCK_ATTACK   = 0x02,
+	PCBLOCK_SKILL    = 0x04,
+	PCBLOCK_USEITEM  = 0x08,
+	PCBLOCK_CHAT     = 0x10,
+	PCBLOCK_IMMUNE   = 0x20,
+	PCBLOCK_SITSTAND = 0x40,
+	PCBLOCK_COMMANDS = 0x80,
+	PCBLOCK_ALL      = 0xFF,
+};
+
+/**
  * Structures
  **/
 

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -1761,6 +1761,9 @@ int status_check_skilluse(struct block_list *src, struct block_list *target, uin
 	if (src != NULL && src->type != BL_PC && status->isdead(src))
 		return 0;
 
+	if (sd != NULL && sd->block_action.skill && skill_id) // *pcblock script command
+		return 0;
+
 	if (!skill_id) { //Normal attack checks.
 		if (!(st->mode&MD_CANATTACK))
 			return 0; //This mode is only needed for melee attacking.

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1091,7 +1091,7 @@ int unit_can_move(struct block_list *bl)
 		pc_issit(sd) ||
 		sd->state.vending ||
 		sd->state.buyingstore ||
-		sd->state.blockedmove
+		sd->block_action.move
 	))
 		return 0; //Can't move
 


### PR DESCRIPTION
This is NOT what I had in mind when I did the previous pull request
but a lot was going on, on the forums, and somehow it turn out this way
... now this has become quite complex
1. I seriously think PCBLOCK_ is a better constant, but the community want it as BLOCK
   because I fear maybe in the future there will be a real BLOCK constants coming from aegis ? I dunno
   that's why it was PCBLOCK_ in the source, BLOCK as scripts
   need Haru opinion on this
2. I don't really like to remove others work, like removing the name [Valaris] in the source code <.<
   but members like the bit-wise method, so meh ...
   so I removed those 2 sd->state.
3. I'm wondering the enum block_action should belongs to script.h or pc.h...
4. we have suggested so many types
   here we go ...

BLOCK_MOVE => its a must
- keep the pcblockmove for backward compatibility, but add this in for a better management control

BLOCK_ATTACK => its a must
BLOCK_SKILL => its a must
- I don't like using OPTION_XMAS or SC_XMAS to prevent the player to attack/skill, need a proper script command

BLOCK_CHAT => its a must
- I don't like using SC_BERSERK to prevent player to chat, need a proper script command

BLOCK_IMMUNE => its a must
- I don't like using atcommand "@monsterignore" in scripts, it will create unnecessary log

BLOCK_USEITEM => look like a must
- although I have a noitem mapflag to do the same, but preventing player to attack, then skill, its logical to prevent item next

BLOCK_STORAGE => redundant
- maybe should code a nostorage mapflag ?

BLOCK_SENDMAIL => no...
- the idea is that, some private server has a special map where players can try out godly item in a closed, nowarp+nowarpto map
  however there is an exploit where players can send item away into another account using friend list-> send mail
  I will make a pull request to prevent this exploit by adding a battle config

BLOCK_EQUIPMENT => no...
- doesn't make sense, should use map_zone_db.conf or my noitem mapflag

BLOCK_TELEPORT => no..
- already have noteleport mapflag

BLOCK_SITSTAND => looks ok
- we have script command *sit, *stand and *issit(),
  means we can actually script it to make the player sit, then pcblocksit to prevent them standing up

BLOCK_VENDING => no ..
- already has novending mapflag and cell_novending

BLOCK_TRADING => no...
- I think *getitembound already make this useless.
- Since the special created item for event is already bound, there is no way for them to trade anymore
- also already has notrade mapflag

BLOCK_PICKITEM => no
- already has nomobloot and nomvploot mapflag

BLOCK_COMMAND => 50% yes 50% no
- nocommand mapflag exist, I know, but there are times maybe they need to talk while having`@command` disabled

BLOCK_GSTORAGE
- I seriously think this should belongs to nostorage mapflag
  but we don't have one

last but not least, tested with this script

```
prontera,155,184,5  script  sdfhdskfj   1_F_MARIA,{
Ontest:
    for ( .@i = 0; .@i < 8; .@i++ )
        .@menu$ = .@menu$ + .name$[.@i] + .flag$[ !!( getpcblock() & (1 << .@i) ) ] +":";
    .@s = select( .@menu$ ) -1;
    pcblock 1 << .@s, !( getpcblock() & (1 << .@s) );
    close;
OnInit:
    bindatcmd "@pcblock", strnpcinfo(0)+"::Ontest";
    setarray .name$, "BLOCK_MOVE", "BLOCK_ATTACK", "BLOCK_SKILL", "BLOCK_USEITEM",
        "BLOCK_CHAT", "BLOCK_IMMUNE", "BLOCK_SITSTAND", "BLOCK_COMMAND";
    setarray .flag$, " [^ff0000OFF^000000]", "[^0000ffON^000000]";
    end;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/842)
<!-- Reviewable:end -->
