### PR TITLE
Updating units direction is now configurable.

### DIFF
--- a/conf/battle/client.conf
+++ b/conf/battle/client.conf
@@ -133,3 +133,9 @@ client_accept_chatdori: 0
 // A value of 100 (allowing 100% blank pixels) disables this check.
 // NOTE: Enabling this option slightly degrades performance.
 client_emblem_max_blank_percent: 100
+
+// Refreshes the direction the client displays for a single unit (player, mob, etc)
+// when a skill or attack is performed. (Note 3)
+// Fixes a bug when the client displays different directions than stored in server side
+// and causes skills based on direction to fail (e.g. backstab)
+update_direction: 0

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7258,6 +7258,7 @@ static const struct battle_data {
 	{ "min_body_style",                     &battle_config.min_body_style,                  0,      0,      SHRT_MAX,       },
 	{ "max_body_style",                     &battle_config.max_body_style,                  4,      0,      SHRT_MAX,       },
 	{ "save_body_style",                    &battle_config.save_body_style,                 0,      0,      1,              },
+	{ "update_direction",                   &battle_config.update_direction,               BL_NUL,  BL_NUL, BL_ALL,         },
 };
 #ifndef STATS_OPT_OUT
 /**

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -539,6 +539,8 @@ struct Battle_Config {
 	// BodyStyle
 	int min_body_style, max_body_style;
 	int save_body_style;
+
+	int update_direction;
 };
 
 /* criteria for battle_config.idletime_critera */

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -5163,7 +5163,7 @@ int skill_castend_id(int tid, int64 tick, int id, intptr_t data) {
 			ud->skill_lv = ud->skilltarget = 0;
 		}
 
-		if (src->id != target->id)
+		if ((src->type&battle_config.update_direction) && src->id != target->id)
 			unit->setdir(src, map->calc_dir(src, target->x, target->y));
 
 		map->freeblock_unlock();
@@ -10061,7 +10061,8 @@ int skill_castend_pos(int tid, int64 tick, int id, intptr_t data)
 		if( sd && sd->skillitem != AL_WARP ) // Warp-Portal thru items will clear data in skill_castend_map. [Inkfish]
 			sd->skillitem = sd->skillitemlv = 0;
 
-		unit->setdir(src, map->calc_dir(src, ud->skillx, ud->skilly));
+		if (src->type&battle_config.update_direction)
+			unit->setdir(src, map->calc_dir(src, ud->skillx, ud->skilly));
 
 		if (ud->skilltimer == INVALID_TIMER) {
 			if (md) md->skill_idx = -1;

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1625,7 +1625,7 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 	ud->skill_lv      = skill_lv;
 
 	if( casttime > 0 ) {
-		if (src->id != target->id) // self-targeted skills shouldn't show different direction
+		if ((src->type&battle_config.update_direction) && src->id != target->id) // self-targeted skills shouldn't show different direction
 			unit->setdir(src, map->calc_dir(src, target->x, target->y));
 		ud->skilltimer = timer->add( tick+casttime, skill->castend_id, src->id, 0 );
 		if( sd && (pc->checkskill(sd,SA_FREECAST) > 0 || skill_id == LG_EXEEDBREAK) )
@@ -1770,7 +1770,8 @@ int unit_skilluse_pos2( struct block_list *src, short skill_x, short skill_y, ui
 	// in official this is triggered even if no cast time.
 	clif->skillcasting(src, src->id, 0, skill_x, skill_y, skill_id, skill->get_ele(skill_id, skill_lv), casttime);
 	if( casttime > 0 ) {
-		unit->setdir(src, map->calc_dir(src, skill_x, skill_y));
+		if (src->type&battle_config.update_direction)
+			unit->setdir(src, map->calc_dir(src, skill_x, skill_y));
 		ud->skilltimer = timer->add( tick+casttime, skill->castend_pos, src->id, 0 );
 		if ( (sd && pc->checkskill(sd, SA_FREECAST) > 0) || skill_id == LG_EXEEDBREAK ) {
 			status_calc_bl(&sd->bl, SCB_SPEED|SCB_ASPD);
@@ -2208,7 +2209,8 @@ int unit_attack_timer_sub(struct block_list* src, int tid, int64 tick) {
 	}
 
 	if(ud->state.attack_continue) {
-		unit->setdir(src, map->calc_dir(src, target->x, target->y));
+		if (src->type&battle_config.update_direction)
+			unit->setdir(src, map->calc_dir(src, target->x, target->y));
 		if( src->type == BL_PC )
 			pc->update_idle_time(sd, BCIDLE_ATTACK);
 		ud->attacktimer = timer->add(ud->attackabletime,unit->attack_timer,src->id,0);


### PR DESCRIPTION
Added update_direction as bitmask option in battle/client.conf, defaults
to 0 (no updates at all).
