### PR TITLE
Fix EXP modifiers to match aegis modifiers calclution.

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2337,11 +2337,6 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type) {
 		if(flag) {
 			if(base_exp || job_exp) {
 				if( md->dmglog[i].flag != MDLF_PET || battle_config.pet_attack_exp_to_master ) {
-#ifdef RENEWAL_EXP
-					int rate = pc->level_penalty_mod(md->level - (tmpsd[i])->status.base_level, md->status.race, md->status.mode, 1);
-					base_exp = (unsigned int)cap_value(base_exp * rate / 100, 1, UINT_MAX);
-					job_exp = (unsigned int)cap_value(job_exp * rate / 100, 1, UINT_MAX);
-#endif
 					pc->gainexp(tmpsd[i], &md->bl, base_exp, job_exp, false);
 				}
 			}

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -993,15 +993,6 @@ int party_exp_share(struct party_data* p, struct block_list* src, unsigned int b
 #endif
 
 	for (i = 0; i < c; i++) {
-#ifdef RENEWAL_EXP
-		struct mob_data *md = BL_CAST(BL_MOB, src);
-		if (md != NULL && md->db->mexp == 0) {
-			int rate = pc->level_penalty_mod(md->level - (sd[i])->status.base_level, md->status.race, md->status.mode, 1);
-
-			base_exp = (unsigned int)cap_value(base_exp_bonus * rate / 100, 1, UINT_MAX);
-			job_exp = (unsigned int)cap_value(job_exp_bonus * rate / 100, 1, UINT_MAX);
-		}
-#endif
 		pc->gainexp(sd[i], src, base_exp, job_exp, false);
 
 		if (zeny) // zeny from mobs [Valaris]

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -5455,7 +5455,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 					heal_get_jobexp = heal_get_jobexp * battle_config.heal_exp / 100;
 					if (heal_get_jobexp <= 0)
 						heal_get_jobexp = 1;
-					pc->gainexp (sd, bl, 0, heal_get_jobexp, false);
+					pc->gainexp(sd, bl, 0, heal_get_jobexp, false);
 				}
 			}
 			break;
@@ -5531,7 +5531,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 							if (jexp < 1) jexp = 1;
 						}
 						if(exp > 0 || jexp > 0)
-							pc->gainexp (sd, bl, exp, jexp, false);
+							pc->gainexp(sd, bl, exp, jexp, false);
 					}
 				}
 			}


### PR DESCRIPTION
- Now Renewal Level Penalty being calculated in pc_calcexp only
- Now Guild Tax is being paid after experience modifiers and not before
- Now Experience modifiers being calculated in right way as in aegis (Race modifiers -> PK modifiers -> Premium modifiers -> Buff modifiers)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1328)
<!-- Reviewable:end -->
