### PR TITLE
Fix *queueiterator return same amount of *queuesize upon *queueremove

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19078,8 +19078,8 @@ BUILDIN(queueiterator) {
 
 	RECREATE(script->hqi[ idx ].item, int, queue->size);
 
-	for ( i = 0; i < queue->size; i++ )
-		if ( queue->item[i] != -1 )
+	for (i = 0; i < queue->size; i++)
+		if (queue->item[i] != -1)
 			script->hqi[idx].item[count++] = queue->item[i];
 
 	script->hqi[ idx ].items = count;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19051,7 +19051,7 @@ BUILDIN(queueiterator) {
 	int qid = script_getnum(st, 2);
 	struct hQueue *queue = NULL;
 	int idx = script->hqis;
-	int i;
+	int i, count = 0;
 
 	if( qid < 0 || qid >= script->hqs || script->hq[qid].size == -1 || !(queue = script->queue(qid)) ) {
 		ShowWarning("queueiterator: invalid queue id %d\n",qid);
@@ -19078,9 +19078,11 @@ BUILDIN(queueiterator) {
 
 	RECREATE(script->hqi[ idx ].item, int, queue->size);
 
-	memcpy(script->hqi[idx].item, queue->item, sizeof(int)*queue->size);
+	for ( i = 0; i < queue->size; i++ )
+		if ( queue->item[i] != -1 )
+			script->hqi[idx].item[count++] = queue->item[i];
 
-	script->hqi[ idx ].items = queue->size;
+	script->hqi[ idx ].items = count;
 	script->hqi[ idx ].pos = 0;
 
 	script_pushint(st,idx);


### PR DESCRIPTION
```
prontera,152,185,5	script	add	1_F_MARIA,{
	if ( !queueadd( $@q, getcharid(3) ) )
		dispbottom "success";
	else
		dispbottom "already join";
	end;
}
prontera,158,185,5	script	remove	1_F_MARIA,{
	if ( !queueremove( $@q, getcharid(3) ) )
		dispbottom "success";
	else
		dispbottom "not yet join";
	end;
}
prontera,155,185,5	script	check	1_F_MARIA,{
	if ( queuesize($@q) ) {
		.@it = queueiterator($@q);
		dispbottom "iterator ID ["+ .@it +"] has "+ queuesize($@q) +" players on it.";
		do {
			dispbottom ( ++.@i )+". "+ qiget(.@it);
		} while ( qicheck(.@it) );
		qiclear .@it;
	}
	else {
		dispbottom "no entry";
	}		
	end;
OnInit:
	$@q = queue();
	end;
}
```
player A join the queue, check will display as
`1. 2000000`
player B join the queue, check will display as
`1. 2000000`
`2. 2000001`
now player A removed from the queue, check will display as
`1. -1`
`2. 2000001`

this is definitely wrong
the `queueiterator` should have the same amount as `queuesize`

this pull request should solve it
*I think there's no need to do what complex index move, just simply list accordingly enough I guess ?*