### PR TITLE
Fixed a bug where you'd skip quest 8102 in rachel sanctuary

### DIFF
--- a/npc/quests/quests_rachel.txt
+++ b/npc/quests/quests_rachel.txt
@@ -7244,7 +7244,10 @@ OnTouch:
 		mes "For now, you may as well";
 		mes "talk to High Priest Zhed.^000000";
 		ra_tem_q = 19;
-		changequest 8102,8103;
+		if (questprogress(8102) == 1)
+			changequest 8102,8103;
+		else
+			changequest 8101,8103;
 		close;
 	}
 	end;


### PR DESCRIPTION
By skipping quest 8102 you'd corrupt your questlog and mapserver would show those error messages:
![mapserver-log](http://skyleo.de/mapserv.png)
You will still be able to complete rachel sanctuary quest, since quest 8102 is not necessary for the main quest.

The fix allows you to skip quest 8102 and also to do quest 8102.

This bug is not related to Issue #1256 