### PR TITLE
Fix *qicheck can return true, can list 1 extra empty entry

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19213,7 +19213,7 @@ BUILDIN(qicheck)
 
 	it = &VECTOR_INDEX(script->hqi, idx);
 
-	if (it->pos <= 0 || it->pos > VECTOR_LENGTH(it->entries)) {
+	if (it->pos <= 0 || it->pos >= VECTOR_LENGTH(it->entries)) {
 		script_pushint(st, 0);
 	} else {
 		script_pushint(st, 1);


### PR DESCRIPTION
```
prontera,152,185,5	script	add	1_F_MARIA,{
	if ( queueadd( $@q, getcharid(3) ) )
		dispbottom "success";
	else
		dispbottom "already join";
	end;
}
prontera,158,185,5	script	remove	1_F_MARIA,{
	if ( queueremove( $@q, getcharid(3) ) )
		dispbottom "success";
	else
		dispbottom "not yet join";
	end;
}
prontera,155,185,5	script	check	1_F_MARIA,{
	if ( queuesize($@q) ) {
		.@it = queueiterator($@q);
		dispbottom "iterator ID ["+ .@it +"] has "+ queuesize($@q) +" players on it.";
//		while ( qicheck(.@it) )
//			dispbottom ( ++.@i )+". "+ qiget(.@it);
		do {
			dispbottom ( ++.@i )+". "+ qiget(.@it);
		} while ( qicheck(.@it) );
//		for ( qiget(.@it); qicheck(.@it); qiget(.@it) )
//			dispbottom ( ++.@i )+". "+ qiget(.@it);
		qiclear .@it;
	}
	else {
		dispbottom "no entry";
	}       
	end;
OnInit:
	$@q = queue();
	end;
}
```
using the do { <statement> } while (qicheck(.@it)) method
the script will listed 1 extra entry as 0
`1. AnnieRuru`
`2. 0`

the problem, is everywhere is telling members to use
`for ( qiget(.@it); qicheck(.@it); qiget(.@it) )`
I tried that, but it never return any result

maybe should tell everyone to use do {} while () ?