### PR TITLE
Add *setgroupid script commands.

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3167,6 +3167,14 @@ behave specially when talked to by GMs.
 
 ---------------------------------------
 
+*setgroupid(<new group id>{,"<character name>"|<account id>})
+
+This function will temporary adjust the id of player group the account to which the 
+player specified if the new group id is available. 
+Return 1 if success, otherwise it will return 0.
+
+---------------------------------------
+ 
 *getgroupid()
 
 This function will return the id of player group the account to which the 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9068,6 +9068,30 @@ BUILDIN(getgmlevel)
 	return true;
 }
 
+/// set the group ID of the player.
+/// setgroupid(<new group id>{,"<character name>"|<account id>})
+/// return 1 on success, 0 if failed.
+BUILDIN(setgroupid) {
+	struct map_session_data* sd = NULL;
+	int new_group = script_getnum(st, 2);
+
+	if (script_hasdata(st, 3)) {
+		if (script_isstringtype(st, 3))
+			sd = script->nick2sd(st, script_getstr(st, 3));
+		else
+			sd = script->id2sd(st, script_getnum(st, 3));
+	}
+	else
+		sd = script->rid2sd(st);
+
+	if (sd == NULL)
+		return true; // no player attached, report source
+
+	script_pushint(st, !pc->set_group(sd, new_group));
+
+	return true;
+}
+
 /// Returns the group ID of the player.
 ///
 /// getgroupid() -> <int>
@@ -20254,6 +20278,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(getgdskilllv,"iv"),
 		BUILDIN_DEF(basicskillcheck,""),
 		BUILDIN_DEF(getgmlevel,""),
+		BUILDIN_DEF(setgroupid, "i?"),
 		BUILDIN_DEF(getgroupid,""),
 		BUILDIN_DEF(end,""),
 		BUILDIN_DEF(checkoption,"i"),


### PR DESCRIPTION
Useful for scripts that temporary adjust the group id of players.

## Example 
```
prontera,155,181,5	script	setgroupid	757,{
	mes "Input new Group ID";
	input .@groupid,0,99;

	dispbottom "Current Group ID : "+getgroupid();
	.@ouput = setgroupid( .@groupid );
	// .@ouput = setgroupid( .@groupid,"name" );
	// .@ouput = setgroupid( .@groupid,2000000 );
	// .@ouput = setgroupid( .@groupid,strcharinfo(0) );
	// .@ouput = setgroupid( .@groupid,getcharid(3) );
	dispbottom "> Update : "+ ( .@ouput ? "SUCCESS":"FAILED" );
	dispbottom "Latest Group ID : "+getgroupid();
	close;
}
```

## Result
![Image of Yaktocat](http://i.imgur.com/FgHx2Tn.png)