### PR TITLE
Fix crash on npc emote, if npc not found.

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -12105,7 +12105,7 @@ BUILDIN(emotion) {
 			clif->emotion(&sd->bl,type);
 	} else if( script_hasdata(st,4) ) {
 		struct npc_data *nd = npc->name2id(script_getstr(st,4));
-		if (nd == NULL)
+		if (nd != NULL)
 			clif->emotion(&nd->bl,type);
 	} else {
 		clif->emotion(map->id2bl(st->oid),type);


### PR DESCRIPTION
Reported in http://herc.ws/board/topic/11994-map-crashed-on-friendly-poring-quest-novice-quest/