### PR TITLE
Fix Cash Shop Item Type

### DIFF
--- a/conf/battle/items.conf
+++ b/conf/battle/items.conf
@@ -93,3 +93,9 @@ item_enabled_npc: 1
 // 2 : disabled equipments are nullify, disabled cards will caused the equipment to unequip
 // 3 : disabled equipments are unequip, disabled cards will caused the equipment to unequip (1+2)
 unequip_restricted_equipment: 0
+
+// Stack Cash Shop Type items
+// Officially this items doesn't stack and unique_id is guaranteed for each
+// 1 : yes
+// 0 : no(official)
+cash_item_stack: 0

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7153,6 +7153,7 @@ static const struct battle_data {
 	{ "feature.roulette",                   &battle_config.feature_roulette,                1,      0,      1,              },
 	{ "show_monster_hp_bar",                &battle_config.show_monster_hp_bar,             1,      0,      1,              },
 	{ "fix_warp_hit_delay_abuse",           &battle_config.fix_warp_hit_delay_abuse,        0,      0,      1,              },
+	{ "cash_item_stack",                    &battle_config.cash_item_stack,                 0,      0,      1,              },
 };
 #ifndef STATS_OPT_OUT
 /**

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -512,6 +512,7 @@ struct Battle_Config {
 	int show_monster_hp_bar; // [Frost]
 
 	int fix_warp_hit_delay_abuse;
+	int cash_item_stack;
 };
 
 /* criteria for battle_config.idletime_critera */

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -511,6 +511,11 @@ int itemdb_isstackable(int nameid)
 		case IT_PETEGG:
 		case IT_PETARMOR:
 			return 0;
+		case IT_CASH:
+			if (battle_config.cash_item_stack)
+				return 1;
+			else
+				return 0;
 		default:
 			return 1;
 	}
@@ -528,6 +533,11 @@ int itemdb_isstackable2(struct item_data *data)
 		case IT_PETEGG:
 		case IT_PETARMOR:
 			return 0;
+		case IT_CASH:
+			if (battle_config.cash_item_stack)
+				return 1;
+			else
+				return 0;
 		default:
 			return 1;
 	}

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -4381,6 +4381,7 @@ int pc_search_inventory(struct map_session_data *sd, int item_id) {
 int pc_additem(struct map_session_data *sd,struct item *item_data,int amount,e_log_pick_type log_type)
 {
 	struct item_data *data;
+	struct item_data *originalitem = NULL;
 	int i;
 	unsigned int w;
 
@@ -4393,6 +4394,8 @@ int pc_additem(struct map_session_data *sd,struct item *item_data,int amount,e_l
 		return 5;
 
 	data = itemdb->search(item_data->nameid);
+	if (script->current_item_id)
+		originalitem = itemdb->search(script->current_item_id);
 
 	if( data->stack.inventory && amount > data->stack.amount )
 	{// item stack limitation
@@ -4461,7 +4464,7 @@ int pc_additem(struct map_session_data *sd,struct item *item_data,int amount,e_l
 		clif->additem(sd,i,amount,0);
 	}
 
-	if( ( !itemdb->isstackable2(data) || data->flag.force_serial || data->type == IT_CASH) && !item_data->unique_id )
+	if( ( !itemdb->isstackable2(data) || data->flag.force_serial || data->type == IT_CASH || (originalitem && originalitem->type == IT_CASH) ) && !item_data->unique_id )
 			sd->status.inventory[i].unique_id = itemdb->unique_id(sd);
 
 	logs->pick_pc(sd, log_type, amount, &sd->status.inventory[i],sd->inventory_data[i]);


### PR DESCRIPTION
Now Cash Shop item type is not stackable with option to make it stackable
in config.
also items coming out from cash shop item type items ( aka boxes ) get a
unique id
Closes #704
