### PR TITLE
Spear Stab damage adjustment

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1931,7 +1931,7 @@ int battle_calc_skillratio(int attack_type, struct block_list *src, struct block
 					skillratio += 10 * skill_lv;
 					break;
 				case KN_SPEARSTAB:
-					skillratio += 15 * skill_lv;
+					skillratio += 20 * skill_lv;
 					break;
 				case KN_SPEARBOOMERANG:
 					skillratio += 50*skill_lv;


### PR DESCRIPTION
Set the skillratio to 20*skill_lv as mentioned in skill describtions.
iro wiki: http://irowiki.org/wiki/Spear_Stab
ratemyserver: http://ratemyserver.net/skill_db.php?skid=58&small=1&back=1