### PR TITLE
Races fix

### DIFF
--- a/db/item_db2.conf
+++ b/db/item_db2.conf
@@ -202,10 +202,7 @@ item_db: (
 	Def: 3
 	Loc: 256
 	View: 216
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,50;
-		bonus2 bExpAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, 50; ">
 },
 */
 /*

--- a/db/pre-re/item_combo_db.txt
+++ b/db/pre-re/item_combo_db.txt
@@ -5,9 +5,9 @@
 
 1166:2527,{ bonus2 bAddRace,RC_Dragon,5; }
 1420:2115,{ bonus3 bAutoSpellWhenHit,"HP_ASSUMPTIO",2,5; }
-1420:2133,{ bonus2 bAddRace,RC_NonBoss,4; bonus2 bAddRace,RC_Boss,4; bonus bDef,2; }
-1421:2133,{ bonus2 bAddRace,RC_NonBoss,4; bonus2 bAddRace,RC_Boss,4; bonus bDef,2; }
-1422:2133,{ bonus2 bAddRace,RC_NonBoss,4; bonus2 bAddRace,RC_Boss,4; bonus bDef,2; }
+1420:2133,{ bonus2 bAddRace, RC_All, 4; bonus bDef,2; }
+1421:2133,{ bonus2 bAddRace, RC_All, 4; bonus bDef,2; }
+1422:2133,{ bonus2 bAddRace, RC_All, 4; bonus bDef,2; }
 1428:2115,{ bonus3 bAutoSpellWhenHit,"HP_ASSUMPTIO",2,5; }
 1472:2677,{ bonus bMatkRate,6; bonus bDex,2; bonus bCastrate,-getequiprefinerycnt(EQI_HAND_R); }
 1472:2711,{ bonus bMatkRate,6; bonus bDex,2; bonus bCastrate,-getequiprefinerycnt(EQI_HAND_R); }
@@ -67,8 +67,8 @@
 //2369:2428:2533:5306,{ bonus2 bSubRace,RC_DemiPlayer,10; bonus bMaxHPrate,20; bonus2 bResEff,Eff_Freeze,10000; skill "WZ_FIREPILLAR",10; }
 2371:2522,{ bonus bAgi,5; bonus bFlee,10; }
 2371:2523,{ bonus bAgi,5; bonus bFlee,10; }
-2374:2729,{ bonus2 bAddRace,RC_NonBoss,3; bonus2 bAddRace,RC_Boss,3; bonus bMatkRate,3; }
-2375:2729,{ bonus2 bAddRace,RC_NonBoss,3; bonus2 bAddRace,RC_Boss,3; bonus bMatkRate,3; }
+2374:2729,{ bonus2 bAddRace, RC_All, 3; bonus bMatkRate,3; }
+2375:2729,{ bonus2 bAddRace, RC_All, 3; bonus bMatkRate,3; }
 2376:2435:2538,{ bonus2 bSubRace,RC_NonDemiPlayer,-300; bonus bVit,3; bonus bMaxHPrate,12; bonus bHealPower2,10; bonus bAddItemHealRate,10; autobonus2 "{ bonus2 bHPRegenRate,600,1000; }",5,10000,BF_WEAPON,"{ specialeffect2 EF_HEAL; }"; }
 2377:2435:2538,{ bonus2 bSubRace,RC_NonDemiPlayer,-300; bonus bStr,3; bonus bMaxHPrate,12; bonus2 bSkillAtk,"MC_MAMMONITE",20; bonus2 bSkillHeal,"AM_POTIONPITCHER",10; bonus2 bSkillHeal2,"AM_POTIONPITCHER",10; bonus2 bSkillHeal2,"AL_HEAL",10; bonus bUnbreakableArmor,0; }
 2378:2435:2538,{ bonus2 bSubRace,RC_NonDemiPlayer,-300; bonus bAgi,3; bonus bMaxHPrate,12; bonus bCritical,5; bonus bAspdRate,5; autobonus "{ bonus2 bHPRegenRate,300,1000; }",10,10000,BF_WEAPON,"{ specialeffect2 EF_HEAL; }"; }
@@ -78,7 +78,7 @@
 2382:2437:2540,{ bonus2 bSubRace,RC_NonDemiPlayer,-300; bonus bDex,3; bonus bMaxHPrate,12; bonus bLongAtkDef,10; bonus bDelayrate,-25; }
 2387:2440:2744,{ bonus bMaxHPrate,7; bonus bMaxSPrate,7; bonus bCastrate,-3; bonus bDelayrate,-15; }
 2390:2749,{ bonus bFlee2,5; }
-2394:2444:2549,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,5; bonus2 bResEff,Eff_Freeze,10000; bonus2 bSkillHeal2,"AM_POTIONPITCHER",3; bonus2 bSkillHeal2,"AL_HEAL",3; bonus2 bSkillHeal2,"PR_SANCTUARY",3; }
+2394:2444:2549,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,5; bonus2 bResEff,Eff_Freeze,10000; bonus2 bSkillHeal2,"AM_POTIONPITCHER",3; bonus2 bSkillHeal2,"AL_HEAL",3; bonus2 bSkillHeal2,"PR_SANCTUARY",3; }
 2399:2553,{ bonus bAgi,5; bonus bFlee,15; }
 2408:2655,{ bonus bBaseAtk,50; bonus2 bAddDefClass,1196,20; bonus2 bAddDefClass,1197,20; }
 2424:2528,{ bonus bHPrecovRate,5; bonus bMaxHPrate,10; }
@@ -106,14 +106,14 @@
 2626:2786,{ bonus2 bSkillAtk,"AL_HEAL",50; bonus2 bSkillAtk,"PR_MAGNUS",30; bonus bSPrecovRate,9; }
 2678:2679,{ bonus4 bAutoSpell,"MO_EXTREMITYFIST",1,3,1; bonus3 bAutoSpell,"PR_LEXAETERNA",1,20; bonus3 bAutoSpell,"AS_SONICBLOW",5,50; bonus3 bAutoSpell,"MO_INVESTIGATE",5,20; bonus3 bAutoSpell,"ASC_METEORASSAULT",2,50; }
 //2679:2792,{ bonus4 bAutoSpell,"MO_EXTREMITYFIST",1,3,1; bonus3 bAutoSpell,"PR_LEXAETERNA",1,20; bonus3 bAutoSpell,"AS_SONICBLOW",5,50; bonus3 bAutoSpell,"MO_INVESTIGATE",5,20; bonus3 bAutoSpell,"ASC_METEORASSAULT",2,50; }
-2720:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2721:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2722:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2723:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2724:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2725:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
+2720:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2721:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2722:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2723:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2724:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2725:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
 2726:2727,{ bonus bUseSPrate,-25; }
-2733:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
+2733:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
 2777:2778:5479,{ bonus bMaxHP,300; bonus bMatkRate,5; bonus2 bSubEle,Ele_Neutral,5; }
 2779:2780:5482,{ bonus bMatkRate,10; bonus bInt,5; bonus2 bSubRace,RC_Angel,10; }
 2779:2780:5577,{ bonus bMatkRate,10; bonus bInt,5; bonus2 bSubRace,RC_Angel,10; }

--- a/db/pre-re/item_db.conf
+++ b/db/pre-re/item_db.conf
@@ -5729,10 +5729,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1178
@@ -6552,10 +6549,7 @@ item_db: (
 	WeaponLv: 4
 	EquipLv: 36
 	View: 1
-	Script: <"
-		bonus bDefRatioAtkRace,RC_Boss;
-		bonus bDefRatioAtkRace,RC_NonBoss;
-	">
+	Script: <" bonus bDefRatioAtkRace, RC_All; ">
 },
 {
 	Id: 1231
@@ -7342,10 +7336,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1273
@@ -9298,10 +9289,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1424
@@ -10042,8 +10030,7 @@ item_db: (
 	EquipLv: 65
 	View: 5
 	Script: <"
-		bonus bIgnoreDefRace,RC_NonBoss;
-		bonus bIgnoreDefRace,RC_Boss;
+		bonus bIgnoreDefRace, RC_All;
 		bonus2 bAddRace,RC_DemiPlayer,10;
 		bonus3 bAutoSpell,KN_PIERCE,5,30;
 	">
@@ -10285,8 +10272,7 @@ item_db: (
 	EquipLv: 1
 	View: 5
 	Script: <"
-		bonus bIgnoreDefRace,RC_NonBoss;
-		bonus bIgnoreDefRace,RC_Boss;
+		bonus bIgnoreDefRace, RC_All;
 		bonus2 bAddRace,RC_DemiPlayer,10;
 		bonus3 bAutoSpell,KN_PIERCE,5,30;
 	">
@@ -10926,10 +10912,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1537
@@ -11569,10 +11552,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1567
@@ -11977,8 +11957,7 @@ item_db: (
 		bonus2 bHPDrainRate,1000,100;
 		bonus2 bSPDrainRate,1000,20;
 		bonus bHealPower,200;
-		bonus2 bAddRace,RC_NonBoss,100;
-		bonus2 bAddRace,RC_Boss,100;
+		bonus2 bAddRace, RC_All, 100;
 		skill WZ_STORMGUST,10;
 		skill WZ_METEOR,10;
 		skill WZ_VERMILION,10;
@@ -12538,8 +12517,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bMatkRate,15;
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
+		bonus2 bAddRace, RC_All, 50;
 	">
 },
 {
@@ -13709,10 +13687,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1736
@@ -15280,10 +15255,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1922
@@ -15965,10 +15937,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1976
@@ -16804,10 +16773,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bSubRace,RC_NonBoss,25;
-		bonus2 bSubRace,RC_Boss,25;
-	">
+	Script: <" bonus2 bSubRace, RC_All, 25; ">
 },
 {
 	Id: 2128
@@ -16937,9 +16903,9 @@ item_db: (
 	EquipLv: 50
 	View: 4
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,1;
-		bonus2 bAddRace,RC_Boss,1;
-		if( Class==Job_Lord_Knight ) bonus bAspdRate,-5;
+		bonus2 bAddRace, RC_All, 1;
+		if (Class == Job_Lord_Knight)
+			bonus bAspdRate,-5;
 	">
 },
 {
@@ -19569,8 +19535,7 @@ item_db: (
 		bonus bMdef,10;
 		bonus bMaxHP,20*BaseLevel;
 		bonus bMaxSP,5*BaseLevel;
-		bonus2 bAddRace,RC_NonBoss,10;
-		bonus2 bAddRace,RC_Boss,10;
+		bonus2 bAddRace, RC_All, 10;
 		bonus bMatkRate,10;
 		bonus bUnbreakableArmor,0;
 		bonus bNoKnockback,0;
@@ -22276,8 +22241,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 	">
 },
@@ -23598,8 +23562,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bHit,10;
 		bonus bMaxHP,500;
@@ -23628,8 +23591,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bFlee,10;
 		bonus bMaxHP,300;
@@ -23658,8 +23620,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bMdef,6;
 		bonus bMaxHP,600;
@@ -23687,8 +23648,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bMdef,6;
 		bonus bMaxHP,600;
@@ -23716,8 +23676,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bCritical,10;
 		bonus bMaxHP,300;
@@ -23746,8 +23705,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bAspdRate,10;
 		bonus bMaxHP,500;
@@ -23919,8 +23877,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bCritical,10;
 		bonus bMaxHP,300;
@@ -24020,8 +23977,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,6;
-		bonus2 bAddRace,RC_Boss,6;
+		bonus2 bAddRace, RC_All, 6;
 		bonus bMatkRate,6;
 	">
 },
@@ -24044,8 +24000,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 	">
 },
@@ -24068,8 +24023,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,3;
-		bonus2 bAddRace,RC_Boss,3;
+		bonus2 bAddRace, RC_All, 3;
 		bonus bMatkRate,3;
 	">
 },
@@ -24294,8 +24248,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 	">
 },
@@ -24958,8 +24911,7 @@ item_db: (
 	EquipLv: 60
 	Refine: false
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,2;
-		bonus2 bAddRace,RC_Boss,2;
+		bonus2 bAddRace, RC_All, 2;
 		bonus bStr,1;
 		bonus bVit,1;
 	">
@@ -28951,8 +28903,7 @@ item_db: (
 	Weight: 10
 	Loc: 2
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,20;
-		bonus2 bAddRace,RC_Boss,20;
+		bonus2 bAddRace, RC_All, 20;
 		bonus3 bAutoSpell,SM_MAGNUM,10,30;
 	">
 },
@@ -30117,8 +30068,7 @@ item_db: (
 	Weight: 10
 	Loc: 2
 	Script: <"
-		bonus bDefRatioAtkRace,RC_Boss;
-		bonus bDefRatioAtkRace,RC_NonBoss;
+		bonus bDefRatioAtkRace, RC_All;
 		bonus bSPDrainValue,-1;
 		bonus bDef,-30;
 		bonus bFlee,-30;
@@ -30220,8 +30170,7 @@ item_db: (
 	Loc: 2
 	Script: <"
 		bonus bUnbreakableWeapon,0;
-		bonus2 bAddRace,RC_NonBoss,10;
-		bonus2 bAddRace,RC_Boss,10;
+		bonus2 bAddRace, RC_All, 10;
 		bonus3 bAutoSpell,SA_DISPELL,1,50;
 	">
 },
@@ -30470,12 +30419,10 @@ item_db: (
 	Weight: 10
 	Loc: 16
 	Script: <"
-		if(BaseJob==Job_Rogue) {
+		if (BaseJob == Job_Rogue) {
 			bonus bMatkRate,10;
-			bonus2 bAddRace,RC_NonBoss,10;
-			bonus2 bAddRace,RC_Boss,10;
+			bonus2 bAddRace, RC_All, 10;
 		}
-
 	">
 },
 {
@@ -31513,10 +31460,7 @@ item_db: (
 	Buy: 20
 	Weight: 10
 	Loc: 16
-	Script: <"
-		bonus2 bAddRace,RC_NonBoss,2;
-		bonus2 bAddRace,RC_Boss,2;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 2; ">
 },
 {
 	Id: 4767
@@ -31526,10 +31470,7 @@ item_db: (
 	Buy: 20
 	Weight: 10
 	Loc: 16
-	Script: <"
-		bonus2 bAddRace,RC_NonBoss,3;
-		bonus2 bAddRace,RC_Boss,3;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 3; ">
 },
 {
 	Id: 4768
@@ -34702,13 +34643,11 @@ item_db: (
 		bonus bMdef,7;
 		bonus bStr,1;
 		bonus bInt,1;
-		bonus2 bAddRace,RC_NonBoss,2;
-		bonus2 bAddRace,RC_Boss,2;
+		bonus2 bAddRace, RC_All, 2;
 		bonus bMatkRate,2;
 		bonus bHealPower,5;
-		if(getrefine()>=7) {
-			bonus2 bAddRace,RC_NonBoss,1;
-			bonus2 bAddRace,RC_Boss,1;
+		if (getrefine() >= 7) {
+			bonus2 bAddRace, RC_All, 1;
 			bonus bMatkRate,1;
 			bonus bHealPower,1;
 		}
@@ -36898,8 +36837,7 @@ item_db: (
 	Refine: false
 	View: 345
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,2;
-		bonus2 bAddRace,RC_Boss,2;
+		bonus2 bAddRace, RC_All, 2;
 		bonus bMatkRate,2;
 		bonus bDex,1;
 	">
@@ -38598,8 +38536,7 @@ item_db: (
 	View: 420
 	Script: <"
 		bonus bStr,1;
-		bonus2 bAddRace,RC_NonBoss,3;
-		bonus2 bAddRace,RC_Boss,3;
+		bonus2 bAddRace, RC_All, 3;
 		bonus bUseSPrate,10;
 	">
 },
@@ -40484,8 +40421,7 @@ item_db: (
 	EquipLv: 1
 	View: 515
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,4;
-		bonus2 bAddRace,RC_Boss,4;
+		bonus2 bAddRace, RC_All, 4;
 		bonus bMatkRate,4;
 	">
 },
@@ -41393,8 +41329,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bStr,1;
-		bonus2 bAddRace,RC_NonBoss,2;
-		bonus2 bAddRace,RC_Boss,2;
+		bonus2 bAddRace, RC_All, 2;
 		bonus bAspdRate,2;
 	">
 },
@@ -43417,14 +43352,12 @@ item_db: (
 	EquipLv: 50
 	View: 613
 	Script: <"
-		if(getrefine()>6) {
-			bonus2 bAddRace,RC_NonBoss,2;
-			bonus2 bAddRace,RC_Boss,2;
+		if (getrefine() > 6) {
+			bonus2 bAddRace, RC_All, 2;
 			bonus bMatkRate,2;
 		}
-		if(getrefine()>8) {
-			bonus2 bAddRace,RC_NonBoss,2;
-			bonus2 bAddRace,RC_Boss,2;
+		if (getrefine() > 8) {
+			bonus2 bAddRace, RC_All, 2;
 			bonus bMatkRate,2;
 		}
 
@@ -45653,10 +45586,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,5;
-		bonus2 bExpAddRace,RC_NonBoss,5;
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, 5; ">
 },
 {
 	Id: 5822
@@ -71780,10 +71710,7 @@ item_db: (
 	WeaponLv: 4
 	EquipLv: 36
 	View: 1
-	Script: <"
-		bonus bDefRatioAtkRace,RC_Boss;
-		bonus bDefRatioAtkRace,RC_NonBoss;
-	">
+	Script: <" bonus bDefRatioAtkRace, RC_All; ">
 },
 {
 	Id: 13018
@@ -72047,10 +71974,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 13030
@@ -72218,7 +72142,7 @@ item_db: (
 		bonus bAgi,1;
 		bonus2 bAddRace,RC_DemiPlayer,75;
 		bonus bUnbreakableWeapon,0;
-		autobonus "{ bonus bDefRatioAtkRace,RC_Boss; bonus bDefRatioAtkRace,RC_NonBoss; }",10,6000,BF_WEAPON,"{ specialeffect2 EF_HASTEUP; }";
+		autobonus "{ bonus bDefRatioAtkRace, RC_All; }",10,6000,BF_WEAPON,"{ specialeffect2 EF_HASTEUP; }";
 		if(Class==Job_Ninja||Class==Job_Rogue||Class==Job_Stalker) bonus bMatkRate,15;
 	">
 },
@@ -72465,7 +72389,7 @@ item_db: (
 	View: 1
 	Script: <"
 		bonus3 bAddEffOnSkill,RG_RAID,Eff_Poison,1000;
-		autobonus "{ bonus2 bAddRace,RC_NonBoss,10; bonus2 bAddRace,RC_Boss,10; }",5,5000,BF_WEAPON|BF_SHORT,"{ specialeffect2 EF_POTION_BERSERK; }";
+		autobonus "{ bonus2 bAddRace, RC_All, 10; }",5,5000,BF_WEAPON|BF_SHORT,"{ specialeffect2 EF_POTION_BERSERK; }";
 	">
 },
 {
@@ -72681,8 +72605,7 @@ item_db: (
 	Script: <"
 		bonus bHit,readparam(bAgi)/10;
 		bonus bAspdRate,readparam(bAgi)/14;
-		bonus2 bAddRace,RC_NonBoss,10;
-		bonus2 bAddRace,RC_Boss,10;
+		bonus2 bAddRace, RC_All, 10;
 		bonus bMatkRate,10;
 	">
 },
@@ -73394,9 +73317,8 @@ item_db: (
 			bonus2 bAddRace,RC_DemiPlayer,(getrefine()-4)*(getrefine()-4);
 			bonus2 bIgnoreDefRate,RC_DemiPlayer,5;
 		}
-		if(getrefine()>8) {
-			bonus2 bAddRace,RC_Boss,getrefine();
-			bonus2 bAddRace,RC_NonBoss,getrefine();
+		if (getrefine() > 8) {
+			bonus2 bAddRace, RC_All, getrefine();
 		}
 
 	">
@@ -74596,10 +74518,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 13407

--- a/db/re/item_combo_db.txt
+++ b/db/re/item_combo_db.txt
@@ -17,9 +17,9 @@
 1408:5782,{ bonus bAtkRate,3; }
 1409:5782,{ bonus bAtkRate,3; }
 1420:2115,{ bonus3 bAutoSpellWhenHit,HP_ASSUMPTIO,2,5; }
-1420:2133,{ bonus2 bAddRace,RC_NonBoss,4; bonus2 bAddRace,RC_Boss,4; bonus bDef,2; }
-1421:2133,{ bonus2 bAddRace,RC_NonBoss,4; bonus2 bAddRace,RC_Boss,4; bonus bDef,2; }
-1422:2133,{ bonus2 bAddRace,RC_NonBoss,4; bonus2 bAddRace,RC_Boss,4; bonus bDef,2; }
+1420:2133,{ bonus2 bAddRace, RC_All, 4; bonus bDef,2; }
+1421:2133,{ bonus2 bAddRace, RC_All, 4; bonus bDef,2; }
+1422:2133,{ bonus2 bAddRace, RC_All, 4; bonus bDef,2; }
 1428:2115,{ bonus3 bAutoSpellWhenHit,HP_ASSUMPTIO,2,5; }
 1433:2153,{ bonus2 bSkillAtk,CR_GRANDCROSS,10; bonus2 bSkillAtk,LG_RAYOFGENESIS,10; }
 1433:2153:18823:28372,{ bonus2 bSkillUseSP,CR_GRANDCROSS,30; bonus2 bSkillUseSP,LG_SHIELDPRESS,5; bonus2 bSkillUseSP,LG_BANISHINGPOINT,15; bonus2 bSkillUseSP,LG_CANNONSPEAR,10; }
@@ -104,7 +104,7 @@
 2171:15056,{ bonus bAgi,2; }
 2173:15055,{ bonus bFlee,10; bonus bFlee2,10; }
 2198:5966,{ if (isequipped(4441)) {} else { if(getequiprefinerycnt(EQI_HAND_L)>6) { bonus2 bSkillCooldown,WL_COMET,-20000; } if(getequiprefinerycnt(EQI_HAND_L)>9) { bonus2 bSkillCooldown,WL_COMET,-20000; } } }
-2254:18912,{ bonus2 bExpAddRace,RC_NonBoss,5; bonus2 bExpAddRace,RC_Boss,5; }
+2254:18912,{ bonus2 bExpAddRace, RC_All, 5; }
 2269:5781,{ bonus bMaxSP,30; bonus bInt,1; }
 2269:5786,{ bonus bMatkRate,1; }
 2269:5891,{ bonus bAllStats,1; }
@@ -134,8 +134,8 @@
 2369:2428:2533:5306,{ bonus2 bSubRace,RC_DemiPlayer,10; bonus bMaxHPrate,20; bonus2 bResEff,Eff_Freeze,10000; skill WZ_FIREPILLAR,10; }
 2371:2522,{ bonus bAgi,5; bonus bFlee,10; }
 2371:2523,{ bonus bAgi,5; bonus bFlee,10; }
-2374:2729,{ bonus2 bAddRace,RC_NonBoss,3; bonus2 bAddRace,RC_Boss,3; bonus bMatkRate,3; }
-2375:2729,{ bonus2 bAddRace,RC_NonBoss,3; bonus2 bAddRace,RC_Boss,3; bonus bMatkRate,3; }
+2374:2729,{ bonus2 bAddRace, RC_All, 3; bonus bMatkRate,3; }
+2375:2729,{ bonus2 bAddRace, RC_All, 3; bonus bMatkRate,3; }
 2376:2435:2538,{ bonus2 bSubRace,RC_NonDemiPlayer,-300; bonus bVit,3; bonus bMaxHPrate,12; bonus bHealPower2,10; bonus bAddItemHealRate,10; autobonus2 "{ bonus2 bHPRegenRate,600,1000; }",5,10000,BF_WEAPON,"{ specialeffect2 EF_HEAL; }"; }
 2377:2435:2538,{ bonus2 bSubRace,RC_NonDemiPlayer,-300; bonus bStr,3; bonus bMaxHPrate,12; bonus2 bSkillAtk,MC_MAMMONITE,20; bonus2 bSkillHeal,AM_POTIONPITCHER,10; bonus2 bSkillHeal2,AM_POTIONPITCHER,10; bonus2 bSkillHeal2,AL_HEAL,10; bonus bUnbreakableArmor,0; }
 2378:2435:2538,{ bonus2 bSubRace,RC_NonDemiPlayer,-300; bonus bAgi,3; bonus bMaxHPrate,12; bonus bCritical,5; bonus bAspdRate,5; autobonus "{ bonus2 bHPRegenRate,300,1000; }",10,10000,BF_WEAPON,"{ specialeffect2 EF_HEAL; }"; }
@@ -145,7 +145,7 @@
 2382:2437:2540,{ bonus2 bSubRace,RC_NonDemiPlayer,-300; bonus bDex,3; bonus bMaxHPrate,12; bonus bLongAtkDef,10; bonus bDelayrate,-25; }
 2387:2440:2744,{ bonus bMaxHPrate,7; bonus bMaxSPrate,7; bonus bVariableCastrate,-3; bonus bDelayrate,-15; }
 2390:2749,{ bonus bFlee2,5; }
-2394:2444:2549,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,5; bonus2 bResEff,Eff_Freeze,10000; bonus2 bSkillHeal2,AM_POTIONPITCHER,3; bonus2 bSkillHeal2,AL_HEAL,3; bonus2 bSkillHeal2,PR_SANCTUARY,3; }
+2394:2444:2549,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,5; bonus2 bResEff,Eff_Freeze,10000; bonus2 bSkillHeal2,AM_POTIONPITCHER,3; bonus2 bSkillHeal2,AL_HEAL,3; bonus2 bSkillHeal2,PR_SANCTUARY,3; }
 2399:2553,{ bonus bAgi,5; bonus bFlee,15; }
 2408:2655,{ bonus bBaseAtk,50; bonus2 bAddDefClass,1196,20; bonus2 bAddDefClass,1197,20; }
 2424:2528,{ bonus bHPrecovRate,5; bonus bMaxHPrate,10; }
@@ -160,9 +160,9 @@
 2472:2570:15030:16013,{ bonus2 bAddRace,RC_Undead,15; bonus2 bMagicAddRace,RC_Undead,15; bonus2 bSkillAtk,AB_ADORAMUS,100; }
 2472:2570:15030:16018,{ bonus2 bAddRace,RC_Undead,30; bonus2 bMagicAddRace,RC_Undead,30; bonus2 bSkillAtk,AB_ADORAMUS,200; bonus bVariableCastrate,-50; }
 2475:2574:2883:15036,{ bonus bMaxHPrate,14; bonus2 bSkillAtk,RK_HUNDREDSPEAR,50; skill CR_AUTOGUARD,1; bonus bUseSPrate,10; bonus2 bSubEle,Ele_Neutral,10; }
-2476:2575:2884:15037,{ bonus2 bAddRace,RC_NonBoss,10; bonus2 bAddRace,RC_Boss,10; bonus2 bSkillAtk,RK_SONICWAVE,100; bonus2 bSkillAtk,RK_WINDCUTTER,100; bonus3 bAutoSpell,RK_STORMBLAST,1,20; autobonus3 "{ bonus bAspd,2; }",1000,10000,LK_CONCENTRATION,"{ specialeffect2 EF_ENHANCE; }"; }
+2476:2575:2884:15037,{ bonus2 bAddRace, RC_All, 10; bonus2 bSkillAtk,RK_SONICWAVE,100; bonus2 bSkillAtk,RK_WINDCUTTER,100; bonus3 bAutoSpell,RK_STORMBLAST,1,20; autobonus3 "{ bonus bAspd,2; }",1000,10000,LK_CONCENTRATION,"{ specialeffect2 EF_ENHANCE; }"; }
 2477:2577:2886:15038,{ bonus bCritical,15; bonus bFlee,10; bonus bCritAtkRate,40; bonus2 bSkillAtk,GC_CROSSIMPACT,20; bonus bUseSPrate,10; }
-2478:2578:2887:15039,{ bonus2 bAddRace,RC_NonBoss,10; bonus2 bAddRace,RC_Boss,10; bonus bMatkRate,10; if(readparam(bStr)>119) { bonus bBaseAtk,30; } bonus3 bAutoSpell,ASC_BREAKER,getskilllv(ASC_BREAKER),10; bonus bCritical,-20; }
+2478:2578:2887:15039,{ bonus2 bAddRace, RC_All, 10; bonus bMatkRate,10; if(readparam(bStr)>119) { bonus bBaseAtk,30; } bonus3 bAutoSpell,ASC_BREAKER,getskilllv(ASC_BREAKER),10; bonus bCritical,-20; }
 2479:2580:2890:15042,{ bonus bAspd,2; bonus bLongAtkRate,30; bonus3 bAutoSpell,AC_DOUBLE,3,10; bonus2 bSkillAtk,RA_ARROWSTORM,50; }
 2480:2581:2891:15043,{ bonus bMaxHPrate,15; bonus2 bSkillAtk,RA_CLUSTERBOMB,20; bonus bFlee2,20; bonus bLongAtkRate,-30; bonus bAspd,-7; }
 2483:2586:15046,{ bonus bVit,5; bonus2 bSubRace,RC_DemiPlayer,15; }
@@ -190,14 +190,14 @@
 2678:2679,{ bonus4 bAutoSpell,MO_EXTREMITYFIST,1,3,1; bonus3 bAutoSpell,PR_LEXAETERNA,1,20; bonus3 bAutoSpell,AS_SONICBLOW,5,50; bonus3 bAutoSpell,MO_INVESTIGATE,5,20; bonus3 bAutoSpell,ASC_METEORASSAULT,2,50; }
 2679:2792,{ bonus4 bAutoSpell,MO_EXTREMITYFIST,1,3,1; bonus3 bAutoSpell,PR_LEXAETERNA,1,20; bonus3 bAutoSpell,AS_SONICBLOW,5,50; bonus3 bAutoSpell,MO_INVESTIGATE,5,20; bonus3 bAutoSpell,ASC_METEORASSAULT,2,50; }
 2701:2881,{ bonus bMatk,20; }
-2720:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2721:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2722:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2723:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2724:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
-2725:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
+2720:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2721:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2722:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2723:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2724:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
+2725:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
 2726:2727,{ bonus bUseSPrate,-25; }
-2733:2772,{ bonus2 bAddRace,RC_NonBoss,5; bonus2 bAddRace,RC_Boss,5; bonus bMatkRate,3; bonus bHealPower,5; }
+2733:2772,{ bonus2 bAddRace, RC_All, 5; bonus bMatkRate,3; bonus bHealPower,5; }
 2747:13061,{ bonus bHit,5; bonus bMatk,5; bonus2 bSkillUseSP,SC_ENERVATION,20; bonus2 bSkillUseSP,SC_GROOMY,20;}
 2777:2778:5479,{ bonus bMaxHP,300; bonus bMatkRate,5; bonus2 bSubEle,Ele_Neutral,5; }
 2779:2780:5482,{ bonus bMatkRate,10; bonus bInt,5; bonus2 bSubRace,RC_Angel,10; }
@@ -267,7 +267,7 @@
 4653:4654,{ bonus2 bSubRace,RC_Brute,5; bonus2 bSubRace,RC_Undead,5; bonus2 bIgnoreMdefRate,50,RC_Brute; bonus2 bIgnoreMdefRate,50,RC_Undead; }
 4653:4655,{ bonus2 bSubRace,RC_Brute,5; bonus2 bSubRace,RC_Undead,5; bonus2 bIgnoreDefRate,50,RC_Brute; bonus2 bIgnoreDefRate,50,RC_Undead; }
 //4656:4657,{ bonus2 bSubEle,Ele_Neutral,5; /* Increase the probability of causing Sleep to all targets on 11x11 cells. */ }
