### PR TITLE
Add *swap script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -7771,6 +7771,19 @@ Example:
 
 ---------------------------------------
 
+*swap <variable>,<variable>;
+
+Swap the value of 2 variables. Both sides must be same integer or string type.
+
+Example:
+	.@var1 = 111;
+	.@var2 = 222;
+	swap .@var1, .@var2;
+	mes "var1 = "+ .@var1; // return 222
+	mes "var2 = "+ .@var2; // return 111
+
+---------------------------------------
+
 *query_sql("your MySQL query"{, <array variable>{, <array variable>{, ...}}});
 *query_logsql("your MySQL query"{, <array variable>{, <array variable>{, ...}}});
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -15710,7 +15710,7 @@ BUILDIN(md5)
 
 BUILDIN(swap)
 {
-	TBL_PC *sd = NULL;
+	struct map_session_data *sd = NULL;
 	struct script_data *data1, *data2;
 	const char *varname1, *varname2;
 	int64 uid1, uid2;
@@ -15718,9 +15718,19 @@ BUILDIN(swap)
 	data1 = script_getdata(st,2);
 	data2 = script_getdata(st,3);
 
-	if (!data_isreference(data1) || !data_isreference(data2)) {
+	if (!data_isreference(data1) || !data_isreference(data2) || reference_toconstant(data1) || reference_toconstant(data2)) {
 		st->state = END;
 		return true; // avoid print error message twice
+	}
+
+	if (reference_toparam(data1) || reference_toparam(data2)) {
+		ShowError("script:swap: detected parameter type constant.\n");
+		if (reference_toparam(data1))
+			script->reportdata(data1);
+		if (reference_toparam(data2))
+			script->reportdata(data2);
+		st->state = END;
+		return false;
 	}
 
 	varname1 = reference_getname(data1);


### PR DESCRIPTION
https://github.com/HerculesWS/Hercules/blob/master/src/common/cbasetypes.h#L329
in the source, there is a swap command
but we don't have script command for it

so I make one XD

tested with all these values
```
prontera,155,187,5	script	test1	1_F_MARIA,{
	.@var1 = 111;
	.@var2 = 222;
	swap .@var1, .@var2;
	dispbottom "var1 = "+ .@var1;
	dispbottom "var2 = "+ .@var2;
}

prontera,157,187,5	script	test2	1_F_MARIA,{
	$var1[99] = 111;
	var2[33] = 222;
	swap $var1[99], var2[33];
	dispbottom "var1 = "+ $var1[99];
	dispbottom "var2 = "+ var2[33];
}

prontera,159,187,5	script	test3	1_F_MARIA,{
	detachrid;
	.@var1 = 111;
	.@var2 = 222;
	swap .@var1, .@var2;
	announce "var1 = "+ .@var1, bc_all;
	announce "var2 = "+ .@var2, bc_all;
}

prontera,161,187,5	script	test4	1_F_MARIA,{
	swap 32132, C_RED; // expect to throw error
}
```
EDIT: allow to swap string will be cool
```
prontera,155,185,5	script	test5	1_F_MARIA,{
	.@var$[0] = "abc";
	.@var$[1] = "xyz";
	swap .@var$[0], .@var$[1];
	dispbottom "var1 = "+ .@var$[0];
	dispbottom "var2 = "+ .@var$[1];
}
```