### PR TITLE
Bow UnEquip Official Behavior

### DIFF
--- a/conf/battle/items.conf
+++ b/conf/battle/items.conf
@@ -93,3 +93,7 @@ item_enabled_npc: 1
 // 2 : disabled equipments are nullify, disabled cards will caused the equipment to unequip
 // 3 : disabled equipments are unequip, disabled cards will caused the equipment to unequip (1+2)
 unequip_restricted_equipment: 0
+
+// When unequip a bow with arrow equipped, it also unequip the arrow?
+// Default: yes (Official behavior, applies only in Renewal)
+bow_unequip_arrow: yes

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7257,6 +7257,7 @@ static const struct battle_data {
 	{ "min_body_style",                     &battle_config.min_body_style,                  0,      0,      SHRT_MAX,       },
 	{ "max_body_style",                     &battle_config.max_body_style,                  4,      0,      SHRT_MAX,       },
 	{ "save_body_style",                    &battle_config.save_body_style,                 0,      0,      1,              },
+	{ "bow_unequip_arrow",                  &battle_config.bow_unequip_arrow,               1,      0,      1,              },
 };
 #ifndef STATS_OPT_OUT
 /**

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -539,6 +539,8 @@ struct Battle_Config {
 	// BodyStyle
 	int min_body_style, max_body_style;
 	int save_body_style;
+	
+	int bow_unequip_arrow;
 };
 
 /* criteria for battle_config.idletime_critera */

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -9789,6 +9789,15 @@ int pc_unequipitem(struct map_session_data *sd,int n,int flag)
 		status_change_end(&sd->bl, SC_BENEDICTIO, INVALID_TIMER);
 		status_change_end(&sd->bl, SC_ARMOR_RESIST, INVALID_TIMER);
 	}
+	
+#ifdef RENEWAL
+	if (battle_config.bow_unequip_arrow) {
+		if (pos & EQP_ARMS) {
+			if (sd->equip_index[EQI_AMMO] > 0)
+				pc->unequipitem(sd, sd->equip_index[EQI_AMMO], PCUNEQUIPITEM_FORCE);
+		}
+	}
+#endif
 
 	if( sd->state.autobonus&pos )
 		sd->state.autobonus &= ~sd->status.inventory[n].equip; //Check for activated autobonus [Inkfish]


### PR DESCRIPTION
- When unequip a bow if there's arrow equipped, it will also unequips the arrow.
- Added battle configuration.

Ref: #745

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1079)
<!-- Reviewable:end -->
