### PR TITLE
Skill tree fix

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -2,7 +2,7 @@
  * This file is part of Hercules.
  * http://herc.ws - http://github.com/HerculesWS/Hercules
  *
- * Copyright (C) 2012-2015  Hercules Dev Team
+ * Copyright (C) 2012-2016  Hercules Dev Team
  * Copyright (C)  Athena Dev Teams
  *
  * Hercules is free software: you can redistribute it and/or modify
@@ -5364,12 +5364,13 @@ ACMD(displayskill) {
  * @skilltree by [MouseJstr]
  * prints the skill tree for a player required to get to a skill
  *------------------------------------------*/
-ACMD(skilltree) {
+ACMD(skilltree)
+{
 	struct map_session_data *pl_sd = NULL;
 	uint16 skill_id;
 	int meets, j, c=0;
 	char target[NAME_LENGTH];
-	struct skill_tree_entry *ent;
+	struct skill_tree_entry *entry;
 
 	if(!*message || sscanf(message, "%5hu %23[^\r\n]", &skill_id, target) != 2) {
 		clif->message(fd, msg_fd(fd,1167)); // Usage: @skilltree <skill ID> <target>
@@ -5387,21 +5388,19 @@ ACMD(skilltree) {
 	safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1168), pc->job_name(c), pc->checkskill(pl_sd, NV_BASIC)); // Player is using %s skill tree (%d basic points).
 	clif->message(fd, atcmd_output);
 
-	ARR_FIND( 0, MAX_SKILL_TREE, j, pc->skill_tree[c][j].id == 0 || pc->skill_tree[c][j].id == skill_id );
-	if( j == MAX_SKILL_TREE || pc->skill_tree[c][j].id == 0 )
-	{
+	ARR_FIND(0, MAX_SKILL_TREE, j, pc->skill_tree[c][j].id == 0 || pc->skill_tree[c][j].id == skill_id);
+	if (j == MAX_SKILL_TREE || pc->skill_tree[c][j].id == 0) {
 		clif->message(fd, msg_fd(fd,1169)); // The player cannot use that skill.
 		return false;
 	}
 
-	ent = &pc->skill_tree[c][j];
+	entry = &pc->skill_tree[c][j];
 
 	meets = 1;
-	for(j=0;j<MAX_PC_SKILL_REQUIRE;j++)
-	{
-		if( ent->need[j].id && pc->checkskill(sd,ent->need[j].id) < ent->need[j].lv)
-		{
-			safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1170), ent->need[j].lv, skill->dbs->db[ent->need[j].id].desc); // Player requires level %d of skill %s.
+	for (j = 0; j < VECTOR_LENGTH(entry->need); j++) {
+		struct skill_tree_requirement *req = &VECTOR_INDEX(entry->need, j);
+		if (pc->checkskill(sd, req->id) < req->lv) {
+			safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1170), req->lv, skill->dbs->db[req->id].desc); // Player requires level %d of skill %s.
 			clif->message(fd, atcmd_output);
 			meets = 0;
 		}

--- a/src/map/homunculus.c
+++ b/src/map/homunculus.c
@@ -2,7 +2,7 @@
  * This file is part of Hercules.
  * http://herc.ws - http://github.com/HerculesWS/Hercules
  *
- * Copyright (C) 2012-2015  Hercules Dev Team
+ * Copyright (C) 2012-2016  Hercules Dev Team
  * Copyright (C)  Athena Dev Teams
  *
  * Hercules is free software: you can redistribute it and/or modify
@@ -227,7 +227,7 @@ int homunculus_calc_skilltree(struct homun_data *hd, int flag_evolve) {
 			if( hd->homunculus.hskill[ id - HM_SKILLBASE ].id )
 				continue; //Skill already known.
 			if(!battle_config.skillfree) {
-				for( j = 0; j < MAX_PC_SKILL_REQUIRE; j++ ) {
+				for (j = 0; j < MAX_HOM_SKILL_REQUIRE; j++) {
 					if( homun->dbs->skill_tree[c][i].need[j].id &&
 					   homun->checkskill(hd,homun->dbs->skill_tree[c][i].need[j].id) < homun->dbs->skill_tree[c][i].need[j].lv ) {
 						f = 0;
@@ -252,7 +252,7 @@ int homunculus_calc_skilltree(struct homun_data *hd, int flag_evolve) {
 		if( j < homun->dbs->skill_tree[c][i].intimacylv )
 			continue;
 		if(!battle_config.skillfree) {
-			for( j = 0; j < MAX_PC_SKILL_REQUIRE; j++ ) {
+			for (j = 0; j < MAX_HOM_SKILL_REQUIRE; j++) {
 				if( homun->dbs->skill_tree[c][i].need[j].id &&
 					homun->checkskill(hd,homun->dbs->skill_tree[c][i].need[j].id) < homun->dbs->skill_tree[c][i].need[j].lv ) {
 					f = 0;
@@ -1234,7 +1234,7 @@ bool homunculus_read_skill_db_sub(char* split[], int columns, int current) {
 	if (minJobLevelPresent)
 		homun->dbs->skill_tree[classid][j].joblv = atoi(split[3]);
 
-	for( k = 0; k < MAX_PC_SKILL_REQUIRE; k++ ) {
+	for (k = 0; k < MAX_HOM_SKILL_REQUIRE; k++) {
 		homun->dbs->skill_tree[classid][j].need[k].id = atoi(split[3+k*2+minJobLevelPresent]);
 		homun->dbs->skill_tree[classid][j].need[k].lv = atoi(split[3+k*2+minJobLevelPresent+1]);
 	}

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -2,7 +2,7 @@
  * This file is part of Hercules.
  * http://herc.ws - http://github.com/HerculesWS/Hercules
  *
- * Copyright (C) 2012-2015  Hercules Dev Team
+ * Copyright (C) 2012-2016  Hercules Dev Team
  * Copyright (C)  Athena Dev Teams
  *
  * Hercules is free software: you can redistribute it and/or modify
@@ -41,7 +41,6 @@
  * Defines
  **/
 #define MAX_PC_BONUS 10
-#define MAX_PC_SKILL_REQUIRE 5
 #define MAX_PC_FEELHATE 3
 #define MAX_PC_DEVOTION 5          ///< Max amount of devotion targets
 #define PVP_CALCRANK_INTERVAL 1000 ///< PVP calculation interval
@@ -714,17 +713,19 @@ END_ZEROED_BLOCK;
 #define pc_can_give_items(sd) ( pc_has_permission((sd),PC_PERM_TRADE) )
 #define pc_can_give_bound_items(sd) ( pc_has_permission((sd),PC_PERM_TRADE_BOUND) )
 
+struct skill_tree_requirement {
+	short id;
+	unsigned short idx;
+	unsigned char lv;
+};
+
 struct skill_tree_entry {
 	short id;
 	unsigned short idx;
 	unsigned char max;
 	unsigned char joblv;
 	short inherited;
-	struct {
-		short id;
-		unsigned short idx;
-		unsigned char lv;
-	} need[MAX_PC_SKILL_REQUIRE];
+	VECTOR_DECL(struct skill_tree_requirement) need;
 }; // Celest
 
 struct sg_data {
@@ -1052,6 +1053,7 @@ END_ZEROED_BLOCK; /* End */
 	int (*autosave) (int tid, int64 tick, int id, intptr_t data);
 	int (*follow_timer) (int tid, int64 tick, int id, intptr_t data);
 	void (*read_skill_tree) (void);
+	void (*clear_skill_tree) (void);
 	int (*isUseitem) (struct map_session_data *sd,int n);
 	int (*show_steal) (struct block_list *bl,va_list ap);
 	int (*checkcombo) (struct map_session_data *sd, struct item_data *data );

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -2,7 +2,7 @@
  * This file is part of Hercules.
  * http://herc.ws - http://github.com/HerculesWS/Hercules
  *
- * Copyright (C) 2012-2015  Hercules Dev Team
+ * Copyright (C) 2012-2016  Hercules Dev Team
  * Copyright (C)  Athena Dev Teams
  *
  * Hercules is free software: you can redistribute it and/or modify
@@ -19082,22 +19082,24 @@ void skill_readdb(bool minimal) {
 	sv->readdb(map->db_path, "skill_changematerial_db.txt",  ',',   4,                    4+2*5,       MAX_SKILL_PRODUCE_DB, skill->parse_row_changematerialdb);
 }
 
-void skill_reload (void) {
+void skill_reload(void)
+{
 	struct s_mapiterator *iter;
 	struct map_session_data *sd;
-	int i,c,k;
+	int i, j, k;
 
 	skill->read_db(false);
 
 	//[Ind/Hercules] refresh index cache
-	for(c = 0; c < CLASS_COUNT; c++) {
-		for( i = 0; i < MAX_SKILL_TREE; i++ ) {
-			if( pc->skill_tree[c][i].id ) {
-				pc->skill_tree[c][i].idx = skill->get_index(pc->skill_tree[c][i].id);
-				for(k = 0; k < MAX_PC_SKILL_REQUIRE; k++) {
-					if( pc->skill_tree[c][i].need[k].id )
-						pc->skill_tree[c][i].need[k].idx = skill->get_index(pc->skill_tree[c][i].need[k].id);
-				}
+	for (j = 0; j < CLASS_COUNT; j++) {
+		for (i = 0; i < MAX_SKILL_TREE; i++) {
+			struct skill_tree_entry *entry = &pc->skill_tree[j][i];
+			if (entry->id == 0)
+				continue;
+			entry->idx = skill->get_index(entry->id);
+			for (k = 0; k < VECTOR_LENGTH(entry->need); k++) {
+				struct skill_tree_requirement *req = &VECTOR_INDEX(entry->need, k);
+				req->idx = skill->get_index(req->id);
 			}
 		}
 	}


### PR DESCRIPTION
Rewritten skill_tree parser in a more robust way

- Fixes an issue that prevented skills with more than 4 pre-requisites
  or more than 3 pre-requisites and a minimum level from being parsed
  correctly (and without any warning or error messages).
- Removes the limit on 5 pre-requisites (replaced a fixed size array
  with a VECTOR)
- Reduces memory usage of skill_tree from 794kB to 440kB (32 bit) or
  523kB (64 bit).
- Fixes an issue that prevented multiple inheritance from working
  correctly in rare cases (incorrect definition order), without any
  warning or error messages. Now a warning is displayed if a job is
  inherited before being defined.
- Fixes an issue that prevented skills inherited from being correctly
  merged with the skills defined for the current job.
- Prevents a job from inheriting itself by accident.
- Correctly detects skills defined twice for the same job.