### PR TITLE
Fix documentation error for autobonus trigger rate (#883)

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5699,7 +5699,7 @@ as expected, refer only to an invoking character.
 What these commands do is 'attach' a script to the player which will get
 executed on attack (or when attacked in the case of autobonus2).
 
-Rate is the trigger rate of the script (10000 = 100%). 
+Rate is the trigger rate of the script (1000 = 100%). 
 
 Duration is the time that the bonus will last for since the script has 
 triggered.


### PR DESCRIPTION
#883
@Jedzkie , try this ?

the value should be 10000 according to documentation
and check all items in item_db.conf, does it use 1000 as 100% or 10000 as 100% ?