### PR TITLE
Update parse of mobs, now we can use 'monster ID constants'.

### DIFF
--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -3741,11 +3741,13 @@ const char *npc_parse_mob(const char *w1, const char *w2, const char *w3, const 
 	if (!npc->viewisid(mob_constname)) {
 		if (!script->get_constant(mob_constname, &class_)) {
 			ShowError("npc_parse_mob: Invalid mob constant '%s' in file '%s', line '%d'.\n", mob_constname, filepath, strline(buffer,start-buffer));
-			if (retval) *retval = EXIT_FAILURE;
+			if (retval)
+				*retval = EXIT_FAILURE;
 			return strchr(start,'\n');// skip and continue
 		}
-	} else
+	} else {
 		class_ = atoi(mob_constname);
+	}
 
 	// check monster ID if exists!
 	if( mob->db_checkid(class_) == 0 ) {

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -3704,6 +3704,7 @@ const char *npc_parse_mob(const char *w1, const char *w2, const char *w3, const 
 	char mapname[32], mobname[NAME_LENGTH];
 	struct spawn_data mobspawn, *data;
 	struct mob_db* db;
+	char mob_constname[NAME_LENGTH]; // [Cretino]
 
 	memset(&mobspawn, 0, sizeof(struct spawn_data));
 
@@ -3714,7 +3715,7 @@ const char *npc_parse_mob(const char *w1, const char *w2, const char *w3, const 
 	// w4=<mob id>,<amount>,<delay1>,<delay2>{,<event>,<mob size>,<mob ai>}
 	if( sscanf(w1, "%31[^,],%d,%d,%d,%d", mapname, &x, &y, &xs, &ys) < 5
 	 || sscanf(w3, "%23[^,],%d", mobname, &mob_lv) < 1
-	 || sscanf(w4, "%d,%d,%u,%u,%50[^,],%d,%d[^\t\r\n]", &class_, &num, &mobspawn.delay1, &mobspawn.delay2, mobspawn.eventname, &size, &ai) < 4
+	 || sscanf(w4, "%23[^,],%d,%u,%u,%50[^,],%d,%d[^\t\r\n]", mob_constname, &num, &mobspawn.delay1, &mobspawn.delay2, mobspawn.eventname, &size, &ai) < 4
 	 ) {
 		ShowError("npc_parse_mob: Invalid mob definition in file '%s', line '%d'.\n * w1=%s\n * w2=%s\n * w3=%s\n * w4=%s\n", filepath, strline(buffer,start-buffer), w1, w2, w3, w4);
 		if (retval) *retval = EXIT_FAILURE;
@@ -3735,6 +3736,19 @@ const char *npc_parse_mob(const char *w1, const char *w2, const char *w3, const 
 		if (retval) *retval = EXIT_FAILURE;
 		return strchr(start,'\n');// skip and continue
 	}
+
+	// Using 'npc->viewisid' to checks if given 'mobname' is an interger or constant. [Cretino]
+	if (!npc->viewisid(mob_constname))
+	{
+		if (!script->get_constant(mob_constname, &class_))
+		{
+			ShowError("npc_parse_mob: Invalid mob constant '%s' in file '%s', line '%d'.\n", mob_constname, filepath, strline(buffer,start-buffer));
+			if (retval) *retval = EXIT_FAILURE;
+			return strchr(start,'\n');// skip and continue
+		}
+	}
+	else
+		class_ = atoi(mob_constname);
 
 	// check monster ID if exists!
 	if( mob->db_checkid(class_) == 0 ) {

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -3738,16 +3738,13 @@ const char *npc_parse_mob(const char *w1, const char *w2, const char *w3, const 
 	}
 
 	// Using 'npc->viewisid' to checks if given 'mob_constname' is an interger or constant. [Cretino]
-	if (!npc->viewisid(mob_constname))
-	{
-		if (!script->get_constant(mob_constname, &class_))
-		{
+	if (!npc->viewisid(mob_constname)) {
+		if (!script->get_constant(mob_constname, &class_)) {
 			ShowError("npc_parse_mob: Invalid mob constant '%s' in file '%s', line '%d'.\n", mob_constname, filepath, strline(buffer,start-buffer));
 			if (retval) *retval = EXIT_FAILURE;
 			return strchr(start,'\n');// skip and continue
 		}
-	}
-	else
+	} else
 		class_ = atoi(mob_constname);
 
 	// check monster ID if exists!

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -3737,7 +3737,7 @@ const char *npc_parse_mob(const char *w1, const char *w2, const char *w3, const 
 		return strchr(start,'\n');// skip and continue
 	}
 
-	// Using 'npc->viewisid' to checks if given 'mobname' is an interger or constant. [Cretino]
+	// Using 'npc->viewisid' to checks if given 'mob_constname' is an interger or constant. [Cretino]
 	if (!npc->viewisid(mob_constname))
 	{
 		if (!script->get_constant(mob_constname, &class_))


### PR DESCRIPTION
Update parse of mobs, now we can use 'monster ID constants'.
eg:
prontera,154,154,0,0	monster	Brown Snake	SIDE_WINDER,1,0,0,0

Old way sill works. :)

Signed-off-by: Cretino <yuri-lolz@hotmail.com>