### PR TITLE
Unittalk script cmd shouldn't display the hidden name of npc

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -16818,8 +16818,12 @@ BUILDIN(unittalk) {
 	bl = map->id2bl(unit_id);
 	if( bl != NULL ) {
 		struct StringBuf sbuf;
+		char blname[NAME_LENGTH];
 		StrBuf->Init(&sbuf);
-		StrBuf->Printf(&sbuf, "%s : %s", clif->get_bl_name(bl), message);
+		safestrncpy(blname, clif->get_bl_name(bl), sizeof(blname));
+		if(bl->type == BL_NPC)
+			strtok(blname, "#");
+		StrBuf->Printf(&sbuf, "%s : %s", blname, message);
 		clif->disp_overhead(bl, StrBuf->Value(&sbuf));
 		StrBuf->Destroy(&sbuf);
 	}


### PR DESCRIPTION
my test:

    prontera,156,153,5	script	afda#123	4_F_MAID,{
     unittalk getnpcid(0),"Hi I m a npc!";
     close;
    }

<img width="136" alt="npctest" src="https://cloud.githubusercontent.com/assets/2773211/14098084/b3dbefb2-f5aa-11e5-9b98-8a470797bbb7.png">

after fixes
<img width="171" alt="02" src="https://cloud.githubusercontent.com/assets/2773211/14098175/bceccd5a-f5ab-11e5-8f79-c82fe217c6b8.png">
