### PR TITLE
Make packet_len usable in plugins

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -77,7 +77,7 @@
 struct clif_interface clif_s;
 struct clif_interface *clif;
 
-struct s_packet_db packet_db[MAX_PACKET_DB + 1];
+struct s_packet_db *packet_db;
 
 /* re-usable */
 static struct packet_itemlist_normal itemlist_normal;
@@ -19059,6 +19059,7 @@ int do_init_clif(bool minimal)
 	if (minimal)
 		return 0;
 
+	packet_db = clif->packet_db;
 	packetdb_loaddb();
 
 	sockt->set_defaultparse(clif->parse);

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -58,7 +58,7 @@ struct view_data;
 /**
  * Defines
  **/
-#define packet_len(cmd) packet_db[cmd].len
+#define packet_len(cmd) clif->packet_db[cmd].len
 #define clif_menuskill_clear(sd) ((sd)->menuskill_id = (sd)->menuskill_val = (sd)->menuskill_val2 = 0)
 #define clif_disp_onlyself(sd,mes,len) clif->disp_message( &(sd)->bl, (mes), (len), SELF )
 #define MAX_ROULETTE_LEVEL 7 /** client-defined value **/
@@ -596,6 +596,7 @@ struct clif_interface {
 	bool ally_only;
 	/* */
 	struct eri *delayed_damage_ers;
+	struct s_packet_db packet_db[MAX_PACKET_DB + 1];
 	/* core */
 	int (*init) (bool minimal);
 	void (*final) (void);


### PR DESCRIPTION
Original packet_len and all packet struct can't not be used in plugins,
so I changed it.