### PR TITLE
Fix *queueremove should return true if player is not in the queue

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8966,15 +8966,15 @@ Returns the amount of entries in the queue instance of <queue_id>.
 
 *queueadd(<queue_id>,<var_id>);
 
-Adds <var_id> to queue of <queue_id>, returning 1 if <var_id> is already
-present in the queue, otherwise returning 0.
+Adds <var_id> to queue of <queue_id>, returning 0 if <var_id> is already
+present in the queue, otherwise returning 1.
 
 ---------------------------------------
 
 *queueremove(<queue_id>,<var_id>);
 
-Removes <var_id> from queue of <queue_id>, returning 1 if <var_id> is not
-present in the queue, otherwise returning 0.
+Removes <var_id> from queue of <queue_id>, returning 0 if <var_id> is not
+present in the queue, otherwise returning 1.
 
 ---------------------------------------
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18923,6 +18923,9 @@ bool script_hqueue_remove(int idx, int var) {
 			}
 
 		}
+		else
+			return true;
+
 	}
 	return false;
 }

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18842,12 +18842,12 @@ bool script_hqueue_add(int idx, int var)
 {
 	if( idx < 0 || idx >= script->hqs || script->hq[idx].size == -1 ) {
 		ShowWarning("script_hqueue_add: unknown queue id %d\n",idx);
-		return true;
+		return false;
 	} else {
 		int i;
 		for (i = 0; i < script->hq[idx].size; i++) {
 			if (script->hq[idx].item[i] == var) {
-				return true;
+				return false;
 			}
 		}
 
@@ -18880,7 +18880,7 @@ bool script_hqueue_add(int idx, int var)
 
 		}
 	}
-	return false;
+	return true;
 }
 /* queueadd(.@queue_id,.@var_id); */
 /* adds a new entry to the queue, returns 1 if already in queue, 0 otherwise */
@@ -18895,7 +18895,7 @@ BUILDIN(queueadd) {
 bool script_hqueue_remove(int idx, int var) {
 	if( idx < 0 || idx >= script->hqs || script->hq[idx].size == -1 ) {
 		ShowWarning("script_hqueue_remove: unknown queue id %d (used with var %d)\n",idx,var);
-		return true;
+		return false;
 	} else {
 		int i;
 
@@ -18924,10 +18924,10 @@ bool script_hqueue_remove(int idx, int var) {
 
 		}
 		else
-			return true;
+			return false;
 
 	}
-	return false;
+	return true;
 }
 /* queueremove(.@queue_id,.@var_id); */
 /* removes a entry from the queue, returns 1 if not in queue, 0 otherwise */


### PR DESCRIPTION
```
prontera,152,185,5	script	add	1_F_MARIA,{
	if ( !queueadd( $@q, getcharid(3) ) )
		dispbottom "success";
	else
		dispbottom "already join";
	end;
}
prontera,158,185,5	script	remove	1_F_MARIA,{
	if ( !queueremove( $@q, getcharid(3) ) )
		dispbottom "success";
	else
		dispbottom "not yet join";
	end;
}
prontera,155,185,5	script	check	1_F_MARIA,{
	if ( queuesize($@q) ) {
		.@it = queueiterator($@q);
		dispbottom "iterator ID ["+ .@it +"] has "+ queuesize($@q) +" players on it.";
		do {
			dispbottom ( ++.@i )+". "+ qiget(.@it);
		} while ( qicheck(.@it) );
		qiclear .@it;
	}
	else {
		dispbottom "no entry";
	}		
	end;
OnInit:
	$@q = queue();
	end;
}
```
even if the player is not in the queue, click on the *queueremove will still return success
this pull request will fix it

*PS: yes there is another bug about iterator return -1, will pull request another one*