### PR TITLE
more meaningful names for fields of enum guild_permission

### DIFF
--- a/src/char/int_guild.c
+++ b/src/char/int_guild.c
@@ -1201,7 +1201,7 @@ int mapif_parse_CreateGuild(int fd,int account_id,char *name,struct guild_member
 	g->member[0].modified = GS_MEMBER_MODIFIED;
 
 	// Set default positions
-	g->position[0].mode = GPERM_BOTH;
+	g->position[0].mode = GPERM_ALL;
 	strcpy(g->position[0].name,"GuildMaster");
 	strcpy(g->position[MAX_GUILDPOSITION-1].name,"Newbie");
 	g->position[0].modified = g->position[MAX_GUILDPOSITION-1].modified = GS_POSITION_MODIFIED;

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -749,7 +749,8 @@ enum { //Change Member Infos
 enum guild_permission { // Guild permissions
 	GPERM_INVITE = 0x01,
 	GPERM_EXPEL = 0x10,
-	GPERM_BOTH = GPERM_INVITE|GPERM_EXPEL,
+	GPERM_ALL = GPERM_INVITE|GPERM_EXPEL,
+	GPERM_MASK = GPERM_ALL,
 };
 
 enum {

--- a/src/map/guild.c
+++ b/src/map/guild.c
@@ -1117,7 +1117,7 @@ int guild_change_position(int guild_id,int idx,int mode,int exp_mode,const char 
 	nullpo_ret(name);
 
 	exp_mode = cap_value(exp_mode, 0, battle_config.guild_exp_limit);
-	p.mode=mode&GPERM_BOTH; // Invite and Expel
+	p.mode=mode&GPERM_MASK;
 	p.exp_mode=exp_mode;
 	safestrncpy(p.name,name,NAME_LENGTH);
 	return intif->guild_position(guild_id,idx,&p);


### PR DESCRIPTION
I came across a custom patch that extended the guild_permission logic with additional features, controlled via atcommands. While cleaning it up to use enum constants instead of hexadecimal values, I found that the current form of GPERM_BOTH does not extend very well. So I tweaked the naming a bit. I also noticed that the same name, GPERM_BOTH, is used in two unrelated contexts, so I split off a more meaningfully named alias.