### PR TITLE
Added 'OnRentalExpireEvent' trigger.

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -1102,6 +1102,41 @@ field for cash windows. It is used to remove items that are set as currency.
 Should be used along with OnCountFunds, see /doc/sample/npc_trader_sample.txt
 for more information.
 
+OnRentalExpireEvent:
+
+This special label is triggered when a rental item expired. It also return a set of 
+temporary variable that stored the information of expired item.
+Example :
+	
+	-	script	rental_expired	-1,{
+		
+		OnRentalExpireEvent:
+			// do whatever you want here when item expired.
+			dispbottom " ---- Item Expired ---- ";
+			dispbottom " > @expire_itemid = "+@expire_itemid;
+			dispbottom " > @expire_refine = "+@expire_refine;
+			dispbottom " > @expire_identify = "+@expire_identify;
+			dispbottom " > @expire_attribute = "+@expire_attribute;
+			dispbottom " > @expire_bound = "+@expire_bound;
+			dispbottom " > @expire_uniqueid = "+@expire_uniqueid;
+			dispbottom " > @expire_card[0] = "+getitemname( @expire_card[0] );
+			dispbottom " > @expire_card[1] = "+getitemname( @expire_card[1] );
+			dispbottom " > @expire_card[2] = "+getitemname( @expire_card[2] );
+			dispbottom " > @expire_card[3] = "+getitemname( @expire_card[3] );
+			
+			// must clear variables to avoid possible exploit !!
+			// especially with multiple NPCs running same label
+			@expire_itemid = 0;
+			@expire_refine = 0;
+			@expire_identify = 0;
+			@expire_attribute = 0;
+			@expire_bound = 0;
+			@expire_uniqueid = 0;
+			deletearray @expire_card;
+			end;
+	}
+
+
 On<label name>:
 
 These special labels are used with Mob scripts mostly, and script commands 

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -4542,14 +4542,15 @@ void npc_read_event_script(void)
 		char *name;
 		const char *event_name;
 	} config[] = {
-		{"Login Event",script->config.login_event_name},
-		{"Logout Event",script->config.logout_event_name},
-		{"Load Map Event",script->config.loadmap_event_name},
-		{"Base LV Up Event",script->config.baselvup_event_name},
-		{"Job LV Up Event",script->config.joblvup_event_name},
-		{"Die Event",script->config.die_event_name},
-		{"Kill PC Event",script->config.kill_pc_event_name},
-		{"Kill NPC Event",script->config.kill_mob_event_name},
+		{ "Login Event",script->config.login_event_name },
+		{ "Logout Event",script->config.logout_event_name },
+		{ "Load Map Event",script->config.loadmap_event_name },
+		{ "Base LV Up Event",script->config.baselvup_event_name },
+		{ "Job LV Up Event",script->config.joblvup_event_name },
+		{ "Die Event",script->config.die_event_name },
+		{ "Kill PC Event",script->config.kill_pc_event_name },
+		{ "Kill NPC Event", script->config.kill_mob_event_name },
+		{ "Rental Expire Event", script->config.rental_expire_name },
 	};
 
 	for (i = 0; i < NPCE_MAX; i++)

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -150,6 +150,7 @@ enum npce_event {
 	NPCE_DIE,
 	NPCE_KILLPC,
 	NPCE_KILLNPC,
+	NPCE_RENTALEXPIRE,
 	NPCE_MAX
 };
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -472,6 +472,7 @@ int pc_inventory_rental_clear(struct map_session_data *sd)
 /* assumes i is valid (from default areas where it is called, it is) */
 void pc_rental_expire(struct map_session_data *sd, int i) {
 	short nameid = sd->status.inventory[i].nameid;
+	int j;
 
 	/* Soon to be dropped, we got plans to integrate it with item db */
 	switch( nameid ) {
@@ -533,6 +534,17 @@ void pc_rental_expire(struct map_session_data *sd, int i) {
 			}
 			break;
 	}
+
+	pc->setreg(sd, script->add_str("@expire_itemid"), nameid);
+	pc->setreg(sd, script->add_str("@expire_refine"), sd->status.inventory[i].refine);
+	pc->setreg(sd, script->add_str("@expire_identify"), sd->status.inventory[i].identify);
+	pc->setreg(sd, script->add_str("@expire_attribute"), sd->status.inventory[i].attribute);
+	pc->setreg(sd, script->add_str("@expire_bound"), sd->status.inventory[i].bound);
+	// pc->setreg(sd, script->add_str("@expire_uniqueid"), sd->status.inventory[i].unique_id);
+	for (j = 0; j < MAX_SLOTS; j++) {
+		pc->setreg(sd, reference_uid(script->add_str("@expire_card"), j), sd->status.inventory[i].card[j]);
+	}
+	npc->script_event(sd, NPCE_RENTALEXPIRE);
 
 	clif->rental_expired(sd->fd, i, sd->status.inventory[i].nameid);
 	pc->delitem(sd, i, sd->status.inventory[i].amount, 0, DELITEM_NORMAL, LOG_TYPE_OTHER);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -21080,7 +21080,8 @@ void script_defaults(void) {
 	script->config.joblvup_event_name = "OnPCJobLvUpEvent";
 	script->config.ontouch_name = "OnTouch_";  //ontouch_name (runs on first visible char to enter area, picks another char if the first char leaves)
 	script->config.ontouch2_name = "OnTouch";  //ontouch2_name (run whenever a char walks into the OnTouch area)
-	script->config.onuntouch_name = "OnUnTouch";  //onuntouch_name (run whenever a char walks from the OnTouch area)
+	script->config.onuntouch_name = "OnUnTouch";  //onuntouch_name (run whenever a char walks from the OnTouch area)		   			  
+	script->config.rental_expire_name = "OnRentalExpireEvent"; // run whenever a rental item expired
 
 	// for ENABLE_CASE_CHECK
 	script->calc_hash_ci = calc_hash_ci;

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -364,6 +364,8 @@ struct Script_Config {
 	const char* ontouch_name;
 	const char* ontouch2_name;
 	const char* onuntouch_name;
+
+	const char *rental_expire_name;
 };
 
 /**


### PR DESCRIPTION
Enable users to create custom events to control the expired items.
Example: return cards/enchantment that compounded within rental items.
## Example NPC Script:

https://pastebin.com/RtxifmSv
![capture](https://cloud.githubusercontent.com/assets/1075099/12036756/f5eaecc8-ae83-11e5-8390-1c40431a7b0a.PNG)
## Screenshot

![capture](https://cloud.githubusercontent.com/assets/1075099/12036200/c565584a-ae7e-11e5-9a75-5983222242de.PNG)
I didnt save the value of `amount` because I believe rental items are removed one by one.

Extra : https://github.com/HerculesWS/Hercules/issues/140

Since I have no idea how to limit the server to only load only one event label, so I have to force the script to clear the variables just in case they loaded more than one OnRentalExpireEvent which might caused exploitations depend on how they setup it.
