### PR TITLE
[Wizard Jobquest] Fixed getting stuck when failing some rooms.

### DIFF
--- a/npc/jobs/2-1/wizard.txt
+++ b/npc/jobs/2-1/wizard.txt
@@ -1423,7 +1423,7 @@ OnTimer60000:
 	end;
 
 OnTimer61000:
-	donpcevent "Room of Earth#Failed::OnEnable";
+	enablenpc "Room of Earth#Failed";
 	end;
 
 OnTimer62000:
@@ -1527,7 +1527,7 @@ OnTimer183000:
 	end;
 
 OnTimer184000:
-	donpcevent "Room of Fire#Failed::OnEnable";
+	enablenpc "Room of Fire#Failed";
 	end;
 
 OnTimer185000:


### PR DESCRIPTION
When failing the 2nd Wave of the Earth Room or the 1st Wave of the Fire Room you won't be correctly warped back, but get stuck.
This is due the NPCs "Room of Fire#Failed" and NPC "Room of Earth#Failed" not being correctly enabled, when the time limit is reached.