### PR TITLE
Tarot Card/Gospel vs Chemical Protection

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -7753,7 +7753,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 						sc_start(src,bl,SC_INCMATKRATE,100,-50,skill->get_time2(skill_id,skill_lv));
 						break;
 					case 2: // all buffs removed
-						status->change_clear_buffs(bl,1);
+						status->change_clear_buffs(bl, SC_CLEAR_BUFF | SC_CLEAR_CHEMICAL_PROTECT);
 						break;
 					case 3: // 1000 damage, random armor destroyed
 						{
@@ -8205,7 +8205,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 			clif->skill_nodamage(src,bl,skill_id,skill_lv,
 			                     sc_start(src,bl,type,100,skill_lv,skill->get_time(skill_id,skill_lv)));
 			status->heal(bl,heal,0,1);
-			status->change_clear_buffs(bl,4);
+			status->change_clear_buffs(bl, SC_CLEAR_DEBUFF_SPECIAL);
 		}
 			break;
 
@@ -8256,7 +8256,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 						type = SC_MILLENNIUMSHIELD;
 					}else if( skill->area_temp[5]&0x20 ){
 						value = status_get_max_hp(bl) * 25 / 100;
-						status->change_clear_buffs(bl,4);
+						status->change_clear_buffs(bl, SC_CLEAR_DEBUFF_SPECIAL);
 						skill->area_temp[5] &= ~0x20;
 						status->heal(bl,value,0,1);
 						type = SC_REFRESH;
@@ -10720,7 +10720,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 				if (!sg) break;
 				if (sce)
 					status_change_end(src, type, INVALID_TIMER); //Was under someone else's Gospel. [Skotlex]
-				status->change_clear_buffs(src,3);
+				status->change_clear_buffs(src, SC_CLEAR_BUFF | SC_CLEAR_DEBUFF);
 				sc_start4(src,src,type,100,skill_lv,0,sg->group_id,BCT_SELF,skill->get_time(skill_id,skill_lv));
 				clif->skill_poseffect(src, skill_id, skill_lv, 0, 0, tick); // PA_GOSPEL music packet
 			}
