### PR TITLE
Fix *getitem2 and @item2 refine bug.

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -1315,12 +1315,11 @@ ACMD(item2)
 			}
 			if (item_data->type == IT_PETARMOR)
 				refine = 0;
-			if (refine > MAX_REFINE)
-				refine = MAX_REFINE;
 		} else {
 			identify = 1;
 			refine = attr = 0;
 		}
+		refine = cap_value(refine, 0, MAX_REFINE);
 		for (i = 0; i < loop; i++) {
 			memset(&item_tmp, 0, sizeof(item_tmp));
 			item_tmp.nameid = item_id;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -7253,7 +7253,7 @@ BUILDIN(getitem2)
 		if (item_data == NULL)
 			return -1;
 		if(item_data->type==IT_WEAPON || item_data->type==IT_ARMOR) {
-			if(ref > MAX_REFINE) ref = MAX_REFINE;
+			ref = cap_value(ref, 0, MAX_REFINE);
 		}
 		else if(item_data->type==IT_PETEGG) {
 			iden = 1;


### PR DESCRIPTION
- Negative refine value isn't allowed.

## Example
Create a NPC that give item using getitem2 script command.
```
prontera,155,175,5	script	Sample#getitem2	1_M_04,{
	getitem2 5353,2,1,-1,1,4403,4403,4403,4403 );
	end;
}
```

## Result
![capture](https://cloud.githubusercontent.com/assets/1075099/12078124/9cf7442e-b241-11e5-8332-2761ac3f95e3.PNG)