### PR TITLE
HPM Config embading update

### DIFF
--- a/src/common/HPM.h
+++ b/src/common/HPM.h
@@ -101,7 +101,8 @@ struct HPMFileNameCache {
 struct HPConfListenStorage {
 	unsigned int pluginID;
 	char key[HPM_ADDCONF_LENGTH];
-	void (*func) (const char *val);
+	void (*parse_func) (const char *key, const char *val);
+	int  (*return_func) (const char *key);
 };
 
 /* Hercules Plugin Manager Interface */
@@ -145,6 +146,7 @@ struct HPM_interface {
 	bool (*addhook_sub) (enum HPluginHookType type, const char *target, void *hook, unsigned int pID);
 	/* for custom config parsing */
 	bool (*parseConf) (const char *w1, const char *w2, enum HPluginConfType point);
+	bool (*getBattleConf) (const char* w1, int* value);
 	/* validates plugin data */
 	bool (*DataCheck) (struct s_HPMDataCheck *src, unsigned int size, int version, char *name);
 	void (*datacheck_init) (const struct s_HPMDataCheck *src, unsigned int length, int version);

--- a/src/common/HPMi.h
+++ b/src/common/HPMi.h
@@ -183,19 +183,19 @@ enum HPluginConfType {
 /* HPMi->addPacket */
 #define addPacket(cmd,len,receive,point) HPMi->addPacket(cmd,len,receive,point,HPMi->pid)
 /* HPMi->addBattleConf */
-#define addBattleConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_BATTLE,bcname,funcname)
+#define addBattleConf(bcname,funcname,returnfunc) HPMi->addConf(HPMi->pid,HPCT_BATTLE,bcname,funcname,returnfunc)
 /* HPMi->addLogin */
-#define addLoginConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_LOGIN,bcname,funcname)
+#define addLoginConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_LOGIN,bcname,funcname,NULL)
 /* HPMi->addChar */
-#define addCharConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_CHAR,bcname,funcname)
+#define addCharConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_CHAR,bcname,funcname,NULL)
 /* HPMi->addCharInter */
-#define addCharInterConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_CHAR_INTER,bcname,funcname)
+#define addCharInterConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_CHAR_INTER,bcname,funcname,NULL)
 /* HPMi->addMapInter */
-#define addMapInterConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_MAP_INTER,bcname,funcname)
+#define addMapInterConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_MAP_INTER,bcname,funcname,NULL)
 /* HPMi->addLog */
-#define addLogConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_LOG,bcname,funcname)
+#define addLogConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_LOG,bcname,funcname,NULL)
 /* HPMi->addScript */
-#define addScriptConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_SCRIPT,bcname,funcname)
+#define addScriptConf(bcname,funcname) HPMi->addConf(HPMi->pid,HPCT_SCRIPT,bcname,funcname,NULL)
 
 /* HPMi->addPCGPermission */
 #define addGroupPermission(pcgname,maskptr) HPMi->addPCGPermission(HPMi->pid,pcgname,&maskptr)
@@ -222,7 +222,7 @@ struct HPMi_interface {
 	/* program --arg/-a */
 	bool (*addArg) (unsigned int pluginID, char *name, bool has_param, CmdlineExecFunc func, const char *help);
 	/* battle-config recv param */
-	bool (*addConf) (unsigned int pluginID, enum HPluginConfType type, char *name, void (*func) (const char *val));
+	bool (*addConf) (unsigned int pluginID, enum HPluginConfType type, char *name, void (*parse_func) (const char *key, const char *val), int  (*return_func) (const char* key));
 	/* pc group permission */
 	void (*addPCGPermission) (unsigned int pluginID, char *name, unsigned int *mask);
 

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7329,15 +7329,23 @@ int battle_set_value(const char* w1, const char* w2)
 	return 1;
 }
 
-int battle_get_value(const char* w1)
+bool battle_get_value(const char *w1, int *value)
 {
 	int i;
-	nullpo_retr(1, w1);
+
+	nullpo_retr(false, w1);
+	nullpo_retr(false, value);
+
 	ARR_FIND(0, ARRAYLENGTH(battle_data), i, strcmpi(w1, battle_data[i].str) == 0);
-	if (i == ARRAYLENGTH(battle_data))
-		return 0; // not found
-	else
-		return *battle_data[i].val;
+	if (i == ARRAYLENGTH(battle_data)) {
+		if (HPM->getBattleConf(w1,value)) 
+			return true;
+	} else {
+		*value = *battle_data[i].val;
+		return true;
+	}
+
+	return false;
 }
 
 void battle_set_defaults(void) {

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -631,7 +631,7 @@ struct battle_interface {
 	int (*config_read) (const char *cfgName);
 	void (*config_set_defaults) (void);
 	int (*config_set_value) (const char* w1, const char* w2);
-	int (*config_get_value) (const char* w1);
+	bool (*config_get_value) (const char* w1, int* value);
 	void (*config_adjust) (void);
 	/* ----------------------------------------- */
 	/* picks a random enemy within the specified range */

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -14620,8 +14620,19 @@ BUILDIN(setbattleflag)
 BUILDIN(getbattleflag)
 {
 	const char *flag;
+	int value;
 	flag = script_getstr(st,2);
-	script_pushint(st,battle->config_get_value(flag));
+	
+	if (battle->config_get_value(flag, &value)) {
+		script_pushint(st,value);
+		return true;
+	} else {
+		script_pushint(st,0);
+		ShowWarning("buildin_getbattleflag: non-exist battle config requested %s \n", flag);
+		script->reportsrc(st);
+		return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
-- Fixed Possible Crash when null parse function pointer passed to HPMi->addConf
-- Fixed issue #723 now it's possible to retrieve Battle Config Settings from plugins into scripts
-- Now it's possible to use same parse function for all config entries
-- Now Battle Config entries must have a return function