### PR TITLE
Fix various ShowWarning that doesn't tell the source of the error

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18854,7 +18854,7 @@ BUILDIN(queuesize)
 	if (idx < 0 || idx >= VECTOR_LENGTH(script->hq) || !VECTOR_INDEX(script->hq, idx).valid) {
 		ShowWarning("buildin_queuesize: unknown queue id %d\n",idx);
 		script_pushint(st, 0);
-		return true;
+		return false;
 	}
 
 	script_pushint(st, VECTOR_LENGTH(VECTOR_INDEX(script->hq, idx).entries));
@@ -19006,7 +19006,7 @@ BUILDIN(queueopt)
 	if (idx < 0 || idx >= VECTOR_LENGTH(script->hq) || !VECTOR_INDEX(script->hq, idx).valid) {
 		ShowWarning("buildin_queueopt: unknown queue id %d\n",idx);
 		script_pushint(st, 0);
-		return true;
+		return false;
 	}
 
 	queue = &VECTOR_INDEX(script->hq, idx);
@@ -19033,7 +19033,7 @@ BUILDIN(queueopt)
 		default:
 			ShowWarning("buildin_queueopt: unsupported optionType %d\n",var);
 			script_pushint(st, 0);
-			return true;
+			return false;
 	}
 	script_pushint(st, 1);
 	return true;
@@ -19133,7 +19133,7 @@ BUILDIN(queueiterator)
 	if (qid < 0 || qid >= VECTOR_LENGTH(script->hq) || !VECTOR_INDEX(script->hq, qid).valid || !(queue = script->queue(qid))) {
 		ShowWarning("queueiterator: invalid queue id %d\n",qid);
 		script_pushint(st, -1);
-		return true;
+		return false;
 	}
 
 	ARR_FIND(0, VECTOR_LENGTH(script->hqi), i, !VECTOR_INDEX(script->hqi, i).valid);
@@ -19174,7 +19174,7 @@ BUILDIN(qiget)
 	if (idx < 0 || idx >= VECTOR_LENGTH(script->hqi) || !VECTOR_INDEX(script->hqi, idx).valid) {
 		ShowWarning("buildin_qiget: unknown queue iterator id %d\n",idx);
 		script_pushint(st, 0);
-		return true;
+		return false;
 	}
 
 	it = &VECTOR_INDEX(script->hqi, idx);
@@ -19208,7 +19208,7 @@ BUILDIN(qicheck)
 	if (idx < 0 || idx >= VECTOR_LENGTH(script->hqi) || !VECTOR_INDEX(script->hqi, idx).valid) {
 		ShowWarning("buildin_qicheck: unknown queue iterator id %d\n",idx);
 		script_pushint(st, 0);
-		return true;
+		return false;
 	}
 
 	it = &VECTOR_INDEX(script->hqi, idx);
@@ -19239,7 +19239,7 @@ BUILDIN(qiclear)
 	if (idx < 0 || idx >= VECTOR_LENGTH(script->hqi) || !VECTOR_INDEX(script->hqi, idx).valid) {
 		ShowWarning("buildin_qiclear: unknown queue iterator id %d\n",idx);
 		script_pushint(st, 0);
-		return true;
+		return false;
 	}
 
 	it = &VECTOR_INDEX(script->hqi, idx);


### PR DESCRIPTION
`return true;`
means its ok.

`return false;`
means the script will still run, nothing wrong, but it just report the source of the error

if want to halt the script, use `st->state = END;`

if want to report the source of error without using return false, use `script->reportsrc(st)`