-5007:18913,{ bonus2 bExpAddRace,RC_NonBoss,5; bonus2 bExpAddRace,RC_Boss,5; }
+5007:18913,{ bonus2 bExpAddRace, RC_All, 5; }
 5021:18824,{ bonus bMaxHP,100; bonus2 bSubEle,Ele_Neutral,getequiprefinerycnt(EQI_HEAD_TOP); }
 5040:5442,{ bonus bAspdRate,3; bonus bVariableCastrate,3; }
 5040:18672,{ bonus bSPrecovRate,3; }
@@ -284,7 +284,7 @@
 5401:5653,{ bonus bInt,1; bonus bMatkRate,2; }
 5470:5653,{ bonus bDex,1; bonus bLongAtkRate,3; }
 5690:13428,{ bonus2 bAddRace,RC_DemiPlayer,10; bonus bHit,10; }
-5890:28306,{ bonus2 bAddRace,RC_Boss,3; bonus2 bAddRace,RC_NonBoss,3; }
+5890:28306,{ bonus2 bAddRace, RC_All, 3; }
 5932:1737,{ if (Class == Job_Ranger || Class == Job_Ranger_T) skill HT_BLITZBEAT,5*getequiprefinerycnt(EQI_HAND_R); }
 //5967:28321,{ skill HT_BLITZBEAT,-200; }
 13027:15044,{ bonus3 bAddMonsterDropItem,929,RC_Brute,100+(getequiprefinerycnt(EQI_HAND_R)*10); bonus3 bAddMonsterDropItem,929,RC_DemiPlayer,100+(getequiprefinerycnt(EQI_HAND_R)*10); bonus3 bAddMonsterDropItem,970,RC_Brute,20+(getequiprefinerycnt(EQI_HAND_R)*2); bonus3 bAddMonsterDropItem,970,RC_DemiPlayer,20+(getequiprefinerycnt(EQI_HAND_R)*2); }