@@ -11761,7 +11761,7 @@ int skill_unit_onplace(struct skill_unit *src, struct block_list *bl, int64 tick
 
 		case UNT_HERMODE:
 			if (sg->src_id!=bl->id && battle->check_target(&src->bl,bl,BCT_PARTY|BCT_GUILD) > 0)
-				status->change_clear_buffs(bl,1); //Should dispell only allies.
+				status->change_clear_buffs(bl, SC_CLEAR_BUFF); //Should dispell only allies.
 		case UNT_RICHMANKIM:
 		case UNT_ETERNALCHAOS:
 		case UNT_DRUMBATTLEFIELD:
@@ -12293,7 +12293,7 @@ int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *bl, int6
 						status->heal(bl,heal,0,0);
 						break;
 					case 1: // End all negative status
-						status->change_clear_buffs(bl,2);
+						status->change_clear_buffs(bl, SC_CLEAR_DEBUFF);
 						if (tsd) clif->gospel_info(tsd, 0x15);
 						break;
 					case 2: // Immunity to all status

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -8502,7 +8502,7 @@ int status_change_start(struct block_list *src, struct block_list *bl, enum sc_t
 					// self effect
 					val2 = tick/10000;
 					tick_time = 10000; // [GodLesZ] tick time
-					status->change_clear_buffs(bl,3); //Remove buffs/debuffs
+					status->change_clear_buffs(bl, SC_CLEAR_BUFF | SC_CLEAR_DEBUFF | SC_CLEAR_CHEMICAL_PROTECT); //Remove buffs/debuffs
 				}
 				break;
 
@@ -9320,7 +9320,7 @@ int status_change_start(struct block_list *src, struct block_list *bl, enum sc_t
 				}
 				val4 = tick / 5000;
 				tick_time = 5000; // [GodLesZ] tick time
-				status->change_clear_buffs(bl,3); //Remove buffs/debuffs
+				status->change_clear_buffs(bl, SC_CLEAR_BUFF | SC_CLEAR_DEBUFF); //Remove buffs/debuffs
 				break;
 			case SC_CRESCENTELBOW:
 				val2 = (sd ? sd->status.job_level : 2) / 2 + 50 + 5 * val1;
@@ -12217,12 +12217,17 @@ void status_update_matk(struct block_list *bl) {
 	return;
 }
 
-/*==========================================
-* Clears buffs/debuffs of a character.
-* type&1 -> buffs, type&2 -> debuffs
-* type&4 -> especific debuffs(implemented with refresh)
-*------------------------------------------*/
-int status_change_clear_buffs (struct block_list* bl, int type) {
+/**
+ * Clears buffs/debuffs on an object
+ * @param bl: Object to clear [PC|MOB|HOM|MER|ELEM]
+ * @param type: Type to remove
+ *	&1: Clear Buffs
+ *	&2: Clear Debuffs
+ *	&4: Specific debuffs with a refresh
+ *  &8: Clear Chemical Protection
+ */
+int status_change_clear_buffs(struct block_list* bl, enum scclear_flag type)
+{
 	int i;
 	struct status_change *sc= status->get_sc(bl);
 
@@ -12269,6 +12274,13 @@ int status_change_clear_buffs (struct block_list* bl, int type) {
 			if(type&4)
 				continue;
 			sc->data[i]->val2 = 0;
+			break;
+		case SC_PROTECTWEAPON:
+		case SC_PROTECTSHIELD:
+		case SC_PROTECTARMOR:
+		case SC_PROTECTHELM:
+			if (!(type&8))
+				continue;
 			break;
 		default:
 			if(type&4)

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -72,14 +72,14 @@ enum refine_type {
  * @see db/sc_config.txt for more information
  **/
 typedef enum sc_conf_type {
-	SC_NO_REM_DEATH  = 0x01,
-	SC_NO_SAVE       = 0x02,
-	SC_NO_DISPELL    = 0x04,
-	SC_NO_CLEARANCE  = 0x08,
-	SC_BUFF          = 0x10,
-	SC_DEBUFF        = 0x20,
-	SC_MADO_NO_RESET = 0x40,
-	SC_NO_CLEAR      = 0x80,
+	SC_NO_REM_DEATH    = 0x001, ///< Cannot be removed by death
+	SC_NO_SAVE         = 0x002, ///< Cannot be saved
+	SC_NO_DISPELL      = 0x004, ///< Cannot be reset by Dispell
+	SC_NO_CLEARANCE    = 0x008, ///< Cannot be reset by Clearance
+	SC_BUFF            = 0x010, ///< SC Considered as buff and be removed by Hermode and etc.
+	SC_DEBUFF          = 0x020, ///< SC considered as debuff and be removed by Gospel and etc.
+	SC_MADO_NO_RESET   = 0x040, ///< cannot be reset when MADO Gear is taken off.
+	SC_NO_CLEAR        = 0x080, ///< cannot be reset by 'sc_end SC_ALL' and status change clear.
 } sc_conf_type;
 
 /**
@@ -94,6 +94,16 @@ enum scstart_flag {
 	SCFLAG_FIXEDRATE = 0x08, ///< rate should not be reduced (not evaluated in status_change_start, but in some calls to other functions).
 	SCFLAG_NOICON    = 0x10, ///< Status icon (SI) should not be sent.
 	SCFLAG_ALL = SCFLAG_NONE|SCFLAG_NOAVOID|SCFLAG_FIXEDTICK|SCFLAG_LOADED|SCFLAG_FIXEDRATE|SCFLAG_NOICON
+};
+
+/**
+ * Flags to be used with change_clear_buffs
+ */
+enum scclear_flag {
+	SC_CLEAR_BUFF             = 0x1, ///< Clears Buff
+	SC_CLEAR_DEBUFF           = 0x2, ///< Clears Debuff
+	SC_CLEAR_DEBUFF_SPECIAL   = 0x4, ///< Clears specific debuff with a refresh
+	SC_CLEAR_CHEMICAL_PROTECT = 0x8, ///< Clears chemical protection
 };
 
 // Status changes listing. These code are for use by the server.
@@ -2243,7 +2253,7 @@ struct status_interface {
 	int (*change_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*change_timer_sub) (struct block_list* bl, va_list ap);
 	int (*change_clear) (struct block_list* bl, int type);
-	int (*change_clear_buffs) (struct block_list* bl, int type);
+	int (*change_clear_buffs) (struct block_list* bl, enum scclear_flag type);
 	void (*calc_bl_) (struct block_list *bl, enum scb_flag flag, enum e_status_calc_opt opt);
 	int (*calc_mob_) (struct mob_data* md, enum e_status_calc_opt opt);
 	int (*calc_pet_) (struct pet_data* pd, enum e_status_calc_opt opt);


### PR DESCRIPTION
* The High Priestess Card from Tarot Card of Fate now removes Chemical Protection (all)
* Gospel now removes Chemical Protection (all) on the caster

Merge of https://github.com/rathena/rathena/commit/894d6f2fe64a401a62ceb57ec48f803e1e7f72be