### PR TITLE
Fix *queuedel doesn't remove player's side queue

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18992,7 +18992,7 @@ bool script_hqueue_del(int idx)
 			if (script->hq[idx].item[i] >= START_ACCOUNT_NUM && (sd = map->id2sd(script->hq[idx].item[i])) != NULL) {
 				int j;
 				for(j = 0; j < sd->queues_count; j++) {
-					if( sd->queues[j] == script->hq[idx].item[i] ) {
+					if (sd->queues[j] == idx) {
 						break;
 					}
 				}


### PR DESCRIPTION
https://github.com/HerculesWS/Hercules/issues/846
I found out the reason

sd->queues[j] is the queue ID from the player
script->hq[idx].item[i] is the account ID of the queue in that array
so it was comparing wrong information

it should be comparing to idx instead

I also just check the `script_hqueue_clear`,
that function IS comparing to idx too