### PR TITLE
Add EQP_ = Equipment Position constants

### DIFF
--- a/db/constants.conf
+++ b/db/constants.conf
@@ -777,22 +777,6 @@ constants_db: {
 	EQI_SHADOW_ACC_R:     19
 	EQI_SHADOW_ACC_L:     20
 
-	/** Look */
-	LOOK_BASE:           0
-	LOOK_HAIR:           1
-	LOOK_WEAPON:         2
-	LOOK_HEAD_BOTTOM:    3
-	LOOK_HEAD_TOP:       4
-	LOOK_HEAD_MID:       5
-	LOOK_HAIR_COLOR:     6
-	LOOK_CLOTHES_COLOR:  7
-	LOOK_SHIELD:         8
-	LOOK_SHOES:          9
-	LOOK_BODY:          10
-	LOOK_FLOOR:         11
-	LOOK_ROBE:          12
-	LOOK_BODY2:         13
-
 	/** Status effects */
 	Eff_Stone:      0
 	Eff_Freeze:     1

--- a/db/constants.conf
+++ b/db/constants.conf
@@ -3678,16 +3678,43 @@ constants_db: {
 	FW_EXTRABOLD:  800
 	FW_HEAVY:      900
 
-	/** setlook */
-	VAR_HEAD:        1
-	VAR_WEAPON:      2
-	VAR_HEAD_TOP:    3
-	VAR_HEAD_MID:    4
-	VAR_HEAD_BOTTOM: 5
-	VAR_HEADPALETTE: 6
-	VAR_BODYPALETTE: 7
-	VAR_SHIELD:      8
-	VAR_SHOES:       9
+	/** old setlook (use LOOK_* constants instead) */
+	VAR_HEAD: {
+		Value: 1
+		Deprecated: true // Use LOOK_HAIR
+	}
+	VAR_WEAPON: {
+		Value: 2
+		Deprecated: true // Use LOOK_WEAPON
+	}
+	VAR_HEAD_TOP: {
+		Value: 3
+		Deprecated: true // Use LOOK_HEAD_TOP
+	}
+	VAR_HEAD_MID: {
+		Value: 4
+		Deprecated: true // Use LOOK_HEAD_MID
+	}
+	VAR_HEAD_BOTTOM: {
+		Value: 5
+		Deprecated: true // Use LOOK_HEAD_BOTTOM
+	}
+	VAR_HEADPALETTE: {
+		Value: 6
+		Deprecated: true // Use LOOK_HAIR_COLOR
+	}
+	VAR_BODYPALETTE: {
+		Value: 7
+		Deprecated: true // Use LOOK_CLOTHES_COLOR
+	}
+	VAR_SHIELD: {
+		Value: 8
+		Deprecated: true // Use LOOK_SHIELD
+	}
+	VAR_SHOES: {
+		Value: 9
+		Deprecated: true // Use LOOK_SHOES
+	}
 
 	/** Directions */
 	DIR_NORTH:     0

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -4530,13 +4530,13 @@ the look value).
 	// This will change your hair(6), so that it uses palette 8, what ever 
 	// your palette 8 is, your hair will use that color.
 
-	setlook VAR_HEADPALETTE, 8;
+	setlook LOOK_HAIR_COLOR, 8;
 
 	// This will change your clothes(7), so they are using palette 1, 
 	// whatever your palette 1 is, your clothes will then use that set of 
 	// colors.
 
-	setlook VAR_BODYPALETTE,1;
+	setlook LOOK_CLOTHES_COLOR, 1;
 
 Here are the possible look types:
 

--- a/npc/merchants/hair_dyer.txt
+++ b/npc/merchants/hair_dyer.txt
@@ -97,7 +97,7 @@ prt_in,243,168,4	script	Jovovich	4_F_02,{
 						close;
 					}
 
-					if (.@headpalette == getlook(VAR_HEADPALETTE)) {
+					if (.@headpalette == getlook(LOOK_HAIR_COLOR)) {
 						mes "[Hairdresser Jovovich]";
 						mes "Eh? But that's the hair color you already have. Please choose a different color.";
 						next;
@@ -130,7 +130,7 @@ prt_in,243,168,4	script	Jovovich	4_F_02,{
 						case 8: delitem Scarlet_Dyestuffs,1; break;
 						}
 						Zeny -= 1000;
-						setlook VAR_HEADPALETTE,.@headpalette;
+						setlook LOOK_HAIR_COLOR,.@headpalette;
 						.@choose_success = 1;
 						break;
 					}
@@ -275,7 +275,7 @@ lhz_in02,100,134,3	script	Hair Dyer#lich	4_F_EINWOMAN,{
 						}
 						break;
 					}
