### PR TITLE
Fixes Mystery Burglary Quest

### DIFF
--- a/npc/re/quests/quests_eclage.txt
+++ b/npc/re/quests/quests_eclage.txt
@@ -6436,7 +6436,7 @@ eclage,222,131,3	script	Wandering Merchant#ecl	1_M_SIGNMCNT,{
 		mes "stench of alcohol -";
 	}
 	else if (ep14_2_detect == 7) {
-		if (questprogress(9248) == 1) {
+		if (questprogress(9258) == 1) {
 			mes "- Upon getting closer,";
 			mes "I smell a terrible";
 			mes "stench of alcohol -";


### PR DESCRIPTION
-NPC checked for wrong quest and therefore didn't do anything on that part of the quest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1349)
<!-- Reviewable:end -->
