### PR TITLE
Move P2PTR Macro and Define Packet DB enums

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -213,6 +213,11 @@
 #define JOBL_BABY 0x2000  //8192
 #define JOBL_THIRD 0x4000 //16384
 
+//Packet DB
+#define MIN_PACKET_DB 0x0064 //what's the point of minimum packet id ? [hemagx]
+#define MAX_PACKET_DB 0x0F00
+#define MAX_PACKET_POS 20
+
 #define SCRIPT_VARNAME_LENGTH 32 ///< Maximum length of a script variable
 
 struct hplugin_data_store;

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -77,6 +77,11 @@ struct hplugin_data_store;
 
 /* [Ind/Hercules] */
 #define RFIFO2PTR(fd) (void*)(sockt->session[fd]->rdata + sockt->session[fd]->rdata_pos)
+#define RP2PTR(fd) RFIFO2PTR(fd)
+
+/* [Hemagx/Hercules] */
+#define WFIFO2PTR(fd) (void*)(sockt->session[fd]->wdata + sockt->session[fd]->wdata_pos)
+#define WP2PTR(fd) WFIFO2PTR(fd)
 
 // buffer I/O macros
 #define RBUFP(p,pos) (((uint8*)(p)) + (pos))

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10396,7 +10396,7 @@ void clif_parse_EquipItem(int fd,struct map_session_data *sd) __attribute__((non
 /// 00a9 <index>.W <position>.W
 /// 0998 <index>.W <position>.L
 void clif_parse_EquipItem(int fd,struct map_session_data *sd) {
-	struct packet_equip_item *p = P2PTR(fd);
+	struct packet_equip_item *p = RP2PTR(fd);
 
 	if(pc_isdead(sd)) {
 		clif->clearunit_area(&sd->bl,CLR_DEAD);
@@ -13377,7 +13377,7 @@ void clif_parse_GM_Monster_Item(int fd, struct map_session_data *sd) __attribute
 /// 013f <item/mob name>.24B
 /// 09ce <item/mob name>.100B [Ind/Yommy<3]
 void clif_parse_GM_Monster_Item(int fd, struct map_session_data *sd) {
-	struct packet_gm_monster_item *p = P2PTR(fd);
+	struct packet_gm_monster_item *p = RP2PTR(fd);
 	int i, count;
 	char *item_monster_name;
 	struct item_data *item_array[10];
@@ -17692,7 +17692,7 @@ void clif_bgqueue_notice_delete(struct map_session_data *sd, enum BATTLEGROUNDS_
 
 void clif_parse_bgqueue_register(int fd, struct map_session_data *sd) __attribute__((nonnull (2)));
 void clif_parse_bgqueue_register(int fd, struct map_session_data *sd) {
-	struct packet_bgqueue_register *p = P2PTR(fd);
+	struct packet_bgqueue_register *p = RP2PTR(fd);
 	struct bg_arena *arena = NULL;
 	if( !bg->queue_on ) return; /* temp, until feature is complete */
 
@@ -17730,7 +17730,7 @@ void clif_bgqueue_update_info(struct map_session_data *sd, unsigned char arena_i
 
 void clif_parse_bgqueue_checkstate(int fd, struct map_session_data *sd) __attribute__((nonnull (2)));
 void clif_parse_bgqueue_checkstate(int fd, struct map_session_data *sd) {
-	struct packet_bgqueue_checkstate *p = P2PTR(fd);
+	struct packet_bgqueue_checkstate *p = RP2PTR(fd);
 
 	nullpo_retv(sd);
 	if ( sd->bg_queue.arena && sd->bg_queue.type ) {
@@ -17741,7 +17741,7 @@ void clif_parse_bgqueue_checkstate(int fd, struct map_session_data *sd) {
 
 void clif_parse_bgqueue_revoke_req(int fd, struct map_session_data *sd) __attribute__((nonnull (2)));
 void clif_parse_bgqueue_revoke_req(int fd, struct map_session_data *sd) {
-	struct packet_bgqueue_revoke_req *p = P2PTR(fd);
+	struct packet_bgqueue_revoke_req *p = RP2PTR(fd);
 
 	if( sd->bg_queue.arena )
 		bg->queue_pc_cleanup(sd);
@@ -17751,7 +17751,7 @@ void clif_parse_bgqueue_revoke_req(int fd, struct map_session_data *sd) {
 
 void clif_parse_bgqueue_battlebegin_ack(int fd, struct map_session_data *sd) __attribute__((nonnull (2)));
 void clif_parse_bgqueue_battlebegin_ack(int fd, struct map_session_data *sd) {
-	struct packet_bgqueue_battlebegin_ack *p = P2PTR(fd);
+	struct packet_bgqueue_battlebegin_ack *p = RP2PTR(fd);
 	struct bg_arena *arena;
 
 	if( !bg->queue_on ) return; /* temp, until feature is complete */
@@ -17890,7 +17890,7 @@ void clif_cart_additem_ack(struct map_session_data *sd, int flag) {
 void clif_parse_BankDeposit(int fd, struct map_session_data* sd) __attribute__((nonnull (2)));
 /* Bank System [Yommy/Hercules] */
 void clif_parse_BankDeposit(int fd, struct map_session_data* sd) {
-	struct packet_banking_deposit_req *p = P2PTR(fd);
+	struct packet_banking_deposit_req *p = RP2PTR(fd);
 	int money;
 
 	if (!battle_config.feature_banking) {
@@ -17905,7 +17905,7 @@ void clif_parse_BankDeposit(int fd, struct map_session_data* sd) {
 
 void clif_parse_BankWithdraw(int fd, struct map_session_data* sd) __attribute__((nonnull (2)));
 void clif_parse_BankWithdraw(int fd, struct map_session_data* sd) {
-	struct packet_banking_withdraw_req *p = P2PTR(fd);
+	struct packet_banking_withdraw_req *p = RP2PTR(fd);
 	int money;
 
 	if (!battle_config.feature_banking) {
@@ -18182,7 +18182,7 @@ void clif_npc_market_purchase_ack(struct map_session_data *sd, struct packet_npc
 void clif_parse_NPCMarketPurchase(int fd, struct map_session_data *sd) __attribute__((nonnull (2)));
 void clif_parse_NPCMarketPurchase(int fd, struct map_session_data *sd) {
 #if PACKETVER >= 20131223
-	struct packet_npc_market_purchase *p = P2PTR(fd);
+	struct packet_npc_market_purchase *p = RP2PTR(fd);
 
 	clif->npc_market_purchase_ack(sd,p,npc->market_buylist(sd,(p->PacketLength - 4) / sizeof(p->list[0]),p));
 #endif
@@ -18866,6 +18866,11 @@ static void __attribute__ ((unused)) packetdb_addpacket(short cmd, int len, ...)
 
 	if (cmd > MAX_PACKET_DB) {
 		ShowError("Packet Error: packet 0x%x is greater than the maximum allowed (0x%x), skipping...\n", cmd, MAX_PACKET_DB);
+		return;
+	}
+
+	if (cmd < MIN_PACKET_DB) {
+		ShowError("Packet Error: packet 0x%x is lower than the minimum allowed (0x%x), skipping...\n", cmd, MIN_PACKET_DB);
 		return;
 	}
 

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -58,7 +58,6 @@ struct view_data;
  * Defines
  **/
 #define packet_len(cmd) packet_db[cmd].len
-#define P2PTR(fd) RFIFO2PTR(fd)
 #define clif_menuskill_clear(sd) ((sd)->menuskill_id = (sd)->menuskill_val = (sd)->menuskill_val2 = 0)
 #define clif_disp_onlyself(sd,mes,len) clif->disp_message( &(sd)->bl, (mes), (len), SELF )
 #define MAX_ROULETTE_LEVEL 7 /** client-defined value **/
@@ -73,12 +72,6 @@ struct view_data;
 /**
  * Enumerations
  **/
-enum {// packet DB
-	MIN_PACKET_DB  = 0x0064,
-	MAX_PACKET_DB  = 0x0F00,
-	MAX_PACKET_POS = 20,
-};
-
 typedef enum send_target {
 	ALL_CLIENT,
 	ALL_SAMEMAP,


### PR DESCRIPTION
Move P2PTR Macro to socket header and split the macro into two macros for WFIFO/RFIFO.
Change packet database enums to defines in mmo.h