-					if (getlook(VAR_HEADPALETTE) == .@headpalette) {
+					if (getlook(LOOK_HAIR_COLOR) == .@headpalette) {
 						mes "[Rossa]";
 						mes "Hmm, your hair color";
 						mes "is still fine, so there's";
@@ -388,7 +388,7 @@ lhz_in02,100,134,3	script	Hair Dyer#lich	4_F_EINWOMAN,{
 						else if (.@headpalette == 6) delitem White_Dyestuffs,1;
 						else if (.@headpalette == 7) delitem Black_Dyestuffs,1;
 						Zeny -= 1000;
-						setlook VAR_HEADPALETTE,.@headpalette;
+						setlook LOOK_HAIR_COLOR,.@headpalette;
 						.@choose_success = 1;
 						break;
 					}

--- a/npc/merchants/hair_style.txt
+++ b/npc/merchants/hair_style.txt
@@ -995,7 +995,7 @@ lhz_in02,100,143,3	script	Hair Dresser#li	2_M_DYEINGER,{
 			mes "you soooooooo beautiful!";
 			close;
 		}
-		else if (getlook(VAR_HEAD) == .@input) {
+		else if (getlook(LOOK_HAIR) == .@input) {
 			mes "[Prince Shammi]";
 			mes "Oh dear me, you're not";
 			mes "going to waste money for";
@@ -1017,7 +1017,7 @@ lhz_in02,100,143,3	script	Hair Dresser#li	2_M_DYEINGER,{
 			next;
 			switch(select("Yes.:No.")) {
 			case 1:
-				if (getlook(VAR_HEADPALETTE) == 0) {
+				if (getlook(LOOK_HAIR_COLOR) == 0) {
 					mes "[Prince Shammi]";
 					mes "Oh, Sweet Christmas,";
 					mes "I almost forgot! Would";
@@ -1072,8 +1072,8 @@ lhz_in02,100,143,3	script	Hair Dresser#li	2_M_DYEINGER,{
 				delitem Long_Hair,100;
 				delitem Golden_Hair,100;
 				delitem Glossy_Hair,100;
-				setlook VAR_HEAD,.@input;
-				setlook VAR_HEADPALETTE,.@headpalette;
+				setlook LOOK_HAIR,.@input;
+				setlook LOOK_HAIR_COLOR,.@headpalette;
 				mes "[Prince Shammi]";
 				mes "Well, we're all finished!";
 				mes "And my, oh my, you look even";
@@ -1272,8 +1272,8 @@ lhz_in02,91,155,5	script	Assistant Beautician#li	4_F_LGTGIRL,{
 				mes "^333333*Pant Pant Pant*^000000";
 				next;
 				Zeny -= 250000;
-				setlook VAR_HEAD,.@style_r;
-				setlook VAR_HEADPALETTE,.@color_r;
+				setlook LOOK_HAIR,.@style_r;
+				setlook LOOK_HAIR_COLOR,.@color_r;
 				mes "[Assistant Beautician]";
 				mes "Bwahahaha! Success!";
 				if (.@input == .@style_r) {

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -20898,6 +20898,29 @@ void script_hardcoded_constants(void)
 	script->set_constant("BG_AREA_WOS",BG_AREA_WOS,false, false);
 	script->set_constant("BG_QUEUE",BG_QUEUE,false, false);
 
+	/* Equip Position in Bits,  use with *getiteminfo type 5,  or @inventorylist_equip */
+	script->set_constant("EQP_HEAD_LOW", EQP_HEAD_LOW, false, false);
+	script->set_constant("EQP_HEAD_MID", EQP_HEAD_MID, false, false);
+	script->set_constant("EQP_HEAD_TOP", EQP_HEAD_TOP, false, false);
+	script->set_constant("EQP_HAND_R", EQP_HAND_R, false, false);
+	script->set_constant("EQP_HAND_L", EQP_HAND_L, false, false);
+	script->set_constant("EQP_ARMOR", EQP_ARMOR, false, false);
+	script->set_constant("EQP_SHOES", EQP_SHOES, false, false);
+	script->set_constant("EQP_GARMENT", EQP_GARMENT, false, false);
+	script->set_constant("EQP_ACC_L", EQP_ACC_L, false, false);
+	script->set_constant("EQP_ACC_R", EQP_ACC_R, false, false);
+	script->set_constant("EQP_COSTUME_HEAD_TOP", EQP_COSTUME_HEAD_TOP, false, false);
+	script->set_constant("EQP_COSTUME_HEAD_MID", EQP_COSTUME_HEAD_MID, false, false);
+	script->set_constant("EQP_COSTUME_HEAD_LOW", EQP_COSTUME_HEAD_LOW, false, false);
+	script->set_constant("EQP_COSTUME_GARMENT", EQP_COSTUME_GARMENT, false, false);
+	script->set_constant("EQP_AMMO", EQP_AMMO, false, false);
+	script->set_constant("EQP_SHADOW_ARMOR", EQP_SHADOW_ARMOR, false, false);
+	script->set_constant("EQP_SHADOW_WEAPON", EQP_SHADOW_WEAPON, false, false);
+	script->set_constant("EQP_SHADOW_SHIELD", EQP_SHADOW_SHIELD, false, false);
+	script->set_constant("EQP_SHADOW_SHOES", EQP_SHADOW_SHOES, false, false);
+	script->set_constant("EQP_SHADOW_ACC_R", EQP_SHADOW_ACC_R, false, false);
+	script->set_constant("EQP_SHADOW_ACC_L", EQP_SHADOW_ACC_L, false, false);
+
 	/* Renewal */
 #ifdef RENEWAL
 	script->set_constant("RENEWAL", 1, false, false);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -20898,6 +20898,22 @@ void script_hardcoded_constants(void)
 	script->set_constant("BG_AREA_WOS",BG_AREA_WOS,false, false);
 	script->set_constant("BG_QUEUE",BG_QUEUE,false, false);
 
+	/* LOOK_ constants, use in setlook/changelook script commands */
+	script->set_constant("LOOK_BASE", LOOK_BASE, false, false);
+	script->set_constant("LOOK_HAIR", LOOK_HAIR, false, false);
+	script->set_constant("LOOK_WEAPON", LOOK_WEAPON, false, false);
+	script->set_constant("LOOK_HEAD_BOTTOM", LOOK_HEAD_BOTTOM, false, false);
+	script->set_constant("LOOK_HEAD_TOP", LOOK_HEAD_TOP, false, false);
+	script->set_constant("LOOK_HEAD_MID", LOOK_HEAD_MID, false, false);
+	script->set_constant("LOOK_HAIR_COLOR", LOOK_HAIR_COLOR, false, false);
+	script->set_constant("LOOK_CLOTHES_COLOR", LOOK_CLOTHES_COLOR, false, false);
+	script->set_constant("LOOK_SHIELD", LOOK_SHIELD, false, false);
+	script->set_constant("LOOK_SHOES", LOOK_SHOES, false, false);
+	script->set_constant("LOOK_BODY", LOOK_BODY, false, false);
+	script->set_constant("LOOK_FLOOR", LOOK_FLOOR, false, false);
+	script->set_constant("LOOK_ROBE", LOOK_ROBE, false, false);
+	script->set_constant("LOOK_BODY2", LOOK_BODY2, false, false);
+
 	/* Equip Position in Bits,  use with *getiteminfo type 5,  or @inventorylist_equip */
 	script->set_constant("EQP_HEAD_LOW", EQP_HEAD_LOW, false, false);
 	script->set_constant("EQP_HEAD_MID", EQP_HEAD_MID, false, false);


### PR DESCRIPTION
the VAR_ constant added on this date
https://github.com/HerculesWS/Hercules/commit/f4278f36db32f35e535a0ea8feb1cf83ca95019e
then the LOOK_ constant added on this date
https://github.com/HerculesWS/Hercules/commit/a25c820fba6bd86fe2fb50e2b5b512295583522d

I compare the value, which both of them exist on the *setlook documentation,
with this script I made some times ago
https://github.com/AnnieRuru/customs/blob/master/scripts/Dressing%20Girl.txt
and found the one made by lone_wolf is wrong, brian is actually correct
so have to remove the one made by lone_wolf

also, the F_GetArmorType global function
https://github.com/HerculesWS/Hercules/blob/master/npc/other/Global_Functions.txt#L312
doesn't seem right, if the upper headgear cover mid, or lower, it will return default case
I wonder maybe should update it ? or better just remove it