@@ -333,7 +333,7 @@
 20718:22009,{ bonus bMaxHPrate,15; bonus bMaxSPrate,5; }
 20718:22010,{ bonus bMaxHPrate,15; bonus bMaxSPrate,5; }
 20718:22011,{ bonus bMaxHPrate,15; bonus bMaxSPrate,5; }
-20732:28101,{ bonus2 bAddRace,RC_NonBoss,25; bonus2 bAddRace,RC_Boss,25; }
+20732:28101,{ bonus2 bAddRace, RC_All, 25; }
 22016:28320,{ bonus2 bAddRace,RC_DemiPlayer,getequiprefinerycnt(EQI_SHOES); bonus2 bAddRace,RC_Player,getequiprefinerycnt(EQI_SHOES); }
 28326:28327,{ bonus bInt,8; bonus bStr,8; }
 
@@ -413,10 +413,10 @@
 // 24194:24206,{ /* Reduces physical and magical damage received from Ghost property monsters by 2% */ }
 // 24195:24207,{ /* Reduces physical and magical damage received from Undead property monsters by 2% */ }
 24196:24197,{ bonus bFlee,5; if(getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_ARMOR)>=15) bonus bSpeedAddRate,3; }
-24208:24209,{ bonus2 bExpAddRace,RC_Boss,((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?10:1); bonus2 bExpAddRace,RC_NonBoss,((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?10:1); }
-24210:24211,{ bonus2 bExpAddRace,RC_Boss,((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?20:10); bonus2 bExpAddRace,RC_NonBoss,((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?20:10); }
-24212:24213,{ bonus2 bExpAddRace,RC_Boss,((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?10:5); bonus2 bExpAddRace,RC_NonBoss,((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?10:5); }
-24214:24215,{ bonus2 bExpAddRace,RC_Boss,((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?4:2); bonus2 bExpAddRace,RC_NonBoss,((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?4:2); }
+24208:24209,{ bonus2 bExpAddRace, RC_All, ((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?10:1); }
+24210:24211,{ bonus2 bExpAddRace, RC_All, ((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?20:10); }
+24212:24213,{ bonus2 bExpAddRace, RC_All, ((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?10:5); }
+24214:24215,{ bonus2 bExpAddRace, RC_All, ((getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_SHIELD))>=15?4:2); }
 24217:24218,{ if(getequiprefinerycnt(EQI_SHADOW_ACC_R)+getequiprefinerycnt(EQI_SHADOW_ACC_L)>=15) bonus bAspd,1; }
 //24223:Enhanced Force Shadow Earring:Enhanced Force Shadow Pendant,{ .@refine = getequiprefinerycnt(EQI_SHADOW_WEAPON)+getequiprefinerycnt(EQI_SHADOW_ACC_R)+getequiprefinerycnt(EQI_SHADOW_ACC_L); if(.@refine)>=25 {bonus bAtkRate,2;} else if(.@refine)>=20 {bonus bAtkRate,1;} bonus bAtkRate,1; }
 24224:24225:24226,{ .@refine = getequiprefinerycnt(EQI_SHADOW_WEAPON)+getequiprefinerycnt(EQI_SHADOW_ACC_R)+getequiprefinerycnt(EQI_SHADOW_ACC_L); if(.@refine)>=25 { bonus bAtkRate,2; } else if(.@refine)>=20 { bonus bAtkRate,1; } bonus bAtk2,10; }

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -5514,10 +5514,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1178
@@ -6521,10 +6518,7 @@ item_db: (
 	WeaponLv: 4
 	EquipLv: 36
 	View: 1
-	Script: <"
-		bonus bDefRatioAtkRace,RC_Boss;
-		bonus bDefRatioAtkRace,RC_NonBoss;
-	">
+	Script: <" bonus bDefRatioAtkRace, RC_All; ">
 },
 {
 	Id: 1231
@@ -7316,10 +7310,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1273
@@ -9903,10 +9894,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1424
@@ -10840,8 +10828,7 @@ item_db: (
 	EquipLv: 65
 	View: 5
 	Script: <"
-		bonus bIgnoreDefRace,RC_NonBoss;
-		bonus bIgnoreDefRace,RC_Boss;
+		bonus bIgnoreDefRace, RC_All;
 		bonus2 bAddRace,RC_DemiPlayer,10;
 		bonus3 bAutoSpell,KN_PIERCE,5,30;
 	">
@@ -11093,8 +11080,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus bIgnoreDefRace,RC_NonBoss;
-		bonus bIgnoreDefRace,RC_Boss;
+		bonus bIgnoreDefRace, RC_All;
 		bonus2 bAddRace,RC_DemiPlayer,10;
 		bonus3 bAutoSpell,KN_PIERCE,5,30;
 	">
@@ -11968,10 +11954,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1537
@@ -12626,10 +12609,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1567
@@ -13300,8 +13280,7 @@ item_db: (
 		bonus2 bHPDrainRate,1000,100;
 		bonus2 bSPDrainRate,1000,20;
 		bonus bHealPower,200;
-		bonus2 bAddRace,RC_NonBoss,100;
-		bonus2 bAddRace,RC_Boss,100;
+		bonus2 bAddRace, RC_All, 100;
 		skill WZ_STORMGUST,10;
 		skill WZ_METEOR,10;
 		skill WZ_VERMILION,10;
@@ -13858,8 +13837,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bInt,4;
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
+		bonus2 bAddRace, RC_All, 50;
 	">
 },
 {
@@ -14960,10 +14938,8 @@ item_db: (
 			.@val = 1;
 			bonus4 bAutoSpell,HW_MAGICPOWER,1,10,0;
 		}
-		if (getrefine()>=4) {
-			.@rate = 5*(.@val+1);
-			bonus2 bMagicAddRace,RC_Boss,.@rate;
-			bonus2 bMagicAddRace,RC_NonBoss,.@rate;
+		if (getrefine() >= 4) {
+			bonus2 bMagicAddRace, RC_All, 5*(.@val+1);
 		}
 	">
 },
@@ -15619,10 +15595,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1736
@@ -17529,10 +17502,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1922
@@ -18490,10 +18460,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 1976
@@ -20113,10 +20080,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bSubRace,RC_NonBoss,25;
-		bonus2 bSubRace,RC_Boss,25;
-	">
+	Script: <" bonus2 bSubRace, RC_All, 25; ">
 },
 {
 	Id: 2128
@@ -20244,9 +20208,9 @@ item_db: (
 	EquipLv: 50
 	View: 4
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,1;
-		bonus2 bAddRace,RC_Boss,1;
-		if( Class == Job_Lord_Knight ) bonus bAspdRate,-5;
+		bonus2 bAddRace, RC_All, 1;
+		if (Class == Job_Lord_Knight)
+			bonus bAspdRate,-5;
 	">
 },
 {
@@ -21070,8 +21034,7 @@ item_db: (
 	View: 2
 	Script: <"
 		bonus bMdef,5;
-		bonus2 bSubRace,RC_NonBoss,30;
-		bonus2 bSubRace,RC_Boss,30;
+		bonus2 bSubRace, RC_All, 30;
 		bonus bUnbreakableShield,1;
 	">
 },
@@ -21091,8 +21054,7 @@ item_db: (
 	Script: <"
 		bonus bVit,20;
 		bonus bMdef,10;
-		bonus2 bAddRaceTolerance,RC_NonBoss,30;
-		bonus2 bAddRaceTolerance,RC_Boss,30;
+		bonus2 bAddRaceTolerance, RC_All, 30;
 		bonus bUnbreakableShield,0;
 /* When you receive Melee Physical damage, chance of casting Protective Light for 60 seconds. */
 /* Cancels Stun, Sleep, Curse, Stone Curse, Poison, Blind, Silence, Bleeding, Chaos, and Frozen. */
@@ -23854,8 +23816,7 @@ item_db: (
 		bonus bMdef,10;
 		bonus bMaxHP,20*BaseLevel;
 		bonus bMaxSP,5*BaseLevel;
-		bonus2 bAddRace,RC_NonBoss,10;
-		bonus2 bAddRace,RC_Boss,10;
+		bonus2 bAddRace, RC_All, 10;
 		bonus bMatkRate,10;
 		bonus bUnbreakableArmor,0;
 		bonus bNoKnockback,0;
@@ -28286,10 +28247,8 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
-		bonus2 bMagicAddRace,RC_NonBoss,5;
-		bonus2 bMagicAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
+		bonus2 bMagicAddRace, RC_All, 5;
 	">
 },
 {
@@ -29641,8 +29600,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bHit,10;
 		bonus bMaxHP,500;
@@ -29671,8 +29629,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bFlee,10;
 		bonus bMaxHP,300;
@@ -29701,8 +29658,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bMdef,6;
 		bonus bMaxHP,600;
@@ -29730,8 +29686,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bMdef,6;
 		bonus bMaxHP,600;
@@ -29759,8 +29714,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bCritical,10;
 		bonus bMaxHP,300;
@@ -29789,8 +29743,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bAspdRate,10;
 		bonus bMaxHP,500;
@@ -29964,8 +29917,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bCritical,10;
 		bonus bMaxHP,300;
@@ -30067,8 +30019,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,6;
-		bonus2 bAddRace,RC_Boss,6;
+		bonus2 bAddRace, RC_All, 6;
 		bonus bMatkRate,6;
 	">
 },
@@ -30091,8 +30042,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 	">
 },
@@ -30115,8 +30065,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,3;
-		bonus2 bAddRace,RC_Boss,3;
+		bonus2 bAddRace, RC_All, 3;
 		bonus bMatkRate,3;
 	">
 },
@@ -30353,8 +30302,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 	">
 },
@@ -32009,8 +31957,7 @@ item_db: (
 		bonus bInt,2;
 		bonus bDex,2;
 		bonus bMdef,2;
-		bonus2 bExpAddRace,RC_Boss,10;
-		bonus2 bExpAddRace,RC_NonBoss,10;
+		bonus2 bExpAddRace, RC_All, 10;
 	">
 },
 {
@@ -32399,10 +32346,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,5;
-		bonus2 bExpAddRace,RC_NonBoss,5;
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, 5; ">
 },
 {
 	Id: 2864
@@ -32597,8 +32541,7 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 	">
 },
@@ -32757,8 +32700,7 @@ item_db: (
 	Script: <"
 		bonus bBaseAtk,30;
 		bonus bMatk,30;
-		bonus2 bExpAddRace,RC_Boss,15;
-		bonus2 bExpAddRace,RC_NonBoss,15;
+		bonus2 bExpAddRace, RC_All, 15;
 		skill CR_AUTOGUARD,3;
 		skill AL_CURE,1;
 	">
@@ -32953,11 +32895,9 @@ item_db: (
 		noauction: true
 	}
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
-		bonus2 bExpAddRace,RC_Boss,1;
-		bonus2 bExpAddRace,RC_NonBoss,1;
+		bonus2 bExpAddRace, RC_All, 1;
 	">
 },
 {
@@ -33132,8 +33072,7 @@ item_db: (
 	Loc: 136
 	Refine: false
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,7;
-		bonus2 bAddRace,RC_Boss,7;
+		bonus2 bAddRace, RC_All, 7;
 		bonus bAspdRate,10;
 	">
 },
@@ -33650,10 +33589,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,10;
-		bonus2 bExpAddRace,RC_NonBoss,10;
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, 10; ">
 },
 {
 	Id: 2959
@@ -33722,10 +33658,7 @@ item_db: (
 	Weight: 200
 	Loc: 136
 	Refine: false
-	Script: <"
-		bonus2 bAddRace,RC_NonBoss,1;
-		bonus2 bAddRace,RC_Boss,1;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 1; ">
 },
 {
 	Id: 2967
@@ -33737,10 +33670,7 @@ item_db: (
 	Slots: 1
 	Loc: 136
 	Refine: false
-	Script: <"
-		bonus2 bAddRace,RC_NonBoss,1;
-		bonus2 bAddRace,RC_Boss,1;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 1; ">
 },
 {
 	Id: 2968
@@ -37490,8 +37420,7 @@ item_db: (
 	Weight: 10
 	Loc: 2
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,20;
-		bonus2 bAddRace,RC_Boss,20;
+		bonus2 bAddRace, RC_All, 20;
 		bonus3 bAutoSpell,SM_MAGNUM,10,30;
 	">
 },
@@ -38649,8 +38578,7 @@ item_db: (
 	Weight: 10
 	Loc: 2
 	Script: <"
-		bonus bDefRatioAtkRace,RC_Boss;
-		bonus bDefRatioAtkRace,RC_NonBoss;
+		bonus bDefRatioAtkRace, RC_All;
 		bonus bSPDrainValue,-1;
 		bonus bDef,-30;
 		bonus bFlee,-30;
@@ -38751,8 +38679,7 @@ item_db: (
 	Loc: 2
 	Script: <"
 		bonus bUnbreakableWeapon,0;
-		bonus2 bAddRace,RC_NonBoss,10;
-		bonus2 bAddRace,RC_Boss,10;
+		bonus2 bAddRace, RC_All, 10;
 		bonus3 bAutoSpell,SA_DISPELL,1,50;
 	">
 },
@@ -39001,10 +38928,9 @@ item_db: (
 	Weight: 10
 	Loc: 16
 	Script: <"
-		if(BaseJob==Job_Rogue) {
+		if (BaseJob == Job_Rogue) {
 			bonus bMatkRate,10;
-			bonus2 bAddRace,RC_NonBoss,10;
-			bonus2 bAddRace,RC_Boss,10;
+			bonus2 bAddRace, RC_All, 10;
 		}
 	">
 },
@@ -39895,9 +39821,7 @@ item_db: (
 	Weight: 10
 	Loc: 2
 	Script: <"
-		.@rate = (getrefine()>14)?15:10;
-		bonus2 bAddRace,RC_NonBoss,.@rate;
-		bonus2 bAddRace,RC_Boss,.@rate;
+		bonus2 bAddRace, RC_All, (getrefine() > 14) ? 15 : 10;
 		bonus3 bAutoSpell,SM_MAGNUM,10,15;
 	">
 },
@@ -40352,8 +40276,7 @@ item_db: (
 	Weight: 10
 	Loc: 769
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,2+(getrefine()/2);
-		bonus2 bAddRace,RC_Boss,2+(getrefine()/2);
+		bonus2 bAddRace, RC_All, 2+(getrefine()/2);
 		bonus bMaxSPrate,-getrefine()/2;
 	">
 },
@@ -40588,10 +40511,9 @@ item_db: (
 	Weight: 10
 	Loc: 16
 	Script: <"
-		if(BaseJob==Job_Rogue) {
+		if (BaseJob == Job_Rogue) {
 			bonus bMatkRate,10;
-			bonus2 bAddRace,RC_NonBoss,10;
-			bonus2 bAddRace,RC_Boss,10;
+			bonus2 bAddRace, RC_All, 10;
 		}
 		bonus bMaxHPrate,getrefine()/2;
 		bonus3 bAddEffOnSkill,SC_BODYPAINT,Eff_Confusion,100;
@@ -41053,8 +40975,7 @@ item_db: (
 	Loc: 2
 	Script: <"
 		bonus bCritAtkRate,30;
-		bonus2 bSubRace,RC_NonBoss,-10;
-		bonus2 bSubRace,RC_Boss,-10;
+		bonus2 bSubRace, RC_All, -10;
 	">
 },
 {
@@ -44034,9 +43955,8 @@ item_db: (
 		if(getrefine()>7) {
 			bonus bStr,3;
 		}
-		if(getrefine()>8) {
-			bonus2 bAddRace,RC_NonBoss,1;
-			bonus2 bAddRace,RC_Boss,1;
+		if (getrefine() > 8) {
+			bonus2 bAddRace, RC_All, 1;
 		}
 		if(getrefine()>11) {
 			bonus bAspd,1;
@@ -44056,9 +43976,8 @@ item_db: (
 		if(getrefine()>7) {
 			bonus bAgi,3;
 		}
-		if(getrefine()>8) {
-			bonus2 bAddRace,RC_NonBoss,1;
-			bonus2 bAddRace,RC_Boss,1;
+		if (getrefine() > 8) {
+			bonus2 bAddRace, RC_All, 1;
 		}
 		if(getrefine()>11) {
 			bonus bAspd,1;
@@ -47245,13 +47164,11 @@ item_db: (
 		bonus bMdef,7;
 		bonus bStr,1;
 		bonus bInt,1;
-		bonus2 bAddRace,RC_NonBoss,2;
-		bonus2 bAddRace,RC_Boss,2;
+		bonus2 bAddRace, RC_All, 2;
 		bonus bMatkRate,2;
 		bonus bHealPower,5;
-		if(getrefine()>=7) {
-			bonus2 bAddRace,RC_NonBoss,1;
-			bonus2 bAddRace,RC_Boss,1;
+		if (getrefine() >= 7) {
+			bonus2 bAddRace, RC_All, 1;
 			bonus bMatkRate,1;
 			bonus bHealPower,1;
 		}
@@ -49231,8 +49148,7 @@ item_db: (
 	View: 345
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bAddRace,RC_NonBoss,2;
-		bonus2 bAddRace,RC_Boss,2;
+		bonus2 bAddRace, RC_All, 2;
 		bonus bMatkRate,2;
 		bonus bDex,1;
 	">
@@ -50441,8 +50357,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bExpAddRace,RC_Boss,100;
-		bonus2 bExpAddRace,RC_NonBoss,100;
+		bonus2 bExpAddRace, RC_All, 100;
 	">
 },
 {
@@ -50894,8 +50809,7 @@ item_db: (
 	View: 420
 	Script: <"
 		bonus bStr,1;
-		bonus2 bAddRace,RC_NonBoss,3;
-		bonus2 bAddRace,RC_Boss,3;
+		bonus2 bAddRace, RC_All, 3;
 		bonus bUseSPrate,10;
 	">
 },
@@ -52660,8 +52574,7 @@ item_db: (
 	Loc: 768
 	View: 515
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,4;
-		bonus2 bAddRace,RC_Boss,4;
+		bonus2 bAddRace, RC_All, 4;
 		bonus bMatkRate,4;
 	">
 },
@@ -53330,8 +53243,7 @@ item_db: (
 	Loc: 768
 	View: 543
 	Script: <"
-		bonus2 bAddRace,RC_NonBoss,6;
-		bonus2 bAddRace,RC_Boss,6;
+		bonus2 bAddRace, RC_All, 6;
 		bonus bMatkRate,6;
 		bonus bLongAtkRate,6;
 		bonus bHealPower,6;
@@ -53473,8 +53385,7 @@ item_db: (
 	View: 548
 	Script: <"
 		bonus bStr,1;
-		bonus2 bAddRace,RC_NonBoss,2;
-		bonus2 bAddRace,RC_Boss,2;
+		bonus2 bAddRace, RC_All, 2;
 		bonus bAspdRate,2;
 	">
 },
@@ -54742,8 +54653,7 @@ item_db: (
 	View: 345
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bAddRace,RC_NonBoss,2;
-		bonus2 bAddRace,RC_Boss,2;
+		bonus2 bAddRace, RC_All, 2;
 		bonus bMatkRate,2;
 		bonus bDex,1;
 	">
@@ -55419,14 +55329,12 @@ item_db: (
 	Loc: 256
 	View: 613
 	Script: <"
-		if(getrefine()>6) {
-			bonus2 bAddRace,RC_NonBoss,2;
-			bonus2 bAddRace,RC_Boss,2;
+		if (getrefine() > 6) {
+			bonus2 bAddRace, RC_All, 2;
 			bonus bMatkRate,2;
 		}
-		if(getrefine()>8) {
-			bonus2 bAddRace,RC_NonBoss,2;
-			bonus2 bAddRace,RC_Boss,2;
+		if (getrefine() > 8) {
+			bonus2 bAddRace, RC_All, 2;
 			bonus bMatkRate,2;
 		}
 	">
@@ -56814,10 +56722,7 @@ item_db: (
 	EquipLv: 50
 	Refine: false
 	View: 644
-	Script: <"
-		bonus2 bAddRace,RC_NonBoss,1;
-		bonus2 bAddRace,RC_Boss,1;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 1; ">
 },
 {
 	Id: 5768
@@ -57361,8 +57266,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bExpAddRace,RC_Boss,10;
-		bonus2 bExpAddRace,RC_NonBoss,10;
+		bonus2 bExpAddRace, RC_All, 10;
 	">
 },
 {
@@ -57386,8 +57290,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bExpAddRace,RC_Boss,20;
-		bonus2 bExpAddRace,RC_NonBoss,20;
+		bonus2 bExpAddRace, RC_All, 20;
 	">
 },
 {
@@ -57411,8 +57314,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bExpAddRace,RC_Boss,30;
-		bonus2 bExpAddRace,RC_NonBoss,30;
+		bonus2 bExpAddRace, RC_All, 30;
 	">
 },
 {
@@ -57436,8 +57338,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bExpAddRace,RC_Boss,40;
-		bonus2 bExpAddRace,RC_NonBoss,40;
+		bonus2 bExpAddRace, RC_All, 40;
 	">
 },
 {
@@ -57754,8 +57655,7 @@ item_db: (
 		bonus bAllStats,2;
 		bonus bMdef,3;
 		bonus bHealPower,10;
-		bonus2 bAddRace,RC_NonBoss,3;
-		bonus2 bAddRace,RC_Boss,3;
+		bonus2 bAddRace, RC_All, 3;
 		bonus bMatkRate,3;
 		bonus bFlee,10;
 		bonus bAspdRate,1;
@@ -57841,10 +57741,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,5;
-		bonus2 bExpAddRace,RC_NonBoss,5;
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, 5; ">
 },
 {
 	Id: 5822
@@ -58565,8 +58462,7 @@ item_db: (
 		bonus bAllStats,10;
 		bonus bMaxHPrate,15;
 		bonus bMaxSPrate,15;
-		bonus2 bAddRace,RC_Boss,15;
-		bonus2 bAddRace,RC_NonBoss,15;
+		bonus2 bAddRace, RC_All, 15;
 		bonus bMatkRate,15;
 		bonus bHit,20;
 		bonus bFlee,20;
@@ -58906,19 +58802,15 @@ item_db: (
 	View: 1360
 	Script: <"
 		bonus bStr,5;
-		bonus2 bAddRace,RC_Boss,7;
-		bonus2 bAddRace,RC_NonBoss,7;
-		if(getrefine()>4) {
-			bonus2 bAddRace,RC_Boss,2;
-			bonus2 bAddRace,RC_NonBoss,2;
+		bonus2 bAddRace, RC_All, 7;
+		if (getrefine() > 4) {
+			bonus2 bAddRace, RC_All, 2;
 		}
-		if(getrefine()>6) {
-			bonus2 bAddRace,RC_Boss,1;
-			bonus2 bAddRace,RC_NonBoss,1;
+		if (getrefine() > 6) {
+			bonus2 bAddRace, RC_All, 1;
 		}
-		if(getrefine()>8) {
-			bonus2 bAddRace,RC_Boss,1;
-			bonus2 bAddRace,RC_NonBoss,1;
+		if (getrefine() > 8) {
+			bonus2 bAddRace, RC_All, 1;
 			bonus bNoSizeFix,0;
 		}
 	">
@@ -88971,10 +88863,7 @@ item_db: (
 	WeaponLv: 4
 	EquipLv: 36
 	View: 1
-	Script: <"
-		bonus bDefRatioAtkRace,RC_Boss;
-		bonus bDefRatioAtkRace,RC_NonBoss;
-	">
+	Script: <" bonus bDefRatioAtkRace, RC_All; ">
 },
 {
 	Id: 13018
@@ -89266,10 +89155,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 13030
@@ -89439,7 +89325,7 @@ item_db: (
 		bonus bAgi,1;
 		bonus2 bAddRace,RC_DemiPlayer,75;
 		bonus bUnbreakableWeapon,0;
-		autobonus "{ bonus bDefRatioAtkRace,RC_Boss; bonus bDefRatioAtkRace,RC_NonBoss; }",10,6000,BF_WEAPON,"{ specialeffect2 EF_HASTEUP; }";
+		autobonus "{ bonus bDefRatioAtkRace, RC_All; }",10,6000,BF_WEAPON,"{ specialeffect2 EF_HASTEUP; }";
 		if(BaseClass==Job_Ninja||BaseClass==Job_Rogue) bonus bMatk,90;
 	">
 },
@@ -89667,7 +89553,7 @@ item_db: (
 	View: 1
 	Script: <"
 		bonus3 bAddEffOnSkill,RG_RAID,Eff_Poison,1000;
-		autobonus "{ bonus2 bAddRace,RC_NonBoss,10; bonus2 bAddRace,RC_Boss,10; }",5,5000,BF_WEAPON|BF_SHORT,"{ specialeffect2 EF_POTION_BERSERK; }";
+		autobonus "{ bonus2 bAddRace, RC_All, 10; }",5,5000,BF_WEAPON|BF_SHORT,"{ specialeffect2 EF_POTION_BERSERK; }";
 	">
 },
 {
@@ -90362,12 +90248,10 @@ item_db: (
 			.@val = 1;
 			bonus4 bAutoSpell,BS_WEAPONPERFECT,1,20,0;
 		}
-		if(getrefine()>=6) {
+		if (getrefine() >= 6) {
 			.@rate = 5*(.@val+1);
-			bonus2 bAddRace,RC_Boss,.@rate;
-			bonus2 bAddRace,RC_NonBoss,.@rate;
-			bonus2 bMagicAddRace,RC_Boss,.@rate;
-			bonus2 bMagicAddRace,RC_NonBoss,.@rate;
+			bonus2 bAddRace, RC_All, .@rate;
+			bonus2 bMagicAddRace, RC_All, .@rate;
 		}
 	">
 },
@@ -90630,8 +90514,7 @@ item_db: (
 	Script: <"
 		bonus bHit,readparam(bAgi)/10;
 		bonus bAspdRate,readparam(bAgi)/14;
-		bonus2 bAddRace,RC_NonBoss,10;
-		bonus2 bAddRace,RC_Boss,10;
+		bonus2 bAddRace, RC_All, 10;
 		bonus bMatkRate,10;
 	">
 },
@@ -91558,9 +91441,8 @@ item_db: (
 			bonus2 bAddRace,RC_DemiPlayer,pow(min(getrefine(),10)-4,2);
 			bonus2 bIgnoreDefRate,RC_DemiPlayer,5;
 		}
-		if(getrefine()>8) {
-			bonus2 bAddRace,RC_Boss,getrefine();
-			bonus2 bAddRace,RC_NonBoss,getrefine();
+		if (getrefine() > 8) {
+			bonus2 bAddRace, RC_All, getrefine();
 		}
 	">
 },
@@ -93412,10 +93294,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <"
-		bonus2 bAddRace,RC_Boss,50;
-		bonus2 bAddRace,RC_NonBoss,50;
-	">
+	Script: <" bonus2 bAddRace, RC_All, 50; ">
 },
 {
 	Id: 13407
@@ -112330,8 +112209,7 @@ item_db: (
 		bonus bMdef,10;
 		bonus bMaxHP,20*BaseLevel;
 		bonus bMaxSP,5*BaseLevel;
-		bonus2 bAddRace,RC_NonBoss,5;
-		bonus2 bAddRace,RC_Boss,5;
+		bonus2 bAddRace, RC_All, 5;
 		bonus bMatkRate,5;
 		bonus bUnbreakableArmor,0;
 		bonus bNoKnockback,0;
@@ -118944,8 +118822,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bExpAddRace,RC_Boss,60;
-		bonus2 bExpAddRace,RC_NonBoss,60;
+		bonus2 bExpAddRace, RC_All, 60;
 	">
 },
 {
@@ -118969,8 +118846,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bExpAddRace,RC_Boss,80;
-		bonus2 bExpAddRace,RC_NonBoss,80;
+		bonus2 bExpAddRace, RC_All, 80;
 	">
 },
 {
@@ -118994,8 +118870,7 @@ item_db: (
 	}
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bExpAddRace,RC_Boss,100;
-		bonus2 bExpAddRace,RC_NonBoss,100;
+		bonus2 bExpAddRace, RC_All, 100;
 	">
 },
 {
@@ -119103,8 +118978,7 @@ item_db: (
 	EquipLv: 30
 	View: 677
 	Script: <"
-		bonus2 bSubRace,RC_NonBoss,5;
-		bonus2 bSubRace,RC_Boss,5;
+		bonus2 bSubRace, RC_All, 5;
 		bonus bLuk,5;
 		bonus bMdef,3;
 		bonus bHit,10;
@@ -119343,8 +119217,7 @@ item_db: (
 	View: 687
 	Script: <"
 		bonus bStr,2;
-		bonus2 bAddRace,RC_Boss,2;
-		bonus2 bAddRace,RC_NonBoss,2;
+		bonus2 bAddRace, RC_All, 2;
 		if(getrefine()>6) { bonus bCriticalRate,10; }
 		if(getrefine()>8) {
 			bonus bLongAtkRate,5;
@@ -124277,8 +124150,7 @@ item_db: (
 	View: 955
 	Script: <"
 		bonus bAspdRate,(getrefine()/3)*2;
-		bonus2 bExpAddRace,RC_Boss,3;
-		bonus2 bExpAddRace,RC_NonBoss,3;
+		bonus2 bExpAddRace, RC_All, 3;
 		if (getrefine()>9) { bonus bAspd,1; }
 	">
 },
@@ -125743,8 +125615,7 @@ item_db: (
 	View: 345
 	Script: <"
 		bonus bUnbreakableHelm,0;
-		bonus2 bAddRace,RC_NonBoss,1;
-		bonus2 bAddRace,RC_Boss,1;
+		bonus2 bAddRace, RC_All, 1;
 		bonus bMatkRate,1;
 		bonus bDex,1;
 	">
@@ -126173,8 +126044,7 @@ item_db: (
 	Script: <"
 		bonus bUnbreakableHelm,0;
 		bonus bVit,1;
-		bonus2 bExpAddRace,RC_NonBoss,1;
-		bonus2 bExpAddRace,RC_Boss,1;
+		bonus2 bExpAddRace, RC_All, 1;
 	">
 },
 {
@@ -126204,8 +126074,7 @@ item_db: (
 	Script: <"
 		bonus bUnbreakableHelm,0;
 		bonus bStr,1;
-		bonus2 bExpAddRace,RC_NonBoss,1;
-		bonus2 bExpAddRace,RC_Boss,1;
+		bonus2 bExpAddRace, RC_All, 1;
 	">
 },
 {
@@ -126220,8 +126089,7 @@ item_db: (
 	Script: <"
 		bonus bUnbreakableHelm,0;
 		bonus bInt,1;
-		bonus2 bExpAddRace,RC_NonBoss,1;
-		bonus2 bExpAddRace,RC_Boss,1;
+		bonus2 bExpAddRace, RC_All, 1;
 	">
 },
 {
@@ -127939,10 +127807,7 @@ item_db: (
 	Type: 5
 	Loc: 2048
 	View: 724
-	Script: <"
-		bonus2 bExpAddRace,RC_NonBoss,1;
-		bonus2 bExpAddRace,RC_Boss,1;
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, 1; ">
 },
 {
 	Id: 19743
@@ -133146,9 +133011,8 @@ item_db: (
 		bonus bMdef,3;
 		bonus bMaxSPrate,10;
 		bonus bUseSPrate,-(1+2*(getrefine()/3));
-		if(getrefine()>=10) {
-			bonus2 bSPGainRace,RC_NonBoss,20;
-			bonus2 bSPGainRace,RC_Boss,20;
+		if (getrefine() >= 10) {
+			bonus bSPGainValue, 20;
 		}
 	">
 },
@@ -136352,10 +136216,7 @@ item_db: (
 	Type: 5
 	Buy: 10
 	Loc: 1048576
-	Script: <"
-		bonus2 bIgnoreDefRate,RC_NonBoss,5+(getrefine()/2);
-		bonus2 bIgnoreDefRate,RC_Boss,5+(getrefine()/2);
-	">
+	Script: <" bonus2 bIgnoreDefRate, RC_All, 5+(getrefine()/2); ">
 },
 {
 	Id: 24167
@@ -136364,10 +136225,7 @@ item_db: (
 	Type: 5
 	Buy: 10
 	Loc: 2097152
-	Script: <"
-		bonus2 bIgnoreDefRate,RC_NonBoss,5+(getrefine()/2);
-		bonus2 bIgnoreDefRate,RC_Boss,5+(getrefine()/2);
-	">
+	Script: <" bonus2 bIgnoreDefRate, RC_All, 5+(getrefine()/2); ">
 },
 {
 	Id: 24168
@@ -136808,10 +136666,7 @@ item_db: (
 	Weight: 100
 	Loc: 524288
 	EquipLv: [150, 175]
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,1;
-		bonus2 bExpAddRace,RC_NonBoss,1;
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, 1; ">
 },
 {
 	Id: 24209
@@ -136821,10 +136676,7 @@ item_db: (
 	Buy: 10
 	Loc: 262144
 	EquipLv: [150, 175]
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,(getrefine()/4);
-		bonus2 bExpAddRace,RC_NonBoss,(getrefine()/4);
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, (getrefine()/4); ">
 },
 {
 	Id: 24210
@@ -136834,10 +136686,7 @@ item_db: (
 	Buy: 20
 	Loc: 524288
 	EquipLv: [1, 49]
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,getrefine();
-		bonus2 bExpAddRace,RC_NonBoss,getrefine();
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, getrefine(); ">
 },
 {
 	Id: 24211
@@ -136847,10 +136696,7 @@ item_db: (
 	Buy: 10
 	Loc: 262144
 	EquipLv: [1, 49]
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,getrefine();
-		bonus2 bExpAddRace,RC_NonBoss,getrefine();
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, getrefine(); ">
 },
 {
 	Id: 24212
@@ -136860,10 +136706,7 @@ item_db: (
 	Buy: 10
 	Loc: 524288
 	EquipLv: [50, 99]
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,(getrefine()/2);
-		bonus2 bExpAddRace,RC_NonBoss,(getrefine()/2);
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, (getrefine()/2); ">
 },
 {
 	Id: 24213
@@ -136873,10 +136716,7 @@ item_db: (
 	Buy: 10
 	Loc: 262144
 	EquipLv: [50, 99]
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,(getrefine()/2);
-		bonus2 bExpAddRace,RC_NonBoss,(getrefine()/2);
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, (getrefine()/2); ">
 },
 {
 	Id: 24214
@@ -136886,10 +136726,7 @@ item_db: (
 	Buy: 20
 	Loc: 524288
 	EquipLv: [100, 149]
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,(getrefine()/3);
-		bonus2 bExpAddRace,RC_NonBoss,(getrefine()/3);
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, (getrefine()/3); ">
 },
 {
 	Id: 24215
@@ -136899,10 +136736,7 @@ item_db: (
 	Buy: 10
 	Loc: 262144
 	EquipLv: [100, 149]
-	Script: <"
-		bonus2 bExpAddRace,RC_Boss,(getrefine()/3);
-		bonus2 bExpAddRace,RC_NonBoss,(getrefine()/3);
-	">
+	Script: <" bonus2 bExpAddRace, RC_All, (getrefine()/3); ">
 },
 {
 	Id: 24216

--- a/src/common/nullpo.h
+++ b/src/common/nullpo.h
@@ -27,10 +27,23 @@
 #include <crtdbg.h>
 #endif // !DEFCPP && WIN && !MINGW
 #define Assert(EX) assert(EX)
+/**
+ * Reports an assertion failure if the passed expression is false.
+ *
+ * @param EX The expression to test.
+ * @return false if the passed expression is true, false otherwise.
+ */
 #define Assert_chk(EX) ( (EX) ? false : (nullpo->assert_report(__FILE__, __LINE__, __func__, #EX, "failed assertion"), true) )
+/**
+ * Reports an assertion failure (without actually checking it).
+ *
+ * @param EX the expression to report.
+ */
+#define Assert_report(EX) (nullpo->assert_report(__FILE__, __LINE__, __func__, #EX, "failed assertion"))
 #else // ! ASSERT_CHECK
 #define Assert(EX) (EX)
 #define Assert_chk(EX) ((EX), false)
+#define Assert_report(EX) ((void)(EX))
 #endif // ASSERT_CHECK
 
 #if defined(NULLPO_CHECK)

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -3714,8 +3714,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 			//Ignore Defense?
 			if (!flag.imdef && (
 				sd->bonus.ignore_mdef_ele & ( 1 << tstatus->def_ele ) ||
-				sd->bonus.ignore_mdef_race & ( 1 << tstatus->race ) ||
-				sd->bonus.ignore_mdef_race & ( is_boss(target) ? 1 << RC_BOSS : 1 << RC_NONBOSS )
+				sd->bonus.ignore_mdef_race & map->race_id2mask(tstatus->race) ||
+				sd->bonus.ignore_mdef_race & map->race_id2mask(is_boss(target) ? RC_BOSS : RC_NONBOSS)
 			))
 				flag.imdef = 1;
 		}
@@ -5195,19 +5195,19 @@ struct Damage battle_calc_weapon_attack(struct block_list *src,struct block_list
 			if( (i=pc->checkskill(sd,AB_EUCHARISTICA)) > 0 &&
 				(tstatus->race == RC_DEMON || tstatus->def_ele == ELE_DARK) )
 				ATK_ADDRATE(-i);
-			if( skill_id != PA_SACRIFICE && skill_id != MO_INVESTIGATE && skill_id != CR_GRANDCROSS && skill_id != NPC_GRANDDARKNESS && skill_id != PA_SHIELDCHAIN && !flag.cri )
-			{ //Elemental/Racial adjustments
-				if( sd->right_weapon.def_ratio_atk_ele & (1<<tstatus->def_ele) ||
-					sd->right_weapon.def_ratio_atk_race & (1<<tstatus->race) ||
-					sd->right_weapon.def_ratio_atk_race & (1<<(is_boss(target)?RC_BOSS:RC_NONBOSS))
+			if (skill_id != PA_SACRIFICE && skill_id != MO_INVESTIGATE && skill_id != CR_GRANDCROSS && skill_id != NPC_GRANDDARKNESS && skill_id != PA_SHIELDCHAIN && !flag.cri) {
+				//Elemental/Racial adjustments
+				if (sd->right_weapon.def_ratio_atk_ele & (1<<tstatus->def_ele)
+				 || sd->right_weapon.def_ratio_atk_race & map->race_id2mask(tstatus->race)
+				 || sd->right_weapon.def_ratio_atk_race & map->race_id2mask(is_boss(target) ? RC_BOSS : RC_NONBOSS)
 				)
 					flag.pdef = 1;
 
-				if( sd->left_weapon.def_ratio_atk_ele & (1<<tstatus->def_ele) ||
-					sd->left_weapon.def_ratio_atk_race & (1<<tstatus->race) ||
-					sd->left_weapon.def_ratio_atk_race & (1<<(is_boss(target)?RC_BOSS:RC_NONBOSS))
-				)
-				{ //Pass effect onto right hand if configured so. [Skotlex]
+				if (sd->left_weapon.def_ratio_atk_ele & (1<<tstatus->def_ele)
+				 || sd->left_weapon.def_ratio_atk_race & map->race_id2mask(tstatus->race)
+				 || sd->left_weapon.def_ratio_atk_race & map->race_id2mask(is_boss(target) ? RC_BOSS : RC_NONBOSS)
+				) {
+					//Pass effect onto right hand if configured so. [Skotlex]
 					if (battle_config.left_cardfix_to_right && flag.rh)
 						flag.pdef = 1;
 					else
@@ -5219,15 +5219,15 @@ struct Damage battle_calc_weapon_attack(struct block_list *src,struct block_list
 				//Ignore Defense?
 				if (!flag.idef && (
 					sd->right_weapon.ignore_def_ele & (1<<tstatus->def_ele) ||
-					sd->right_weapon.ignore_def_race & (1<<tstatus->race) ||
-					sd->right_weapon.ignore_def_race & (is_boss(target)?1<<RC_BOSS:1<<RC_NONBOSS)
+					sd->right_weapon.ignore_def_race & map->race_id2mask(tstatus->race) ||
+					sd->right_weapon.ignore_def_race & map->race_id2mask(is_boss(target) ? RC_BOSS : RC_NONBOSS)
 				))
 					flag.idef = 1;
 
 				if (!flag.idef2 && (
 					sd->left_weapon.ignore_def_ele & (1<<tstatus->def_ele) ||
-					sd->left_weapon.ignore_def_race & (1<<tstatus->race) ||
-					sd->left_weapon.ignore_def_race & (is_boss(target)?1<<RC_BOSS:1<<RC_NONBOSS)
+					sd->left_weapon.ignore_def_race & map->race_id2mask(tstatus->race) ||
+					sd->left_weapon.ignore_def_race & map->race_id2mask(is_boss(target) ? RC_BOSS : RC_NONBOSS)
 				)) {
 						if(battle_config.left_cardfix_to_right && flag.rh) //Move effect to right hand. [Skotlex]
 							flag.idef = 1;

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2068,6 +2068,8 @@ uint32 map_race_id2mask(int race)
 		return RCMASK_NONDEMIPLAYER;
 
 	ShowWarning("map_race_id2mask: Invalid race: %d\n", race);
+	Assert_report((race >= RC_FORMLESS && race < RC_NONDEMIPLAYER) || race == RC_ALL);
+
 	return RCMASK_NONE;
 }
 

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2040,6 +2040,37 @@ struct mob_data * map_id2boss(int id)
 	return (struct mob_data*)idb_get(map->bossid_db,id);
 }
 
+/**
+ * Returns the equivalent bitmask to the given race ID.
+ *
+ * @param race A race identifier (@see enum Race)
+ *
+ * @return The equivalent race bitmask.
+ */
+uint32 map_race_id2mask(int race)
+{
+	if (race >= RC_FORMLESS && race < RC_MAX)
+		return 1 << race;
+
+	if (race == RC_ALL)
+		return RCMASK_ALL;
+
+	if (race == RC_NONPLAYER)
+		return RCMASK_NONPLAYER;
+
+	if (race == RC_NONDEMIHUMAN)
+		return RCMASK_NONDEMIHUMAN;
+
+	if (race == RC_DEMIPLAYER)
+		return RCMASK_DEMIPLAYER;
+
+	if (race == RC_NONDEMIPLAYER)
+		return RCMASK_NONDEMIPLAYER;
+
+	ShowWarning("map_race_id2mask: Invalid race: %d\n", race);
+	return RCMASK_NONE;
+}
+
 /// Applies func to all the players in the db.
 /// Stops iterating if func returns -1.
 void map_vforeachpc(int (*func)(struct map_session_data* sd, va_list args), va_list args) {
@@ -6127,6 +6158,7 @@ void map_defaults(void) {
 	map->nick2sd = map_nick2sd;
 	map->getmob_boss = map_getmob_boss;
 	map->id2boss = map_id2boss;
+	map->race_id2mask = map_race_id2mask;
 	// reload config file looking only for npcs
 	map->reloadnpc = map_reloadnpc;
 

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -251,26 +251,64 @@ enum bl_type {
 
 enum npc_subtype { WARP, SHOP, SCRIPT, CASHSHOP, TOMB };
 
-enum {
-	RC_FORMLESS=0,
-	RC_UNDEAD,
-	RC_BRUTE,
-	RC_PLANT,
-	RC_INSECT,
-	RC_FISH,
-	RC_DEMON,
-	RC_DEMIHUMAN,
-	RC_ANGEL,
-	RC_DRAGON,
-	RC_PLAYER,
-	RC_BOSS,
-	RC_NONBOSS,
-	RC_MAX,
-	RC_NONDEMIHUMAN,
-	RC_NONPLAYER,
-	RC_DEMIPLAYER,
-	RC_NONDEMIPLAYER,
-	RC_ALL = 0xFF
+/**
+ * Race type IDs.
+ *
+ * Mostly used by scripts/bonuses.
+ */
+enum Race {
+	// Base Races
+	RC_FORMLESS = 0,  ///< Formless
+	RC_UNDEAD,        ///< Undead
+	RC_BRUTE,         ///< Beast/Brute
+	RC_PLANT,         ///< Plant
+	RC_INSECT,        ///< Insect
+	RC_FISH,          ///< Fish
+	RC_DEMON,         ///< Demon
+	RC_DEMIHUMAN,     ///< Demi-Human (not including Player)
+	RC_ANGEL,         ///< Angel
+	RC_DRAGON,        ///< Dragon
+	RC_PLAYER,        ///< Player
+	// Boss
+	RC_BOSS,          ///< Boss
+	RC_NONBOSS,       ///< Non-boss
+
+	RC_MAX,           // Array size delimiter (keep before the combination races)
+
+	// Combination Races
+	RC_NONDEMIHUMAN,   ///< Every race except Demi-Human (including Player)
+	RC_NONPLAYER,      ///< Every non-player race
+	RC_DEMIPLAYER,     ///< Demi-Human (including Player)
+	RC_NONDEMIPLAYER,  ///< Every race except Demi-Human (and except Player)
+	RC_ALL = 0xFF,     ///< Every race (implemented as equivalent to RC_BOSS and RC_NONBOSS)
+};
+
+/**
+ * Race type bitmasks.
+ *
+ * Used by several bonuses internally, to simplify handling of race combinations.
+ */
+enum RaceMask {
+	RCMASK_NONE      = 0,
+	RCMASK_FORMLESS  = 1<<RC_FORMLESS,
+	RCMASK_UNDEAD    = 1<<RC_UNDEAD,
+	RCMASK_BRUTE     = 1<<RC_BRUTE,
+	RCMASK_PLANT     = 1<<RC_PLANT,
+	RCMASK_INSECT    = 1<<RC_INSECT,
+	RCMASK_FISH      = 1<<RC_FISH,
+	RCMASK_DEMON     = 1<<RC_DEMON,
+	RCMASK_DEMIHUMAN = 1<<RC_DEMIHUMAN,
+	RCMASK_ANGEL     = 1<<RC_ANGEL,
+	RCMASK_DRAGON    = 1<<RC_DRAGON,
+	RCMASK_PLAYER    = 1<<RC_PLAYER,
+	RCMASK_BOSS      = 1<<RC_BOSS,
+	RCMASK_NONBOSS   = 1<<RC_NONBOSS,
+	RCMASK_NONDEMIPLAYER = RCMASK_FORMLESS | RCMASK_UNDEAD | RCMASK_BRUTE | RCMASK_PLANT | RCMASK_INSECT | RCMASK_FISH | RCMASK_DEMON | RCMASK_ANGEL | RCMASK_DRAGON,
+	RCMASK_NONDEMIHUMAN = RCMASK_NONDEMIPLAYER | RCMASK_PLAYER,
+	RCMASK_NONPLAYER    = RCMASK_NONDEMIPLAYER | RCMASK_DEMIHUMAN,
+	RCMASK_DEMIPLAYER   = RCMASK_DEMIHUMAN | RCMASK_PLAYER,
+	RCMASK_ALL          = RCMASK_BOSS | RCMASK_NONBOSS,
+	RCMASK_ANY          = RCMASK_NONPLAYER | RCMASK_PLAYER,
 };
 
 enum {
@@ -1010,6 +1048,7 @@ END_ZEROED_BLOCK;
 	struct map_session_data * (*nick2sd) (const char *nick);
 	struct mob_data * (*getmob_boss) (int16 m);
 	struct mob_data * (*id2boss) (int id);
+	uint32 (*race_id2mask) (int race);
 	// reload config file looking only for npcs
 	void (*reloadnpc) (bool clear);
 

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2411,8 +2411,8 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type) {
 			{
 				if ( sd->add_drop[i].race == -md->class_ ||
 					( sd->add_drop[i].race > 0 && (
-						sd->add_drop[i].race & (1<<mstatus->race) ||
-						sd->add_drop[i].race & (1<<((mstatus->mode&MD_BOSS)?RC_BOSS:RC_NONBOSS))
+						sd->add_drop[i].race & map->race_id2mask(mstatus->race) ||
+						sd->add_drop[i].race & map->race_id2mask((mstatus->mode&MD_BOSS) ? RC_BOSS : RC_NONBOSS)
 					)))
 				{
 					//check if the bonus item drop rate should be multiplied with mob level/10 [Lupus]

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -2480,7 +2480,8 @@ int pc_bonus(struct map_session_data *sd,int type,int val) {
 				sd->bonus.misc_def_rate += val;
 			break;
 		case SP_IGNORE_MDEF_RATE:
-			if(sd->state.lr_flag != 2) {
+			if (sd->state.lr_flag != 2) {
+				// Decomposed RC_ALL:
 				sd->ignore_mdef[RC_NONBOSS] += val;
 				sd->ignore_mdef[RC_BOSS] += val;
 			}
@@ -2756,21 +2757,23 @@ int pc_bonus(struct map_session_data *sd,int type,int val) {
 				sd->bonus.unstripable_equip |= EQP_SHIELD;
 			break;
 		case SP_HP_DRAIN_VALUE:
-			if(!sd->state.lr_flag) {
+			if (sd->state.lr_flag == 0) {
+				// Decomposed RC_ALL:
 				sd->right_weapon.hp_drain[RC_NONBOSS].value += val;
 				sd->right_weapon.hp_drain[RC_BOSS].value += val;
-			}
-			else if(sd->state.lr_flag == 1) {
+			} else if (sd->state.lr_flag == 1) {
+				// Decomposed RC_ALL:
 				sd->left_weapon.hp_drain[RC_NONBOSS].value += val;
 				sd->left_weapon.hp_drain[RC_BOSS].value += val;
 			}
 			break;
 		case SP_SP_DRAIN_VALUE:
-			if(!sd->state.lr_flag) {
+			if (sd->state.lr_flag == 0) {
+				// Decomposed RC_ALL:
 				sd->right_weapon.sp_drain[RC_NONBOSS].value += val;
 				sd->right_weapon.sp_drain[RC_BOSS].value += val;
-			}
-			else if(sd->state.lr_flag == 1) {
+			} else if (sd->state.lr_flag == 1) {
+				// Decomposed RC_ALL:
 				sd->left_weapon.sp_drain[RC_NONBOSS].value += val;
 				sd->left_weapon.sp_drain[RC_BOSS].value += val;
 			}
@@ -2828,7 +2831,7 @@ int pc_bonus(struct map_session_data *sd,int type,int val) {
 	#endif
 		case SP_ADD_MONSTER_DROP_CHAINITEM:
 			if (sd->state.lr_flag != 2)
-				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), 0, val, map->race_id2mask(RC_BOSS)|map->race_id2mask(RC_NONBOSS), 10000);
+				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), 0, val, map->race_id2mask(RC_ALL), 10000);
 		break;
 		default:
 			ShowWarning("pc_bonus: unknown type %d %d !\n",type,val);
@@ -3094,13 +3097,14 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 				memmove(&sd->add_mdef[i], &sd->add_mdef[i+1], sizeof(sd->add_mdef) - (i+1)*sizeof(sd->add_mdef[0]));
 			break;
 		case SP_HP_DRAIN_RATE:
-			if(!sd->state.lr_flag) {
+			if (sd->state.lr_flag == 0) {
+				// Decomposed RC_ALL:
 				sd->right_weapon.hp_drain[RC_NONBOSS].rate += type2;
 				sd->right_weapon.hp_drain[RC_NONBOSS].per += val;
 				sd->right_weapon.hp_drain[RC_BOSS].rate += type2;
 				sd->right_weapon.hp_drain[RC_BOSS].per += val;
-			}
-			else if(sd->state.lr_flag == 1) {
+			} else if (sd->state.lr_flag == 1) {
+				// Decomposed RC_ALL:
 				sd->left_weapon.hp_drain[RC_NONBOSS].rate += type2;
 				sd->left_weapon.hp_drain[RC_NONBOSS].per += val;
 				sd->left_weapon.hp_drain[RC_BOSS].rate += type2;
@@ -3108,13 +3112,14 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			}
 			break;
 		case SP_HP_DRAIN_VALUE:
-			if(!sd->state.lr_flag) {
+			if (sd->state.lr_flag == 0) {
+				// Decomposed RC_ALL:
 				sd->right_weapon.hp_drain[RC_NONBOSS].value += type2;
 				sd->right_weapon.hp_drain[RC_NONBOSS].type = val;
 				sd->right_weapon.hp_drain[RC_BOSS].value += type2;
 				sd->right_weapon.hp_drain[RC_BOSS].type = val;
-			}
-			else if(sd->state.lr_flag == 1) {
+			} else if (sd->state.lr_flag == 1) {
+				// Decomposed RC_ALL:
 				sd->left_weapon.hp_drain[RC_NONBOSS].value += type2;
 				sd->left_weapon.hp_drain[RC_NONBOSS].type = val;
 				sd->left_weapon.hp_drain[RC_BOSS].value += type2;
@@ -3122,13 +3127,14 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			}
 			break;
 		case SP_SP_DRAIN_RATE:
-			if(!sd->state.lr_flag) {
+			if (sd->state.lr_flag == 0) {
+				// Decomposed RC_ALL:
 				sd->right_weapon.sp_drain[RC_NONBOSS].rate += type2;
 				sd->right_weapon.sp_drain[RC_NONBOSS].per += val;
 				sd->right_weapon.sp_drain[RC_BOSS].rate += type2;
 				sd->right_weapon.sp_drain[RC_BOSS].per += val;
-			}
-			else if(sd->state.lr_flag == 1) {
+			} else if (sd->state.lr_flag == 1) {
+				// Decomposed RC_ALL:
 				sd->left_weapon.sp_drain[RC_NONBOSS].rate += type2;
 				sd->left_weapon.sp_drain[RC_NONBOSS].per += val;
 				sd->left_weapon.sp_drain[RC_BOSS].rate += type2;
@@ -3136,13 +3142,14 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			}
 			break;
 		case SP_SP_DRAIN_VALUE:
-			if(!sd->state.lr_flag) {
+			if (sd->state.lr_flag == 0) {
+				// Decomposed RC_ALL:
 				sd->right_weapon.sp_drain[RC_NONBOSS].value += type2;
 				sd->right_weapon.sp_drain[RC_NONBOSS].type = val;
 				sd->right_weapon.sp_drain[RC_BOSS].value += type2;
 				sd->right_weapon.sp_drain[RC_BOSS].type = val;
-			}
-			else if(sd->state.lr_flag == 1) {
+			} else if (sd->state.lr_flag == 1) {
+				// Decomposed RC_ALL:
 				sd->left_weapon.sp_drain[RC_NONBOSS].value += type2;
 				sd->left_weapon.sp_drain[RC_NONBOSS].type = val;
 				sd->left_weapon.sp_drain[RC_BOSS].value += type2;
@@ -3440,7 +3447,7 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			break;
 		case SP_ADD_MONSTER_DROP_ITEM:
 			if (sd->state.lr_flag != 2)
-				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), type2, 0, map->race_id2mask(RC_BOSS)|map->race_id2mask(RC_NONBOSS), val);
+				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), type2, 0, map->race_id2mask(RC_ALL), val);
 			break;
 		case SP_SP_LOSS_RATE:
 			if(sd->state.lr_flag != 2) {
@@ -3741,16 +3748,16 @@ int pc_bonus3(struct map_session_data *sd,int type,int type2,int type3,int val)
 			}
 			break;
 		case SP_SP_DRAIN_RATE:
-			if(!sd->state.lr_flag) {
+			if (sd->state.lr_flag == 0) {
+				// Decomposed RC_ALL:
 				sd->right_weapon.sp_drain[RC_NONBOSS].rate += type2;
 				sd->right_weapon.sp_drain[RC_NONBOSS].per += type3;
 				sd->right_weapon.sp_drain[RC_NONBOSS].type = val;
 				sd->right_weapon.sp_drain[RC_BOSS].rate += type2;
 				sd->right_weapon.sp_drain[RC_BOSS].per += type3;
 				sd->right_weapon.sp_drain[RC_BOSS].type = val;
-
-			}
-			else if(sd->state.lr_flag == 1) {
+			} else if (sd->state.lr_flag == 1) {
+				// Decomposed RC_ALL:
 				sd->left_weapon.sp_drain[RC_NONBOSS].rate += type2;
 				sd->left_weapon.sp_drain[RC_NONBOSS].per += type3;
 				sd->left_weapon.sp_drain[RC_NONBOSS].type = val;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -2455,29 +2455,17 @@ int pc_bonus(struct map_session_data *sd,int type,int val) {
 			}
 			break;
 		case SP_IGNORE_DEF_RACE:
-			if (val == RC_MAX || (val > RC_NONDEMIPLAYER && val != RC_ALL) || val < RC_FORMLESS ) {
-				ShowWarning("pc_bonus: SP_IGNORE_DEF_RACE: Invalid Race(%d)\n",val);
+		{
+			uint32 race_mask = map->race_id2mask(val);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus: SP_IGNORE_DEF_RACE: Invalid Race (%d)\n", val);
 				break;
 			}
-			if ( val >= RC_MAX ) {
-				for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-					if ( (val == RC_NONPLAYER && i == RC_PLAYER) ||
-						 (val == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-						 (val == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-						 (val == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-						)
-						continue;
-					if(!sd->state.lr_flag)
-						sd->right_weapon.ignore_def_race |= 1<<i;
-					else if(sd->state.lr_flag == 1)
-						sd->left_weapon.ignore_def_race |= 1<<i;
-				}
-			} else {
-				if(!sd->state.lr_flag)
-					sd->right_weapon.ignore_def_race |= 1<<val;
-				else if(sd->state.lr_flag == 1)
-					sd->left_weapon.ignore_def_race |= 1<<val;
-			}
+			if (!sd->state.lr_flag)
+				sd->right_weapon.ignore_def_race |= race_mask;
+			else if (sd->state.lr_flag == 1)
+				sd->left_weapon.ignore_def_race |= race_mask;
+		}
 			break;
 		case SP_ATK_RATE:
 			if(sd->state.lr_flag != 2)
@@ -2513,25 +2501,16 @@ int pc_bonus(struct map_session_data *sd,int type,int val) {
 			}
 			break;
 		case SP_IGNORE_MDEF_RACE:
-			if (val == RC_MAX || (val > RC_NONDEMIPLAYER && val != RC_ALL) || val < RC_FORMLESS ) {
-				ShowWarning("pc_bonus: SP_IGNORE_MDEF_RACE: Invalid Race(%d)\n",val);
+		{
+			uint32 race_mask = map->race_id2mask(val);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus: SP_IGNORE_MDEF_RACE: Invalid Race (%d)\n", val);
 				break;
 			}
-			if(sd->state.lr_flag != 2) {
-				if ( val >= RC_MAX ) {
-					for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-						if ( (val == RC_NONPLAYER && i == RC_PLAYER) ||
-							 (val == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-							 (val == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-							 (val == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-							)
-							continue;
-						sd->bonus.ignore_mdef_race |= 1<<i;
-					}
-				} else {
-						sd->bonus.ignore_mdef_race |= 1<<val;
-				}
+			if (sd->state.lr_flag != 2) {
+				sd->bonus.ignore_mdef_race |= race_mask;
 			}
+		}
 			break;
 		case SP_PERFECT_HIT_RATE:
 			if(sd->state.lr_flag != 2 && sd->bonus.perfect_hit < val)
@@ -2565,29 +2544,17 @@ int pc_bonus(struct map_session_data *sd,int type,int val) {
 			}
 			break;
 		case SP_DEF_RATIO_ATK_RACE:
-			if (val == RC_MAX || (val > RC_NONDEMIPLAYER && val != RC_ALL) || val < RC_FORMLESS ) {
-				ShowWarning("pc_bonus: SP_DEF_RATIO_ATK_RACE: Invalid Race(%d)\n",val);
+		{
+			uint32 race_mask = map->race_id2mask(val);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus: SP_DEF_RATIO_ATK_RACE: Invalid Race (%d)\n", val);
 				break;
 			}
-			if ( val >= RC_MAX ) {
-				for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-					if ( (val == RC_NONPLAYER && i == RC_PLAYER) ||
-						 (val == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-						 (val == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-						 (val == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-						)
-						continue;
-					if(!sd->state.lr_flag)
-						sd->right_weapon.def_ratio_atk_race |= 1<<i;
-					else if(sd->state.lr_flag == 1)
-						sd->left_weapon.def_ratio_atk_race |= 1<<i;
-				}
-			} else {
-				if(!sd->state.lr_flag)
-					sd->right_weapon.def_ratio_atk_race |= 1<<val;
-				else if(sd->state.lr_flag == 1)
-					sd->left_weapon.def_ratio_atk_race |= 1<<val;
-			}
+			if (!sd->state.lr_flag)
+				sd->right_weapon.def_ratio_atk_race |= race_mask;
+			else if (sd->state.lr_flag == 1)
+				sd->left_weapon.def_ratio_atk_race |= race_mask;
+		}
 			break;
 		case SP_HIT_RATE:
 			if(sd->state.lr_flag != 2)
@@ -2861,7 +2828,7 @@ int pc_bonus(struct map_session_data *sd,int type,int val) {
 	#endif
 		case SP_ADD_MONSTER_DROP_CHAINITEM:
 			if (sd->state.lr_flag != 2)
-				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), 0, val, (1<<RC_BOSS)|(1<<RC_NONBOSS), 10000);
+				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), 0, val, map->race_id2mask(RC_BOSS)|map->race_id2mask(RC_NONBOSS), 10000);
 		break;
 		default:
 			ShowWarning("pc_bonus: unknown type %d %d !\n",type,val);
@@ -3473,7 +3440,7 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			break;
 		case SP_ADD_MONSTER_DROP_ITEM:
 			if (sd->state.lr_flag != 2)
-				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), type2, 0, (1<<RC_BOSS)|(1<<RC_NONBOSS), val);
+				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), type2, 0, map->race_id2mask(RC_BOSS)|map->race_id2mask(RC_NONBOSS), val);
 			break;
 		case SP_SP_LOSS_RATE:
 			if(sd->state.lr_flag != 2) {
@@ -3694,8 +3661,15 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			}
 			break;
 		case SP_ADD_MONSTER_DROP_CHAINITEM:
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_ADD_MONSTER_DROP_CHAINITEM: Invalid Race (%d)\n", type2);
+				break;
+			}
 			if (sd->state.lr_flag != 2)
-				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), 0, val, 1<<type2, 10000);
+				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), 0, val, race_mask, 10000);
+		}
 			break;
 #ifdef RENEWAL
 		case SP_RACE_TOLERANCE:
@@ -3734,8 +3708,15 @@ int pc_bonus3(struct map_session_data *sd,int type,int type2,int type3,int val)
 
 	switch(type){
 		case SP_ADD_MONSTER_DROP_ITEM:
-			if(sd->state.lr_flag != 2)
-				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), type2, 0, 1<<type3, val);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_ADD_MONSTER_DROP_ITEM: Invalid Race (%d)\n", type3);
+				break;
+			}
+			if (sd->state.lr_flag != 2)
+				pc->bonus_item_drop(sd->add_drop, ARRAYLENGTH(sd->add_drop), type2, 0, race_mask, val);
+		}
 			break;
 		case SP_ADD_CLASS_DROP_ITEM:
 			if(sd->state.lr_flag != 2)

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1960,7 +1960,7 @@ int pc_bonus_addeff_onskill(struct s_addeffectonskill* effect, int max, enum sc_
 	return 1;
 }
 
-int pc_bonus_item_drop(struct s_add_drop *drop, const short max, short id, short group, int race, int rate) {
+int pc_bonus_item_drop(struct s_add_drop *drop, const short max, short id, short group, int race_mask, int rate) {
 	int i;
 
 	//Apply config rate adjustment settings.
@@ -1978,12 +1978,10 @@ int pc_bonus_item_drop(struct s_add_drop *drop, const short max, short id, short
 			rate = -1;
 	}
 	for(i = 0; i < max && (drop[i].id || drop[i].group); i++) {
-		if(
-			((id && drop[i].id == id) ||
-			(group && drop[i].group == group))
-			&& race > 0
+		if (((id && drop[i].id == id) || (group && drop[i].group == group))
+		 && race_mask != RCMASK_NONE
 		) {
-			drop[i].race |= race;
+			drop[i].race |= race_mask;
 			if (drop[i].rate > 0 && rate > 0) {
 				//Both are absolute rates.
 				if (drop[i].rate < rate)
@@ -2004,7 +2002,7 @@ int pc_bonus_item_drop(struct s_add_drop *drop, const short max, short id, short
 	}
 	drop[i].id = id;
 	drop[i].group = group;
-	drop[i].race |= race;
+	drop[i].race |= race_mask;
 	drop[i].rate = rate;
 	return 1;
 }
@@ -2178,6 +2176,17 @@ int pc_bonus_subele(struct map_session_data* sd, unsigned char ele, short rate, 
 
 	return 0;
 }
+
+/**
+ * Loops through the fields in a race bitmask (enum RaceMask => enum Race)
+ *
+ * To be used in pc_bonus functions with races represented in array form.
+ */
+#define BONUS_FOREACH_RCARRAY_FROMMASK(loop_counter, mask) \
+	for ((loop_counter) = RC_FORMLESS; (loop_counter) < RC_MAX; ++(loop_counter)) \
+		if (((mask) & 1<<(loop_counter)) == RCMASK_NONE) { \
+			continue; \
+		} else
 
 /*==========================================
  * Add a bonus(type) to player sd
@@ -2874,33 +2883,22 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			}
 			break;
 		case SP_ADDRACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_ADDRACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_ADDRACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if ( type2 >= RC_MAX ) {
-				for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-					if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-						 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-						 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-						 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-						)
-						continue;
-					if ( !sd->state.lr_flag )
-						sd->right_weapon.addrace[i] += val;
-					else if ( sd->state.lr_flag == 1 )
-						sd->left_weapon.addrace[i] += val;
-					else if ( sd->state.lr_flag == 2 )
-						sd->arrow_addrace[i] += val;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				if (sd->state.lr_flag == 0) {
+					sd->right_weapon.addrace[i] += val;
+				} else if (sd->state.lr_flag == 1) {
+					sd->left_weapon.addrace[i] += val;
+				} else if (sd->state.lr_flag == 2) {
+					sd->arrow_addrace[i] += val;
 				}
-			} else {
-				if(!sd->state.lr_flag)
-					sd->right_weapon.addrace[type2] += val;
-				else if(sd->state.lr_flag == 1)
-					sd->left_weapon.addrace[type2] += val;
-				else if(sd->state.lr_flag == 2)
-					sd->arrow_addrace[type2] += val;
 			}
+		}
 			break;
 		case SP_ADDSIZE:
 			if(!sd->state.lr_flag)
@@ -2926,25 +2924,18 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			}
 			break;
 		case SP_SUBRACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_SUBRACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_SUBRACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if(sd->state.lr_flag != 2) {
-				if (type2 >= RC_MAX ) {
-					for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-						if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-							 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-							 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-							 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-							)
-							continue;
-						sd->subrace[i] += val;
-					}
-				} else {
-					sd->subrace[type2]+=val;
-				}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->subrace[i] += val;
 			}
+		}
 			break;
 		case SP_ADDEFF:
 			if (type2 > SC_MAX) {
@@ -2987,25 +2978,18 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			}
 			break;
 		case SP_MAGIC_ADDRACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_MAGIC_ADDRACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_MAGIC_ADDRACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if(sd->state.lr_flag != 2){
-				if ( type2 >= RC_MAX ){
-					for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-						if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-							 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-							 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-							 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-							)
-							continue;
-						sd->magic_addrace[i] += val;
-					}
-				} else {
-					sd->magic_addrace[type2]+=val;
-				}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->magic_addrace[i] += val;
 			}
+		}
 			break;
 		case SP_MAGIC_ADDSIZE:
 			if(sd->state.lr_flag != 2)
@@ -3191,26 +3175,19 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			sd->special_state.bonus_coma = 1;
 			break;
 		case SP_WEAPON_COMA_RACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_WEAPON_COMA_RACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_WEAPON_COMA_RACE: Invalid Race (%d)\n", type2);
 				break;
 			}
 			if(sd->state.lr_flag == 2)
 				break;
-			if ( type2 >= RC_MAX ) {
-				for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-					if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-						 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-						 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-						 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-						)
-							continue;
-					sd->weapon_coma_race[i] += val;
-				}
-			} else {
-				sd->weapon_coma_race[type2] += val;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->weapon_coma_race[i] += val;
 			}
 			sd->special_state.bonus_coma = 1;
+		}
 			break;
 		case SP_WEAPON_ATK:
 			if(sd->state.lr_flag != 2)
@@ -3221,25 +3198,18 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 				sd->weapon_atk_rate[type2]+=val;
 			break;
 		case SP_CRITICAL_ADDRACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_CRITICAL_ADDRACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_CRITICAL_ADDRACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if(sd->state.lr_flag != 2){
-				if ( type2 >= RC_MAX ){
-					for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-						if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-							 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-							 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-							 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-							)
-							continue;
-						sd->critaddrace[i] += val*10;
-					}
-				} else {
-					sd->critaddrace[type2] += val*10;
-				}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->critaddrace[i] += val*10;
 			}
+		}
 			break;
 		case SP_ADDEFF_WHENHIT:
 			if (type2 > SC_MAX) {
@@ -3404,46 +3374,32 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			sd->itemhealrate[i].rate += val;
 			break;
 		case SP_EXP_ADDRACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_EXP_ADDRACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_EXP_ADDRACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if(sd->state.lr_flag != 2) {
-				if ( type2 >= RC_MAX ){
-					for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-						if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-							 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-							 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-							 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-							)
-							continue;
-						sd->expaddrace[i] += val;
-					}
-				} else {
-					sd->expaddrace[type2] += val;
-				}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->expaddrace[i] += val;
 			}
+		}
 			break;
 		case SP_SP_GAIN_RACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_SP_GAIN_RACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_SP_GAIN_RACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if(sd->state.lr_flag != 2) {
-				if ( type2 >= RC_MAX ){
-					for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-						if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-							 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-							 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-							 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-							)
-							continue;
-						sd->sp_gain_race[i] += val;
-					}
-				} else {
-					sd->sp_gain_race[type2] += val;
-				}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->sp_gain_race[i] += val;
 			}
+		}
 			break;
 		case SP_ADD_MONSTER_DROP_ITEM:
 			if (sd->state.lr_flag != 2)
@@ -3462,112 +3418,90 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			}
 			break;
 		case SP_HP_DRAIN_VALUE_RACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_HP_DRAIN_VALUE_RACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_HP_DRAIN_VALUE_RACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if ( type2 >= RC_MAX ){
-				for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-					if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-						 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-						 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-						 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-						)
-						continue;
-					if(!sd->state.lr_flag) {
-						sd->right_weapon.hp_drain[i].value += val;
-					}
-					else if(sd->state.lr_flag == 1) {
-						sd->left_weapon.hp_drain[i].value += val;
-					}
-				}
-			} else {
-				if(!sd->state.lr_flag) {
-					sd->right_weapon.hp_drain[type2].value += val;
-				}
-				else if(sd->state.lr_flag == 1) {
-					sd->left_weapon.hp_drain[type2].value += val;
-				}
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				if (sd->state.lr_flag == 0)
+					sd->right_weapon.hp_drain[i].value += val;
+				else if(sd->state.lr_flag == 1)
+					sd->left_weapon.hp_drain[i].value += val;
 			}
+		}
 			break;
 		case SP_SP_DRAIN_VALUE_RACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_SP_DRAIN_VALUE_RACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_SP_DRAIN_VALUE_RACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if ( type2 >= RC_MAX ){
-				for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-					if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-						 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-						 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-						 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-						)
-						continue;
-					if(!sd->state.lr_flag) {
-						sd->right_weapon.sp_drain[i].value += val;
-					}
-					else if(sd->state.lr_flag == 1) {
-						sd->left_weapon.sp_drain[i].value += val;
-					}
-				}
-			} else {
-				if(!sd->state.lr_flag) {
-					sd->right_weapon.sp_drain[type2].value += val;
-				}
-				else if(sd->state.lr_flag == 1) {
-					sd->left_weapon.sp_drain[type2].value += val;
-				}
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				if (sd->state.lr_flag == 0)
+					sd->right_weapon.sp_drain[i].value += val;
+				else if (sd->state.lr_flag == 1)
+					sd->left_weapon.sp_drain[i].value += val;
 			}
+		}
 			break;
 		case SP_IGNORE_MDEF_RATE:
-			if(sd->state.lr_flag != 2)
-				sd->ignore_mdef[type2] += val;
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_IGNORE_MDEF_RATE: Invalid Race (%d)\n", type2);
+				break;
+			}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->ignore_mdef[i] += val;
+			}
+		}
 			break;
 		case SP_IGNORE_DEF_RATE:
-			if(sd->state.lr_flag != 2)
-				sd->ignore_def[type2] += val;
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_IGNORE_DEF_RATE: Invalid Race (%d)\n", type2);
+				break;
+			}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->ignore_def[i] += val;
+			}
+		}
 			break;
 		case SP_SP_GAIN_RACE_ATTACK:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_SP_GAIN_RACE_ATTACK: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_SP_GAIN_RACE_ATTACK: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if(sd->state.lr_flag != 2) {
-				if ( type2 >= RC_MAX ) {
-					for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-						if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-							 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-							 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-							 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-							)
-							continue;
-						sd->sp_gain_race_attack[i] = cap_value(sd->sp_gain_race_attack[i] + val, 0, INT16_MAX);
-					}
-				} else {
-						sd->sp_gain_race_attack[type2] = cap_value(sd->sp_gain_race_attack[type2] + val, 0, INT16_MAX);
-				}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->sp_gain_race_attack[i] = cap_value(sd->sp_gain_race_attack[i] + val, 0, INT16_MAX);
 			}
+		}
 			break;
 		case SP_HP_GAIN_RACE_ATTACK:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_HP_GAIN_RACE_ATTACK: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_HP_GAIN_RACE_ATTACK: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if(sd->state.lr_flag != 2) {
-				if ( type2 >= RC_MAX ) {
-					for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-						if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-							 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-							 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-							 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-							)
-							continue;
-						sd->hp_gain_race_attack[i] = cap_value(sd->hp_gain_race_attack[i] + val, 0, INT16_MAX);
-					}
-				} else {
-						sd->hp_gain_race_attack[type2] = cap_value(sd->hp_gain_race_attack[type2] + val, 0, INT16_MAX);
-				}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				sd->hp_gain_race_attack[i] = cap_value(sd->hp_gain_race_attack[i] + val, 0, INT16_MAX);
 			}
+		}
 			break;
 		case SP_SKILL_USE_SP_RATE: //bonus2 bSkillUseSPrate,n,x;
 			if(sd->state.lr_flag == 2)
@@ -3680,24 +3614,16 @@ int pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 			break;
 #ifdef RENEWAL
 		case SP_RACE_TOLERANCE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus2: SP_RACE_TOLERANCE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus2: SP_RACE_TOLERANCE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if(sd->state.lr_flag != 2) {
-				if ( type2 >= RC_MAX ) {
-					for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-						if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-							 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-							 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-							 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-							)
-							continue;
-						sd->race_tolerance[i] += val;
-					}
-				} else {
-						sd->race_tolerance[type2] += val;
-				}
+			if (sd->state.lr_flag == 2)
+				break;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask)
+				sd->race_tolerance[i] += val;
 			}
 			break;
 #endif
@@ -3767,70 +3693,40 @@ int pc_bonus3(struct map_session_data *sd,int type,int type2,int type3,int val)
 			}
 			break;
 		case SP_HP_DRAIN_RATE_RACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus3: SP_HP_DRAIN_RATE_RACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus3: SP_HP_DRAIN_RATE_RACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if ( type2 >= RC_MAX ) {
-				for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-					if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-						 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-						 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-						 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-						)
-						continue;
-					if(!sd->state.lr_flag) {
-						sd->right_weapon.hp_drain[i].rate += type3;
-						sd->right_weapon.hp_drain[i].per += val;
-					}
-					else if(sd->state.lr_flag == 1) {
-						sd->left_weapon.hp_drain[i].rate += type3;
-						sd->left_weapon.hp_drain[i].per += val;
-					}
-				}
-			} else {
-				if(!sd->state.lr_flag) {
-					sd->right_weapon.hp_drain[type2].rate += type3;
-					sd->right_weapon.hp_drain[type2].per += val;
-				}
-				else if(sd->state.lr_flag == 1) {
-					sd->left_weapon.hp_drain[type2].rate += type3;
-					sd->left_weapon.hp_drain[type2].per += val;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				if (sd->state.lr_flag == 0) {
+					sd->right_weapon.hp_drain[i].rate += type3;
+					sd->right_weapon.hp_drain[i].per += val;
+				} else if(sd->state.lr_flag == 1) {
+					sd->left_weapon.hp_drain[i].rate += type3;
+					sd->left_weapon.hp_drain[i].per += val;
 				}
 			}
+		}
 			break;
 		case SP_SP_DRAIN_RATE_RACE:
-			if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-				ShowWarning("pc_bonus3: SP_SP_DRAIN_RATE_RACE: Invalid Race(%d)\n",type2);
+		{
+			uint32 race_mask = map->race_id2mask(type2);
+			if (race_mask == RCMASK_NONE) {
+				ShowWarning("pc_bonus3: SP_SP_DRAIN_RATE_RACE: Invalid Race (%d)\n", type2);
 				break;
 			}
-			if ( type2 >= RC_MAX ) {
-				for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-					if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-						 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-						 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-						 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-						)
-						continue;
-					if(!sd->state.lr_flag) {
-						sd->right_weapon.sp_drain[i].rate += type3;
-						sd->right_weapon.sp_drain[i].per += val;
-					}
-					else if(sd->state.lr_flag == 1) {
-						sd->left_weapon.sp_drain[i].rate += type3;
-						sd->left_weapon.sp_drain[i].per += val;
-					}
-				}
-			} else {
-				if(!sd->state.lr_flag) {
-					sd->right_weapon.sp_drain[type2].rate += type3;
-					sd->right_weapon.sp_drain[type2].per += val;
-				}
-				else if(sd->state.lr_flag == 1) {
-					sd->left_weapon.sp_drain[type2].rate += type3;
-					sd->left_weapon.sp_drain[type2].per += val;
+			BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+				if (sd->state.lr_flag == 0) {
+					sd->right_weapon.sp_drain[i].rate += type3;
+					sd->right_weapon.sp_drain[i].per += val;
+				} else if(sd->state.lr_flag == 1) {
+					sd->left_weapon.sp_drain[i].rate += type3;
+					sd->left_weapon.sp_drain[i].per += val;
 				}
 			}
+		}
 			break;
 		case SP_ADDEFF:
 			if (type2 > SC_MAX) {
@@ -3938,55 +3834,37 @@ int pc_bonus4(struct map_session_data *sd,int type,int type2,int type3,int type4
 		break;
 
 	case SP_SET_DEF_RACE: //bonus4 bSetDefRace,n,x,r,y;
-		if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-			ShowWarning("pc_bonus4: SP_SET_DEF_RACE: Invalid Race(%d)\n",type2);
+	{
+		uint32 race_mask = map->race_id2mask(type2);
+		if (race_mask == RCMASK_NONE) {
+			ShowWarning("pc_bonus4: SP_SET_DEF_RACE: Invalid Race (%d)\n", type2);
 			break;
 		}
-		if(sd->state.lr_flag == 2)
+		if (sd->state.lr_flag == 2)
 			break;
-		if ( type2 >= RC_MAX ) {
-			for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-				if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-	 				 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-	 				 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-	 				 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-					)
-					continue;
-				sd->def_set_race[i].rate = type3;
-				sd->def_set_race[i].tick = type4;
-				sd->def_set_race[i].value = val;
-			}
-		} else {
-			sd->def_set_race[type2].rate = type3;
-			sd->def_set_race[type2].tick = type4;
-			sd->def_set_race[type2].value = val;
+		BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+			sd->def_set_race[i].rate = type3;
+			sd->def_set_race[i].tick = type4;
+			sd->def_set_race[i].value = val;
 		}
+	}
 		break;
 
 	case SP_SET_MDEF_RACE: //bonus4 bSetMDefRace,n,x,r,y;
-		if (type2 == RC_MAX || (type2 > RC_NONDEMIPLAYER && type2 != RC_ALL) || type2 < RC_FORMLESS ){
-			ShowWarning("pc_bonus4: SP_SET_MDEF_RACE: Invalid Race(%d)\n",type2);
+	{
+		uint32 race_mask = map->race_id2mask(type2);
+		if (race_mask == RCMASK_NONE) {
+			ShowWarning("pc_bonus4: SP_SET_MDEF_RACE: Invalid Race (%d)\n", type2);
 			break;
 		}
-		if(sd->state.lr_flag == 2)
+		if (sd->state.lr_flag == 2)
 			break;
-		if ( type2 >= RC_MAX ) {
-			for ( i = RC_FORMLESS; i < RC_BOSS; i++ ) {
-				if ( (type2 == RC_NONPLAYER && i == RC_PLAYER) ||
-	 				 (type2 == RC_NONDEMIHUMAN && i == RC_DEMIHUMAN) ||
-	 				 (type2 == RC_DEMIPLAYER && (i != RC_PLAYER && i != RC_DEMIHUMAN)) ||
-	 				 (type2 == RC_NONDEMIPLAYER && (i == RC_PLAYER || i == RC_DEMIHUMAN))
-					)
-					continue;
-				sd->mdef_set_race[i].rate = type3;
-				sd->mdef_set_race[i].tick = type4;
-				sd->mdef_set_race[i].value = val;
-			}
-		} else {
-			sd->mdef_set_race[type2].rate = type3;
-			sd->mdef_set_race[type2].tick = type4;
-			sd->mdef_set_race[type2].value = val;
+		BONUS_FOREACH_RCARRAY_FROMMASK(i, race_mask) {
+			sd->mdef_set_race[i].rate = type3;
+			sd->mdef_set_race[i].tick = type4;
+			sd->mdef_set_race[i].value = val;
 		}
+	}
 		break;
 
 	case SP_ADDEFF:
@@ -4042,6 +3920,8 @@ int pc_bonus5(struct map_session_data *sd,int type,int type2,int type3,int type4
 
 	return 0;
 }
+
+#undef BONUS_FOREACH_RCARRAY_FROMMASK
 
 /*==========================================
  * Grants a player a given skill.
@@ -10588,17 +10468,17 @@ int pc_level_penalty_mod(int diff, unsigned char race, unsigned short mode, int 
 	if( diff < 0 )
 		diff = MAX_LEVEL + ( ~diff + 1 );
 
-	for(i=0; i<RC_MAX; i++){
+	for (i = RC_FORMLESS; i < RC_MAX; i++) {
 		int tmp;
 
-		if( race != i ){
-			if( mode&MD_BOSS && i < RC_BOSS )
+		if (race != i) {
+			if (mode&MD_BOSS && i < RC_BOSS)
 				i = RC_BOSS;
-			else if( i <= RC_BOSS )
+			else if (i <= RC_BOSS)
 				continue;
 		}
 
-		if( (tmp=pc->level_penalty[type][i][diff]) > 0 ){
+		if ((tmp=pc->level_penalty[type][i][diff]) > 0) {
 			rate = tmp;
 			break;
 		}
@@ -10812,7 +10692,7 @@ bool pc_readdb_levelpenalty(char* fields[], int columns, int current) {
 		return false;
 	}
 
-	if( race < 0 || race > RC_MAX ){
+	if (race < RC_FORMLESS || race > RC_MAX) {
 		ShowWarning("pc_readdb_levelpenalty: Invalid race %d specified.\n", race);
 		return false;
 	}
@@ -10920,7 +10800,7 @@ int pc_readdb(void) {
 #if defined(RENEWAL_DROP) || defined(RENEWAL_EXP)
 	sv->readdb(map->db_path, "re/level_penalty.txt", ',', 4, 4, -1, pc->readdb_levelpenalty);
 	for( k=1; k < 3; k++ ){ // fill in the blanks
-		for( j = 0; j < RC_MAX; j++ ){
+		for (j = RC_FORMLESS; j < RC_MAX; j++) {
 			int tmp = 0;
 			for( i = 0; i < MAX_LEVEL*2; i++ ){
 				if( i == MAX_LEVEL+1 )


### PR DESCRIPTION
This corrects various issues with the race handling, especially with regards to the RC_All, RC_DemiPlayer, RC_Nonplayer, etc aggregate races. Specifically:
- The following bonuses now work correctly with RC_DemiPlayer, RC_NonDemiPlayer, RC_NonDemiHuman, RC_Nonplayer:
  * bIgnoreDefRace
  * bIgnoreMdefRace
  * bDefRatioAtkRace
  * bAddMonsterDropChainItem (bonus3)
  * bAddMonsterDropItem (bonus3)
- The handling of RC_All (defined as RC_Boss and RC_NonBoss) is now properly implemented in:
  * bAddRace
  * bSubRace
  * bMagicAddRace
  * bWeaponComaRace
  * bCriticalAddRace
  * bExpAddRace
  * bSPGainRace
  * bHPDrainValueRace
  * bSPDrainValueRace
  * bSPGainRaceAttack
  * bHPGainRaceAttack
  * bRaceTolerance
  * bHPDrainRateRace
  * bSPDrainRateRace
  * bSetDefRace
  * bSetMDefRace
- Out-of-bound array accesses (memory corruption) were found and corrected in:
  * bIgnoreMdefRate
  * bIgnoreDefRate

Since the RC_All behavior is now consistent through all the race-based bonuses, items scripts that used a combination of RC_Boss and RC_NonBoss have been simplified to use RC_All, as an equivalent alternative.