### PR TITLE
*Correct the wrong example for *queueopt

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -978,12 +978,10 @@ Within executable script code, some lines can be labels:
 Labels are points of reference in your script, which can be used to route 
 execution with 'goto' and 'menu' commands, invoked with 'doevent', 'donpcevent'
 and 'callsub' commands and are otherwise essential. A label's name may not be
-longer than 22 characters. (23rd is the ':'.) There is some confusion in the
-source about whether it's 22, 23 or 24 all over the place, so keeping labels
-under 22 characters could be wise. It may only contain alphanumeric characters
-and underscore. In addition to labels you name yourself, there are also some
-special labels which the script engine will start execution from if a special
-event happens:
+longer than 23 characters. (24th is the ':'.) It may only contain alphanumeric
+characters and underscore. In addition to labels you name yourself, there are
+also some special labels which the script engine will start execution from if
+a special event happens:
 
 OnClock<hour><minute>:
 OnMinute<minute>:

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8997,7 +8997,7 @@ When the QUEUEOPT_MAPCHANGE event is triggered, it sets a temp char var
 @Queue_Destination_Map$ with the destination map name.
 
 Example:
-	queueopt(.@queue_id, QUEUEOPT_DEATH, "MyNPC::MyOnQueueMemberDeathEventName");
+	queueopt(.@queue_id, QUEUEOPT_DEATH, "MyNPC::OnQueueMemberDeathEvent");
 	
 ---------------------------------------
 


### PR DESCRIPTION
```
prontera,155,185,5	script	MyNPC	1_F_MARIA,{
	queueadd .q, getcharid(3);
	if ( queuesize(.q) ) {
		.@it = queueiterator(.q);
		dispbottom "iterator ID ["+ .@it +"] has "+ queuesize(.q) +" players on it.";
		for ( .@aid = qiget(.@it); qicheck(.@it); .@aid = qiget(.@it) )
			dispbottom ( ++.@i )+". "+ rid2name(.@aid);
		qiclear .@it;
	}
	end;
OnInit:
    .q = queue();
	queueopt .q, QUEUEOPT_DEATH, "MyNPC::MyOnQueueMemberDeathEventName";
    end;
MyOnQueueMemberDeathEventName:
	dispbottom "die die die";
	end;
}
```
I seriously don't want to write this example, 
BUT !!!
just want to confirm it

the server print this error
`[Error]: npc_parse_script: label name longer than 23 chars! (MyOnQueueMemberDeathEventName) in file 'npc/zzz.txt'.`

AND
the event name MUST start with `On`
`[Error]: npc_event: event not found [MyNPC::QueueMemberDeathEvent]`