### PR TITLE
Fix 3rd jobs BaseLevel requirement

### DIFF
--- a/npc/re/jobs/3-1/archbishop.txt
+++ b/npc/re/jobs/3-1/archbishop.txt
@@ -64,7 +64,7 @@ prt_church,103,88,3	script	Praying Minister#arch	1_M_PASTOR,{
 		mes "I'm going to make them ministers worthy of serving Odin.";
 		close;
 	}
-	if ((BaseLevel == 99) && (JobLevel > 49)) {
+	if ((BaseLevel >= 99) && (JobLevel > 49)) {
 		if (job_arch == 0) {
 			if (SkillPoint) {
 				mes "You can't change jobs without using all your skill points. Please use all of your skill points before applying to change jobs~";
@@ -775,7 +775,7 @@ job3_arch01,29,34,3	script	Valkyrie#arch	4_F_VALKYRIE2,{
 		mes "- and come for the challenge again. -";
 		close;
 	}
-	if ((BaseLevel != 99) || (JobLevel < 50) || (BaseJob != Job_Priest)) {
+	if ((BaseLevel < 99) || (JobLevel < 50) || (BaseJob != Job_Priest)) {
 		warp "odin_tem02",282,263;
 		end;
 	}

--- a/npc/re/jobs/3-1/guillotine_cross.txt
+++ b/npc/re/jobs/3-1/guillotine_cross.txt
@@ -37,7 +37,7 @@
 que_job01,75,96,3	script	Guild Member#3rdgc01	4_M_MOCASS1,{
 	if (job_3rd_gc == 0) {
 		if (Class == Job_Assassin || Class == Job_Assassin_Cross || Class == Job_Baby_Assassin) {
-			if (BaseLevel == 99) {
+			if (BaseLevel >= 99) {
 			L_Mission:
 				mes "[Ahcart]";
 				mes "Finally, it's time...";
@@ -127,7 +127,7 @@ que_job01,75,96,3	script	Guild Member#3rdgc01	4_M_MOCASS1,{
 		mes "You are not an assassin.";
 		close;
 	} else if (job_3rd_gc == 1) {
-		if (BaseLevel == 99) goto L_Mission;
+		if (BaseLevel >= 99) goto L_Mission;
 		mes "[Ahcart]";
 		mes "If you become stronger and more skillful, then the assassin's guild will give you a special task.";
 		mes "Go for it.";


### PR DESCRIPTION
continue on the adventure on my friends server...
he increased the BaseLevel on all jobs on db\re\exp.txt
although his server has [job changer npc](https://github.com/HerculesWS/Hercules/blob/master/npc/custom/jobmaster.txt),
but I found out the official script gives 3rd job exclusive items, so I do the 3rd class quest

what a weird thing is, my gypsy can do the wanderer job change quest on level100+, no problem
but my high priest can't start the quest .... what a stupid check

on a side note, I noticed warlock check with [BaseLevel > 94](https://github.com/HerculesWS/Hercules/blob/master/npc/re/jobs/3-1/warlock.txt#L61)
is this seriously official ?
although the npc only start the quest on level99+