### PR TITLE
Add *setgroupid script command.

### DIFF
--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -120,6 +120,10 @@ show_hp_sp_drain: no
 // Display the gained hp/sp values from killing mobs? (Ie: Sky Deleter Card)
 show_hp_sp_gain: yes
 
+// Show the critical bonus for katar class weapon in player status window?
+// On official server, the critical bonus from katar class weapon isn't display. (Default: no)
+show_katar_crit_bonus: no
+
 // If set, when A accepts B as a friend, B will also be added to A's friend
 // list, otherwise, only A appears in B's friend list.
 // NOTE: this setting only enables friend auto-adding; auto-deletion does not work yet
@@ -175,3 +179,9 @@ snovice_call_type: 0
 // Be mindful that the more options used, the easier it becomes to cheat features that rely on idletime (e.g. checkidle()).
 // Default: walk ( 0x1 ) + useskilltoid ( 0x2 ) + useskilltopos ( 0x4 ) + useitem ( 0x8 ) + attack ( 0x10 ) = 0x1F
 idletime_criteria: 0x1F
+
+// Can players get ATK/DEF from refinements on costume/shadow equips?
+// Default: yes (Official behavior not known)
+costume_refine_def: yes
+shadow_refine_def: yes
+shadow_refine_atk: yes

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3167,6 +3167,14 @@ behave specially when talked to by GMs.
 
 ---------------------------------------
 
+*setgroupid(<new group id>{,"<character name>"|<account id>})
+
+This function will temporary adjust the id of player group the account to which the 
+player specified if the new group id is available. 
+Return 1 if success, otherwise it will return 0.
+
+---------------------------------------
+
 *getgroupid()
 
 This function will return the id of player group the account to which the 

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4558,8 +4558,8 @@ struct Damage battle_calc_weapon_attack(struct block_list *src,struct block_list
 	{
 		short cri = sstatus->cri;
 		if (sd)	{
-			// Check for katar here as katar crit bonus should not be displayed
-			if (sd->status.weapon == W_KATAR) {
+			// if show_katar_crit_bonus is enabled, it already done the calculation in status.c
+			if (!battle_config.show_katar_crit_bonus && sd->status.weapon == W_KATAR) {
 				cri <<= 1;
 			}
 
@@ -7078,6 +7078,7 @@ static const struct battle_data {
 	{ "mob_remove_damaged",                 &battle_config.mob_remove_damaged,              1,      0,      1,              },
 	{ "show_hp_sp_drain",                   &battle_config.show_hp_sp_drain,                0,      0,      1,              },
 	{ "show_hp_sp_gain",                    &battle_config.show_hp_sp_gain,                 1,      0,      1,              },
+	{ "show_katar_crit_bonus",              &battle_config.show_katar_crit_bonus,           0,      0,      1,              },
 	{ "mob_npc_event_type",                 &battle_config.mob_npc_event_type,              1,      0,      1,              },
 	{ "character_size",                     &battle_config.character_size,                  1|2,    0,      1|2,            },
 	{ "retaliate_to_master",                &battle_config.retaliate_to_master,             1,      0,      1,              },
@@ -7192,6 +7193,9 @@ static const struct battle_data {
 	{ "feature.roulette",                   &battle_config.feature_roulette,                1,      0,      1,              },
 	{ "show_monster_hp_bar",                &battle_config.show_monster_hp_bar,             1,      0,      1,              },
 	{ "fix_warp_hit_delay_abuse",           &battle_config.fix_warp_hit_delay_abuse,        0,      0,      1,              },
+	{ "costume_refine_def",                 &battle_config.costume_refine_def,              1,      0,      1,              },
+	{ "shadow_refine_def",                  &battle_config.shadow_refine_def,               1,      0,      1,              },
+	{ "shadow_refine_atk",                  &battle_config.shadow_refine_atk,               1,      0,      1,              },
 };
 #ifndef STATS_OPT_OUT
 /**

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -399,6 +399,7 @@ struct Battle_Config {
 	int boss_active_time;
 
 	int show_hp_sp_drain, show_hp_sp_gain; //[Skotlex]
+	int show_katar_crit_bonus;
 
 	int mob_npc_event_type; //Determines on who the npc_event is executed. [Skotlex]
 
@@ -528,6 +529,9 @@ struct Battle_Config {
 	int show_monster_hp_bar; // [Frost]
 
 	int fix_warp_hit_delay_abuse;
+	
+	int costume_refine_def, shadow_refine_def;
+	int shadow_refine_atk;
 };
 
 /* criteria for battle_config.idletime_critera */

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9068,6 +9068,30 @@ BUILDIN(getgmlevel)
 	return true;
 }
 
+/// set the group ID of the player.
+/// setgroupid(<new group id>{,"<character name>"|<account id>})
+/// return 1 on success, 0 if failed.
+BUILDIN(setgroupid) {
+	struct map_session_data* sd = NULL;
+	int new_group = script_getnum(st, 2);
+
+	if (script_hasdata(st, 3)) {
+		if (script_isstringtype(st, 3))
+			sd = script->nick2sd(st, script_getstr(st, 3));
+		else
+			sd = script->id2sd(st, script_getnum(st, 3));
+	}
+	else
+		sd = script->rid2sd(st);
+
+	if (sd == NULL)
+		return true; // no player attached, report source
+
+	script_pushint(st, !pc->set_group(sd, new_group));
+
+	return true;
+}
+
 /// Returns the group ID of the player.
 ///
 /// getgroupid() -> <int>
@@ -20253,7 +20277,8 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(getskilllv,"v"),
 		BUILDIN_DEF(getgdskilllv,"iv"),
 		BUILDIN_DEF(basicskillcheck,""),
-		BUILDIN_DEF(getgmlevel,""),
+		BUILDIN_DEF(getgmlevel, ""),
+		BUILDIN_DEF(setgroupid, "i?"),
 		BUILDIN_DEF(getgroupid,""),
 		BUILDIN_DEF(end,""),
 		BUILDIN_DEF(checkoption,"i"),


### PR DESCRIPTION
Useful for scripts that temporary adjust the group id of players.

## Example 
```
prontera,155,181,5	script	setgroupid	757,{
	mes "Input new Group ID";
	input .@groupid,0,99;

	dispbottom "Current Group ID : "+getgroupid();
	.@ouput = setgroupid( .@groupid );
	// .@ouput = setgroupid( .@groupid,"name" );
	// .@ouput = setgroupid( .@groupid,2000000 );
	// .@ouput = setgroupid( .@groupid,strcharinfo(0) );
	// .@ouput = setgroupid( .@groupid,getcharid(3) );
	dispbottom "> Update : "+ ( .@ouput ? "SUCCESS":"FAILED" );
	dispbottom "Latest Group ID : "+getgroupid();
	close;
}
```

## Result
![Image of Yaktocat](http://i.imgur.com/FgHx2Tn.png)