### PR TITLE
Monster Vulture's Eye and Snake's Eye removed

### DIFF
--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -81,6 +81,12 @@ view_range_rate: 100
 // column in the mob_db. (Note 2)
 chase_range_rate: 100
 
+// Which level of of Vulture's Eye and Snake's Eye should monsters have learned?
+// Officially monsters don't have these skills learned, so their ranged skills
+// only have a range of 9. If you put a number higher than 0, their range will
+// be increased by that number.
+monster_eye_range_bonus: 0
+
 // Allow monsters to be aggresive and attack first? (Note 1)
 monster_active_enable: yes
 

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7258,6 +7258,7 @@ static const struct battle_data {
 	{ "min_body_style",                     &battle_config.min_body_style,                  0,      0,      SHRT_MAX,       },
 	{ "max_body_style",                     &battle_config.max_body_style,                  4,      0,      SHRT_MAX,       },
 	{ "save_body_style",                    &battle_config.save_body_style,                 0,      0,      1,              },
+	{ "monster_eye_range_bonus",            &battle_config.mob_eye_range_bonus,             0,      0,      10,             },
 };
 #ifndef STATS_OPT_OUT
 /**

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -539,6 +539,8 @@ struct Battle_Config {
 	// BodyStyle
 	int min_body_style, max_body_style;
 	int save_body_style;
+
+	int mob_eye_range_bonus; //Vulture's Eye and Snake's Eye range bonus
 };
 
 /* criteria for battle_config.idletime_critera */

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -292,7 +292,7 @@ int skill_get_range2 (struct block_list *bl, uint16 skill_id, uint16 skill_lv) {
 			if (sd != NULL)
 				range += pc->checkskill(sd, AC_VULTURE);
 			else
-				range += 10; //Assume level 10?
+				range += battle_config.mob_eye_range_bonus;
 			break;
 		// added to allow GS skills to be effected by the range of Snake Eyes [Reddozen]
 		case GS_RAPIDSHOWER:
@@ -303,7 +303,7 @@ int skill_get_range2 (struct block_list *bl, uint16 skill_id, uint16 skill_lv) {
 			if (sd != NULL)
 				range += pc->checkskill(sd, GS_SNAKEEYE);
 			else
-				range += 10; //Assume level 10?
+				range += battle_config.mob_eye_range_bonus;
 			break;
 		case NJ_KIRIKAGE:
 			if (sd != NULL)


### PR DESCRIPTION
- Monsters no longer have Vulture's Eye level 10 and Snake's Eye level 10 learned by default
- When you tank Cecil Damon from 10-14 cells away, she will no longer use her target skills
- Added a configuration with which you can set the level of Vulture's Eye and Snake's Eye that monsters have learned
  Merged rathena/rathena@cccd1496f716fe02a3db20780b6e52b3c33391b4
  Credit: Playtester
