### PR TITLE
Huld improvements (2)

### DIFF
--- a/npc/airports/airships.txt
+++ b/npc/airports/airships.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Athena Dev Teams
 //=
 //= Hercules is free software: you can redistribute it and/or modify
@@ -64,124 +64,124 @@ OnInit:
 	initnpctimer;
 	end;
 OnTimer20000:
-	mapannounce "airplane","We are heading to Einbroch.",bc_map,"0x00ff00";
+	mapannounce("airplane", _("We are heading to Einbroch."), bc_map, "0x00ff00");
 	end;
 OnTimer50000:
-	mapannounce "airplane","We will arrive in Einbroch shortly.",bc_map,"0x00ff00";
+	mapannounce("airplane", _("We will arrive in Einbroch shortly."), bc_map, "0x00ff00");
 	end;
 OnTimer60000:
 	$@airplanelocation = 1;
 	donpcevent "#AirshipWarp-1::OnUnhide";
 	donpcevent "#AirshipWarp-2::OnUnhide";
-	mapannounce "airplane","Welcome to Einbroch. Have a safe trip.",bc_map,"0x00ff00";
+	mapannounce("airplane", _("Welcome to Einbroch. Have a safe trip."), bc_map, "0x00ff00");
 	end;
 OnTimer70000:
-	mapannounce "airplane","Currently we are in Einbroch. The Airship will take off shortly.",bc_map,"0x00ff00";
+	mapannounce("airplane", _("Currently we are in Einbroch. The Airship will take off shortly."), bc_map, "0x00ff00");
 	end;
 OnTimer80000:
 	donpcevent "#AirshipWarp-1::OnHide";
 	donpcevent "#AirshipWarp-2::OnHide";
-	mapannounce "airplane","The Airship is now taking off. Our next destination is Lighthalzen.",bc_map,"0x70dbdb";
+	mapannounce("airplane", _("The Airship is now taking off. Our next destination is Lighthalzen."), bc_map, "0x70dbdb");
 	end;
 OnTimer100000:
-	mapannounce "airplane","We are heading to Lighthalzen.",bc_map,"0x70dbdb";
+	mapannounce("airplane", _("We are heading to Lighthalzen."), bc_map, "0x70dbdb");
 	end;
 OnTimer130000:
-	mapannounce "airplane","We will arrive in Lighthalzen shortly.",bc_map,"0x70dbdb";
+	mapannounce("airplane", _("We will arrive in Lighthalzen shortly."), bc_map, "0x70dbdb");
 	end;
 OnTimer140000:
 	$@airplanelocation = 2;
 	donpcevent "#AirshipWarp-1::OnUnhide";
 	donpcevent "#AirshipWarp-2::OnUnhide";
-	mapannounce "airplane","Welcome to Lighthalzen. Have a safe trip.",bc_map,"0x70dbdb";
+	mapannounce("airplane", _("Welcome to Lighthalzen. Have a safe trip."), bc_map, "0x70dbdb");
 	end;
 OnTimer150000:
-	mapannounce "airplane","Currently we are in Lighthalzen. The Airship will leave shortly.",bc_map,"0x70dbdb";
+	mapannounce("airplane", _("Currently we are in Lighthalzen. The Airship will leave shortly."), bc_map, "0x70dbdb");
 	end;
 OnTimer160000:
 	donpcevent "#AirshipWarp-1::OnHide";
 	donpcevent "#AirshipWarp-2::OnHide";
-	mapannounce "airplane","The Airship is leaving the ground. Our next destination is Einbroch.",bc_map,"0x00ff00";
+	mapannounce("airplane", _("The Airship is leaving the ground. Our next destination is Einbroch."), bc_map, "0x00ff00");
 	end;
 OnTimer180000:
-	mapannounce "airplane","We are heading to Einbroch.",bc_map,"0x00ff00";
+	mapannounce("airplane", _("We are heading to Einbroch."), bc_map, "0x00ff00");
 	end;
 OnTimer210000:
-	mapannounce "airplane","We will arrive in Einbroch shortly.",bc_map,"0x00FF00";
+	mapannounce("airplane", _("We will arrive in Einbroch shortly."), bc_map, "0x00FF00");
 	end;
 OnTimer220000:
 	$@airplanelocation = 1;
 	donpcevent "#AirshipWarp-1::OnUnhide";
 	donpcevent "#AirshipWarp-2::OnUnhide";
-	mapannounce "airplane","Welcome to Einbroch. Have a safe trip.",bc_map,"0x00ff00";
+	mapannounce("airplane", _("Welcome to Einbroch. Have a safe trip."), bc_map, "0x00ff00");
 	end;
 OnTimer230000:
-	mapannounce "airplane","Currently we are in Einbroch. The Airship will take off shortly.",bc_map,"0x00ff00";
+	mapannounce("airplane", _("Currently we are in Einbroch. The Airship will take off shortly."), bc_map, "0x00ff00");
 	end;
 OnTimer240000:
 	donpcevent "#AirshipWarp-1::OnHide";
 	donpcevent "#AirshipWarp-2::OnHide";
-	mapannounce "airplane","The Airship is now taking off. Our next destination is Juno.",bc_map,"0xff8200";
+	mapannounce("airplane", _("The Airship is now taking off. Our next destination is Juno."), bc_map, "0xff8200");
 	end;
 OnTimer260000:
-	mapannounce "airplane","We are heading to Juno.",bc_map,"0xff8200";
+	mapannounce("airplane", _("We are heading to Juno."), bc_map, "0xff8200");
 	end;
 OnTimer290000:
-	mapannounce "airplane","We will arrive in Juno shortly.",bc_map,"0xff8200";
+	mapannounce("airplane", _("We will arrive in Juno shortly."), bc_map, "0xff8200");
 	end;
 OnTimer300000:
 	$@airplanelocation = 0;
 	donpcevent "#AirshipWarp-1::OnUnhide";
 	donpcevent "#AirshipWarp-2::OnUnhide";
-	mapannounce "airplane","Welcome to Juno. Have a safe trip.",bc_map,"0xff8200";
+	mapannounce("airplane", _("Welcome to Juno. Have a safe trip."), bc_map, "0xff8200");
 	end;
 OnTimer310000:
-	mapannounce "airplane","Currently we are in Juno. The Airship will leave shortly.",bc_map,"0xff8200";
+	mapannounce("airplane", _("Currently we are in Juno. The Airship will leave shortly."), bc_map, "0xff8200");
 	end;
 OnTimer320000:
 	donpcevent "#AirshipWarp-1::OnHide";
 	donpcevent "#AirshipWarp-2::OnHide";
-	mapannounce "airplane","The Airship is leaving the ground. Our next destination is Hugel.",bc_map,"0xca4bf3";
+	mapannounce("airplane", _("The Airship is leaving the ground. Our next destination is Hugel."), bc_map, "0xca4bf3");
 	end;
 OnTimer340000:
-	mapannounce "airplane","We are heading to Hugel.",bc_map,"0xca4bf3";
+	mapannounce("airplane", _("We are heading to Hugel."), bc_map, "0xca4bf3");
 	end;
 OnTimer370000:
-	mapannounce "airplane","We will arrive in Hugel shortly.",bc_map,"0xca4bf3";
+	mapannounce("airplane", _("We will arrive in Hugel shortly."), bc_map, "0xca4bf3");
 	end;
 OnTimer380000:
 	$@airplanelocation = 3;
 	donpcevent "#AirshipWarp-1::OnUnhide";
 	donpcevent "#AirshipWarp-2::OnUnhide";
-	mapannounce "airplane","Welcome to Hugel. Have a safe trip.",bc_map,"0xca4bf3";
+	mapannounce("airplane", _("Welcome to Hugel. Have a safe trip."), bc_map, "0xca4bf3");
 	end;
 OnTimer390000:
-	mapannounce "airplane","Currently we are in Hugel. The Airship will leave shortly.",bc_map,"0xca4bf3";
+	mapannounce("airplane", _("Currently we are in Hugel. The Airship will leave shortly."), bc_map, "0xca4bf3");
 	end;
 OnTimer400000:
 	donpcevent "#AirshipWarp-1::OnHide";
 	donpcevent "#AirshipWarp-2::OnHide";
-	mapannounce "airplane","The Airship is leaving the ground. Our next destination is Juno.",bc_map,"0xff8200";
+	mapannounce("airplane", _("The Airship is leaving the ground. Our next destination is Juno."), bc_map, "0xff8200");
 	end;
 OnTimer420000:
-	mapannounce "airplane","We are heading to Juno.",bc_map,"0xff8200";
+	mapannounce("airplane", _("We are heading to Juno."), bc_map, "0xff8200");
 	end;
 OnTimer450000:
-	mapannounce "airplane","We will arrive in Juno shortly.",bc_map,"0xff8200";
+	mapannounce("airplane", _("We will arrive in Juno shortly."), bc_map, "0xff8200");
 	end;
 OnTimer460000:
 	$@airplanelocation = 0;
 	donpcevent "#AirshipWarp-1::OnUnhide";
 	donpcevent "#AirshipWarp-2::OnUnhide";
-	mapannounce "airplane","Welcome to Juno. Have a safe trip.",bc_map,"0xff8200";
+	mapannounce("airplane", _("Welcome to Juno. Have a safe trip."), bc_map, "0xff8200");
 	end;
 OnTimer470000:
-	mapannounce "airplane","Currently we are in Juno. The Airship will leave shortly.",bc_map,"0xff8200";
+	mapannounce("airplane", _("Currently we are in Juno. The Airship will leave shortly."), bc_map, "0xff8200");
 	end;
 OnTimer480000:
 	donpcevent "#AirshipWarp-1::OnHide";
 	donpcevent "#AirshipWarp-2::OnHide";
-	mapannounce "airplane","The Airship is leaving the ground. Our next destination is Einbroch.",bc_map,"0x00ff00";
+	mapannounce("airplane", _("The Airship is leaving the ground. Our next destination is Einbroch."), bc_map, "0x00ff00");
 	stopnpctimer;
 	initnpctimer;
 }
@@ -194,92 +194,89 @@ airplane,240,40,1	duplicate(ExitAirplane)	Exit#airplane2a	4_BOARD3
 airplane,247,40,1	duplicate(ExitAirplane)	Exit#airplane2b	4_BOARD3
 
 airplane,100,69,3	script	Airship Crew#ein-1	4_M_EIN_SOLDIER,{
-	mes "[Airship Crew]";
-	mes "If we've landed at";
-	mes "your destination and";
-	mes "you'd like to leave the";
-	mes "Airship, please use the";
-	mes "stairs up ahead. Thank";
-	mes "you for your patronage.";
+	mes("[Airship Crew]");
+	mes("If we've landed at\r"
+		"your destination and\r"
+		"you'd like to leave the\r"
+		"Airship, please use the\r"
+		"stairs up ahead. Thank\r"
+		"you for your patronage.");
 	close;
 }
 
 airplane,64,94,1	script	Umbala Kid#ein_p	4_M_UMKID,{
 	emotion e_swt2;
-	mes "[Kid]";
+	mes("[Kid]");
 	if (event_umbala >= 3) {
-		mes "Wow, mom!";
-		mes "L-look at this!";
-		mes "We're flying! W-we're...";
-		mes "We're in the freakin' sky!";
-	}
-	else {
-		mes "Makumalagu!";
-		mes "Saampa joojimbo";
-		mes "kaku na jedi Solo.";
-		mes "Bwahahahahahahaah!";
+		mes("Wow, mom!");
+		mes("L-look at this!");
+		mes("We're flying! W-we're...");
+		mes("We're in the freakin' sky!");
+	} else {
+		mes("Makumalagu!");
+		mes("Saampa joojimbo");
+		mes("kaku na jedi Solo.");
+		mes("Bwahahahahahahaah!");
 	}
 	close;
 }
 
 airplane,66,93,3	script	Umbala Lady#ein_p	4_F_UMWOMAN,{
 	emotion e_dots;
-	mes "[Lady]";
+	mes("[Lady]");
 	if (event_umbala >= 3) {
-		mes "Shush...";
-		mes "Honey, behave~";
-		mes "Don't act so excited";
-		mes "when we're out in a";
-		mes "public place like this!";
-	}
-	else {
-		mes "Chooktu!";
-		mes "Sacraup matii!";
-		mes "Shaka gurftalfi";
-		mes "huntiki manjoo!";
+		mes("Shush...");
+		mes("Honey, behave~");
+		mes("Don't act so excited\r"
+			"when we're out in a\r"
+			"public place like this!");
+	} else {
+		mes("Chooktu!");
+		mes("Sacraup matii!");
+		mes("Shaka gurftalfi\r"
+			"huntiki manjoo!");
 	}
 	close;
 }
 
 airplane,71,91,7	script	Umbala Man#ein_p	4_M_UMSOLDIER,{
 	if (event_umbala >= 3) {
-		mes "[Chrmlim]";
-		mes "Hey there~";
-		mes "From that look on";
-		mes "your face, I see that";
-		mes "you can understand";
-		mes "me. ^333333*Whew...!*^000000";
+		mes("[Chrmlim]");
+		mes("Hey there~");
+		mes("From that look on\r"
+			"your face, I see that\r"
+			"you can understand\r"
+			"me. ^333333*Whew...!*^000000");
 		next;
 		emotion e_pif;
-		mes "[Chrmlim]";
-		mes "I've been helping the";
-		mes "Airship enterprise by";
-		mes "having the Airship Crewmen";
-		mes "train in Umbala to overcome";
-		mes "any acrophobia they might have through bungee jumping. Neat, eh?";
+		mes("[Chrmlim]");
+		mes("I've been helping the\r"
+			"Airship enterprise by\r"
+			"having the Airship Crewmen\r"
+			"train in Umbala to overcome\r"
+			"any acrophobia they might have through bungee jumping. Neat, eh?");
 		next;
-		mes "[Chrmlim]";
-		mes "But...";
-		mes "Some of them couldn't";
-		mes "overcome their fear of";
-		mes "heights. And a few even";
-		mes "ended up, um, ^333333in Nifflheim^000000.";
-	}
-	else {
-		mes "[Chrmlim]";
-		mes "Bajoo ga";
-		mes "nukta Airship.";
+		mes("[Chrmlim]");
+		mes("But...");
+		mes("Some of them couldn't\r"
+			"overcome their fear of\r"
+			"heights. And a few even\r"
+			"ended up, um, ^333333in Nifflheim^000000.");
+	} else {
+		mes("[Chrmlim]");
+		mes("Bajoo ga\r"
+			"nukta Airship.");
 		next;
-		mes "[Chrmlim]";
-		mes "...";
-		mes "......";
+		mes("[Chrmlim]");
+		mes("...");
+		mes("......");
 		next;
 		emotion e_pif;
-		mes "[Chrmlim]";
-		mes "Shabala moow bajama";
-		mes "Airship kulaha googoona ";
-		mes "salu. Dama, kookoo na nu";
-		mes "yukuta. Um, fashuku na ret!";
+		mes("[Chrmlim]");
+		mes("Shabala moow bajama\r"
+			"Airship kulaha googoona\r"
+			"salu. Dama, kookoo na nu\r"
+			"yukuta. Um, fashuku na ret!");
 	}
 	close;
 }
@@ -287,377 +284,378 @@ airplane,71,91,7	script	Umbala Man#ein_p	4_M_UMSOLDIER,{
 airplane,250,58,2	script	Airship Staff#airplane	1_F_02,{
 	// Hugel quest addition
 	if (hg_ma1 == 3) {
-		mes "[Airship Staff]";
-		mes "Welcome";
-		mes "to the Airship.";
-		mes "How may I help you?";
+		mes("[Airship Staff]");
+		mes("Welcome\r"
+			"to the Airship.");
+		mes("How may I help you?");
 		next;
 		select("Do you have a passenger named Thierry?");
-		mes "[Airship Staff]";
-		mes "I am sorry, but I do not think that we have a passenger by that name.";
+		mes("[Airship Staff]");
+		mes("I am sorry, but I do not think that we have a passenger by that name.");
 		close;
 	}
 	// Hugel quest end
-	mes "[Airship Staff]";
-	mes "Welcome";
-	mes "to the Airship.";
-	mes "How may I help you?";
+	mes("[Airship Staff]");
+	mes("Welcome\r"
+		"to the Airship.");
+	mes("How may I help you?");
 	next;
 	switch (select("Using the Airship", "Captain's Cabin", "Facilities", "Cancel")) {
 	case 1:
-		mes "[Airship Staff]";
-		mes "When you see a broadcast";
-		mes "announcing that we have";
-		mes "arrived at your destination,";
-		mes "please use one of the exits";
-		mes "located at the north and";
-		mes "south ends of the Airship.";
+		mes("[Airship Staff]");
+		mes("When you see a broadcast\r"
+			"announcing that we have\r"
+			"arrived at your destination,\r"
+			"please use one of the exits\r"
+			"located at the north and\r"
+			"south ends of the Airship.");
 		next;
-		mes "[Airship Staff]";
-		mes "If you happen to miss";
-		mes "your stop, don't worry.";
-		mes "The Airship is constantly";
-		mes "en route and you'll get";
-		mes "another chance to arrive";
-		mes "to your intended destination.";
+		mes("[Airship Staff]");
+		mes("If you happen to miss\r"
+			"your stop, don't worry.\r"
+			"The Airship is constantly\r"
+			"en route and you'll get\r"
+			"another chance to arrive\r"
+			"to your intended destination.");
 		close;
 	case 2:
-		mes "[Airship Staff]";
-		mes "The Captain's Cabin";
-		mes "is located at the front";
-		mes "of the Airship. There, you";
-		mes "can meet the captain and";
-		mes "the pilot of the Airship.";
+		mes("[Airship Staff]");
+		mes("The Captain's Cabin\r"
+			"is located at the front\r"
+			"of the Airship. There, you\r"
+			"can meet the captain and\r"
+			"the pilot of the Airship.");
 		close;
 	case 3:
-		mes "[Airship Staff]";
-		mes "The Airship provides";
-		mes "various Mini Games for";
-		mes "the entertainment of all";
-		mes "our passengers. We invite";
-		mes "you to try your luck and skills";
-		mes "in the Airship's Mini Games~";
+		mes("[Airship Staff]");
+		mes("The Airship provides\r"
+			"various Mini Games for\r"
+			"the entertainment of all\r"
+			"our passengers. We invite\r"
+			"you to try your luck and skills\r"
+			"in the Airship's Mini Games~");
 		close;
 	case 4:
-		mes "[Airship Staff]";
-		mes "Well, I hope you";
-		mes "your flight aboard";
-		mes "our Airships. Thank";
-		mes "you and have a good day.";
+		mes("[Airship Staff]");
+		mes("Well, I hope you\r"
+			"your flight aboard\r"
+			"our Airships. Thank\r"
+			"you and have a good day.");
 		close;
 	}
 }
 
 airplane,80,71,2	script	Zerta#01airplane	4_M_BUDDHIST,{
-	mes "[Zerta]";
-	mes "Oh, hello adventurer.";
-	mes "I am currently on a";
-	mes "sacred journey, offering";
-	mes "prayer for the sake of the";
-	mes "Rune-Midgard continent.";
+	mes("[Zerta]");
+	mes("Oh, hello adventurer.\r"
+		"I am currently on a\r"
+		"sacred journey, offering\r"
+		"prayer for the sake of the\r"
+		"Rune-Midgard continent.");
 	close;
 }
 
 airplane,65,63,4	script	Maelin#01airplane	4_F_06,{
-	mes "[Maelin]";
-	mes "Um, this Airship is";
-	mes "to Lutie, isn't it? I've";
-	mes "waiting so long,";
-	mes "but I haven't heard any";
-	mes "broadcast about Lutie.";
+	mes("[Maelin]");
+	mes("Um, this Airship is\r"
+		"to Lutie, isn't it? I've\r"
+		"waiting so long,\r"
+		"but I haven't heard any\r"
+		"broadcast about Lutie.");
 	close;
 }
 
 airplane,72,34,6	script	Aanos#01airplane	4_F_GON,{
-	mes "[Aanos]";
-	mes "Oh wooow~";
-	mes "The sky looks";
-	mes "so different and";
-	mes "pretty from up there!";
+	mes("[Aanos]");
+	mes("Oh wooow~");
+	mes("The sky looks\r"
+		"so different and\r"
+		"pretty from up there!\r");
 	close;
 }
 
 airplane,221,158,2	script	Pilot#airplane	4_M_EIN_SOLDIER,{
 	// Hugel quest addition
 	if (hg_ma1 == 3) {
-		mes "[Pilot]";
-		mes "I wish that I could go drink a cold fresh beer.";
-		mes "Drinking is the goal of my life! Drinking gives me energy!";
-		mes "I am nothing without drinks!";
+		mes("[Pilot]");
+		mes("I wish that I could go drink a cold fresh beer.");
+		mes("Drinking is the goal of my life! Drinking gives me energy!");
+		mes("I am nothing without drinks!");
 		next;
-		mes "[Pilot]";
-		mes "But! Driving under the influence is not good.";
-		mes "But! That makes me want to drink more and more!";
+		mes("[Pilot]");
+		mes("But! Driving under the influence is not good.");
+		mes("But! That makes me want to drink more and more!");
 		emotion e_sob;
 		next;
 		select("Do you know a passenger named Thierry?");
-		mes "[Pilot]";
-		mes "This uniform is";
-		mes "really dapper, but";
-		mes "it's way too thick to";
-		mes "wear around the Airship.";
+		mes("[Pilot]");
+		mes("This uniform is\r"
+			"really dapper, but\r"
+			"it's way too thick to\r"
+			"wear around the Airship.");
 		next;
-		mes "[Pilot]";
-		mes "...";
-		mes "......";
-		mes "No one ever really";
-		mes "comes into this room.";
-		mes "And the captain IS a reindeer. I could just strip to my boxers.";
+		mes("[Pilot]");
+		mes("...");
+		mes("......");
+		mes("No one ever really\r"
+			"comes into this room.");
+		mes("And the captain IS a reindeer. I could just strip to my boxers.");
 		next;
 		emotion e_omg;
-		mes "[Pilot]";
-		mes "Wah!? Who is it!";
+		mes("[Pilot]");
+		mes("Wah!? Who is it!");
 		next;
-		mes "- ...He is not listening to you, at all. -";
+		mes("- ...He is not listening to you, at all. -");
 		close;
 	}
 	// Hugel quest end
 	switch (rand(1,4)) {
 	case 1:
-		mes "[Pilot]";
-		mes "It's been sooo";
-		mes "long since I've";
-		mes "enjoyed a nice, cold";
-		mes "alcoholic brew. But the";
-		mes "job requires me to be as";
-		mes "clear headed as I can!";
+		mes("[Pilot]");
+		mes("It's been sooo\r"
+			"long since I've\r"
+			"enjoyed a nice, cold\r"
+			"alcoholic brew. But the\r"
+			"job requires me to be as\r"
+			"clear headed as I can!");
 		next;
-		mes "[Pilot]";
-		mes "Always drink responsibly!";
-		mes "Still, I can't remember the";
-		mes "last time I had a real vacation";
-		mes "or even a day off. Yeap, some";
-		mes "booze, some chips, some TV";
-		mes "and serius R&R is in order.";
+		mes("[Pilot]");
+		mes("Always drink responsibly!");
+		mes("Still, I can't remember the\r"
+			"last time I had a real vacation\r"
+			"or even a day off. Yeap, some\r"
+			"booze, some chips, some TV\r"
+			"and serius R&R is in order.");
 		emotion e_sob;
 		close;
 	case 2:
-		mes "[Pilot]";
-		mes "Man, the weather";
-		mes "is really nice today.";
-		mes "Bright, open skies make";
-		mes "for some good visibility";
-		mes "and safe, carefree flying.";
+		mes("[Pilot]");
+		mes("Man, the weather\r"
+			"is really nice today.");
+		mes("Bright, open skies make\r"
+			"for some good visibility\r"
+			"and safe, carefree flying.");
 		close;
 	case 3:
-		mes "[Pilot]";
-		mes "You know, our captain's a";
-		mes "respectable guy. Him and";
-		mes "his brother are actually well";
-		mes "known in the aircraft industry.";
-		mes "Who knew reindeer made";
-		mes "such good captains?";
+		mes("[Pilot]");
+		mes("You know, our captain's a\r"
+			"respectable guy. Him and\r"
+			"his brother are actually well\r"
+			"known in the aircraft industry.");
+		mes("Who knew reindeer made\r"
+			"such good captains?");
 		next;
-		mes "[Pilot]";
-		mes "Just between you";
-		mes "and me, I gotta tell";
-		mes "you, that Santa was onto";
-		mes "something, getting reindeers";
-		mes "and elves to work for him.";
-		mes "The man must be a genius!";
+		mes("[Pilot]");
+		mes("Just between you\r"
+			"and me, I gotta tell\r"
+			"you, that Santa was onto\r"
+			"something, getting reindeers\r"
+			"and elves to work for him.");
+		mes("The man must be a genius!");
 		close;
 	default:
-		mes "[Pilot]";
-		mes "You know, this whole";
-		mes "piloting thing in the air,";
-		mes "it's rather new, you know?";
-		mes "Yeah, they got this Airship";
-		mes "operation in a hurry.";
+		mes("[Pilot]");
+		mes("You know, this whole\r"
+			"piloting thing in the air,\r"
+			"it's rather new, you know?");
+		mes("Yeah, they got this Airship\r"
+			"operation in a hurry.");
 		next;
 		emotion e_omg;
-		mes "[Pilot]";
-		mes "Still, they where real";
-		mes "serius, really thought";
-		mes "ahead. I mean, they had us";
-		mes "training while the Airships";
-		mes "were still being invented.";
-		mes "Isn't that freakin' crazy?!";
+		mes("[Pilot]");
+		mes("Still, they where real\r"
+			"serius, really thought\r"
+			"ahead. I mean, they had us\r"
+			"training while the Airships\r"
+			"were still being invented.");
+		mes("Isn't that freakin' crazy?!");
 		close;
 	}
 }
 
 airplane,50,66,5	script	Apple Merchant#airplane	4_M_04,{
-	mes "[Fruitz]";
-	mes "Welcome to Fruitz's";
-	mes "Shop where you can";
-	mes "purchase Apples or grind";
-	mes "them to make Apple Juice.";
+	mes("[Fruitz]");
+	mes("Welcome to Fruitz's\r"
+		"Shop where you can\r"
+		"purchase Apples or grind\r"
+		"them to make Apple Juice.");
 	next;
 	switch (select("Buy Apples.", "Make Apple Juice.", "Why are you here?", "Cancel.")) {
 	case 1:
-		mes "[Fruitz]";
-		mes "Please enter the amount";
-		mes "of Apples that you wish to";
-		mes "buy. Each Apple is 15 zeny";
-		mes "and you can buy a maximum";
-		mes "of 500 at a time. Please enter";
-		mes " '0' to cancel your order.";
+		mes("[Fruitz]");
+		mes("Please enter the amount\r"
+			"of Apples that you wish to\r"
+			"buy. Each Apple is 15 zeny\r"
+			"and you can buy a maximum\r"
+			"of 500 at a time. Please enter\r"
+			" '0' to cancel your order.");
 		next;
 		while (1) {
 			input .@input;
 			.@pay = .@input * 15;
 			if (.@input == 0) {
-				mes "[Fruitz]";
-				mes "Thanks for stopping";
-				mes "by my shop. Farewell!";
-				mes "Come by anytime when";
-				mes "you feel like having an";
-				mes "Apple to snack on~";
+				mes("[Fruitz]");
+				mes("Thanks for stopping\r"
+					"by my shop. Farewell!");
+				mes("Come by anytime when\r"
+					"you feel like having an\r"
+					"Apple to snack on~");
 				close;
 			}
 			else if (.@input < 1 || .@input > 500) {
-				mes "[Fruitz]";
-				mes "You've entered a number";
-				mes "higher than the maximum";
-				mes "value of 500. Please enter";
-				mes "the number of Apples you";
-				mes "wish to purchase again.";
+				mes("[Fruitz]");
+				mes("You've entered a number\r"
+					"higher than the maximum\r"
+					"value of 500. Please enter\r"
+					"the number of Apples you\r"
+					"wish to purchase again.");
 				next;
 			}
 			else {
-				mes "[Fruitz]";
-				mes "A total of ^FF0000" + .@input + "^000000 Apples";
-				mes "will cost you ^FF0000" + .@pay + " Zeny^000000 zeny.";
-				mes "Would you like to continue?";
+				mes("[Fruitz]");
+				mesf("A total of ^FF0000%d^000000 Apples\r"
+					"will cost you ^FF0000%d Zeny^000000.",
+					.@input, .@pay);
+				mes("Would you like to continue?");
 				next;
 				if (select("Yes", "No") == 2) {
-					mes "[Fruitz]";
-					mes "Thanks for stopping";
-					mes "by my shop. Farewell!";
-					mes "Come by anytime when";
-					mes "you feel like having an";
-					mes "Apple to snack on~";
+					mes("[Fruitz]");
+					mes("Thanks for stopping\r"
+						"by my shop. Farewell!");
+					mes("Come by anytime when\r"
+						"you feel like having an\r"
+						"Apple to snack on~");
 					close;
 				}
 				break;
 			}
 		}
 		if (Zeny < .@pay) {
-			mes "[Fruitz]";
-			mes "I'm sorry, but you don't";
-			mes "have enough money to";
-			mes "purchase that many Apples.";
-			mes "Please check your zeny or";
-			mes "purchase fewer Apples.";
+			mes("[Fruitz]");
+			mes("I'm sorry, but you don't\r"
+				"have enough money to\r"
+				"purchase that many Apples.");
+			mes("Please check your zeny or\r"
+				"purchase fewer Apples.");
 			close;
 		}
 		else if (checkweight(Apple,.@input) == 0) {
-			mes "[Fruitz]";
-			mes "Hmmm, I don't think";
-			mes "you've got enough room in";
-			mes "your inventory to carry this";
-			mes "many Apples. Why don't you free up some of your inventory space?";
+			mes("[Fruitz]");
+			mes("Hmmm, I don't think\r"
+				"you've got enough room in\r"
+				"your inventory to carry this\r"
+				"many Apples. Why don't you free up some of your inventory space?");
 			close;
 		}
 		else {
 			Zeny -= .@pay;
 			getitem Apple,.@input;
-			mes "[Fruitz]";
-			mes "Thanks for stopping by";
-			mes "my shop. I hope you enjoy";
-			mes "the flavor of these Apples~!";
+			mes("[Fruitz]");
+			mes("Thanks for stopping by\r"
+				"my shop. I hope you enjoy\r"
+				"the flavor of these Apples~!");
 			close;
 		}
 	case 2:
-		mes "[Fruitz]";
-		mes "Okay, I'll need";
-		mes "^FF00003 Apples and 1 Empty Bottle^000000";
-		mes "to make 1 Apple Juice for you.";
-		mes "Would you like to proceed?";
+		mes("[Fruitz]");
+		mes("Okay, I'll need\r"
+			"^FF00003 Apples and 1 Empty Bottle^000000\r"
+			"to make 1 Apple Juice for you.");
+		mes("Would you like to proceed?");
 		next;
 		switch (select("Yes", "No")) {
 		case 1:
 			if (countitem(Apple) < 3 || countitem(Empty_Bottle) < 1) {
-				mes "[Fruitz]";
-				mes "I'm sorry, but you don't";
-				mes "have enough materials to";
-				mes "create a bottle of Apple Juice.";
-				mes "Remember, I need 3 Apples";
-				mes "and 1 Empty Bottle to do it.";
+				mes("[Fruitz]");
+				mes("I'm sorry, but you don't\r"
+					"have enough materials to\r"
+					"create a bottle of Apple Juice.");
+				mes("Remember, I need 3 Apples\r"
+					"and 1 Empty Bottle to do it.");
 				close;
 			}
 			else {
-				mes "[Fruitz]";
-				mes "Thank you,";
-				mes "please wait";
-				mes "just a moment.";
+				mes("[Fruitz]");
+				mes("Thank you,\r"
+					"please wait\r"
+					"just a moment.");
 				next;
-				mes "^3355FF*Grind grind*";
-				mes "*Grind grind*";
-				mes "*Clang...!*^000000";
+				mes("^3355FF*Grind grind*");
+				mes("*Grind grind*");
+				mes("*Clang...!*^000000");
 				next;
 				delitem Apple,3;
 				delitem Empty_Bottle,1;
 				getitem Apple_Juice,1;
-				mes "[Fruitz]";
-				mes "There you go~";
-				mes "I hope you enjoy!";
-				mes "Please feel free to";
-				mes "stop by for your Apple";
-				mes "and Apple Juice needs";
-				mes "at anytime, adventurer~";
+				mes("[Fruitz]");
+				mes("There you go~");
+				mes("I hope you enjoy!");
+				mes("Please feel free to\r"
+					"stop by for your Apple\r"
+					"and Apple Juice needs\r"
+					"at anytime, adventurer~");
 				close;
 			}
 		case 2:
-			mes "[Fruitz]";
-			mes "Thanks for stopping";
-			mes "by my shop. Farewell!";
-			mes "Come by anytime when";
-			mes "you feel like having an";
-			mes "Apple to snack on~";
+			mes("[Fruitz]");
+			mes("Thanks for stopping\r"
+				"by my shop. Farewell!");
+			mes("Come by anytime when\r"
+				"you feel like having an\r"
+				"Apple to snack on~");
 			close;
 		}
 	case 3:
-		mes "[Fruitz]";
-		mes "I used to be a wandering";
-		mes "vagabond when, one day,";
-		mes "I took a nap and something";
-		mes "struck my head and awoke";
-		mes "me from my restful slumber.";
+		mes("[Fruitz]");
+		mes("I used to be a wandering\r"
+			"vagabond when, one day,\r"
+			"I took a nap and something\r"
+			"struck my head and awoke\r"
+			"me from my restful slumber.");
 		next;
-		mes "[Fruitz]";
-		mes "It turns out that I was";
-		mes "sleeping beneath an apple";
-		mes "tree and that an apple fell";
-		mes "and hit me on the head.";
-		mes "I was dying of hunger and";
-		mes "was about to eat that Apple...";
+		mes("[Fruitz]");
+		mes("It turns out that I was\r"
+			"sleeping beneath an apple\r"
+			"tree and that an apple fell\r"
+			"and hit me on the head.");
+		mes("I was dying of hunger and\r"
+			"was about to eat that Apple...");
 		next;
-		mes "[Fruitz]";
-		mes "But suddenly, Kain, my old";
-		mes "friend from the mining days,";
-		mes "asked me to help him around";
-		mes "on the Airship. So I did, and";
-		mes "it was there where I found some";
-		mes "people playing the Dice game.";
+		mes("[Fruitz]");
+		mes("But suddenly, Kain, my old\r"
+			"friend from the mining days,\r"
+			"asked me to help him around\r"
+			"on the Airship. So I did, and\r"
+			"it was there where I found some\r"
+			"people playing the Dice game.");
 		next;
-		mes "[Fruitz]";
-		mes "I was bored and curious";
-		mes "and ended up wagering that";
-		mes "single Apple in a game of";
-		mes "dice. But for some reason,";
-		mes "I had this incredible lucky";
-		mes "streak. One apple became two... ";
+		mes("[Fruitz]");
+		mes("I was bored and curious\r"
+			"and ended up wagering that\r"
+			"single Apple in a game of\r"
+			"dice. But for some reason,\r"
+			"I had this incredible lucky\r"
+			"streak. One apple became two...");
 		next;
-		mes "[Fruitz]";
-		mes "Two became four and";
-		mes "before I knew it, I had";
-		mes "cornered the Apple market!";
-		mes "I won so many Apples, I just";
-		mes "started my own business here";
-		mes "on the Airship. Weird, huh?";
+		mes("[Fruitz]");
+		mes("Two became four and\r"
+			"before I knew it, I had\r"
+			"cornered the Apple market!");
+		mes("I won so many Apples, I just\r"
+			"started my own business here\r"
+			"on the Airship. Weird, huh?");
 		next;
-		mes "[Fruitz]";
-		mes "So Apples are good";
-		mes "for you. They were";
-		mes "certainly very good";
-		mes "to me. Hahahahaah~!";
+		mes("[Fruitz]");
+		mes("So Apples are good\r"
+			"for you. They were\r"
+			"certainly very good\r"
+			"to me. Hahahahaah~!");
 		close;
 	case 4:
-		mes "[Fruitz]";
-		mes "Thank you for";
-		mes "using my shop.";
-		mes "Farewell~";
+		mes("[Fruitz]");
+		mes("Thank you for\r"
+			"using my shop.");
+		mes("Farewell~");
 		close;
 	}
 }
@@ -700,64 +698,64 @@ OnEnable:
 	initnpctimer;
 	end;
 OnTimer25000:
-	mapannounce "airplane_01","We are heading to Izlude.",bc_map,"0x00ff00";
+	mapannounce("airplane_01", _("We are heading to Izlude."), bc_map, "0x00ff00");
 	end;
 OnTimer50000:
-	mapannounce "airplane_01","We will arrive in Izlude shortly.",bc_map,"0x00ff00";
+	mapannounce("airplane_01", _("We will arrive in Izlude shortly."), bc_map, "0x00ff00");
 	end;
 OnTimer60000:
 	$@airplanelocation2 = 1;
 	donpcevent "#AirshipWarp-3::OnUnhide";
 	donpcevent "#AirshipWarp-4::OnUnhide";
-	mapannounce "airplane_01","Welcome to Izlude. Have a safe trip.",bc_map,"0x00ff00";
+	mapannounce("airplane_01", _("Welcome to Izlude. Have a safe trip."), bc_map, "0x00ff00");
 	end;
 OnTimer70000:
-	mapannounce "airplane_01","We are currently in Izlude. The Airship will take off shortly.",bc_map,"0x00ff00";
+	mapannounce("airplane_01", _("We are currently in Izlude. The Airship will take off shortly."), bc_map, "0x00ff00");
 	end;
 OnTimer80000:
 	donpcevent "#AirshipWarp-3::OnHide";
 	donpcevent "#AirshipWarp-4::OnHide";
-	mapannounce "airplane_01","The Airship is now taking off. Our next destination is Juno.",bc_map,"0x70dbdb";
+	mapannounce("airplane_01", _("The Airship is now taking off. Our next destination is Juno."), bc_map, "0x70dbdb");
 	end;
 OnTimer105000:
-	mapannounce "airplane_01","We are heading to Juno.",bc_map,"0x70dbdb";
+	mapannounce("airplane_01", _("We are heading to Juno."), bc_map, "0x70dbdb");
 	end;
 OnTimer130000:
-	mapannounce "airplane_01","We will arrive in Juno shortly.",bc_map,"0x70dbdb";
+	mapannounce("airplane_01", _("We will arrive in Juno shortly."), bc_map, "0x70dbdb");
 	end;
 OnTimer140000:
 	$@airplanelocation2 = 2;
 	donpcevent "#AirshipWarp-3::OnUnhide";
 	donpcevent "#AirshipWarp-4::OnUnhide";
-	mapannounce "airplane_01","Welcome to Juno. Have a safe trip.",bc_map,"0x70dbdb";
+	mapannounce("airplane_01", _("Welcome to Juno. Have a safe trip."), bc_map, "0x70dbdb");
 	end;
 OnTimer150000:
-	mapannounce "airplane_01","We are currently in Juno. The Airship will leave shortly.",bc_map,"0x70dbdb";
+	mapannounce("airplane_01", _("We are currently in Juno. The Airship will leave shortly."), bc_map, "0x70dbdb");
 	end;
 OnTimer160000:
 	donpcevent "#AirshipWarp-3::OnHide";
 	donpcevent "#AirshipWarp-4::OnHide";
-	mapannounce "airplane_01","The Airship is leaving the ground. Our next destination is Rachel.",bc_map,"0xFF8200";
+	mapannounce("airplane_01", _("The Airship is leaving the ground. Our next destination is Rachel."), bc_map, "0xFF8200");
 	end;
 OnTimer185000:
-	mapannounce "airplane_01","We are heading to Rachel.",bc_map,"0xFF8200";
+	mapannounce("airplane_01", _("We are heading to Rachel."), bc_map, "0xFF8200");
 	end;
 OnTimer210000:
-	mapannounce "airplane_01","We will arrive in Rachel shortly.",bc_map,"0xFF8200";
+	mapannounce("airplane_01", _("We will arrive in Rachel shortly."), bc_map, "0xFF8200");
 	end;
 OnTimer220000:
 	$@airplanelocation2 = 0;
 	donpcevent "#AirshipWarp-3::OnUnhide";
 	donpcevent "#AirshipWarp-4::OnUnhide";
-	mapannounce "airplane_01","Welcome to Rachel. Have a safe trip.",bc_map,"0xFF8200";
+	mapannounce("airplane_01", _("Welcome to Rachel. Have a safe trip."), bc_map, "0xFF8200");
 	end;
 OnTimer230000:
-	mapannounce "airplane_01","We are currently in Rachel. The Airship will take off shortly.",bc_map,"0xFF8200";
+	mapannounce("airplane_01", _("We are currently in Rachel. The Airship will take off shortly."), bc_map, "0xFF8200");
 	end;
 OnTimer240000:
 	donpcevent "#AirshipWarp-3::OnHide";
 	donpcevent "#AirshipWarp-4::OnHide";
-	mapannounce "airplane_01","The Airship is now taking off. Our next destination is Izlude.",bc_map,"0x00ff00";
+	mapannounce("airplane_01", _("The Airship is now taking off. Our next destination is Izlude."), bc_map, "0x00ff00");
 	stopnpctimer;
 	++.moninv;
 	if (.moninv == 7) {
@@ -779,196 +777,197 @@ airplane_01,240,40,1	duplicate(ExitAirplane01)	Exit#airplane_012a	4_BOARD3
 airplane_01,247,40,1	duplicate(ExitAirplane01)	Exit#airplane_012b	4_BOARD3
 
 airplane_01,250,58,2	script	Airship Staff#airplane01	1_F_02,{
-	mes "[Airship Staff]";
-	mes "Welcome";
-	mes "to the Airship.";
-	mes "How may I help you?";
+	mes("[Airship Staff]");
+	mes("Welcome\r"
+		"to the Airship.");
+	mes("How may I help you?");
 	next;
 	switch (select("Using the Airship", "Captain's Cabin", "Facilities", "Cancel")) {
 	case 1:
-		mes "[Airship Staff]";
-		mes "When you see a broadcast";
-		mes "announcing that we have";
-		mes "arrived at your destination,";
-		mes "please use one of the exits";
-		mes "located at the north and";
-		mes "south ends of the Airship.";
+		mes("[Airship Staff]");
+		mes("When you see a broadcast\r"
+			"announcing that we have\r"
+			"arrived at your destination,\r"
+			"please use one of the exits\r"
+			"located at the north and\r"
+			"south ends of the Airship.");
 		next;
-		mes "[Airship Staff]";
-		mes "If you happen to miss";
-		mes "your stop, don't worry.";
-		mes "The Airship is constantly";
-		mes "en route and you'll get";
-		mes "another chance to arrive";
-		mes "to your intended destination.";
+		mes("[Airship Staff]");
+		mes("If you happen to miss\r"
+			"your stop, don't worry.");
+		mes("The Airship is constantly\r"
+			"en route and you'll get\r"
+			"another chance to arrive\r"
+			"to your intended destination.");
 		close;
 	case 2:
-		mes "[Airship Staff]";
-		mes "The Captain's Cabin";
-		mes "is located at the front";
-		mes "of the Airship. There, you";
-		mes "can meet the captain and";
-		mes "the pilot of the Airship.";
+		mes("[Airship Staff]");
+		mes("The Captain's Cabin\r"
+			"is located at the front\r"
+			"of the Airship. There, you\r"
+			"can meet the captain and\r"
+			"the pilot of the Airship.");
 		close;
 	case 3:
-		mes "[Airship Staff]";
-		mes "The Airship provides";
-		mes "various Mini Games for";
-		mes "the entertainment of all";
-		mes "our passengers. We invite";
-		mes "you to try your luck and skills";
-		mes "in the Airship's Mini Games~";
+		mes("[Airship Staff]");
+		mes("The Airship provides\r"
+			"various Mini Games for\r"
+			"the entertainment of all\r"
+			"our passengers. We invite\r"
+			"you to try your luck and skills\r"
+			"in the Airship's Mini Games~");
 		close;
 	case 4:
-		mes "[Airship Staff]";
-		mes "Well, I hope you";
-		mes "your flight aboard";
-		mes "our Airships. Thank";
-		mes "you and have a good day.";
+		mes("[Airship Staff]");
+		mes("Well, I hope you\r"
+			"your flight aboard\r"
+			"our Airships. Thank\r"
+			"you and have a good day.");
 		close;
 	}
 }
 
 airplane_01,50,66,5	script	Apple Merchant#air01	4_M_04,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Meltz]";
-	mes "Welcome to Meltz's";
-	mes "Shop where you can";
-	mes "purchase Apples or grind";
-	mes "them to make Apple Juice.";
+	mes("[Meltz]");
+	mes("Welcome to Meltz's\r"
+		"Shop where you can\r"
+		"purchase Apples or grind\r"
+		"them to make Apple Juice.");
 	next;
 	switch (select("Buy Apples.", "Make Apple Juice.", "Cancel.")) {
 	case 1:
-		mes "[Meltz]";
-		mes "Please enter the amount";
-		mes "of Apples that you wish to";
-		mes "buy. Each Apple is 15 zeny";
-		mes "and you can buy a maximum";
-		mes "of 500 at a time. Please enter";
-		mes "'0' to cancel your order.";
+		mes("[Meltz]");
+		mes("Please enter the amount\r"
+			"of Apples that you wish to\r"
+			"buy. Each Apple is 15 zeny\r"
+			"and you can buy a maximum\r"
+			"of 500 at a time. Please enter\r"
+			"'0' to cancel your order.");
 		next;
 		while (1) {
 			input .@input;
 			.@pay = .@input * 15;
 			if (.@input == 0) {
-				mes "[Meltz]";
-				mes "Thanks for stopping";
-				mes "by my shop. Farewell!";
-				mes "Come by anytime when";
-				mes "you feel like having an";
-				mes "Apple to snack on~";
+				mes("[Meltz]");
+				mes("Thanks for stopping\r"
+					"by my shop. Farewell!");
+				mes("Come by anytime when\r"
+					"you feel like having an\r"
+					"Apple to snack on~");
 				close;
 			}
 			else if (.@input < 1 || .@input > 500) {
-				mes "[Meltz]";
-				mes "You've entered a number";
-				mes "higher than the maximum";
-				mes "value of 500. Please enter";
-				mes "the number of Apples you";
-				mes "wish to purchase again.";
+				mes("[Meltz]");
+				mes("You've entered a number\r"
+					"higher than the maximum\r"
+					"value of 500. Please enter\r"
+					"the number of Apples you\r"
+					"wish to purchase again.");
 				next;
 			}
 			else {
-				mes "[Meltz]";
-				mes "A total of ^FF0000" + .@input + "^000000 Apples";
-				mes "will cost you ^FF0000" + .@pay + "^000000 zeny.";
-				mes "Would you like to continue?";
+				mes("[Meltz]");
+				mesf("A total of ^FF0000%d^000000 Apples\r"
+					"will cost you ^FF0000%d Zeny^000000.",
+					.@input, .@pay);
+				mes("Would you like to continue?");
 				next;
 				if (select("Yes", "No") == 2) {
-					mes "[Meltz]";
-					mes "Thanks for stopping";
-					mes "by my shop. Farewell!";
-					mes "Come by anytime when";
-					mes "you feel like having an";
-					mes "Apple to snack on~";
+					mes("[Meltz]");
+					mes("Thanks for stopping\r"
+						"by my shop. Farewell!");
+					mes("Come by anytime when\r"
+						"you feel like having an\r"
+						"Apple to snack on~");
 					close;
 				}
 				break;
 			}
 		}
 		if (Zeny < .@pay) {
-			mes "[Meltz]";
-			mes "I'm sorry, you don't have";
-			mes "enough money with you.";
-			mes "Please check your funds or";
-			mes "purchase less Apples.";
+			mes("[Meltz]");
+			mes("I'm sorry, you don't have\r"
+				"enough money with you.");
+			mes("Please check your funds or\r"
+				"purchase less Apples.");
 			close;
 		}
 		else if (checkweight(Apple,.@input) == 0) {
-			mes "[Meltz]";
-			mes "Hmm, I don't think you've";
-			mes "got enough room to carry";
-			mes "this many Apples. You might";
-			mes "want to free up your inventory";
-			mes "space.";
+			mes("[Meltz]");
+			mes("Hmm, I don't think you've\r"
+				"got enough room to carry\r"
+				"this many Apples. You might\r"
+				"want to free up your inventory\r"
+				"space.");
 			close;
 		}
 		else {
 			Zeny -= .@pay;
 			getitem Apple,.@input;
-			mes "[Meltz]";
-			mes "Thanks for stopping by";
-			mes "my shop. I hope you enjoy";
-			mes "the flavor of these Apples~!";
+			mes("[Meltz]");
+			mes("Thanks for stopping by\r"
+				"my shop. I hope you enjoy\r"
+				"the flavor of these Apples~!");
 			close;
 		}
 	case 2:
-		mes "[Meltz]";
-		mes "Okay, I'll need";
-		mes "^FF00003 Apples and 1 Empty Bottle^000000";
-		mes "to make 1 Apple Juice for you.";
-		mes "Would you like to proceed?";
+		mes("[Meltz]");
+		mes("Okay, I'll need\r"
+			"^FF00003 Apples and 1 Empty Bottle^000000\r"
+			"to make 1 Apple Juice for you.");
+		mes("Would you like to proceed?");
 		next;
 		switch (select("Yes", "No")) {
 		case 1:
 			if (countitem(Apple) < 3 || countitem(Empty_Bottle) < 1) {
-				mes "[Meltz]";
-				mes "I'm sorry, but you don't";
-				mes "have enough materials to";
-				mes "create a bottle of Apple Juice.";
-				mes "Remember, I need 3 Apples";
-				mes "and 1 Empty Bottle to do it.";
+				mes("[Meltz]");
+				mes("I'm sorry, but you don't\r"
+					"have enough materials to\r"
+					"create a bottle of Apple Juice.");
+				mes("Remember, I need 3 Apples\r"
+					"and 1 Empty Bottle to do it.");
 				close;
 			}
 			else {
-				mes "[Meltz]";
-				mes "Thank you, please wait.";
+				mes("[Meltz]");
+				mes("Thank you, please wait.");
 				next;
-				mes "^3355FF*Grind* *Grind*";
-				mes "*Grind* *Grind*";
-				mes "*Clang...!*^000000";
+				mes("^3355FF*Grind* *Grind*");
+				mes("*Grind* *Grind*");
+				mes("*Clang...!*^000000");
 				next;
 				delitem Apple,3;
 				delitem Empty_Bottle,1;
 				getitem Apple_Juice,1;
-				mes "[Meltz]";
-				mes "There you go~";
-				mes "Please come again.";
+				mes("[Meltz]");
+				mes("There you go~");
+				mes("Please come again.");
 				close;
 			}
 		case 2:
-			mes "[Meltz]";
-			mes "Thanks for stopping";
-			mes "by my shop. Farewell!";
-			mes "Come by anytime when";
-			mes "you feel like having an";
-			mes "Apple to snack on~";
+			mes("[Meltz]");
+			mes("Thanks for stopping\r"
+				"by my shop. Farewell!");
+			mes("Come by anytime when\r"
+				"you feel like having an\r"
+				"Apple to snack on~");
 			close;
 		}
 	case 3:
-		mes "[Meltz]";
-		mes "Thanks for stopping";
-		mes "by my shop. Farewell!";
-		mes "Come by anytime when";
-		mes "you feel like having an";
-		mes "Apple to snack on~";
+		mes("[Meltz]");
+		mes("Thanks for stopping\r"
+			"by my shop. Farewell!");
+		mes("Come by anytime when\r"
+			"you feel like having an\r"
+			"Apple to snack on~");
 		close;
 	}
 }
@@ -976,67 +975,67 @@ airplane_01,50,66,5	script	Apple Merchant#air01	4_M_04,{
 airplane_01,221,158,2	script	Pilot#airplane_01	4_M_EIN_SOLDIER,{
 	switch (rand(1,4)) {
 	case 1:
-		mes "[Pilot]";
-		mes "Longitude, 131 degrees east.";
-		mes "Latitude, 37 degrees north.";
-		mes "We're right on course, captain.";
+		mes("[Pilot]");
+		mes("Longitude, 131 degrees east.");
+		mes("Latitude, 37 degrees north.");
+		mes("We're right on course, captain.");
 		close;
 	case 2:
-		mes "[Pilot]";
-		mes "Looks like a really";
-		mes "cloudy day. Always hard";
-		mes "to navigate when the skies";
-		mes "aren't clear. Guess we'll";
-		mes "need to amp the radar.";
+		mes("[Pilot]");
+		mes("Looks like a really\r"
+			"cloudy day. Always hard\r"
+			"to navigate when the skies\r"
+			"aren't clear. Guess we'll\r"
+			"need to amp the radar.");
 		close;
 	case 3:
-		mes "[Pilot]";
-		mes "The Captain is a good";
-		mes "man and I can't think of";
-		mes "a finer person to command";
-		mes "this ship. Still, he's pretty";
-		mes "tough, a real slave driver.";
+		mes("[Pilot]");
+		mes("The Captain is a good\r"
+			"man and I can't think of\r"
+			"a finer person to command\r"
+			"this ship. Still, he's pretty\r"
+			"tough, a real slave driver.");
 		next;
-		mes "[^ff0000Tarlock^000000]";
-		mes "^ff0000Hey...!^000000";
-		mes "^ff0000Less chit-chat^000000";
-		mes "^ff0000and more piloting!^000000";
+		mes("[^ff0000Tarlock^000000]");
+		mes("^ff0000Hey...!^000000");
+		mes("^ff0000Less chit-chat^000000");
+		mes("^ff0000and more piloting!^000000");
 		next;
-		mes "[Pilot]";
-		mes "R-right away, sir!";
-		mes "(See what I mean?)";
+		mes("[Pilot]");
+		mes("R-right away, sir!");
+		mes("(See what I mean?)");
 		close;
 	default:
-		mes "[Pilot]";
-		mes "This uniform is";
-		mes "really dapper, but";
-		mes "it's way too thick to";
-		mes "wear around the Airship.";
+		mes("[Pilot]");
+		mes("This uniform is\r"
+			"really dapper, but\r"
+			"it's way too thick to\r"
+			"wear around the Airship.");
 		next;
-		mes "[Pilot]";
-		mes "...";
-		mes "......";
-		mes "No one ever really";
-		mes "comes into this room.";
-		mes "And the captain IS a reindeer.";
-		mes "I could just strip to my boxers.";
+		mes("[Pilot]");
+		mes("...");
+		mes("......");
+		mes("No one ever really\r"
+			"comes into this room.");
+		mes("And the captain IS a reindeer.");
+		mes("I could just strip to my boxers.");
 		next;
 		emotion e_omg;
-		mes "[Pilot]";
-		mes "Oh...! Hello there!";
-		mes "E-e-enjoying your flight?!";
+		mes("[Pilot]");
+		mes("Oh...! Hello there!");
+		mes("E-e-enjoying your flight?!");
 		close;
 	}
 }
 
 airplane_01,83,61,2	script	Dianne#01airplane_01	1_F_MARIA,2,2,{
-	mes "[Dianne]";
-	mes "It's so weird!";
-	mes "I went to visit the";
-	mes "Airship Captain and";
-	mes "all I saw was this";
-	mes "weird reindeer. Oh!";
-	mes "Do you think that...";
+	mes("[Dianne]");
+	mes("It's so weird!");
+	mes("I went to visit the\r"
+		"Airship Captain and\r"
+		"all I saw was this\r"
+		"weird reindeer. Oh!");
+	mes("Do you think that...");
 	close;
 
 OnTouch:
@@ -1045,48 +1044,48 @@ OnTouch:
 }
 
 airplane_01,69,63,2	script	Mendel#01airplane_01	1_M_JOBTESTER,{
-	mes "[Mendel]";
-	mes "As I expected, the";
-	mes "in-flight meals are";
-	mes "three star quality at best.";
-	mes "*Harrrumph* I really should";
-	mes "have brought my chef so that";
-	mes "I could enjoy a real meal.";
+	mes("[Mendel]");
+	mes("As I expected, the\r"
+		"in-flight meals are\r"
+		"three star quality at best.");
+	mes("*Harrrumph* I really should\r"
+		"have brought my chef so that\r"
+		"I could enjoy a real meal.");
 	close;
 }
 
 airplane_01,71,31,2	script	Swordsman Shimizu#air_01	1_M_MOC_LORD,{
-	mes "[Swordsman Shimizu]";
-	mes "Finally, after five";
-	mes "years of waiting...";
-	mes "I can have my revenge!";
+	mes("[Swordsman Shimizu]");
+	mes("Finally, after five\r"
+		"years of waiting...");
+	mes("I can have my revenge!");
 	next;
-	mes "[Swordsman Shimizu]";
-	mes "I just...";
-	mes "Have to make sure that";
-	mes "I don't keep missing my";
-	mes "stop. But soon, very soon,";
-	mes "vengeance will be mine!";
+	mes("[Swordsman Shimizu]");
+	mes("I just...");
+	mes("Have to make sure that\r"
+		"I don't keep missing my\r"
+		"stop. But soon, very soon,\r"
+		"vengeance will be mine!");
 	close;
 }
 
 //=== Typing Challenge =====================================
 airplane_01,32,61,4	script	Nils#ein	1_M_03,1,1,{
-	mes "[Nils]";
-	mes "Welcome to the";
-	mes "^ff0000RO Typing Challenge^000000.";
-	mes "Would you like to play";
-	mes "a quick typing game?";
+	mes("[Nils]");
+	mes("Welcome to the\r"
+		"^ff0000RO Typing Challenge^000000.");
+	mes("Would you like to play\r"
+		"a quick typing game?");
 	next;
 	switch (select("Play ^ff0000RO Typing Challenge^000000", "Information", "View Top Records", "Cancel")) {
 	case 1:
-		mes "[Nils]";
-		mes "Okay, we have";
-		mes "a new challenger!";
-		mes "Enter the following";
-		mes "text as quickly as you";
-		mes "can without making any";
-		mes "mistakes! Let's start~!";
+		mes("[Nils]");
+		mes("Okay, we have\r"
+			"a new challenger!");
+		mes("Enter the following\r"
+			"text as quickly as you\r"
+			"can without making any\r"
+			"mistakes! Let's start~!");
 		setarray .@line1_1$[0],	"^3cbcbccallipygian salacius lascivious^000000",
 					"^3cbcbcBy the power of^000000",
 					"^0000ffthkelfkskeldmsiejdlslehfndkelsheidl^000000",
@@ -1145,18 +1144,18 @@ airplane_01,32,61,4	script	Nils#ein	1_M_03,1,1,{
 					1450;
 		.@wordtest = rand(7);
 		next;
-		mes "[Nils]";
-		mes .@line1_1$[.@wordtest];
-		mes .@line1_2$[.@wordtest];
-		mes .@line1_3$[.@wordtest];
+		mes("[Nils]");
+		mes(.@line1_1$[.@wordtest]);
+		mes(.@line1_2$[.@wordtest]);
+		mes(.@line1_3$[.@wordtest]);
 		.@start_time = gettime(GETTIME_HOUR)*60*60 + gettime(GETTIME_MINUTE)*60 + gettime(GETTIME_SECOND);
 		next;
 		input .@save1$;
 		.@end_time = gettime(GETTIME_HOUR)*60*60 + gettime(GETTIME_MINUTE)*60 + gettime(GETTIME_SECOND);
 		.@total_time = .@end_time - .@start_time;
-		mes "[Nils]";
-		mes .@line2_1$[.@wordtest];
-		mes .@line2_2$[.@wordtest];
+		mes("[Nils]");
+		mes(.@line2_1$[.@wordtest]);
+		mes(.@line2_2$[.@wordtest]);
 		.@start_time = gettime(GETTIME_HOUR)*60*60 + gettime(GETTIME_MINUTE)*60 + gettime(GETTIME_SECOND);
 		next;
 		input .@save2$;
@@ -1164,229 +1163,236 @@ airplane_01,32,61,4	script	Nils#ein	1_M_03,1,1,{
 		.@total_time = .@total_time + (.@start_time - .@end_time);
 		.@tasoo = (.@letters[.@wordtest] / .@total_time) * 6;
 		if ((.@save1$ == .@word1$[.@wordtest]) && (.@save2$ == .@word2$[.@wordtest])) {
-			mes "[Nils]";
-			mes "Your record is ^ff0000" + .@total_time + " seconds^000000 and";
-			mes "the total letters are " + .@tasoo + ".";
+			mes("[Nils]");
+			mesf("Your record is ^ff0000%d seconds^000000 and\r"
+				"the total letters are %d.",
+				.@total_time, .@tasoo);
 			next;
 			if (.@tasoo >= 1300) {
-				mes "[Nils]";
-				mes "Hmmm, this record isn't";
-				mes "humanly possible unless you";
-				mes "copy and paste the whole";
-				mes "sentence. Please play fairly";
-				mes "next time.";
+				mes("[Nils]");
+				mes("Hmmm, this record isn't\r"
+					"humanly possible unless you\r"
+					"copy and paste the whole\r"
+					"sentence. Please play fairly\r"
+					"next time.");
 				close;
 			}
 			if (.@tasoo >= $050320_ein_typing) {
-				mes "[Nils]";
-				mes "The previous top record was";
-				mes "made by ^0000ff" + $050320_minus1_typing$ + "^000000";
-				mes "with the total ^0000ff" + $050320_ein_typing + "^000000 letters.";
-				mes "However, ^ff0000" + strcharinfo(0) + "^000000,";
-				mes "you made the new top record";
-				mes "this time. Congratulations!";
+				mes("[Nils]");
+				mesf("The previous top record was\r"
+					"made by ^0000ff%s^000000\r"
+					"with the total ^0000ff%d^000000 letters.",
+					$050320_minus1_typing$, $050320_ein_typing);
+				mesf("However, ^ff0000%s^000000,\r"
+					"you made the new top record\r"
+					"this time. Congratulations!",
+					strcharinfo(0));
 				$050320_minus1_typing$ = strcharinfo(0);
 				$050320_ein_typing = .@tasoo;
 				close;
 			}
 			else {
-				mes "[Nils]";
-				mes "^0000ff" + $050320_minus1_typing$ + "^000000";
-				mes "is the current";
-				mes "record holder with";
-				mes "a letter total of ^0000ff" + $050320_ein_typing + "^000000";
-				mes "characters. Try to beat";
-				mes "that record next time~";
+				mes("[Nils]");
+				mesf("^0000ff%s^000000\r"
+					"is the current\r"
+					"record holder with\r"
+					"a letter total of ^0000ff%d^000000\r"
+					"characters. Try to beat\r"
+					"that record next time~",
+					$050320_minus1_typing$, $050320_ein_typing);
 				close;
 			}
 		}
 		else {
-			mes "[Nils]";
-			mes "Oooh...";
-			mes "I'm sorry, but";
-			mes "you entered the";
-			mes "text incorrectly...";
+			mes("[Nils]");
+			mes("Oooh...");
+			mes("I'm sorry, but\r"
+				"you entered the\r"
+				"text incorrectly...");
 			close;
 		}
 	case 2:
-		mes "[Nils]";
-		mes "The ^ff0000RO Typing Challenge^000000";
-		mes "is a game where you enter";
-		mes "the given text as quickly as you";
-		mes "can. The name of the top player";
-		mes "is recorded for posterity. If you";
-		mes "want fame, here's your chance!";
+		mes("[Nils]");
+		mes("The ^ff0000RO Typing Challenge^000000\r"
+			"is a game where you enter\r"
+			"the given text as quickly as you\r"
+			"can. The name of the top player\r"
+			"is recorded for posterity. If you\r"
+			"want fame, here's your chance!");
 		next;
-		mes "[Nils]";
-		mes "I'd just like to let";
-		mes "you know that you type";
-		mes "all the text that you see";
-		mes "in the single input line that";
-		mes "you're given. So don't press";
-		mes "the enter key, just click 'OK.'";
+		mes("[Nils]");
+		mes("I'd just like to let\r"
+			"you know that you type\r"
+			"all the text that you see\r"
+			"in the single input line that\r"
+			"you're given. So don't press\r"
+			"the enter key, just click 'OK.'");
 		close;
 	case 3:
-		mes "[Nils]";
-		mes "^0000ff" + $050320_minus1_typing$ + "^000000";
-		mes "is the current";
-		mes "record holder with";
-		mes "a letter total of ^0000ff" + $050320_ein_typing + "^000000";
-		mes "characters. Try to beat";
-		mes "that record next time~";
+		mes("[Nils]");
+		mesf("^0000ff%s^000000\r"
+			"is the current\r"
+			"record holder with\r"
+			"a letter total of ^0000ff%d^000000\r"
+			"characters. Try to beat\r"
+			"that record next time~",
+			$050320_minus1_typing$, $050320_ein_typing);
 		close;
 	case 4:
-		mes "[Nils]";
-		mes "Feel free to take on the";
-		mes "^ff0000RO Typing Challenge^000000";
-		mes "anytime. I'll be here~";
+		mes("[Nils]");
+		mes("Feel free to take on the\r"
+			"^ff0000RO Typing Challenge^000000\r"
+			"anytime. I'll be here~");
 		close;
 	}
 }
 
 //== Apple Gambling ========================================
 airplane_01,33,68,4	script	Clarice	1_F_MERCHANT_02,{
-	mes "[Clarice]";
-	mes "Hi, I'm Clarice~";
-	mes "How would you like";
-	mes "to wager some Apples";
-	mes "in a friendly game of Dice?";
+	mes("[Clarice]");
+	mes("Hi, I'm Clarice~");
+	mes("How would you like\r"
+		"to wager some Apples\r"
+		"in a friendly game of Dice?");
 	next;
-	callfunc "applegamble","Clarice";
+	callfunc("applegamble", _("Clarice"));
 	end;
 }
 
 function	script	applegamble	{
-
+	.@n$ = sprintf(_$("[%s]"), getarg(0));
 	switch (select("Play Dice Game", "Learn Dice Game Rules", "Cancel")) {
 	case 3:
-		mes "["+getarg(0)+"]";
-		mes "I'm up for a game of";
-		mes "dice whenever you feel";
-		mes "like it. Just talk to me if";
-		mes "you ever get hit with the";
-		mes "sudden urge to gamble, kay?";
+		mes(.@n$);
+		mes("I'm up for a game of\r"
+			"dice whenever you feel\r"
+			"like it. Just talk to me if\r"
+			"you ever get hit with the\r"
+			"sudden urge to gamble, kay?");
 		close;
 	case 2:
-		mes "["+getarg(0)+"]";
-		mes "The rules for the Dice game";
-		mes "are pretty simple. First, you";
-		mes "place a bet by wagering Apples.";
-		mes "You can bet a maximum of 50";
-		mes "Apples at a time. To keep things";
-		mes "legal, I can only accept Apples.";
+		mes(.@n$);
+		mes("The rules for the Dice game\r"
+			"are pretty simple. First, you\r"
+			"place a bet by wagering Apples.");
+		mes("You can bet a maximum of 50\r"
+			"Apples at a time. To keep things\r"
+			"legal, I can only accept Apples.");
 		next;
-		mes "["+getarg(0)+"]";
-		mes "But hey, if all that zeny";
-		mes "is burning a hole in your";
-		mes "pocket, head over to Fruitz";
-		mes "and you can buy as many";
-		mes "Apples as you want, playah~";
+		mes(.@n$);
+		mes("But hey, if all that zeny\r"
+			"is burning a hole in your\r"
+			"pocket, head over to Fruitz\r"
+			"and you can buy as many\r"
+			"Apples as you want, playah~");
 		next;
-		mes "["+getarg(0)+"]";
-		mes "Now, we begin with me";
-		mes "rolling two 6-sided dice.";
-		mes "When it's your turn, you'll";
-		mes "roll two 6-sided dice. After";
-		mes "that, both of us will have the";
-		mes "option of rolling a third die.";
+		mes(.@n$);
+		mes("Now, we begin with me\r"
+			"rolling two 6-sided dice.");
+		mes("When it's your turn, you'll\r"
+			"roll two 6-sided dice. After\r"
+			"that, both of us will have the\r"
+			"option of rolling a third die.");
 		next;
-		mes "["+getarg(0)+"]";
-		mes "Now here's the important";
-		mes "thing. If your total is higher";
-		mes "than 12, you'll bust, meaning";
-		mes "that you lose. Otherwise, the";
-		mes "person with the higher total";
-		mes "is the winner. Got it?";
+		mes(.@n$);
+		mes("Now here's the important\r"
+			"thing. If your total is higher\r"
+			"than 12, you'll bust, meaning\r"
+			"that you lose. Otherwise, the\r"
+			"person with the higher total\r"
+			"is the winner. Got it?");
 		next;
-		mes "["+getarg(0)+"]";
-		mes "Now, you'll be the first";
-		mes "to decide whether or not";
-		mes "you'll roll the third die. Then,";
-		mes "depending on your result, I'll";
-		mes "roll my third die... Or maybe not.";
+		mes(.@n$);
+		mes("Now, you'll be the first\r"
+			"to decide whether or not\r"
+			"you'll roll the third die. Then,\r"
+			"depending on your result, I'll\r"
+			"roll my third die... Or maybe not.");
 		next;
-		mes "["+getarg(0)+"]";
-		mes "When you win, you'll";
-		mes "receive twice as many";
-		mes "Apples as you wagered.";
-		mes "But if we happen to tie, you";
-		mes "get the Apples that you bet";
-		mes "returned to you. Fair, right?";
+		mes(.@n$);
+		mes("When you win, you'll\r"
+			"receive twice as many\r"
+			"Apples as you wagered.");
+		mes("But if we happen to tie, you\r"
+			"get the Apples that you bet\r"
+			"returned to you. Fair, right?");
 		close;
 	case 1:
 		break;
 	}
-	mes "["+getarg(0)+"]";
-	mes "Ooh, so you'll play with";
-	mes "me? Great! How many";
-	mes "Apples would you like to bet?";
-	mes "Remember, you can wager";
-	mes "up to 50 Apples. If you'd like";
-	mes "to cancel, please enter '0'.";
+	mes(.@n$);
+	mes("Ooh, so you'll play with\r"
+		"me? Great! How many\r"
+		"Apples would you like to bet?");
+	mes("Remember, you can wager\r"
+		"up to 50 Apples. If you'd like\r"
+		"to cancel, please enter '0'.");
 	next;
 	while(1) {
 		input .@amount;
 		if (.@amount == 0) {
-			mes "["+getarg(0)+"]";
-			mes "Changed your mind?";
-			mes "I understand. Well then,";
-			mes "I hope we can play sometime.";
+			mes(.@n$);
+			mes("Changed your mind?");
+			mes("I understand. Well then,\r"
+				"I hope we can play sometime.");
 			close;
 		}
 		else if (.@amount < 1 || .@amount > 50) {
-			mes "["+getarg(0)+"]";
-			mes "You can't bet more than";
-			mes "50 Apples. Remember, we";
-			mes "need to keep these stakes";
-			mes "reasonable. Please enter";
-			mes "a value no greater than 50.";
+			mes(.@n$);
+			mes("You can't bet more than\r"
+				"50 Apples. Remember, we\r"
+				"need to keep these stakes\r"
+				"reasonable. Please enter\r"
+				"a value no greater than 50.");
 			next;
 			continue;
 		}
-		mes "["+getarg(0)+"]";
-		mes "So you'll be";
-		mes "betting ^FF0000"+.@amount+"^000000 Apples.";
-		mes "Is that right?";
+		mes(.@n$);
+		mesf("So you'll be\r"
+			"betting ^FF0000%d^000000 Apples.",
+			.@amount);
+		mes("Is that right?");
 		next;
 		if (select("Yes", "No") == 2) {
-			mes "["+getarg(0)+"]";
-			mes "Mm, made a mistake?";
-			mes "Alright, please enter the";
-			mes "number of Apples you";
-			mes "wish to place in this bet";
+			mes(.@n$);
+			mes("Mm, made a mistake?");
+			mes("Alright, please enter the\r"
+				"number of Apples you\r"
+				"wish to place in this bet");
 			next;
 			continue;
 		}
 		if (countitem(Apple) <.@amount) {
-			mes "I'm sorry, but you";
-			mes "don't seem to have";
-			mes "enough Apples for this";
-			mes "bet... You can't gamble";
-			mes "if you can't play, you know.";
+			mes(.@n$);
+			mes("I'm sorry, but you\r"
+				"don't seem to have\r"
+				"enough Apples for this\r"
+				"bet... You can't gamble\r"
+				"if you can't play, you know.");
 			next;
 			continue;
 		}
 		delitem 512,.@amount;
-		mes "["+getarg(0)+"]";
-		mes "Good!";
-		mes "Now we can start";
-		mes "this game! I'll roll first~";
+		mes(.@n$);
+		mes("Good!");
+		mes("Now we can start\r"
+			"this game! I'll roll first~");
 		break;
 	}
-	mes "^3355FF*Rolling and rumbling*^000000";
+	mes("^3355FF*Rolling and rumbling*^000000");
 	next;
 	.@giveapple = .@amount*2;
 	.@table1 = rand(1,6);
 	.@table2 = rand(1,6);
 	.@tablesub = .@table1 + .@table2;
 	.@tabletotal = .@tablesub;
-	mes "["+getarg(0)+"]";
-	mes "I got a ^0000FF" + .@table1 + "^000000 and a ^0000FF" + .@table2 + "^000000.";
-	mes "That's a total of ^0000FF" + .@tablesub + "^000000.";
-	mes "^FF0000" + strcharinfo(0) + "^000000, now it's your turn.";
+	mes(.@n$);
+	mesf("I got a ^0000FF%d^000000 and a ^0000FF%d^000000.", .@table1, .@table2);
+	mesf("That's a total of ^0000FF%d^000000.", .@tablesub);
+	mesf("^FF0000%s^000000, now it's your turn.", strcharinfo(0));
 	next;
 	select("Cast Dice.");
-	mes "^3355FF*Rolling and rumbling*^000000";
+	mes("^3355FF*Rolling and rumbling*^000000");
 	.@player1 = rand(1,6);
 	.@player2 = rand(1,6);
 	.@playersub = .@player1 + .@player2;
@@ -1397,95 +1403,125 @@ function	script	applegamble	{
 	}
 	.@playertotal = .@playersub;
 	next;
-	mes "["+getarg(0)+"]";
-	mes "^FF0000" + strcharinfo(0) + "^000000, you have ^FF0000" + .@player1 + "^000000 and ^FF0000" + .@player2 + "^000000. The total is ^FF0000" + .@playersub + "^000000 .";
+	mes(.@n$);
+	mesf("^FF0000%s^000000, you have ^FF0000%d^000000 and ^FF0000%d^000000. The total is ^FF0000%d^000000.",
+		strcharinfo(0), .@player1, .@player2, .@playersub);
 	next;
-	mes "["+getarg(0)+"]";
+	mes(.@n$);
 	if(.@playersub == .@tablesub) {
-		mes "Currently my total is ^0000FF" + .@tablesub + "^000000 and ^FF0000" + strcharinfo(0) + "^000000, your total is ^FF0000" + .@playersub + "^000000. We are making an even game. Would you like to cast dice again?";
+		mesf("Currently my total is ^0000FF%d^000000 and ^FF0000%s^000000, your total is ^FF0000%d^000000. "
+			"We are making an even game. Would you like to cast dice again?",
+			.@tablesub, strcharinfo(0), .@playersub);
 	} else if (.@playersub > .@tablesub) {
-		mes "Currently my total is ^0000FF" + .@tablesub + "^000000 and ^FF0000" + strcharinfo(0) + "^000000, your total is ^FF0000" + .@playersub + "^000000. ^FF0000" + strcharinfo(0) + "^000000, you are currently winning this game. Would you like to cast dice again?";
+		mesf("Currently my total is ^0000FF%d^000000 and ^FF0000%s^000000, your total is ^FF0000%d^000000. "
+			"^FF0000%s^000000, you are currently winning this game. Would you like to cast dice again?",
+			.@tablesub, strcharinfo(0), .@playersub, strcharinfo(0));
 	} else if(.@tablesub > .@playersub) {
-		mes "Currently my total is ^0000FF" + .@tablesub + "^000000 and ^FF0000" + strcharinfo(0) + "^000000, your total is ^FF0000" + .@playersub + "^000000. I am winning this game. Would you like to cast dice again?";
+		mesf("Currently my total is ^0000FF%d^000000 and ^FF0000%s^000000, your total is ^FF0000%d^000000. "
+			"I am winning this game. Would you like to cast dice again?",
+			.@tablesub, strcharinfo(0), .@playersub);
 	}
 	next;
 	switch (select("Cast dice.", "Cancel.")) {
 	case 1:
-		mes "^3355FF*Rolling and rumbling*^000000";
+		mes("^3355FF*Rolling and rumbling*^000000");
 		.@player3 = rand(1,6);
 		.@playertotal += .@player3;
 		next;
-		mes "["+getarg(0)+"]";
+		mes(.@n$);
 		if (.@playertotal > 12) {
-			mes "^FF0000" + strcharinfo(0) + "^000000, you got ^FF0000" + .@player3 + "^000000 and the total is now ^FF0000" + .@playertotal + "^000000. You lost this game. I am sorry but please try again.";
+			mesf("^FF0000%s^000000, you got ^FF0000%d^000000 and the total is now ^FF0000%d^000000. "
+				"You lost this game. I am sorry but please try again.",
+				strcharinfo(0), .@player3, .@playertotal);
 			close;
 		}
 		else if (.@playertotal < .@tablesub) {
-			mes "^FF0000" + strcharinfo(0) + "^000000, you got ^FF0000" + .@player3 + "^000000 and the total is now ^FF0000" + .@playertotal + "^000000. Even though you casted dice again, still your total is smaller than mine. You lost the game. I am sorry and please try again.";
+			mesf("^FF0000%s^000000, you got ^FF0000%d^000000 and the total is now ^FF0000%d^000000. "
+				"Even though you casted dice again, still your total is smaller than mine. "
+				"You lost the game. I am sorry and please try again.",
+				strcharinfo(0), .@player3, .@playertotal);
 			close;
 		}
 		else if (.@playertotal == .@tablesub) {
 			if (.@tablesub > 8) {
-				mes "^FF0000" + strcharinfo(0) + "^000000, you got ^FF0000" + .@player3 + "^000000 and the total is now ^FF0000" + .@playertotal + "^000000. I don't want to take any risk, let's end this game in a draw. Let's play again some other time~";
+				mesf("^FF0000%s^000000, you got ^FF0000%d^000000 and the total is now ^FF0000%d^000000. "
+					"I don't want to take any risk, let's end this game in a draw. "
+					"Let's play again some other time~",
+					strcharinfo(0), .@player3, .@playertotal);
 				close2;
 				getitem Apple,.@amount;
 				end;
 			}
 		}
 		else {
-			mes "^FF0000" + strcharinfo(0) + "^000000, you got ^FF0000" + .@player3 + "^000000 and the total is now ^FF0000" + .@playertotal + "^000000. Now it is my turn.";
+			mesf("^FF0000%s^000000, you got ^FF0000%d^000000 and the total is now ^FF0000%d^000000. "
+					"Now it is my turn.",
+				strcharinfo(0), .@player3, .@playertotal);
 		}
 		break;
 	case 2:
-		mes "["+getarg(0)+"]";
+		mes(.@n$);
 		if (.@playersub > .@tablesub) {
-			mes "I see, you don't want to take risk of losing the game. Okay, let me cast dice again.";
+			mes("I see, you don't want to take risk of losing the game. Okay, let me cast dice again.");
 		}
 		else if (.@playersub == .@tablesub) {
 			if (.@tablesub > 8) {
-				mes "I see, you don't want to take risk of losing this game. Neither do I, let's end this game in a draw. Let's play again some other time~";
+				mes("I see, you don't want to take risk of losing this game. "
+					"Neither do I, let's end this game in a draw. "
+					"Let's play again some other time~");
 				close2;
 				getitem Apple,.@amount;
 				end;
 			}
-			mes "Alright.";
-			mes "Let me cast the dice again.";
+			mes("Alright.");
+			mes("Let me cast the dice again.");
 		}
 		else {
-			mes "It couldn't hurt to try.";
-			mes "Well, I win this time.";
-			mes "I'm sorry, let's try play";
-			mes "again sometime.";
+			mes("It couldn't hurt to try.");
+			mes("Well, I win this time.");
+			mes("I'm sorry, let's try play\r"
+				"again sometime.");
 			close;
 		}
 		break;
 	}
 	next;
-	mes "^3355FF*Rolling and rumbling*^000000";
+	mes("^3355FF*Rolling and rumbling*^000000");
 	.@table3 = rand(1,6);
 	.@tabletotal += .@table3;
 	next;
-	mes "["+getarg(0)+"]";
+	mes(.@n$);
 	if (.@tabletotal > 12) {
-		mes "I got ^0000FF" + .@table3 + "^000000 and the total is now ^0000FF" + .@tabletotal + "^000000. I lost this game since my total exceeded 12. Let me give you my apples. Congratulations, that was a great game.";
+		mesf("I got ^0000FF%d^000000 and the total is now ^0000FF%d^000000. "
+			"I lost this game since my total exceeded 12. Let me give you my apples. "
+			"Congratulations, that was a great game.",
+			.@table3, .@tabletotal);
 		close2;
 		getitem Apple,.@giveapple;
 		end;
 	}
 	else if (.@playertotal > .@tabletotal) {
-		mes "I got ^0000FF" + .@table3 + "^000000 and the total is now ^0000FF" + .@tabletotal + "^000000. With total ^FF0000" + .@playertotal + "^000000 you won this game, ^FF0000" + strcharinfo(0) + "^000000. Let me give you my apples. It was a great game and I hope we will play again some other time.";
+		mesf("I got ^0000FF%d^000000 and the total is now ^0000FF%d^000000. "
+			"With total ^FF0000%d^000000 you won this game, ^FF0000%s^000000. Let me give you my apples. "
+			"It was a great game and I hope we will play again some other time.",
+			.@table3, .@tabletotal, .@playertotal, strcharinfo(0));
 		close2;
 		getitem Apple,.@giveapple;
 		end;
 	}
 	else if (.@playertotal == .@tabletotal) {
-		mes "I got ^0000FF" + .@table3 + "^000000 and the total is now ^0000FF" + .@tabletotal + "^000000. With total ^FF0000" + .@playertotal + "^000000 this game came out even, ^FF0000" + strcharinfo(0) + "^000000. Let me give you your apple back. It was a great game and I hope we will play again some other time.";
+		mesf("I got ^0000FF%d^000000 and the total is now ^0000FF%d^000000. "
+			"With total ^FF0000%d^000000 this game came out even, ^FF0000%s^000000. "
+			"Let me give you your apple back. It was a great game and I hope we will play again some other time.",
+			.@table3, .@tabletotal, .@playertotal, strcharinfo(0));
 		close2;
 		getitem Apple,.@amount;
 		end;
 	}
 	else if (.@playertotal < .@tabletotal) {
-		mes "I got ^0000FF" + .@table3 + "^000000 and the total is now ^0000FF" + .@tabletotal + "^000000. With total ^FF0000" + .@playertotal + "^000000 you lost this game, ^FF0000" + strcharinfo(0) + "^000000. I am sorry but please try again.";
+		mesf("I got ^0000FF%d^000000 and the total is now ^0000FF%d^000000. "
+			"With total ^FF0000%d^000000 you lost this game, ^FF0000%s^000000. I am sorry but please try again.",
+			.@table3, .@tabletotal, .@playertotal, strcharinfo(0));
 		close;
 	}
 }

--- a/npc/airports/einbroch.txt
+++ b/npc/airports/einbroch.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Muad_Dib
 //= Copyright (C)  L0ne_W0lf
 //=
@@ -30,20 +30,20 @@
 //=========================================================================
 
 airport,143,43,5	script	Airport Staff#airport1a::airport1	4_F_01,{
-	mes "[Airport Staff]";
-	mes "Welcome to the";
-	mes "Einbroch Airport,";
-	mes "where we offer nonstop";
-	mes "flights to the cities of";
-	mes "Juno, Lighthalzen and Hugel.";
+	mes("[Airport Staff]");
+	mes("Welcome to the\r"
+		"Einbroch Airport,\r"
+		"where we offer nonstop\r"
+		"flights to the cities of\r"
+		"Juno, Lighthalzen and Hugel.");
 	next;
 	if (select("Board the Airship", "Cancel") == 1) {
-		mes "[Airport Staff]";
-		mes "The Airship boarding fee";
-		mes "is 1,200 zeny, but if you've";
-		mes "got a Free Ticket for Airship,";
-		mes "the fee will be waived. Will";
-		mes "you board the Airship?";
+		mes("[Airport Staff]");
+		mes("The Airship boarding fee\r"
+			"is 1,200 zeny, but if you've\r"
+			"got a Free Ticket for Airship,\r"
+			"the fee will be waived. Will\r"
+			"you board the Airship?");
 		next;
 		if (select("Yes", "No") == 1) {
 			if (countitem(Free_Flying_Ship_Ticket) > 0) {
@@ -56,19 +56,19 @@ airport,143,43,5	script	Airport Staff#airport1a::airport1	4_F_01,{
 				warp "airport",148,51;
 				end;
 			}
-			mes "[Airport Staff]";
-			mes "I'm sorry, but you don't";
-			mes "have a Free Ticket for";
-			mes "Airship and you don't have";
-			mes "enough zeny for boarding";
-			mes "the Airship. Remember, the";
-			mes "boarding fee is 1,200 zeny.";
+			mes("[Airport Staff]");
+			mes("I'm sorry, but you don't\r"
+				"have a Free Ticket for\r"
+				"Airship and you don't have\r"
+				"enough zeny for boarding\r"
+				"the Airship. Remember, the\r"
+				"boarding fee is 1,200 zeny.");
 			close;
 		}
 	}
-	mes "[Airport Staff]";
-	mes "Thank you and";
-	mes "have a nice day.";
+	mes("[Airport Staff]");
+	mes("Thank you and\r"
+		"have a nice day.");
 	close;
 }
 
@@ -76,31 +76,31 @@ airport,158,43,5	duplicate(airport1)	Airport Staff#airport1b	4_F_01
 airport,126,43,5	duplicate(airport1)	Airport Staff#airport1c	4_F_01
 
 airport,143,49,3	script	Arrival Staff#airport2a::airport2	4_F_01,{
-	mes "[Arrival Staff]";
-	mes "Welcome to Einbroch Airport.";
-	mes "If you are arriving from your";
-	mes "flight, let me guide you to the";
-	mes "main terminal. Otherwise, please board the Airship to depart to";
-	mes "Juno, Lighthalzen and Hugel.";
+	mes("[Arrival Staff]");
+	mes("Welcome to Einbroch Airport.");
+	mes("If you are arriving from your\r"
+		"flight, let me guide you to the\r"
+		"main terminal. Otherwise, please board the Airship to depart to\r"
+		"Juno, Lighthalzen and Hugel.");
 	next;
 	if (select("Exit to main terminal.", "Cancel.") == 1) {
-		mes "[Arrival Staff]";
-		mes "Once you're in the main terminal, you will need to pay the fee again";
-		mes "to board an Airship. You should";
-		mes "only exit if the city of Einbroch";
-		mes "is your intended destination.";
-		mes "Proceed to the main terminal?";
+		mes("[Arrival Staff]");
+		mes("Once you're in the main terminal, you will need to pay the fee again\r"
+			"to board an Airship. You should\r"
+			"only exit if the city of Einbroch\r"
+			"is your intended destination.");
+		mes("Proceed to the main terminal?");
 		next;
 		if (select("Yes", "No") == 1) {
 			warp "airport",142,40;
 			end;
 		}
 	}
-	mes "[Arrival Staff]";
-	mes "Alright, thank you";
-	mes "for your patronage";
-	mes "and I hope you have";
-	mes "a pleasant flight~";
+	mes("[Arrival Staff]");
+	mes("Alright, thank you\r"
+		"for your patronage\r"
+		"and I hope you have\r"
+		"a pleasant flight~");
 	close;
 }
 
@@ -108,20 +108,20 @@ airport,126,51,3	duplicate(airport2)	Arrival Staff#airport2b	4_F_01
 airport,158,50,3	duplicate(airport2)	Arrival Staff#airport2c	4_F_01
 
 einbroch,94,267,3	script	Airship Staff#ein01	4_F_02,{
-	mes "[Airship Staff]";
-	mes "Welcome to the";
-	mes "Einbroch Airport.";
-	mes "Please use this door to";
-	mes "board the Airship which stops";
-	mes "over Juno, Lighthalzen and";
-	mes "Hugel in the Schwaltzvalt Republic.";
+	mes("[Airship Staff]");
+	mes("Welcome to the\r"
+		"Einbroch Airport.");
+	mes("Please use this door to\r"
+		"board the Airship which stops\r"
+		"over Juno, Lighthalzen and\r"
+		"Hugel in the Schwaltzvalt Republic.");
 	next;
-	mes "[Airship Staff]";
-	mes "Otherwise, if Einbroch is";
-	mes "your intended destination,";
-	mes "please head down the stairs";
-	mes "and ask the Arrival Staff to lead";
-	mes "you to the main terminal. Thank";
-	mes "you, and enjoy your travels.";
+	mes("[Airship Staff]");
+	mes("Otherwise, if Einbroch is\r"
+		"your intended destination,\r"
+		"please head down the stairs\r"
+		"and ask the Arrival Staff to lead\r"
+		"you to the main terminal. Thank\r"
+		"you, and enjoy your travels.");
 	close;
 }

--- a/npc/airports/hugel.txt
+++ b/npc/airports/hugel.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -32,8 +32,8 @@
 hugel,178,142,0	script	toairplane#hugel	WARPNPC,1,1,{
 	end;
 OnTouch:
-	mes "To use the airship, you are required to pay 1,200 zeny or a Free Airship Ticket.";
-	mes "Would you like to use the service?";
+	mes("To use the airship, you are required to pay 1,200 zeny or a Free Airship Ticket.");
+	mes("Would you like to use the service?");
 	next;
 	if (select("Yes", "No") == 1) {
 		if (countitem(Free_Flying_Ship_Ticket) > 0) {
@@ -46,10 +46,10 @@ OnTouch:
 			warp "airplane",244,58;
 			end;
 		}
-		mes "I am sorry, but you do not have enough money.";
-		mes "Please remember, you are required to pay 1,200 zeny to use the service.";
+		mes("I am sorry, but you do not have enough money.");
+		mes("Please remember, you are required to pay 1,200 zeny to use the service.");
 		close;
 	}
-	mes "Thank you, please come again.";
+	mes("Thank you, please come again.");
 	close;
 }

--- a/npc/airports/izlude.txt
+++ b/npc/airports/izlude.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  rAthena Dev Team
 //= Copyright (C)  eAthena Dev Team
 //=
@@ -32,19 +32,19 @@
 //=========================================================================
 
 -	script	::Airship_Staff_izlude	FAKE_NPC,{
-	mes "[Airship Staff]";
-	mes "Welcome! Would you like";
-	mes "to board the Airship that";
-	mes "departs on the flight wich stops";
-	mes "in Juno and Rachel?";
+	mes("[Airship Staff]");
+	mes("Welcome! Would you like\r"
+		"to board the Airship that\r"
+		"departs on the flight wich stops\r"
+		"in Juno and Rachel?");
 	next;
 	if (select("Board the Airship to Juno/Rachel.", "Cancel.") == 1) {
-		mes "[Airship Staff]";
-		mes "The boarding fee is";
-		mes "1,200 zeny. However, this";
-		mes "charged is waived if you use";
-		mes "a Free Ticket for Airship. Now,";
-		mes "would you still like to board?";
+		mes("[Airship Staff]");
+		mes("The boarding fee is\r"
+			"1,200 zeny. However, this\r"
+			"charged is waived if you use\r"
+			"a Free Ticket for Airship. Now,\r"
+			"would you still like to board?");
 		next;
 		if (select("Yes", "No") == 1) {
 			if (countitem(Free_Flying_Ship_Ticket) > 0) {
@@ -57,16 +57,16 @@
 				warp "airplane_01",244,58;
 				end;
 			}
-			mes "[Airship Staff]";
-			mes "I'm sorry, but you don't";
-			mes "have 1,200 zeny to pay";
-			mes "for the boarding fee.";
+			mes("[Airship Staff]");
+			mes("I'm sorry, but you don't\r"
+				"have 1,200 zeny to pay\r"
+				"for the boarding fee.");
 			close;
 		}
 	}
-	mes "[Airship Staff]";
-	mes "Thank you and";
-	mes "please come again.";
-	mes "Have a good day~";
+	mes("[Airship Staff]");
+	mes("Thank you and\r"
+		"please come again.");
+	mes("Have a good day~");
 	close;
 }

--- a/npc/airports/lighthalzen.txt
+++ b/npc/airports/lighthalzen.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Muad_Dib
 //= Copyright (C)  L0ne_W0lf
 //=
@@ -32,18 +32,18 @@
 //=========================================================================
 
 lhz_airport,143,43,5	script	Airport Staff#lhz_air1a::lhz_airport1	4_F_01,{
-	mes "[Airport Staff]";
-	mes "Welcome to the";
-	mes "Lighthalzen Airport,";
-	mes "where we offer nonstop";
-	mes "flights to Einbroch, Juno and Hugel.";
+	mes("[Airport Staff]");
+	mes("Welcome to the\r"
+		"Lighthalzen Airport,\r"
+		"where we offer nonstop\r"
+		"flights to Einbroch, Juno and Hugel.");
 	next;
 	if (select("Board the Airship.", "Cancel.") == 1) {
-		mes "[Airport Staff]";
-		mes "The boarding fee is";
-		mes "1,200 zeny, but you can";
-		mes "waive the fee if you redeem";
-		mes "a Free Ticket for Airship.";
+		mes("[Airport Staff]");
+		mes("The boarding fee is\r"
+			"1,200 zeny, but you can\r"
+			"waive the fee if you redeem\r"
+			"a Free Ticket for Airship.");
 		next;
 		if (select("Yes", "No") == 1) {
 			if (countitem(Free_Flying_Ship_Ticket) > 0) {
@@ -56,17 +56,17 @@ lhz_airport,143,43,5	script	Airport Staff#lhz_air1a::lhz_airport1	4_F_01,{
 				warp "lhz_airport",148,51;
 				end;
 			}
-			mes "[Airship Staff]";
-			mes "I'm sorry, but you don't";
-			mes "have 1,200 zeny to pay";
-			mes "for the boarding fee.";
+			mes("[Airship Staff]");
+			mes("I'm sorry, but you don't\r"
+				"have 1,200 zeny to pay\r"
+				"for the boarding fee.");
 			close;
 		}
 	}
-	mes "[Airport Staff]";
-	mes "Thank you and";
-	mes "please come again.";
-	mes "Have a good day~";
+	mes("[Airport Staff]");
+	mes("Thank you and\r"
+		"please come again.");
+	mes("Have a good day~");
 	close;
 }
 
@@ -74,29 +74,29 @@ lhz_airport,158,43,5	duplicate(lhz_airport1)	Airship Staff#lhz_air1b	4_F_01
 lhz_airport,126,43,5	duplicate(lhz_airport1)	Airship Staff#lhz_air1c	4_F_01
 
 lhz_airport,143,49,3	script	Arrival Staff#lhz_air2a::lhz_airport2	4_F_01,{
-	mes "[Arrival Staff]";
-	mes "Welcome to Lighthalzen Airport.";
-	mes "Please let me guide you to the";
-	mes "main terminal if you are arriving from your flight. Otherwise, please";
-	mes "board the departing Airship to reach your intended destination.";
+	mes("[Arrival Staff]");
+	mes("Welcome to Lighthalzen Airport.");
+	mes("Please let me guide you to the\r"
+		"main terminal if you are arriving from your flight. Otherwise, please\r"
+		"board the departing Airship to reach your intended destination.");
 	next;
 	if (select("Exit to main terminal.", "Cancel.") == 1) {
-		mes "[Arrival Staff]";
-		mes "Once you're in the main terminal, you will need to pay the fee again";
-		mes "to board an Airship. You should";
-		mes "only exit if Lighthalzen is your intended destination. Shall we";
-		mes "proceed to the main terminal?";
+		mes("[Arrival Staff]");
+		mes("Once you're in the main terminal, you will need to pay the fee again\r"
+			"to board an Airship. You should\r"
+			"only exit if Lighthalzen is your intended destination. Shall we\r"
+			"proceed to the main terminal?");
 		next;
 		if (select("Yes", "No") == 1) {
 			warp "lhz_airport",142,40;
 			end;
 		}
 	}
-	mes "[Arrival Staff]";
-	mes "Alright, thank you";
-	mes "for your patronage";
-	mes "and I hope you have";
-	mes "a pleasant flight~";
+	mes("[Arrival Staff]");
+	mes("Alright, thank you\r"
+		"for your patronage\r"
+		"and I hope you have\r"
+		"a pleasant flight~");
 	close;
 }
 

--- a/npc/airports/rachel.txt
+++ b/npc/airports/rachel.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  rAthena Dev Team
 //= Copyright (C)  eAthena Dev Team
 //=
@@ -34,8 +34,8 @@
 ra_fild12,295,208,0	script	toairplane#rachel	WARPNPC,1,1,{
 	end;
 OnTouch:
-	mes "To use the airship, you are required to pay 1,200 zeny or a Free Airship Ticket.";
-	mes "Would you like to use the service?";
+	mes("To use the airship, you are required to pay 1,200 zeny or a Free Airship Ticket.");
+	mes("Would you like to use the service?");
 	next;
 	if (select("Yes", "No") == 1) {
 		if (countitem(Free_Flying_Ship_Ticket) > 0) {
@@ -48,10 +48,10 @@ OnTouch:
 			warp "airplane_01",245,60;
 			end;
 		}
-		mes "I am sorry, but you do not have enough money.";
-		mes "Please remember, you are required to pay 1,200 zeny to use the service.";
+		mes("I am sorry, but you do not have enough money.");
+		mes("Please remember, you are required to pay 1,200 zeny to use the service.");
 		close;
 	}
-	mes "Thank you, please come again.";
+	mes("Thank you, please come again.");
 	close;
 }

--- a/npc/airports/yuno.txt
+++ b/npc/airports/yuno.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Muad_Dib
 //= Copyright (C)  L0ne_W0lf
 //=
@@ -32,17 +32,17 @@
 //=========================================================================
 
 y_airport,143,43,5	script	Airport Staff#y_air1a::y_airport1	4_F_01,{
-	mes "[Airport Staff]";
-	mes "Welcome to Juno Airport where we offer domestic flights to Einbroch, Lighthalzen and Hugel,";
-	mes "and international flights to Izlude and Rachel.";
-	mes "How may I be of service?";
+	mes("[Airport Staff]");
+	mes("Welcome to Juno Airport where we offer domestic flights to Einbroch, Lighthalzen and Hugel,\r"
+		"and international flights to Izlude and Rachel.");
+	mes("How may I be of service?");
 	next;
 	if (select("Board the Airship.", "Cancel.") == 1) {
-		mes "[Airport Staff]";
-		mes "The boarding fee for all";
-		mes "flights is 1,200 zeny. If you";
-		mes "use a Free Ticket for Airship,";
-		mes "the boarding fee will be waived.So would you like to depart?";
+		mes("[Airport Staff]");
+		mes("The boarding fee for all\r"
+			"flights is 1,200 zeny. If you\r"
+			"use a Free Ticket for Airship,\r"
+			"the boarding fee will be waived.So would you like to depart?");
 		next;
 		if (select("Yes", "No") == 1) {
 			if (countitem(Free_Flying_Ship_Ticket) > 0) {
@@ -55,16 +55,16 @@ y_airport,143,43,5	script	Airport Staff#y_air1a::y_airport1	4_F_01,{
 				warp "y_airport",148,51;
 				end;
 			}
-			mes "[Airport Staff]";
-			mes "I'm sorry, but you don't";
-			mes "have 1,200 zeny to pay";
-			mes "for the boarding fee.";
+			mes("[Airport Staff]");
+			mes("I'm sorry, but you don't\r"
+				"have 1,200 zeny to pay\r"
+				"for the boarding fee.");
 			close;
 		}
 	}
-	mes "[Airport Staff]";
-	mes "Thank you and";
-	mes "have a nice day.";
+	mes("[Airport Staff]");
+	mes("Thank you and\r"
+		"have a nice day.");
 	close;
 }
 
@@ -72,28 +72,28 @@ y_airport,158,43,5	duplicate(y_airport1)	Airport Staff#y_air1b	4_F_01
 y_airport,126,43,5	duplicate(y_airport1)	Airport Staff#y_air1c	4_F_01
 
 y_airport,143,49,3	script	Arrival Staff#y_air2a::y_airport2	4_F_01,{
-	mes "[Airport Staff]";
-	mes "Welcome to Juno Airport. If you've just arrived from your";
-	mes "flight, let me guide you to the main terminal. Otherwise, please";
-	mes "board the departing Airship to reach your intended destination.";
+	mes("[Airport Staff]");
+	mes("Welcome to Juno Airport. If you've just arrived from your\r"
+		"flight, let me guide you to the main terminal. Otherwise, please\r"
+		"board the departing Airship to reach your intended destination.");
 	next;
 	if (select("Exit to main terminal", "Cancel") == 1) {
-		mes "[Airport Staff]";
-		mes "Once you're in the main terminal, you must pay the fee once again";
-		mes "to board a departing Airship. You should only exit if your intended";
-		mes "destination is Juno. Proceed to";
-		mes "exit to the main terminal?";
+		mes("[Airport Staff]");
+		mes("Once you're in the main terminal, you must pay the fee once again\r"
+			"to board a departing Airship. You should only exit if your intended\r"
+			"destination is Juno. Proceed to\r"
+			"exit to the main terminal?");
 		next;
 		if (select("Yes", "No") == 1) {
 			warp "y_airport",142,40;
 			end;
 		}
 	}
-	mes "[Airport Staff]";
-	mes "Alright, thank you";
-	mes "for your patronage";
-	mes "and I hope you have";
-	mes "a pleasant flight~";
+	mes("[Airport Staff]");
+	mes("Alright, thank you\r"
+		"for your patronage\r"
+		"and I hope you have\r"
+		"a pleasant flight~");
 	close;
 }
 
@@ -101,80 +101,80 @@ y_airport,126,51,3	duplicate(y_airport2)	Arrival Staff#y_air2b	4_F_01
 y_airport,158,50,3	duplicate(y_airport2)	Arrival Staff#y_air2c	4_F_01
 
 y_airport,145,63,5	script	Domestic Boarding	4_F_02,{
-	mes "[Boarding Staff]";
-	mes "Would you like to board the";
-	mes "Airship that flies to Einbroch,";
-	mes "Lighthalzen and Hugel? If so,";
-	mes "please let me guide you to that";
-	mes "Airship's boarding area.";
+	mes("[Boarding Staff]");
+	mes("Would you like to board the\r"
+		"Airship that flies to Einbroch,\r"
+		"Lighthalzen and Hugel? If so,\r"
+		"please let me guide you to that\r"
+		"Airship's boarding area.");
 	next;
 	if (select("Yes", "No") == 1) {
 		warp "yuno",59,244;
 		end;
 	}
-	mes "[Boarding Staff]";
-	mes "Very well, then.";
-	mes "Thank you for your";
-	mes "patronage, and I hope";
-	mes "you enjoy your travels~";
+	mes("[Boarding Staff]");
+	mes("Very well, then.");
+	mes("Thank you for your\r"
+		"patronage, and I hope\r"
+		"you enjoy your travels~");
 	close;
 }
 
 y_airport,140,63,5	script	International Boarding	4_F_02,{
-	mes "[Boarding Staff]";
-	mes "Would you like to board";
-	mes "the Airship which flies to";
-	mes "Juno, Izlude and Rachel?";
-	mes "If so, let me guide";
-	mes "you to the boarding area.";
+	mes("[Boarding Staff]");
+	mes("Would you like to board\r"
+		"the Airship which flies to\r"
+		"Juno, Izlude and Rachel?");
+	mes("If so, let me guide\r"
+		"you to the boarding area.");
 	next;
 	if (select("Yes", "No") == 1) {
 		warp "yuno",47,244;
 		end;
 	}
-	mes "[Boarding Staff]";
-	mes "Alright, then.";
-	mes "Thank you for flying";
-	mes "with us, and I hope you";
-	mes "enjoy your travels on our";
-	mes "state of the art Airships.";
+	mes("[Boarding Staff]");
+	mes("Alright, then.");
+	mes("Thank you for flying\r"
+		"with us, and I hope you\r"
+		"enjoy your travels on our\r"
+		"state of the art Airships.");
 	close;
 }
 
 yuno,14,262,5	script	Airship Staff#yuno01	4_F_02,{
-	mes "[Airship Staff]";
-	mes "Welcome to Juno Airport.";
-	mes "Please use this door to";
-	mes "board the Airship that will";
-	mes "be flying all the way to Izlude";
-	mes "in the Rune-Midgarts Kingdom,";
-	mes "and to Rachel in the Arunafeltz";
-	mes "Republic.";
+	mes("[Airship Staff]");
+	mes("Welcome to Juno Airport.");
+	mes("Please use this door to\r"
+		"board the Airship that will\r"
+		"be flying all the way to Izlude\r"
+		"in the Rune-Midgarts Kingdom,\r"
+		"and to Rachel in the Arunafeltz\r"
+		"Republic.");
 	next;
-	mes "[Airship Staff]";
-	mes "Otherwise, if Juno is";
-	mes "your intended destination,";
-	mes "please head down the stairs";
-	mes "and ask the Arrival Staff to lead";
-	mes "you to the main terminal. Thank";
-	mes "you, and enjoy your travels.";
+	mes("[Airship Staff]");
+	mes("Otherwise, if Juno is\r"
+		"your intended destination,\r"
+		"please head down the stairs\r"
+		"and ask the Arrival Staff to lead\r"
+		"you to the main terminal. Thank\r"
+		"you, and enjoy your travels.");
 	close;
 }
 
 yuno,88,263,3	script	Airship Staff#yuno02	4_F_02,{
-	mes "[Airship Staff]";
-	mes "Welcome to Juno Airport.";
-	mes "Please use this door to";
-	mes "board the Airship which stops";
-	mes "over Einbroch, Lighthalzen and";
-	mes "Hugel in the Schwaltzvalt Republic.";
+	mes("[Airship Staff]");
+	mes("Welcome to Juno Airport.");
+	mes("Please use this door to\r"
+		"board the Airship which stops\r"
+		"over Einbroch, Lighthalzen and\r"
+		"Hugel in the Schwaltzvalt Republic.");
 	next;
-	mes "[Airship Staff]";
-	mes "Otherwise, if Juno is";
-	mes "your intended destination,";
-	mes "please head down the stairs";
-	mes "and ask the Arrival Staff to lead";
-	mes "you to the main terminal. Thank";
-	mes "you, and enjoy your travels.";
+	mes("[Airship Staff]");
+	mes("Otherwise, if Juno is\r"
+		"your intended destination,\r"
+		"please head down the stairs\r"
+		"and ask the Arrival Staff to lead\r"
+		"you to the main terminal. Thank\r"
+		"you, and enjoy your travels.");
 	close;
 }

--- a/npc/battleground/bg_common.txt
+++ b/npc/battleground/bg_common.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Euphy
 //= Copyright (C)  L0ne_W0lf
 //=
@@ -44,58 +44,58 @@ bat_room,161,160,3	script	Gen. Guillaume's Aide#03	4_M_KY_HEAD,{ end; }
 
 bat_room,160,141,3	script	Prince Croix	4_M_CRU_CRUA,{
 	cutin "bat_crua1",2;
-	mes "[Prince Croix]";
-	mes "Wise adventurer, why don't you lend us your power for victory?";
+	mes("[Prince Croix]");
+	mes("Wise adventurer, why don't you lend us your power for victory?");
 	next;
 	switch(select("What's the reason for the Battle?", "Tell me about General Guillaume")) {
 	case 1:
 		cutin "bat_crua2",2;
-		mes "[Prince Croix]";
-		mes "Maroll's great king, Marcel Marollo VII, is very sick lately.";
-		mes "His Majesty has declared that he will be leaving the future of Maroll to me or the 3rd prince, General Guillaume.";
+		mes("[Prince Croix]");
+		mes("Maroll's great king, Marcel Marollo VII, is very sick lately.");
+		mes("His Majesty has declared that he will be leaving the future of Maroll to me or the 3rd prince, General Guillaume.");
 		next;
-		mes "[Prince Croix]";
-		mes "General Guillaume may have an advantage in this battle as he is the great general of Maroll, but that doesn't automatically mean he'll win.";
-		mes "I want to win this battle so that I can bring prosperity to the people of Maroll. They've suffered enough from war...";
+		mes("[Prince Croix]");
+		mes("General Guillaume may have an advantage in this battle as he is the great general of Maroll, but that doesn't automatically mean he'll win.");
+		mes("I want to win this battle so that I can bring prosperity to the people of Maroll. They've suffered enough from war...");
 		next;
 		switch(select("Yes, I want to join you.", "End Conversation")) {
 		case 1:
 			cutin "bat_crua1",2;
-			mes "[Prince Croix]";
-			mes "Thank you so much. I feel like I can win with the help of adventurers like you.";
-			mes "Now, please go downstairs and join your comrades in sharpening their skills to fight the enemy!";
+			mes("[Prince Croix]");
+			mes("Thank you so much. I feel like I can win with the help of adventurers like you.");
+			mes("Now, please go downstairs and join your comrades in sharpening their skills to fight the enemy!");
 			break;
 		case 2:
-			mes "[Prince Croix]";
-			mes "For Maroll!";
+			mes("[Prince Croix]");
+			mes("For Maroll!");
 			break;
 		}
 		break;
 	case 2:
 		cutin "bat_crua2",2;
-		mes "[Prince Croix]";
-		mes "The 3rd Prince Guillaume is the great general of Maroll.";
-		mes "It's a waste of time to explain to you how great a leader or warlord he is, since he commands the great military power of Maroll.";
+		mes("[Prince Croix]");
+		mes("The 3rd Prince Guillaume is the great general of Maroll.");
+		mes("It's a waste of time to explain to you how great a leader or warlord he is, since he commands the great military power of Maroll.");
 		next;
-		mes "[Prince Croix]";
-		mes "Unfortunately, there's something he and his followers are unaware of:";
-		mes "Do the people of Maroll really want them to spend so much money on military power?";
-		mes "We have suffered enough from wars.";
-		mes "I believe weapons aren't the best way to bring prosperity to a nation.";
+		mes("[Prince Croix]");
+		mes("Unfortunately, there's something he and his followers are unaware of:");
+		mes("Do the people of Maroll really want them to spend so much money on military power?");
+		mes("We have suffered enough from wars.");
+		mes("I believe weapons aren't the best way to bring prosperity to a nation.");
 		next;
-		mes "[Prince Croix]";
-		mes "I do not wish to shed blood, but I have no choice but to fight for the possibility of peace and for the sake of my people.";
+		mes("[Prince Croix]");
+		mes("I do not wish to shed blood, but I have no choice but to fight for the possibility of peace and for the sake of my people.");
 		next;
 		switch(select("Yes, I want to join you.", "End Conversation")) {
 		case 1:
 			cutin "bat_crua1",2;
-			mes "[Prince Croix]";
-			mes "Thank you so much. I feel like I can win with the help of adventurers like you.";
-			mes "Now, please go downstairs and join your comrades in sharpening their skills to fight the enemy!";
+			mes("[Prince Croix]");
+			mes("Thank you so much. I feel like I can win with the help of adventurers like you.");
+			mes("Now, please go downstairs and join your comrades in sharpening their skills to fight the enemy!");
 			break;
 		case 2:
-			mes "[Prince Croix]";
-			mes "For Maroll!";
+			mes("[Prince Croix]");
+			mes("For Maroll!");
 			break;
 		}
 		break;
@@ -111,72 +111,74 @@ bat_room,161,142,3	script	Prince Croix's Aide#02	4_M_CRU_HEAD,{ end; }
 
 bat_room,160,159,3	script	General Guillaume	4_M_KY_KIYOM,{
 	cutin "bat_kiyom2",2;
-	mes "[General Guillaume]";
-	mes "Hot-blooded adventurer, we need your ability to win this battle.";
+	mes("[General Guillaume]");
+	mes("Hot-blooded adventurer, we need your ability to win this battle.");
 	next;
 	switch(select("What's the reason for the Battle?", "Tell me about Prince Croix")) {
 	case 1:
 		cutin "bat_kiyom1",2;
-		mes "[General Guillaume]";
-		mes "Our great king, Marcel Marollo VII, is very sick lately.";
-		mes "His Majesty has declared that he has chosen either me or Prince Croix as the next king amongst his 9 sons.";
+		mes("[General Guillaume]");
+		mes("Our great king, Marcel Marollo VII, is very sick lately.");
+		mes("His Majesty has declared that he has chosen either me or Prince Croix as the next king amongst his 9 sons.");
 		next;
-		mes "[General Guillaume]";
-		mes "Two kings can't share a nation! Only the one victorious from His Majesty's appointed battle will be enthroned.";
+		mes("[General Guillaume]");
+		mes("Two kings can't share a nation! Only the one victorious from His Majesty's appointed battle will be enthroned.");
 		next;
-		mes "[General Guillaume]";
-		mes "This is, however, not just a battle between us. This battle will determine the future of this country.";
-		mes "I pledge on my honor to prove that I'm the one who can protect this Maroll from outside threats.";
+		mes("[General Guillaume]");
+		mes("This is, however, not just a battle between us. This battle will determine the future of this country.");
+		mes("I pledge on my honor to prove that I'm the one who can protect this Maroll from outside threats.");
 		next;
 		switch(select("Yes, I want to join you.", "End Conversation")) {
 		case 1:
 			cutin "bat_kiyom2",2;
-			mes "[General Guillaume]";
-			mes "Welcome to my army, comrade.";
-			mes "Your eyes tell me that you're a soldier that I can trust.";
+			mes("[General Guillaume]");
+			mes("Welcome to my army, comrade.");
+			mes("Your eyes tell me that you're a soldier that I can trust.");
 			next;
-			mes "[General Guillaume]";
-			mes "Now, go upstairs and apply for battle with your comrades.";
-			mes "I'm sure they'll welcome you whole-heartedly!";
+			mes("[General Guillaume]");
+			mes("Now, go upstairs and apply for battle with your comrades.");
+			mes("I'm sure they'll welcome you whole-heartedly!");
 			break;
 		case 2:
-			mes "[General Guillaume]";
-			mes "I'll be the one who will capture the flag!";
+			mes("[General Guillaume]");
+			mes("I'll be the one who will capture the flag!");
 			break;
 		}
 		break;
 	case 2:
 		cutin "bat_kiyom1",2;
-		mes "[General Guillaume]";
-		mes "The 5th Prince Croix is currently titled as the Prime Minister of Maroll.";
-		mes "He thinks all national matters of a nation can be discussed and determined on a desk,";
-		mes "and believes in peaceful co-existence with other countries.";
+		mes("[General Guillaume]");
+		mes("The 5th Prince Croix is currently titled as the Prime Minister of Maroll.");
+		mes("He thinks all national matters of a nation can be discussed and determined on a desk,\r"
+			"and believes in peaceful co-existence with other countries.");
 		next;
-		mes "[General Guillaume]";
-		mes "He's too ignorant to admit that so-called peace is built on countless lives that are sacrificed in wars while normal citizens and upper classes can live, oblivious to the horrors that allow them to live that way.";
+		mes("[General Guillaume]");
+		mes("He's too ignorant to admit that so-called peace is built on countless lives that are sacrificed in "
+			"wars while normal citizens and upper classes can live, oblivious to the horrors that allow them to live that way.");
 		next;
-		mes "[General Guillaume]";
-		mes "He's too naive to understand the reality....";
-		mes "I can't leave Maroll to someone like him who lives in a dream!";
+		mes("[General Guillaume]");
+		mes("He's too naive to understand the reality....");
+		mes("I can't leave Maroll to someone like him who lives in a dream!");
 		next;
-		mes "[General Guillaume]";
-		mes "His unrealistic beliefs will drown this country in poverty and make the people weak. If he becomes the king, Maroll will never rest from the onslaughts of other countries.";
-		mes "I want to teach him what makes this small country so powerful and prosperous. It's military power!";
+		mes("[General Guillaume]");
+		mes("His unrealistic beliefs will drown this country in poverty and make the people weak. If he becomes the king, "
+				"Maroll will never rest from the onslaughts of other countries.");
+		mes("I want to teach him what makes this small country so powerful and prosperous. It's military power!");
 		next;
 		switch(select("I want to join your army!", "End Conversation")) {
 		case 1:
 			cutin "bat_kiyom2",2;
-			mes "[General Guillaume]";
-			mes "Welcome to my army, comrade.";
-			mes "Your eyes tell me that you're a soldier that I can trust.";
+			mes("[General Guillaume]");
+			mes("Welcome to my army, comrade.");
+			mes("Your eyes tell me that you're a soldier that I can trust.");
 			next;
-			mes "[General Guillaume]";
-			mes "Now, go upstairs and apply for battle from your comrades.";
-			mes "I'm sure they'll welcome you whole-heartedly!";
+			mes("[General Guillaume]");
+			mes("Now, go upstairs and apply for battle from your comrades.");
+			mes("I'm sure they'll welcome you whole-heartedly!");
 			break;
 		case 2:
-			mes "[General Guillaume]";
-			mes "I'll be the one who will capture the flag!";
+			mes("[General Guillaume]");
+			mes("I'll be the one who will capture the flag!");
 			break;
 		}
 		break;
@@ -195,68 +197,68 @@ bat_room,160,159,3	script	General Guillaume	4_M_KY_KIYOM,{
 
 //== BattleGround Warper ===================================
 bat_room,148,150,5	script	Teleporter#Battlefield	4_F_TELEPORTER,{
-	mes "[Teleporter]";
-	mes "Do you wish to leave the battlefield? Use my services to return to town.";
+	mes("[Teleporter]");
+	mes("Do you wish to leave the battlefield? Use my services to return to town.");
 	next;
 	switch(select("Leave", "Don't Leave")) {
 	case 1:
-		mes "[Teleporter]";
+		mes("[Teleporter]");
 		switch(bat_return) {
 		default:
 		case 1:
-			setarray .@mapname$[0],"Prontera.","prontera";
+			setarray .@mapname$[0], _("Prontera"), "prontera";
 			setarray .@xy[0],116,72;
 			break;
 		case 2:
-			setarray .@mapname$[0],"Morroc","moc_ruins";
+			setarray .@mapname$[0], _("Morroc"), "moc_ruins";
 			setarray .@xy[0],152,48;
 			break;
 		case 3:
-			setarray .@mapname$[0],"Al De Baran.","aldebaran";
+			setarray .@mapname$[0], _("Al De Baran"), "aldebaran";
 			setarray .@xy[0],168,112;
 			break;
 		case 4:
-			setarray .@mapname$[0],"Geffen.","geffen";
+			setarray .@mapname$[0], _("Geffen"), "geffen";
 			setarray .@xy[0],120,39;
 			break;
 		case 5:
-			setarray .@mapname$[0],"Payon.","payon";
+			setarray .@mapname$[0], _("Payon"), "payon";
 			setarray .@xy[0],161,58;
 			break;
 		case 6:
-			setarray .@mapname$[0],"Lighthalzen.","lighthalzen";
+			setarray .@mapname$[0], _("Lighthalzen"), "lighthalzen";
 			setarray .@xy[0],159,93;
 			break;
 		case 7:
-			setarray .@mapname$[0],"Rachel.","rachel";
+			setarray .@mapname$[0], _("Rachel"), "rachel";
 			setarray .@xy[0],115,124;
 			break;
 		}
-		mes "You will be sent back to "+.@mapname$[0]+".";
+		mesf("You will be sent back to %s.", .@mapname$[0]);
 		close2;
 		warp .@mapname$[1],.@xy[0],.@xy[1];
 		break;
 	case 2:
-		mes "[Teleporter]";
-		mes "I'll be here whenever you're in need of my services.";
+		mes("[Teleporter]");
+		mes("I'll be here whenever you're in need of my services.");
 		close;
 	}
 	end;
 }
 
 -	script	Maroll Battle Recruiter::BatRecruit	4_F_JOB_KNIGHT,{
-	mes "[Maroll Battle Recruiter]";
-	mes "Good day, adventurer.";
-	mes "I'm a knight from a far country called Maroll Kingdom.";
+	mes("[Maroll Battle Recruiter]");
+	mes("Good day, adventurer.");
+	mes("I'm a knight from a far country called Maroll Kingdom.");
 	next;
-	mes "[Maroll Battle Recruiter]";
-	mes "The two princes of the kingdom are now battling for the throne of Maroll, and are in need of experienced soldiers like you.";
-	mes "How would you like to lend your power to one of the princes in the Maroll Kingdom?";
+	mes("[Maroll Battle Recruiter]");
+	mes("The two princes of the kingdom are now battling for the throne of Maroll, and are in need of experienced soldiers like you.");
+	mes("How would you like to lend your power to one of the princes in the Maroll Kingdom?");
 	next;
 	switch(select("Join", "Don't Join")) {
 	case 1:
-		mes "[Maroll Battle Recruiter]";
-		mes "May the war god bless you.";
+		mes("[Maroll Battle Recruiter]");
+		mes("May the war god bless you.");
 		close2;
 		getmapxy(.@mapname$, .@x, .@y, UNITTYPE_NPC);
 		if (.@mapname$ == "prontera")
@@ -278,8 +280,8 @@ bat_room,148,150,5	script	Teleporter#Battlefield	4_F_TELEPORTER,{
 		warp "bat_room",154,150;
 		break;
 	case 2:
-		mes "[Maroll Battle Recruiter]";
-		mes "I'll always be stationed here for more soldiers. Feel free to come back whenever you're interested.";
+		mes("[Maroll Battle Recruiter]");
+		mes("I'll always be stationed here for more soldiers. Feel free to come back whenever you're interested.");
 		close;
 	}
 	end;
@@ -330,7 +332,7 @@ bat_room,148,147,4	script	Kafra Staff::kaf_bat	4_F_KAFRA9,{
 
 //== Repairman =============================================
 bat_room,138,144,4	script	Repairman#bg	4_M_04,{
-	callfunc "repairmain","Repairman";
+	callfunc("repairmain", _("Repairman"));
 	end;
 }
 
@@ -338,12 +340,12 @@ bat_room,138,144,4	script	Repairman#bg	4_M_04,{
 bat_room,1,151,3	script	Switch#batgnd	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
 	if (.@i == -1) {
-		mes "The command has been cancelled.";
+		mes("The command has been cancelled.");
 		close;
 	} else if (.@i == 0) {
 		end;
 	} else {
-		mes "May I help you?";
+		mes("May I help you?");
 		next;
 		switch(select("Close Battlefield", "Open Battlefield", "Reset a01", "Reset b01", "Reset a02", "Reset b02")) {
 		case 1:
@@ -379,7 +381,7 @@ bat_room,1,151,3	script	Switch#batgnd	4_DOG01,{
 			donpcevent "start#bat_b02::OnEnable";
 			break;
 		}
-		mes "Complete";
+		mes("Complete");
 		close;
 	}
 }
@@ -387,104 +389,105 @@ bat_room,1,151,3	script	Switch#batgnd	4_DOG01,{
 //== Badges Exchange =======================================
 bat_room,160,150,3	script	Erundek	4_M_MANAGER,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Erundek]";
-	mes "Do you have the battlefield badges?";
-	mes "I can exchange Bravery Badges and Valor Badges for reward items.";
+	mes("[Erundek]");
+	mes("Do you have the battlefield badges?");
+	mes("I can exchange Bravery Badges and Valor Badges for reward items.");
 	next;
 	switch(select("Exchange Badges", "Check the Catalog")) {
 	case 1:
-		mes "[Erundek]";
-		mes "Which type of items would you like to exchange?";
-		mes "To check more information about the reward items, please use our ^3131FFCatalog^000000.";
+		mes("[Erundek]");
+		mes("Which type of items would you like to exchange?");
+		mes("To check more information about the reward items, please use our ^3131FFCatalog^000000.");
 		next;
 		switch(select("Weapon", "Armor", "Accessory", "Consumable")) {
 		case 1:
-			mes "[Erundek]";
-			mes "You chose ^3131FFWeapon^000000.";
-			mes "The following weapons are available for exchange with the battlefield badges.";
-			mes "Please note that items for ^3131FFBravery Badges are indicated as (BB)^000000, and ^3131FFValor Badges as (VB)^000000.";
+			mes("[Erundek]");
+			mes("You chose ^3131FFWeapon^000000.");
+			mes("The following weapons are available for exchange with the battlefield badges.");
+			mes("Please note that items for ^3131FFBravery Badges are indicated as (BB)^000000, and ^3131FFValor Badges as (VB)^000000.");
 			next;
 			switch(select("Dagger/OneSword/TwoSword/TwoSpear", "Staff/Mace/TwoAxe/Shuriken", "Bow/Katar/Music/Whip", "Book/Knuckle", "Revolver/Rifle/Gatling/Shotgun/Launcher")) {
 			case 1:
-				mes "[Erundek]";
-				mes "The following items are available in the ^3131FFDagger, One-Handed Sword, Two-Handed Sword, and Two-Handed Spear^000000 category.";
+				mes("[Erundek]");
+				mes("The following items are available in the ^3131FFDagger, One-Handed Sword, Two-Handed Sword, and Two-Handed Spear^000000 category.");
 				next;
 				setarray .@Weapons[0],13036,7828,13037,7829,13411,7828,13410,7829,1183,7828,1184,7829,1425,7828,1482,7829;
 				break;
 			case 2:
-				mes "[Erundek]";
-				mes "The following items are available in the ^3131FFStaff / Mace / Two-Handed Axe / Huuma Shuriken^000000 category.";
+				mes("[Erundek]");
+				mes("The following items are available in the ^3131FFStaff / Mace / Two-Handed Axe / Huuma Shuriken^000000 category.");
 				next;
 				setarray .@Weapons[0],1632,7828,1633,7829,1634,7828,1635,7829,1543,7828,1542,7829,1380,7828,1379,7829,13305,7828,13306,7829;
 				break;
 			case 3:
-				mes "[Erundek]";
-				mes "The following weapons are available in the ^3131FFBow / Katar / Musical Instrument / Whip^000000 category.";
+				mes("[Erundek]");
+				mes("The following weapons are available in the ^3131FFBow / Katar / Musical Instrument / Whip^000000 category.");
 				next;
 				setarray .@Weapons[0],1739,7828,1738,7829,1279,7828,1280,7829,1924,7828,1923,7829,1978,7828,1977,7829;
 				break;
 			case 4:
-				mes "[Erundek]";
-				mes "The following weapons are available in the ^3131FFBook / Knuckle^000000 category.";
+				mes("[Erundek]");
+				mes("The following weapons are available in the ^3131FFBook / Knuckle^000000 category.");
 				next;
 				setarray .@Weapons[0],1574,7828,1575,7829,1824,7828,1823,7829;
 				break;
 			case 5:
-				mes "[Erundek]";
-				mes "The following weapons are available in the ^3131FFRevolver / Rifle / Gatling Gun / Shotgun / Grenade Launcher^000000 category.";
+				mes("[Erundek]");
+				mes("The following weapons are available in the ^3131FFRevolver / Rifle / Gatling Gun / Shotgun / Grenade Launcher^000000 category.");
 				next;
 				setarray .@Weapons[0],13108,7828,13171,7829,13172,7828,13173,7829,13174,7829;
 				break;
 			}
 			.@menu$ = "";
 			for (.@i = 0; .@i < getarraysize(.@Weapons); .@i += 2)
-				.@menu$ += getitemname(.@Weapons[.@i])+((.@Weapons[.@i+1]==7828)?"(BB)":"(VB)")+":";
+				.@menu$ += getitemname(.@Weapons[.@i]) + ((.@Weapons[.@i+1]==7828) ? _("(BB)") : _("(VB)")) + ":";
 			.@i = (select(.@menu$)-1)*2;
-			.@type$ = ((.@Weapons[.@i+1]==7828)?"(BB)":"(VB)");
-			mes "[Erundek]";
-			mes "You chose ^3131FF"+getitemname(.@Weapons[.@i])+.@type$+"^000000.";
-			mes "You can exchange for this item with ^FF0000100 "+getitemname(.@Weapons[.@i+1])+"^000000.";
-			mes "Would you like to exchange?";
+			.@type$ = ((.@Weapons[.@i+1]==7828) ? _("(BB)") : _("(VB)"));
+			mes("[Erundek]");
+			mesf("You chose ^3131FF%s%s^000000.", getitemname(.@Weapons[.@i]), .@type$);
+			mesf("You can exchange for this item with ^FF0000100 %s^000000.", getitemname(.@Weapons[.@i+1]));
+			mes("Would you like to exchange?");
 			next;
 			switch(select("Do not exchange", "Exchange")) {
 			case 1:
 				break;
 			case 2:
-				mes "[Erundek]";
-				mes "Would you like to spend ^FF0000100 "+getitemname(.@Weapons[.@i+1])+"^000000 and receive a ^3131FF"+getitemname(.@Weapons[.@i])+.@type$+"^000000?";
+				mes("[Erundek]");
+				mesf("Would you like to spend ^FF0000100 %s^000000 and receive a ^3131FF%s%s^000000?",
+					getitemname(.@Weapons[.@i+1]), getitemname(.@Weapons[.@i]), .@type$);
 				next;
-				mes "[Erundek]";
-				mes "Remember, Battleground Reward Items are ^FF0000Character Bound^000000. Are you sure you want this item?";
+				mes("[Erundek]");
+				mes("Remember, Battleground Reward Items are ^FF0000Character Bound^000000. Are you sure you want this item?");
 				next;
 				switch(select("Yes", "No")) {
 				case 1:
-					mes "[Erundek]";
+					mes("[Erundek]");
 					if (countitem(.@Weapons[.@i+1]) >= 100) {
-						mes "Thank you for exchanging.";
+						mes("Thank you for exchanging.");
 						delitem .@Weapons[.@i+1],100;
 						getitem .@Weapons[.@i],1;
 					}
-					else mes "I'm sorry, but you don't have enough badges to exchange.";
+					else mes("I'm sorry, but you don't have enough badges to exchange.");
 					close;
 				case 2:
 					break;
 				}
 				break;
 			}
-			mes "[Erundek]";
-			mes "Do you need more time to check the items?";
+			mes("[Erundek]");
+			mes("Do you need more time to check the items?");
 			close;
 		case 2:
-			mes "[Erundek]";
-			mes "You chose ^3131FFArmor^000000.";
-			mes "The following armors are available for exchange with the battlefield badges.";
+			mes("[Erundek]");
+			mes("You chose ^3131FFArmor^000000.");
+			mes("The following armors are available for exchange with the battlefield badges.");
 			next;
 			switch(select("Garments / Shoes", "Armor")) {
 			case 1:
@@ -496,25 +499,27 @@ bat_room,160,150,3	script	Erundek	4_M_MANAGER,{
 			}
 			break;
 		case 3:
-			mes "[Erundek]";
-			mes "You chose ^3131FFAccessory^000000.";
-			mes "You can exchange the Medal of Honors with your Badges according to the job classes, as follows:";
+			mes("[Erundek]");
+			mes("You chose ^3131FFAccessory^000000.");
+			mes("You can exchange the Medal of Honors with your Badges according to the job classes, as follows:");
 			next;
 			setarray .@items[0],2733,500,2720,500,2721,500,2722,500,2723,500,2724,500,2725,500;
-			.@menu1$ = "Gunslinger:Swordman/Taekwon Master:Thief:Acolyte:Magician:Archer:Merchant";
+			.@menu1$ = sprintf("%s:%s/%s:%s:%s:%s:%s:%s",
+					jobname(Job_Gunslinger), jobname(Job_Swordman), jobname(Job_Star_Gladiator), jobname(Job_Thief),
+					jobname(Job_Acolyte), jobname(Job_Mage), jobname(Job_Archer), jobname(Job_Merchant));
 			break;
 		case 4:
-			mes "[Erundek]";
-			mes "You chose ^3131FFConsumable^000000.";
-			mes "The following consumable items are available for exchange with the battlefield badges:";
+			mes("[Erundek]");
+			mes("You chose ^3131FFConsumable^000000.");
+			mes("The following consumable items are available for exchange with the battlefield badges:");
 			next;
 			setarray .@items[0],12269,10,12270,10,12271,5,12272,10,12273,10;
 			break;
 		}
 		break;
 	case 2:
-		mes "[Erundek]";
-		mes "We have many items, so please take a look and purchase deliberately.";
+		mes("[Erundek]");
+		mes("We have many items, so please take a look and purchase deliberately.");
 		close2;
 		readbook 11010,1;
 		end;
@@ -524,49 +529,49 @@ bat_room,160,150,3	script	Erundek	4_M_MANAGER,{
 	else for (.@i = 0; .@i < getarraysize(.@items); .@i += 2)
 		.@menu$ += getitemname(.@items[.@i])+":";
 	.@i = (select(.@menu$)-1)*2;
-	mes "[Erundek]";
-	mes "You chose ^3131FF"+getitemname(.@items[.@i])+"^000000.";
+	mes("[Erundek]");
+	mesf("You chose ^3131FF%s^000000.", getitemname(.@items[.@i]));
 	switch(.@items[.@i]) {
-		case 2720: mes "This item is for Swordman and Taekwon Master Class only."; break;
-		case 2721: mes "This item is for Thief Class only."; break;
-		case 2722: mes "This item is for Acolyte Class only."; break;
-		case 2723: mes "This item is for Magician Class only."; break;
-		case 2724: mes "This item is for Archer Class only."; break;
-		case 2725: mes "This item is for Merchant Class only."; break;
-		case 2733: mes "This item is for Gunslinger only."; break;
+		case 2720: mes("This item is for Swordman and Taekwon Master Class only."); break;
+		case 2721: mes("This item is for Thief Class only."); break;
+		case 2722: mes("This item is for Acolyte Class only."); break;
+		case 2723: mes("This item is for Magician Class only."); break;
+		case 2724: mes("This item is for Archer Class only."); break;
+		case 2725: mes("This item is for Merchant Class only."); break;
+		case 2733: mes("This item is for Gunslinger only."); break;
 		default: break;
 	}
-	mes "You can exchange for this item with ^FF0000"+.@items[.@i+1]+" "+getitemname(7828)+" or "+.@items[.@i+1]+" "+getitemname(7829)+"^000000.";
-	mes "Would you like to exchange?";
+	mesf("You can exchange for this item with ^FF0000%d %s or %d %s^000000.", .@items[.@i+1], getitemname(7828), .@items[.@i+1], getitemname(7829));
+	mes("Would you like to exchange?");
 	next;
 	switch(select("Do not exchange", "Exchange")) {
 	case 1:
-		mes "[Erundek]";
-		mes "Do you need more time to check the items?";
+		mes("[Erundek]");
+		mes("Do you need more time to check the items?");
 		break;
 	case 2:
-		mes "[Erundek]";
-		mes "Which Badge do you want to exchange?";
-		mes "You need ^3131FF"+.@items[.@i+1]+" Badges^000000 to exchange.";
+		mes("[Erundek]");
+		mes("Which Badge do you want to exchange?");
+		mesf("You need ^3131FF%d Badges^000000 to exchange.", .@items[.@i+1]);
 		next;
 		if (.@item[0] < 12269 || .@item[0] > 12273 ) {
-			mes "[Erundek]";
-			mes "Remember, Battleground Reward Items are ^FF0000Character Bound^000000. Are you sure you want this item?";
+			mes("[Erundek]");
+			mes("Remember, Battleground Reward Items are ^FF0000Character Bound^000000. Are you sure you want this item?");
 			next;
 		}
 		.@j = select("Bravery Badge", "Valor Badge", "Cancel");
-		mes "[Erundek]";
+		mes("[Erundek]");
 		if (.@j == 3) {
-			mes "You cancelled the exchange.";
+			mes("You cancelled the exchange.");
 			break;
 		}
 		.@cost = ((.@j==1)?7828:7829);
 		if (countitem(.@cost) >= .@items[.@i+1]) {
-			mes "Thank you for exchanging.";
+			mes("Thank you for exchanging.");
 			delitem .@cost, .@items[.@i+1];
 			getitem .@items[.@i],1;
 		}
-		else mes "You do not have enough "+getitemname(.@cost)+"s.";
+		else mesf("You do not have enough %ss.", getitemname(.@cost));
 		break;
 	}
 	close;

--- a/npc/battleground/flavius/flavius01.txt
+++ b/npc/battleground/flavius/flavius01.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Euphy
 //= Copyright (C)  Kisuka
 //= Copyright (C)  L0ne_W0lf
@@ -40,7 +40,7 @@
 bat_room,86,227,4	script	Lieutenant Ator	4_M_KY_KNT,{
 	end;
 OnInit:
-	waitingroom "Battle Station",11,"start#bat_b01::OnReadyCheck",1,0,80;
+	waitingroom(_("Battle Station"), 11, "start#bat_b01::OnReadyCheck", 1, 0, 80);
 	end;
 OnEnterBG:
 	$@FlaviusBG1_id1 = waitingroom2bg("bat_b01",10,290,"start#bat_b01::OnGuillaumeQuit","");
@@ -50,7 +50,7 @@ OnEnterBG:
 bat_room,85,204,0	script	Lieutenant Thelokus	4_M_CRU_KNT,{
 	end;
 OnInit:
-	waitingroom "Battle Station",11,"start#bat_b01::OnReadyCheck",1,0,80;
+	waitingroom(_("Battle Station"), 11, "start#bat_b01::OnReadyCheck", 1, 0, 80);
 	end;
 OnEnterBG:
 	$@FlaviusBG1_id2 = waitingroom2bg("bat_b01",390,10,"start#bat_b01::OnCroixQuit","");
@@ -173,7 +173,7 @@ OnKill:
 
 OnMyMobDead:
 	if (mobcount("bat_b01","OBJ#bat_b01_a::OnMyMobDead") < 1) {
-		mapannounce "bat_b01", "Guillaume's Crystal has been destroyed.",bc_map,"0xFFCE00";
+		mapannounce("bat_b01", _("Guillaume's Crystal has been destroyed."), bc_map, "0xFFCE00");
 		if ($@Croix_ScoreBG1 > 0) {
 			$@FlaviusBG1_Victory = 2;
 			++$@Croix_ScoreBG1;
@@ -197,7 +197,7 @@ OnMyMobDead:
 
 bat_b01,1,2,3	script	OBJ#bat_b01_b	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@FlaviusBG1_id2,"bat_b01",328,150,"Blue Crystal",1914,"OBJ#bat_b01_b::OnMyMobDead";
+	bg_monster($@FlaviusBG1_id2, "bat_b01", 328, 150, _("Blue Crystal"), 1914, "OBJ#bat_b01_b::OnMyMobDead");
 	end;
 
 OnKill:
@@ -206,7 +206,7 @@ OnKill:
 
 OnMyMobDead:
 	if (mobcount("bat_b01","OBJ#bat_b01_b::OnMyMobDead") < 1) {
-		mapannounce "bat_b01", "Croix's Crystal has been destroyed.",bc_map,"0xFFCE00";
+		mapannounce("bat_b01", _("Croix's Crystal has been destroyed."), bc_map, "0xFFCE00");
 		if ($@Guill_ScoreBG1 > 0) {
 			$@FlaviusBG1_Victory = 1;
 			++$@Guill_ScoreBG1;
@@ -230,8 +230,8 @@ OnMyMobDead:
 
 bat_b01,1,3,3	script	guardian#bat_b01_a	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@FlaviusBG1_id1,"bat_b01",108,159,"Guillaume Camp Guardian",1949,"guardian#bat_b01_a::OnMyMobDead";
-	bg_monster $@FlaviusBG1_id1,"bat_b01",108,141,"Guillaume Camp Guardian",1949,"guardian#bat_b01_a::OnMyMobDead";
+	bg_monster($@FlaviusBG1_id1, "bat_b01", 108, 159, _("Guillaume Camp Guardian"), 1949, "guardian#bat_b01_a::OnMyMobDead");
+	bg_monster($@FlaviusBG1_id1, "bat_b01", 108, 141, _("Guillaume Camp Guardian"), 1949, "guardian#bat_b01_a::OnMyMobDead");
 	end;
 
 OnKill:
@@ -241,15 +241,15 @@ OnKill:
 OnMyMobDead:
 	if (mobcount("bat_b01","guardian#bat_b01_a::OnMyMobDead") < 1) {
 		donpcevent "cell#bat_b01_a::OnGreen";
-		mapannounce "bat_b01", "The Guardian protecting Guillaume's Crystal has been slain.",bc_map,"0xFFCE00";
+		mapannounce("bat_b01", _("The Guardian protecting Guillaume's Crystal has been slain."), bc_map, "0xFFCE00");
 	}
 	end;
 }
 
 bat_b01,1,3,3	script	guardian#bat_b01_b	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@FlaviusBG1_id2,"bat_b01",307,160,"Croix Camp Guardian",1949,"guardian#bat_b01_b::OnMyMobDead";
-	bg_monster $@FlaviusBG1_id2,"bat_b01",307,138,"Croix Camp Guardian",1949,"guardian#bat_b01_b::OnMyMobDead";
+	bg_monster($@FlaviusBG1_id2, "bat_b01", 307, 160, _("Croix Camp Guardian"), 1949, "guardian#bat_b01_b::OnMyMobDead");
+	bg_monster($@FlaviusBG1_id2, "bat_b01", 307, 138, _("Croix Camp Guardian"), 1949, "guardian#bat_b01_b::OnMyMobDead");
 	end;
 
 OnKill:
@@ -259,7 +259,7 @@ OnKill:
 OnMyMobDead:
 	if (mobcount("bat_b01","guardian#bat_b01_b::OnMyMobDead") < 1) {
 		donpcevent "cell#bat_b01_b::OnGreen";
-		mapannounce "bat_b01", "The Guardian protecting Croix's Crystal has been slain.",bc_map,"0xFFCE00";
+		mapannounce("bat_b01", _("The Guardian protecting Croix's Crystal has been slain."), bc_map, "0xFFCE00");
 	}
 	end;
 }
@@ -302,10 +302,10 @@ OnStop:
 
 bat_b01,10,294,3	script	Battle Therapist#b01_a	4_F_SISTER,{
 	specialeffect2 EF_HEAL;
-	mes "[Battle Therapist]";
-	mes "Just close your eyes,";
-	mes "and take a deep breath.";
-	mes "You can be free from pain.";
+	mes("[Battle Therapist]");
+	mes("Just close your eyes,\r"
+		"and take a deep breath.");
+	mes("You can be free from pain.");
 	close;
 
 OnTimer25000:
@@ -347,10 +347,10 @@ OnTouch:
 
 bat_b01,389,14,3	script	Battle Therapist#b01_b	4_F_SISTER,{
 	specialeffect2 EF_HEAL;
-	mes "[Battle Therapist]";
-	mes "Just close your eyes,";
-	mes "and take a deep breath.";
-	mes "You can be free from pain.";
+	mes("[Battle Therapist]");
+	mes("Just close your eyes,\r"
+		"and take a deep breath.");
+	mes("You can be free from pain.");
 	close;
 
 OnTimer25000:
@@ -410,18 +410,18 @@ bat_b01,10,294,3	script	Guillaume Vintenar#b01_a	4_M_RASWORD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 8) {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,9;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -430,18 +430,18 @@ bat_b01,10,294,3	script	Guillaume Vintenar#b01_a	4_M_RASWORD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -462,18 +462,18 @@ bat_b01,389,14,3	script	Croix Vintenar#b01_b	4_M_RASWORD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 8) {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,9;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -482,18 +482,18 @@ bat_b01,389,14,3	script	Croix Vintenar#b01_b	4_M_RASWORD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -523,31 +523,31 @@ OnStop:
 	end;
 
 OnTimer7000:
-	mapannounce "bat_b01", "Guillaume Vintenar Axl Rose : Let's attack to destroy that Crystal!",bc_map,"0xFF9900";
+	mapannounce("bat_b01", _("Guillaume Vintenar Axl Rose : Let's attack to destroy that Crystal!"), bc_map, "0xFF9900");
 	end;
 
 OnTimer8000:
-	mapannounce "bat_b01", "Croix Vintenar Swandery : Even though Guillaume is struggling to win against us, the victory is ours. Let's show them our power.",bc_map,"0xFF99CC";
+	mapannounce("bat_b01", _("Croix Vintenar Swandery : Even though Guillaume is struggling to win against us, the victory is ours. Let's show them our power."), bc_map, "0xFF99CC");
 	end;
 
 OnTimer1800000:
-	mapannounce "bat_b01", "Marollo VII : Guillaume Marollo, Croix Marollo! And their followers!",bc_map,"0x99CC00";
+	mapannounce("bat_b01", _("Marollo VII : Guillaume Marollo, Croix Marollo! And their followers!"), bc_map, "0x99CC00");
 	end;
 
 OnTimer1803000:
-	mapannounce "bat_b01", "Marollo VII : Both camps are competitive, so it's hard to judge which team is superior.",bc_map,"0x99CC00";
+	mapannounce("bat_b01", _("Marollo VII : Both camps are competitive, so it's hard to judge which team is superior."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1808000:
-	mapannounce "bat_b01", "Marollo VII : This battle of Flavian is such a waste of time. I will decide victory and defeat by your progress.",bc_map,"0x99CC00";
+	mapannounce("bat_b01", _("Marollo VII : This battle of Flavian is such a waste of time. I will decide victory and defeat by your progress."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1822000:
-	mapannounce "bat_b01", "Marollo VII : If you can't accept the results, try again in another valley battle!",bc_map,"0x99CC00";
+	mapannounce("bat_b01", _("Marollo VII : If you can't accept the results, try again in another valley battle!"), bc_map, "0x99CC00");
 	end;
 
 OnTimer1825000:
-	mapannounce "bat_b01", "Axl Rose, Swandery : Yes, sir.",bc_map,"0x99CC00";
+	mapannounce("bat_b01", _("Axl Rose, Swandery : Yes, sir."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1830000:
@@ -595,18 +595,18 @@ bat_b01,10,294,3	script	Vintenar#bat_b01_aover	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 8) {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,9;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -615,18 +615,18 @@ bat_b01,10,294,3	script	Vintenar#bat_b01_aover	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -635,26 +635,26 @@ bat_b01,10,294,3	script	Vintenar#bat_b01_aover	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
 		}
 	}
 	else {
-		mes "[Axl Rose]";
-		mes "Why are you here, Croix mercenary? I am definitely sure of victory against foolish Croix such as you. Ha!";
+		mes("[Axl Rose]");
+		mes("Why are you here, Croix mercenary? I am definitely sure of victory against foolish Croix such as you. Ha!");
 		close;
 	}
 	bg_leave;
@@ -673,18 +673,18 @@ bat_b01,389,14,3	script	Vintenar#bat_b01_bover	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -693,18 +693,18 @@ bat_b01,389,14,3	script	Vintenar#bat_b01_bover	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -713,26 +713,26 @@ bat_b01,389,14,3	script	Vintenar#bat_b01_bover	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 8) {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,9;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
 		}
 	}
 	else {
-		mes "[Swandery]";
-		mes "Why do you come here as a Guillaume? You will be sent to where you should be!";
+		mes("[Swandery]");
+		mes("Why do you come here as a Guillaume? You will be sent to where you should be!");
 		close;
 	}
 	bg_leave;
@@ -747,21 +747,21 @@ OnInit:
 bat_b01,1,10,3	script	Release all#b01	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
 	if (.@i == -1) {
-		mes "Cancelled.";
+		mes("Cancelled.");
 		close;
 	} else if (.@i == 0) {
 		end;
 	} else {
-		mes "May I help you?";
+		mes("May I help you?");
 		next;
 		switch(select("Release all.", "Cancel.")) {
 		case 1:
-			mes "Bye.";
+			mes("Bye.");
 			close2;
 			mapwarp "bat_b01","bat_room",154,150;
 			end;
 		case 2:
-			mes "Cancelled.";
+			mes("Cancelled.");
 			close;
 		}
 	}

--- a/npc/battleground/flavius/flavius02.txt
+++ b/npc/battleground/flavius/flavius02.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Euphy
 //= Copyright (C)  Kisuka
 //= Copyright (C)  L0ne_W0lf
@@ -40,7 +40,7 @@
 bat_room,142,227,4	script	Lieutenant Huvas	4_M_KY_KNT,{
 	end;
 OnInit:
-	waitingroom "Battle Station",11,"start#bat_b02::OnReadyCheck",1,0,80;
+	waitingroom(_("Battle Station"), 11, "start#bat_b02::OnReadyCheck", 1, 0, 80);
 	end;
 OnEnterBG:
 	$@FlaviusBG2_id1 = waitingroom2bg("bat_b02",10,290,"start#bat_b02::OnGuillaumeQuit","");
@@ -50,7 +50,7 @@ OnEnterBG:
 bat_room,142,204,0	script	Lieutenant Yukon	4_M_CRU_KNT,{
 	end;
 OnInit:
-	waitingroom "Battle Station",11,"start#bat_b02::OnReadyCheck",1,0,80;
+	waitingroom(_("Battle Station"), 11, "start#bat_b02::OnReadyCheck", 1, 0, 80);
 	end;
 OnEnterBG:
 	$@FlaviusBG2_id2 = waitingroom2bg("bat_b02",390,10,"start#bat_b02::OnCroixQuit","");
@@ -173,7 +173,7 @@ OnKill:
 
 OnMyMobDead:
 	if (mobcount("bat_b02","OBJ#bat_b02_a::OnMyMobDead") < 1) {
-		mapannounce "bat_b02", "Guillaume's Crystal has been destroyed.",bc_map,"0xFFCE00";
+		mapannounce("bat_b02", _("Guillaume's Crystal has been destroyed."), bc_map, "0xFFCE00");
 		if ($@Croix_ScoreBG2 > 0) {
 			$@FlaviusBG2_Victory = 2;
 			$@Croix_ScoreBG2 = $@Croix_ScoreBG2+1;
@@ -197,7 +197,7 @@ OnMyMobDead:
 
 bat_b02,1,2,3	script	OBJ#bat_b02_b	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@FlaviusBG2_id2,"bat_b02",328,150,"Blue Crystal",1914,"OBJ#bat_b02_b::OnMyMobDead";
+	bg_monster($@FlaviusBG2_id2, "bat_b02", 328, 150, _("Blue Crystal"), 1914, "OBJ#bat_b02_b::OnMyMobDead");
 	end;
 
 OnKill:
@@ -206,7 +206,7 @@ OnKill:
 
 OnMyMobDead:
 	if (mobcount("bat_b02","OBJ#bat_b02_b::OnMyMobDead") < 1) {
-		mapannounce "bat_b02", "Croix's Crystal has been destroyed.",bc_map,"0xFFCE00";
+		mapannounce("bat_b02", _("Croix's Crystal has been destroyed."), bc_map, "0xFFCE00");
 		if ($@Guill_ScoreBG2 > 0) {
 			$@FlaviusBG2_Victory = 1;
 			++$@Guill_ScoreBG2;
@@ -230,8 +230,8 @@ OnMyMobDead:
 
 bat_b02,1,3,3	script	guardian#bat_b02_a	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@FlaviusBG2_id1,"bat_b02",108,159,"Guillaume Camp Guardian",1949,"guardian#bat_b02_a::OnMyMobDead";
-	bg_monster $@FlaviusBG2_id1,"bat_b02",108,141,"Guillaume Camp Guardian",1949,"guardian#bat_b02_a::OnMyMobDead";
+	bg_monster($@FlaviusBG2_id1, "bat_b02", 108, 159, _("Guillaume Camp Guardian"), 1949, "guardian#bat_b02_a::OnMyMobDead");
+	bg_monster($@FlaviusBG2_id1, "bat_b02", 108, 141, _("Guillaume Camp Guardian"), 1949, "guardian#bat_b02_a::OnMyMobDead");
 	end;
 
 OnKill:
@@ -241,15 +241,15 @@ OnKill:
 OnMyMobDead:
 	if (mobcount("bat_b02","guardian#bat_b02_a::OnMyMobDead") < 1) {
 		donpcevent "cell#bat_b02_a::OnGreen";
-		mapannounce "bat_b02", "The Guardian protecting Guillaume's Crystal has been slain.",bc_map,"0xFFCE00";
+		mapannounce("bat_b02", _("The Guardian protecting Guillaume's Crystal has been slain."), bc_map, "0xFFCE00");
 	}
 	end;
 }
 
 bat_b02,1,3,3	script	guardian#bat_b02_b	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@FlaviusBG2_id2,"bat_b02",307,160,"Croix Camp Guardian",1949,"guardian#bat_b02_b::OnMyMobDead";
-	bg_monster $@FlaviusBG2_id2,"bat_b02",307,138,"Croix Camp Guardian",1949,"guardian#bat_b02_b::OnMyMobDead";
+	bg_monster($@FlaviusBG2_id2, "bat_b02", 307, 160, _("Croix Camp Guardian"), 1949, "guardian#bat_b02_b::OnMyMobDead");
+	bg_monster($@FlaviusBG2_id2, "bat_b02", 307, 138, _("Croix Camp Guardian"), 1949, "guardian#bat_b02_b::OnMyMobDead");
 	end;
 
 OnKill:
@@ -259,7 +259,7 @@ OnKill:
 OnMyMobDead:
 	if (mobcount("bat_b02","guardian#bat_b02_b::OnMyMobDead") < 1) {
 		donpcevent "cell#bat_b02_b::OnGreen";
-		mapannounce "bat_b02", "The Guardian protecting Croix's Crystal has been slain.",bc_map,"0xFFCE00";
+		mapannounce("bat_b02", _("The Guardian protecting Croix's Crystal has been slain."), bc_map, "0xFFCE00");
 	}
 	end;
 }
@@ -302,10 +302,10 @@ OnStop:
 
 bat_b02,10,294,3	script	Battle Therapist#b02_a	4_F_SISTER,{
 	specialeffect2 EF_HEAL;
-	mes "[Battle Therapist]";
-	mes "Just close your eyes,";
-	mes "and take a deep breath.";
-	mes "You can be free from pain.";
+	mes("[Battle Therapist]");
+	mes("Just close your eyes,\r"
+		"and take a deep breath.");
+	mes("You can be free from pain.");
 	close;
 
 OnTimer25000:
@@ -347,10 +347,10 @@ OnTouch:
 
 bat_b02,389,14,3	script	Battle Therapist#b02_b	4_F_SISTER,{
 	specialeffect2 EF_HEAL;
-	mes "[Battle Therapist]";
-	mes "Just close your eyes,";
-	mes "and take a deep breath.";
-	mes "You can be free from pain.";
+	mes("[Battle Therapist]");
+	mes("Just close your eyes,\r"
+		"and take a deep breath.");
+	mes("You can be free from pain.");
 	close;
 
 OnTimer25000:
@@ -410,18 +410,18 @@ bat_b02,10,294,3	script	Guillaume Vintenar#b02_a	4_M_RASWORD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 8) {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,9;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -430,18 +430,18 @@ bat_b02,10,294,3	script	Guillaume Vintenar#b02_a	4_M_RASWORD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -462,18 +462,18 @@ bat_b02,389,14,3	script	Croix Vintenar#b02_b	4_M_RASWORD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 8) {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,9;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -482,18 +482,18 @@ bat_b02,389,14,3	script	Croix Vintenar#b02_b	4_M_RASWORD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -523,31 +523,31 @@ OnStop:
 	end;
 
 OnTimer7000:
-	mapannounce "bat_b02", "Guillaume Vintenar Axl Rose : Let's attack to destroy that Crystal!",bc_map,"0xFF9900";
+	mapannounce("bat_b02", _("Guillaume Vintenar Axl Rose : Let's attack to destroy that Crystal!"), bc_map, "0xFF9900");
 	end;
 
 OnTimer8000:
-	mapannounce "bat_b02", "Croix Vintenar Swandery : Even though Guillaume is struggling to win against us, the victory is ours. Let's show them our power.",bc_map,"0xFF99CC";
+	mapannounce("bat_b02", _("Croix Vintenar Swandery : Even though Guillaume is struggling to win against us, the victory is ours. Let's show them our power."), bc_map, "0xFF99CC");
 	end;
 
 OnTimer1800000:
-	mapannounce "bat_b02", "Marollo VII : Guillaume Marollo, Croix Marollo! And their followers!",bc_map,"0x99CC00";
+	mapannounce("bat_b02", _("Marollo VII : Guillaume Marollo, Croix Marollo! And their followers!"), bc_map, "0x99CC00");
 	end;
 
 OnTimer1803000:
-	mapannounce "bat_b02", "Marollo VII : Both camps are competitive, so it's hard to judge which team is superior.",bc_map,"0x99CC00";
+	mapannounce("bat_b02", _("Marollo VII : Both camps are competitive, so it's hard to judge which team is superior."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1808000:
-	mapannounce "bat_b02", "Marollo VII : This battle of Flavian is such a waste of time. I will decide victory and defeat by your progress.",bc_map,"0x99CC00";
+	mapannounce("bat_b02", _("Marollo VII : This battle of Flavian is such a waste of time. I will decide victory and defeat by your progress."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1822000:
-	mapannounce "bat_b02", "Marollo VII : If you can't accept the results, try again in another valley battle!",bc_map,"0x99CC00";
+	mapannounce("bat_b02", _("Marollo VII : If you can't accept the results, try again in another valley battle!"), bc_map, "0x99CC00");
 	end;
 
 OnTimer1825000:
-	mapannounce "bat_b02", "Axl Rose, Swandery : Yes, sir.",bc_map,"0x99CC00";
+	mapannounce("bat_b02", _("Axl Rose, Swandery : Yes, sir."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1830000:
@@ -595,18 +595,18 @@ bat_b02,10,294,3	script	Vintenar#bat_b02_aover	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 8) {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,9;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -615,18 +615,18 @@ bat_b02,10,294,3	script	Vintenar#bat_b02_aover	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -635,26 +635,26 @@ bat_b02,10,294,3	script	Vintenar#bat_b02_aover	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, next time you will definitely win.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
 		}
 	}
 	else {
-		mes "[Axl Rose]";
-		mes "Why are you here, Croix mercenary? I am definitely sure of victory against foolish Croix such as you. Ha!";
+		mes("[Axl Rose]");
+		mes("Why are you here, Croix mercenary? I am definitely sure of victory against foolish Croix such as you. Ha!");
 		close;
 	}
 	bg_leave;
@@ -673,18 +673,18 @@ bat_b02,389,14,3	script	Vintenar#bat_b02_bover	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -693,18 +693,18 @@ bat_b02,389,14,3	script	Vintenar#bat_b02_bover	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+". Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s. Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
@@ -713,26 +713,26 @@ bat_b02,389,14,3	script	Vintenar#bat_b02_bover	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge2);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 8) {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,9;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge2,.@medal_gap;
 			}
 		}
 	}
 	else {
-		mes "[Swandery]";
-		mes "Why do you come here as a Guillaume? You will be sent to where you should be!";
+		mes("[Swandery]");
+		mes("Why do you come here as a Guillaume? You will be sent to where you should be!");
 		close;
 	}
 	bg_leave;
@@ -747,21 +747,21 @@ OnInit:
 bat_b02,1,10,3	script	Release all#b02	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
 	if (.@i == -1) {
-		mes "Cancelled.";
+		mes("Cancelled.");
 		close;
 	} else if (.@i == 0) {
 		end;
 	} else {
-		mes "May I help you?";
+		mes("May I help you?");
 		next;
 		switch(select("Release all.", "Cancel.")) {
 		case 1:
-			mes "Bye.";
+			mes("Bye.");
 			close2;
 			mapwarp "bat_b02","bat_room",154,150;
 			end;
 		case 2:
-			mes "Cancelled.";
+			mes("Cancelled.");
 			close;
 		}
 	}

--- a/npc/battleground/flavius/flavius_enter.txt
+++ b/npc/battleground/flavius/flavius_enter.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  L0ne_W0lf
 //=
 //= Hercules is free software: you can redistribute it and/or modify
@@ -35,59 +35,59 @@
 //== Flavius Officer - Guillaume ===========================
 bat_room,133,178,5	script	Flavius Officer#01a	4_M_KY_KNT,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Guillaume Army Officer]";
-	mes "Let's show the power of the Guillaume Army to those stinky Croixs!";
+	mes("[Guillaume Army Officer]");
+	mes("Let's show the power of the Guillaume Army to those stinky Croixs!");
 	next;
 	switch(select("I want to join your army!", "End Conversation")) {
 	case 1:
 		if ((Class == Job_Novice) || (BaseClass == Job_SuperNovice)) {
-			mes "[Guillaume Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Guillaume Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		if (BaseLevel < 80) {
-			mes "[Guillaume Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Guillaume Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		.@chk_urtime = questprogress(2070, PLAYTIME);
 		if (.@chk_urtime == 1) {
-			mes "[Guillaume Army Officer]";
-			mes "You seem to have just returned from the battlefield.";
-			mes "It's too early for you to go back. Go rest, and leave the enemies to us!";
+			mes("[Guillaume Army Officer]");
+			mes("You seem to have just returned from the battlefield.");
+			mes("It's too early for you to go back. Go rest, and leave the enemies to us!");
 			break;
 		}
 		if (.@chk_urtime == 2)
 			erasequest 2070;
 		if (getmapusers("bat_b01") > 0) {
-			mes "[Guillaume Army Officer]";
-			mes "I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Croixs already.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Guillaume Army Officer]");
+			mes("I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Croixs already.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
 		if ($@FlaviusBG1 > 0) {
-			mes "[Guillaume Army Officer]";
-			mes "An elite corps is already standing by to be dispatched to the battlefield.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Guillaume Army Officer]");
+			mes("An elite corps is already standing by to be dispatched to the battlefield.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
-		mes "[Guillaume Army Officer]";
-		mes "You definitely seem to be ready for battle!";
-		mes "Go show the Croixs what fear truly means!";
-		mes "Today, our cry of victory shall echo all over the battlefield!";
+		mes("[Guillaume Army Officer]");
+		mes("You definitely seem to be ready for battle!");
+		mes("Go show the Croixs what fear truly means!");
+		mes("Today, our cry of victory shall echo all over the battlefield!");
 		close2;
 		warp "bat_room",85,223;
 		end;
 	case 2:
-		mes "[Guillaume Army Officer]";
-		mes "Today, we shall be victorious!";
+		mes("[Guillaume Army Officer]");
+		mes("Today, we shall be victorious!");
 		break;
 	}
 	close;
@@ -95,208 +95,208 @@ bat_room,133,178,5	script	Flavius Officer#01a	4_M_KY_KNT,{
 
 bat_room,133,121,1	script	Flavius Officer#01b	4_M_CRU_KNT,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Croix Army Officer]";
-	mes "Let's show the Guillaumes the power of the Croix Army!";
+	mes("[Croix Army Officer]");
+	mes("Let's show the Guillaumes the power of the Croix Army!");
 	next;
 	switch(select("I want to join your army!", "End Conversation")) {
 	case 1:
 		if ((Class == Job_Novice) || (BaseClass == Job_SuperNovice)) {
-			mes "[Croix Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Croix Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		if (BaseLevel < 80) {
-			mes "[Croix Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Croix Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		.@chk_urtime = questprogress(2070,PLAYTIME);
 		if (.@chk_urtime == 1) {
-			mes "[Croix Army Officer]";
-			mes "You seem to have just returned from the battlefield.";
-			mes "It's too early for you to go back. Go rest, and leave the enemies to us!";
+			mes("[Croix Army Officer]");
+			mes("You seem to have just returned from the battlefield.");
+			mes("It's too early for you to go back. Go rest, and leave the enemies to us!");
 			break;
 		}
 		if (.@chk_urtime == 2)
 			erasequest 2070;
 		if (getmapusers("bat_b01") > 0) {
-			mes "[Croix Army Officer]";
-			mes "I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Guillaume already.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Croix Army Officer]");
+			mes("I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Guillaume already.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
 		if ($@FlaviusBG1 > 0) {
-			mes "[Croix Army Officer]";
-			mes "An elite corps is already standing by to be dispatched to the battlefield.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Croix Army Officer]");
+			mes("An elite corps is already standing by to be dispatched to the battlefield.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
-		mes "[Croix Army Officer]";
-		mes "You definitely seem to be ready for battle!";
-		mes "Go show the Guillaumes what fear truly means!";
-		mes "Today, our cry of victory shall echo all over the battlefield!";
+		mes("[Croix Army Officer]");
+		mes("You definitely seem to be ready for battle!");
+		mes("Go show the Guillaumes what fear truly means!");
+		mes("Today, our cry of victory shall echo all over the battlefield!");
 		close2;
 		warp "bat_room",85,207;
 		end;
 	case 2:
-		mes "[Croix Army Officer]";
-		mes "Today, we shall be victorious!";
+		mes("[Croix Army Officer]");
+		mes("Today, we shall be victorious!");
 		break;
 	}
 	close;
 }
 
 bat_room,135,178,5	script	Guillaume Knight#3	4_M_KY_SOLD,{
-	mes "[Guillaume Knight]";
-	mes "The objective of the Flavius Battle is to score 2 points before your enemy by destroying their crystal.";
+	mes("[Guillaume Knight]");
+	mes("The objective of the Flavius Battle is to score 2 points before your enemy by destroying their crystal.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "The crystals for both armies are protected by special barricades that cannot be destroyed by direct attacks.";
+	mes("[Guillaume Knight]");
+	mes("The crystals for both armies are protected by special barricades that cannot be destroyed by direct attacks.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "But they can be removed by destroying the Guardians that protect the enemy army base.";
+	mes("[Guillaume Knight]");
+	mes("But they can be removed by destroying the Guardians that protect the enemy army base.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "The crystals are immune to every type of skill; your physical attacks are the only choice for destroying your enemy's crystal.";
+	mes("[Guillaume Knight]");
+	mes("The crystals are immune to every type of skill; your physical attacks are the only choice for destroying your enemy's crystal.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Please remember: when you join a battle, you will be receiving a token which indicates the set duration for which you cannot participate in the same type of battle.";
-	mes "You may check the duration by pressing the Alt+U keys.";
+	mes("[Guillaume Knight]");
+	mes("Please remember: when you join a battle, you will be receiving a token which indicates the set duration for which you cannot participate in the same type of battle.");
+	mes("You may check the duration by pressing the Alt+U keys.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Are you ready for battle? Then apply with the recruiter next to me!";
+	mes("[Guillaume Knight]");
+	mes("Are you ready for battle? Then apply with the recruiter next to me!");
 	close;
 }
 
 bat_room,151,178,5	script	Guillaume Knight#4	4_M_KY_SOLD,{
-	mes "[Guillaume Knight]";
-	mes "The objective of the Flavius Battle is to score 2 points before your enemy by destroying their crystal.";
+	mes("[Guillaume Knight]");
+	mes("The objective of the Flavius Battle is to score 2 points before your enemy by destroying their crystal.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "The crystals for both armies are protected by special barricades that cannot be destroyed by direct attacks.";
+	mes("[Guillaume Knight]");
+	mes("The crystals for both armies are protected by special barricades that cannot be destroyed by direct attacks.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "But they can be removed by destroying the Guardians that protect the enemy army base.";
+	mes("[Guillaume Knight]");
+	mes("But they can be removed by destroying the Guardians that protect the enemy army base.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "The crystals are immune to every type of skill; your physical attacks are the only choice for destroying your enemy's crystal.";
+	mes("[Guillaume Knight]");
+	mes("The crystals are immune to every type of skill; your physical attacks are the only choice for destroying your enemy's crystal.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Please remember: when you join a battle, you will be receiving a token which indicates the set duration for which you cannot participate in the same type of battle.";
-	mes "You may check the duration by pressing the Alt+U keys.";
+	mes("[Guillaume Knight]");
+	mes("Please remember: when you join a battle, you will be receiving a token which indicates the set duration for which you cannot participate in the same type of battle.");
+	mes("You may check the duration by pressing the Alt+U keys.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Are you ready for battle? Then apply with the recruiter next to me!";
+	mes("[Guillaume Knight]");
+	mes("Are you ready for battle? Then apply with the recruiter next to me!");
 	close;
 }
 
 bat_room,135,121,1	script	Croix Knight#3	4_M_CRU_SOLD,{
-	mes "[Croix Knight]";
-	mes "The objective of the Flavius Battle is to score 2 points before your enemy by destroying their crystal.";
+	mes("[Croix Knight]");
+	mes("The objective of the Flavius Battle is to score 2 points before your enemy by destroying their crystal.");
 	next;
-	mes "[Croix Knight]";
-	mes "The crystals for both armies are protected by special barricades that cannot be destroyed by direct attacks.";
+	mes("[Croix Knight]");
+	mes("The crystals for both armies are protected by special barricades that cannot be destroyed by direct attacks.");
 	next;
-	mes "[Croix Knight]";
-	mes "But they can be removed by destroying the Guardians that protect the enemy army base.";
+	mes("[Croix Knight]");
+	mes("But they can be removed by destroying the Guardians that protect the enemy army base.");
 	next;
-	mes "[Croix Knight]";
-	mes "The crystals are immune to every type of skill; your physical attacks are the only choice for destroying your enemy's crystal.";
+	mes("[Croix Knight]");
+	mes("The crystals are immune to every type of skill; your physical attacks are the only choice for destroying your enemy's crystal.");
 	next;
-	mes "[Croix Knight]";
-	mes "Please remember: when you join a battle, you will be receiving a token which indicates the set duration for which you cannot participate in the same type of battle.";
-	mes "You may check the duration by pressing the Alt+U keys.";
+	mes("[Croix Knight]");
+	mes("Please remember: when you join a battle, you will be receiving a token which indicates the set duration for which you cannot participate in the same type of battle.");
+	mes("You may check the duration by pressing the Alt+U keys.");
 	next;
-	mes "[Croix Knight]";
-	mes "Are you ready for battle? Then apply with the recruiter next to me!";
+	mes("[Croix Knight]");
+	mes("Are you ready for battle? Then apply with the recruiter next to me!");
 	close;
 }
 
 bat_room,151,121,1	script	Croix Knight#4	4_M_CRU_SOLD,{
-	mes "[Croix Knight]";
-	mes "The objective of the Flavius Battle is to score 2 points before your enemy by destroying their crystal.";
+	mes("[Croix Knight]");
+	mes("The objective of the Flavius Battle is to score 2 points before your enemy by destroying their crystal.");
 	next;
-	mes "[Croix Knight]";
-	mes "The crystals for both armies are protected by special barricades that cannot be destroyed by direct attacks.";
+	mes("[Croix Knight]");
+	mes("The crystals for both armies are protected by special barricades that cannot be destroyed by direct attacks.");
 	next;
-	mes "[Croix Knight]";
-	mes "But they can be removed by destroying the Guardians that protect the enemy army base.";
+	mes("[Croix Knight]");
+	mes("But they can be removed by destroying the Guardians that protect the enemy army base.");
 	next;
-	mes "[Croix Knight]";
-	mes "The crystals are immune to every type of skill; your physical attacks are the only choice for destroying your enemy's crystal.";
+	mes("[Croix Knight]");
+	mes("The crystals are immune to every type of skill; your physical attacks are the only choice for destroying your enemy's crystal.");
 	next;
-	mes "[Croix Knight]";
-	mes "Please remember: when you join a battle, you will be receiving a token which indicates the set duration for which you cannot participate in the same type of battle.";
-	mes "You may check the duration by pressing the Alt+U keys.";
+	mes("[Croix Knight]");
+	mes("Please remember: when you join a battle, you will be receiving a token which indicates the set duration for which you cannot participate in the same type of battle.");
+	mes("You may check the duration by pressing the Alt+U keys.");
 	next;
-	mes "[Croix Knight]";
-	mes "Are you ready for battle? Then apply with the recruiter next to me!";
+	mes("[Croix Knight]");
+	mes("Are you ready for battle? Then apply with the recruiter next to me!");
 	close;
 }
 
 //== Flavius Officer - Croix ===============================
 bat_room,148,178,5	script	Flavius Officer#02a	4_M_KY_KNT,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Guillaume Army Officer]";
-	mes "Let's show the power of the Guillaume Army to those stinky Croixs!";
+	mes("[Guillaume Army Officer]");
+	mes("Let's show the power of the Guillaume Army to those stinky Croixs!");
 	next;
 	switch(select("I want to join your army!", "End Conversation")) {
 	case 1:
 		if ((Class == Job_Novice) || (BaseClass == Job_SuperNovice)) {
-			mes "[Guillaume Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Guillaume Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		if (BaseLevel < 80) {
-			mes "[Guillaume Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Guillaume Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		.@chk_urtime = questprogress(2070, PLAYTIME);
 		if (.@chk_urtime == 1) {
-			mes "[Guillaume Army Officer]";
-			mes "You seem to have just returned from the battlefield.";
-			mes "It's too early for you to go back. Go rest, and leave the enemies to us!";
+			mes("[Guillaume Army Officer]");
+			mes("You seem to have just returned from the battlefield.");
+			mes("It's too early for you to go back. Go rest, and leave the enemies to us!");
 			break;
 		}
 		if (.@chk_urtime == 2)
 			erasequest 2070;
 		if (getmapusers("bat_b02") > 0) {
-			mes "[Guillaume Army Officer]";
-			mes "I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Croixs already.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Guillaume Army Officer]");
+			mes("I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Croixs already.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
 		if ($@FlaviusBG2 > 0) {
-			mes "[Guillaume Army Officer]";
-			mes "An elite corps is already standing by to be dispatched to the battlefield.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Guillaume Army Officer]");
+			mes("An elite corps is already standing by to be dispatched to the battlefield.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
-		mes "[Guillaume Army Officer]";
-		mes "You definitely seem to be ready for battle!";
-		mes "Go show the Croixs what fear truly means!";
-		mes "Today, our cry of victory shall echo all over the battlefield!";
+		mes("[Guillaume Army Officer]");
+		mes("You definitely seem to be ready for battle!");
+		mes("Go show the Croixs what fear truly means!");
+		mes("Today, our cry of victory shall echo all over the battlefield!");
 		close2;
 		warp "bat_room",141,224;
 		end;
 	case 2:
-		mes "[Guillaume Army Officer]";
-		mes "Today, we shall be victorious!";
+		mes("[Guillaume Army Officer]");
+		mes("Today, we shall be victorious!");
 		break;
 	}
 	close;
@@ -304,59 +304,59 @@ bat_room,148,178,5	script	Flavius Officer#02a	4_M_KY_KNT,{
 
 bat_room,148,121,1	script	Flavius Officer#02b	4_M_CRU_KNT,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Croix Army Officer]";
-	mes "Let's show the power of the Croix Army to those stinky Guillaumes!";
+	mes("[Croix Army Officer]");
+	mes("Let's show the power of the Croix Army to those stinky Guillaumes!");
 	next;
 	switch(select("I want to join your army!", "End Conversation")) {
 	case 1:
 		if ((Class == Job_Novice) || (BaseClass == Job_SuperNovice)) {
-			mes "[Croix Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Croix Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		if (BaseLevel < 80) {
-			mes "[Croix Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Croix Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		.@chk_urtime = questprogress(2070,PLAYTIME);
 		if (.@chk_urtime == 1) {
-			mes "[Croix Army Officer]";
-			mes "You seem to have just returned from the battlefield.";
-			mes "It's too early for you to go back. Go rest, and leave the enemies to us!";
+			mes("[Croix Army Officer]");
+			mes("You seem to have just returned from the battlefield.");
+			mes("It's too early for you to go back. Go rest, and leave the enemies to us!");
 			break;
 		}
 		if (.@chk_urtime == 2)
 			erasequest 2070;
 		if (getmapusers("bat_b02") > 0) {
-			mes "[Croix Army Officer]";
-			mes "I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Guillaume already.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Croix Army Officer]");
+			mes("I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Guillaume already.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
 		if ($@FlaviusBG2 > 0) {
-			mes "[Croix Army Officer]";
-			mes "An elite corps is already standing by to be dispatched to the battlefield.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Croix Army Officer]");
+			mes("An elite corps is already standing by to be dispatched to the battlefield.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
-		mes "[Croix Army Officer]";
-		mes "You definitely seem to be ready for battle!";
-		mes "Go show the Guillaumes what fear truly means!";
-		mes "Today, our cry of victory shall echo all over the battlefield!";
+		mes("[Croix Army Officer]");
+		mes("You definitely seem to be ready for battle!");
+		mes("Go show the Guillaumes what fear truly means!");
+		mes("Today, our cry of victory shall echo all over the battlefield!");
 		close2;
 		warp "bat_room",141,207;
 		end;
 	case 2:
-		mes "[Croix Army Officer]";
-		mes "Today, we shall be victorious!";
+		mes("[Croix Army Officer]");
+		mes("Today, we shall be victorious!");
 		break;
 	}
 	close;

--- a/npc/battleground/kvm/kvm01.txt
+++ b/npc/battleground/kvm/kvm01.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  L0ne_W0lf
 //=
 //= Hercules is free software: you can redistribute it and/or modify
@@ -39,7 +39,7 @@ bat_room,169,226,5	script	KVM Waiting Room#a::KvM01R_Guillaume	4_M_KY_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station 5 Players",6,"KvM01_BG::OnGuillaumeJoin",1;
+	waitingroom(_("Battle Station 5 Players"), 6, "KvM01_BG::OnGuillaumeJoin", 1);
 	end;
 
 OnEnterBG:
@@ -53,7 +53,7 @@ bat_room,169,205,3	script	KVM Waiting Room#b::KvM01R_Croix	4_M_CRU_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station 5 Players",6,"KvM01_BG::OnCroixJoin",1;
+	waitingroom(_("Battle Station 5 Players"), 6, "KvM01_BG::OnCroixJoin", 1);
 	end;
 
 OnEnterBG:
@@ -160,8 +160,8 @@ OnGuillaumeDie:
 		bg_updatescore "bat_c01",.Guillaume_Count,.Croix_Count;
 		if( .Guillaume_Count < 1 ) donpcevent "KvM01_BG::OnCroixWin";
 		else {
-			mapannounce "bat_c01", "The number of Guillaumes is "+.Guillaume_Count+".",bc_map,"0x00ff00";
-			mapannounce "bat_c01", "The number of Croixes is "+.Croix_Count+".",bc_map,"0x00ff00";
+			mapannounce("bat_c01", sprintf(_$("The number of Guillaumes is %d."), .Guillaume_Count), bc_map, "0x00ff00");
+			mapannounce("bat_c01", sprintf(_$("The number of Croixes is %d."), .Croix_Count), bc_map, "0x00ff00");
 		}
 	}
 	end;
@@ -174,8 +174,8 @@ OnCroixDie:
 		bg_updatescore "bat_c01",.Guillaume_Count,.Croix_Count;
 		if( .Croix_Count < 1 ) donpcevent "KvM01_BG::OnGuillaumeWin";
 		else {
-			mapannounce "bat_c01", "The number of Guillaumes is "+.Guillaume_Count+".",bc_map,"0x00ff00";
-			mapannounce "bat_c01", "The number of Croixes is "+.Croix_Count+".",bc_map,"0x00ff00";
+			mapannounce("bat_c01", sprintf(_$("The number of Guillaumes is %d."), .Guillaume_Count), bc_map, "0x00ff00");
+			mapannounce("bat_c01", sprintf(_$("The number of Croixes is %d."), .Croix_Count), bc_map, "0x00ff00");
 		}
 	}
 	end;
@@ -206,16 +206,16 @@ OnStart:
 	end;
 
 OnTimer1000:
-	mapannounce "bat_c01", "In 1 minute, KVM will start.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("In 1 minute, KVM will start."), bc_map, "0x00ff00");
 	end;
 
 OnTimer3000:
-	mapannounce "bat_c01", "The maximum time for a KVM battle is 5 minutes.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("The maximum time for a KVM battle is 5 minutes."), bc_map, "0x00ff00");
 	end;
 
 OnTimer6000:
-	mapannounce "bat_c01", "Please prepare for the KVM battle.",bc_map,"0x00ff00";
-	mapannounce "bat_c01", "You can buff your people.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("Please prepare for the KVM battle."), bc_map, "0x00ff00");
+	mapannounce("bat_c01", _("You can buff your people."), bc_map, "0x00ff00");
 	donpcevent "#A_camp_start01::OnEnable";
 	donpcevent "#B_camp_start01::OnEnable";
 	end;
@@ -226,26 +226,26 @@ OnTimer13000:
 	end;
 
 OnTimer30000:
-	mapannounce "bat_c01", "30 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("30 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer45000:
-	mapannounce "bat_c01", "15 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("15 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01One";
 	end;
 
 OnTimer50000:
-	mapannounce "bat_c01", "10 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("10 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01Two";
 	end;
 
 OnTimer55000:
-	mapannounce "bat_c01", "5 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("5 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01One";
 	end;
 
 OnTimer59000:
-	mapannounce "bat_c01", "KVM is now commencing.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("KVM is now commencing."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01Two";
 	end;
 
@@ -257,7 +257,7 @@ OnTimer61000:
 	{
 		$@KvM01BG_Victory = 3;
 		$@KvM01BG = 3;
-		mapannounce "bat_c01","There are not enough players to start the battle",1,0x696969;
+		mapannounce("bat_c01", _("There are not enough players to start the battle"), bc_map, "0x696969");
 		stopnpctimer;
 		donpcevent "KvM01_BG::OnStop";
 		end;
@@ -268,27 +268,27 @@ OnTimer61000:
 	end;
 
 OnTimer300000:
-	mapannounce "bat_c01", "1 minute remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("1 minute remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer330000:
-	mapannounce "bat_c01", "30 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("30 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer345000:
-	mapannounce "bat_c01", "15 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("15 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer350000:
-	mapannounce "bat_c01", "10 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("10 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer355000:
-	mapannounce "bat_c01", "5 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("5 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer360000:
-	mapannounce "bat_c01", "The KVM battle is over.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("The KVM battle is over."), bc_map, "0x00ff00");
 	if( .Croix_Count > .Guillaume_Count )
 		donpcevent "KvM01_BG::OnCroixWin";
 	else if( .Croix_Count < .Guillaume_Count )
@@ -297,9 +297,9 @@ OnTimer360000:
 	{ // Draw Game
 		$@KvM01BG = 3;
 		$@KvM01BG_Victory = 3;
-		mapannounce "bat_c01", "The number of Guillaumes is "+.Guillaume_Count+".",bc_map,"0x00ff00";
-		mapannounce "bat_c01", "The number of Croixes is "+.Croix_Count+".",bc_map,"0x00ff00";
-		mapannounce "bat_c01", "This battle has ended in a draw.",bc_map,"0x00ff00";
+		mapannounce("bat_c01", sprintf(_$("The number of Guillaumes is %d."), .Guillaume_Count), bc_map, "0x00ff00");
+		mapannounce("bat_c01", sprintf(_$("The number of Croixes is %d."), .Croix_Count), bc_map, "0x00ff00");
+		mapannounce("bat_c01", _("This battle has ended in a draw."), bc_map, "0x00ff00");
 		donpcevent "KvM01_BG::OnStop";
 	}
 	end;
@@ -307,18 +307,18 @@ OnTimer360000:
 OnGuillaumeWin:
 	$@KvM01BG = 3;
 	$@KvM01BG_Victory = 1;
-	mapannounce "bat_c01", "Guillaume wins!",bc_map,"0x00ff00";
-	mapannounce "bat_c01", "Congratulations to Guillaume members.",bc_map,"0x00ff00";
-	mapannounce "bat_c01", "Everyone will be moved to the start point.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("Guillaume wins!"), bc_map, "0x00ff00");
+	mapannounce("bat_c01", _("Congratulations to Guillaume members."), bc_map, "0x00ff00");
+	mapannounce("bat_c01", _("Everyone will be moved to the start point."), bc_map, "0x00ff00");
 	donpcevent "KvM01_BG::OnStop";
 	end;
 
 OnCroixWin:
 	$@KvM01BG = 3;
 	$@KvM01BG_Victory = 2;
-	mapannounce "bat_c01", "Croix wins!",bc_map,"0x00ff00";
-	mapannounce "bat_c01", "Congratulations to Croix members.",bc_map,"0x00ff00";
-	mapannounce "bat_c01", "Everyone will be moved to the start point.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("Croix wins!"), bc_map, "0x00ff00");
+	mapannounce("bat_c01", _("Congratulations to Croix members."), bc_map, "0x00ff00");
+	mapannounce("bat_c01", _("Everyone will be moved to the start point."), bc_map, "0x00ff00");
 	donpcevent "KvM01_BG::OnStop";
 	end;
 
@@ -356,21 +356,21 @@ OnBegin:
 	end;
 
 OnTimer1000:
-	mapannounce "bat_c01", "Please apply with the Officer to acquire KVM points.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("Please apply with the Officer to acquire KVM points."), bc_map, "0x00ff00");
 	end;
 
 OnTimer3000:
-	mapannounce "bat_c01", "The Officer will grant you the points for 30 seconds.",bc_map,"0x00ff00";
-	mapannounce "bat_c01", "In 30 seconds, the Officer will be sent away.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("The Officer will grant you the points for 30 seconds."), bc_map, "0x00ff00");
+	mapannounce("bat_c01", _("In 30 seconds, the Officer will be sent away."), bc_map, "0x00ff00");
 	end;
 
 OnTimer5000:
-	mapannounce "bat_c01", "Unless you talk to the Officer, you cannot gain the points.",bc_map,"0x00ff00";
-	mapannounce "bat_c01", "Please be careful.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("Unless you talk to the Officer, you cannot gain the points."), bc_map, "0x00ff00");
+	mapannounce("bat_c01", _("Please be careful."), bc_map, "0x00ff00");
 	end;
 
 OnTimer55000:
-	mapannounce "bat_c01", "You will be sent back.",bc_map,"0x00ff00";
+	mapannounce("bat_c01", _("You will be sent back."), bc_map, "0x00ff00");
 	end;
 
 OnTimer60000:
@@ -386,17 +386,17 @@ bat_c01,51,130,5	script	KVM Officer#KVM01A	4_M_KY_HEAD,{
 		if( $@KvM01BG_Victory == Bat_Team )
 		{ // Victory
 			kvm_point += 5;
-			mes "[KVM Officer]";
-			mes "Good Game.";
-			mes "May the glory of KVM be with you.";
-			mes "You aquire the winning points: 5";
+			mes("[KVM Officer]");
+			mes("Good Game.");
+			mes("May the glory of KVM be with you.");
+			mes("You aquire the winning points: 5");
 			close2;
 		} else {
 			++kvm_point;
-			mes "[KVM Officer]";
-			mes "I am so sorry.";
-			mes "I wish you better luck next time.";
-			mes "You aquire the losing points: 1";
+			mes("[KVM Officer]");
+			mes("I am so sorry.");
+			mes("I wish you better luck next time.");
+			mes("You aquire the losing points: 1");
 			close2;
 		}
 		bg_leave;
@@ -413,17 +413,17 @@ bat_c01,148,53,1	script	KVM Officer#KVM01B	4_M_CRU_HEAD,{
 		if( $@KvM01BG_Victory == Bat_Team )
 		{ // Victory
 			kvm_point += 5;
-			mes "[KVM Officer]";
-			mes "Good Game.";
-			mes "May the glory of KVM be with you.";
-			mes "You aquire the winning points: 5";
+			mes("[KVM Officer]");
+			mes("Good Game.");
+			mes("May the glory of KVM be with you.");
+			mes("You aquire the winning points: 5");
 			close2;
 		} else {
 			++kvm_point;
-			mes "[KVM Officer]";
-			mes "I am so sorry.";
-			mes "I wish you better luck next time.";
-			mes "You aquire the losing points: 1";
+			mes("[KVM Officer]");
+			mes("I am so sorry.");
+			mes("I wish you better luck next time.");
+			mes("You aquire the losing points: 1");
 			close2;
 		}
 		bg_leave;

--- a/npc/battleground/kvm/kvm02.txt
+++ b/npc/battleground/kvm/kvm02.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Ai4rei
 //= Copyright (C)  L0ne_W0lf
 //=
@@ -40,7 +40,7 @@ bat_room,197,226,5	script	KVM Waiting Room#a2::KvM02R_Guillaume	4_M_KY_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station 5 Players",6,"KvM02_BG::OnGuillaumeJoin",1;
+	waitingroom(_("Battle Station 5 Players"), 6, "KvM02_BG::OnGuillaumeJoin", 1);
 	end;
 
 OnEnterBG:
@@ -54,7 +54,7 @@ bat_room,197,205,3	script	KVM Waiting Room#b2::KvM02R_Croix	4_M_CRU_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station 5 Players",6,"KvM02_BG::OnCroixJoin",1;
+	waitingroom(_("Battle Station 5 Players"), 6, "KvM02_BG::OnCroixJoin", 1);
 	end;
 
 OnEnterBG:
@@ -161,8 +161,8 @@ OnGuillaumeDie:
 		bg_updatescore "bat_c02",.Guillaume_Count,.Croix_Count;
 		if( .Guillaume_Count < 1 ) donpcevent "KvM02_BG::OnCroixWin";
 		else {
-			mapannounce "bat_c02", "The number of Guillaumes is "+.Guillaume_Count+".",bc_map,"0x00ff00";
-			mapannounce "bat_c02", "The number of Croixes is "+.Croix_Count+".",bc_map,"0x00ff00";
+			mapannounce("bat_c02", sprintf(_$("The number of Guillaumes is %d."), .Guillaume_Count), bc_map, "0x00ff00");
+			mapannounce("bat_c02", sprintf(_$("The number of Croixes is %d."), .Croix_Count), bc_map, "0x00ff00");
 		}
 	}
 	end;
@@ -175,8 +175,8 @@ OnCroixDie:
 		bg_updatescore "bat_c02",.Guillaume_Count,.Croix_Count;
 		if( .Croix_Count < 1 ) donpcevent "KvM02_BG::OnGuillaumeWin";
 		else {
-			mapannounce "bat_c02", "The number of Guillaumes is "+.Guillaume_Count+".",bc_map,"0x00ff00";
-			mapannounce "bat_c02", "The number of Croixes is "+.Croix_Count+".",bc_map,"0x00ff00";
+			mapannounce("bat_c02", sprintf(_$("The number of Guillaumes is %d."), .Guillaume_Count), bc_map, "0x00ff00");
+			mapannounce("bat_c02", sprintf(_$("The number of Croixes is %d."), .Croix_Count), bc_map, "0x00ff00");
 		}
 	}
 	end;
@@ -207,16 +207,16 @@ OnStart:
 	end;
 
 OnTimer1000:
-	mapannounce "bat_c02", "In 1 minute, KVM will start.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("In 1 minute, KVM will start."), bc_map, "0x00ff00");
 	end;
 
 OnTimer3000:
-	mapannounce "bat_c02", "The maximum time for a KVM battle is 5 minutes.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("The maximum time for a KVM battle is 5 minutes."), bc_map, "0x00ff00");
 	end;
 
 OnTimer6000:
-	mapannounce "bat_c02", "Please prepare for the KVM battle.",bc_map,"0x00ff00";
-	mapannounce "bat_c02", "You can buff your people.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("Please prepare for the KVM battle."), bc_map, "0x00ff00");
+	mapannounce("bat_c02", _("You can buff your people."), bc_map, "0x00ff00");
 	donpcevent "#A_camp_start02::OnEnable";
 	donpcevent "#B_camp_start02::OnEnable";
 	end;
@@ -227,26 +227,26 @@ OnTimer13000:
 	end;
 
 OnTimer30000:
-	mapannounce "bat_c02", "30 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("30 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer45000:
-	mapannounce "bat_c02", "15 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("15 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01One";
 	end;
 
 OnTimer50000:
-	mapannounce "bat_c02", "10 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("10 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01Two";
 	end;
 
 OnTimer55000:
-	mapannounce "bat_c02", "5 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("5 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01One";
 	end;
 
 OnTimer59000:
-	mapannounce "bat_c02", "KVM is now commencing.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("KVM is now commencing."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01Two";
 	end;
 
@@ -258,7 +258,7 @@ OnTimer61000:
 	{
 		$@KvM02BG_Victory = 3;
 		$@KvM02BG = 3;
-		mapannounce "bat_c02","There are not enough players to start the battle",1,0x808080;
+		mapannounce("bat_c02", _("There are not enough players to start the battle"), bc_map, "0x808080");
 		stopnpctimer;
 		donpcevent "KvM02_BG::OnStop";
 		end;
@@ -269,27 +269,27 @@ OnTimer61000:
 	end;
 
 OnTimer300000:
-	mapannounce "bat_c02", "1 minute remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("1 minute remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer330000:
-	mapannounce "bat_c02", "30 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("30 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer345000:
-	mapannounce "bat_c02", "15 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("15 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer350000:
-	mapannounce "bat_c02", "10 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("10 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer355000:
-	mapannounce "bat_c02", "5 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("5 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer360000:
-	mapannounce "bat_c02", "The KVM battle is over.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("The KVM battle is over."), bc_map, "0x00ff00");
 	if( .Croix_Count > .Guillaume_Count )
 		donpcevent "KvM02_BG::OnCroixWin";
 	else if( .Croix_Count < .Guillaume_Count )
@@ -298,9 +298,9 @@ OnTimer360000:
 	{ // Draw Game
 		$@KvM02BG = 3;
 		$@KvM02BG_Victory = 3;
-		mapannounce "bat_c02", "The number of Guillaumes is "+.Guillaume_Count+".",bc_map,"0x00ff00";
-		mapannounce "bat_c02", "The number of Croixes is "+.Croix_Count+".",bc_map,"0x00ff00";
-		mapannounce "bat_c02", "This battle has ended in a draw.",bc_map,"0x00ff00";
+		mapannounce("bat_c02", sprintf(_$("The number of Guillaumes is %d."), .Guillaume_Count), bc_map, "0x00ff00");
+		mapannounce("bat_c02", sprintf(_$("The number of Croixes is %d."), .Croix_Count), bc_map, "0x00ff00");
+		mapannounce("bat_c02", _("This battle has ended in a draw."), bc_map, "0x00ff00");
 		donpcevent "KvM02_BG::OnStop";
 	}
 	end;
@@ -308,18 +308,18 @@ OnTimer360000:
 OnGuillaumeWin:
 	$@KvM02BG = 3;
 	$@KvM02BG_Victory = 1;
-	mapannounce "bat_c02", "Guillaume wins!",bc_map,"0x00ff00";
-	mapannounce "bat_c02", "Congratulations to Guillaume members.",bc_map,"0x00ff00";
-	mapannounce "bat_c02", "Everyone will be moved to the start point.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("Guillaume wins!"), bc_map, "0x00ff00");
+	mapannounce("bat_c02", _("Congratulations to Guillaume members."), bc_map, "0x00ff00");
+	mapannounce("bat_c02", _("Everyone will be moved to the start point."), bc_map, "0x00ff00");
 	donpcevent "KvM02_BG::OnStop";
 	end;
 
 OnCroixWin:
 	$@KvM02BG = 3;
 	$@KvM02BG_Victory = 2;
-	mapannounce "bat_c02", "Croix wins!",bc_map,"0x00ff00";
-	mapannounce "bat_c02", "Congratulations to Croix members.",bc_map,"0x00ff00";
-	mapannounce "bat_c02", "Everyone will be moved to the start point.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("Croix wins!"), bc_map, "0x00ff00");
+	mapannounce("bat_c02", _("Congratulations to Croix members."), bc_map, "0x00ff00");
+	mapannounce("bat_c02", _("Everyone will be moved to the start point."), bc_map, "0x00ff00");
 	donpcevent "KvM02_BG::OnStop";
 	end;
 
@@ -357,21 +357,21 @@ OnBegin:
 	end;
 
 OnTimer1000:
-	mapannounce "bat_c02", "Please apply with the Officer to acquire KVM points.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("Please apply with the Officer to acquire KVM points."), bc_map, "0x00ff00");
 	end;
 
 OnTimer3000:
-	mapannounce "bat_c02", "The Officer will grant you the points for 30 seconds.",bc_map,"0x00ff00";
-	mapannounce "bat_c02", "In 30 seconds, the Officer will be sent away.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("The Officer will grant you the points for 30 seconds."), bc_map, "0x00ff00");
+	mapannounce("bat_c02", _("In 30 seconds, the Officer will be sent away."), bc_map, "0x00ff00");
 	end;
 
 OnTimer5000:
-	mapannounce "bat_c02", "Unless you talk to the Officer, you cannot gain the points.",bc_map,"0x00ff00";
-	mapannounce "bat_c02", "Please be careful.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("Unless you talk to the Officer, you cannot gain the points."), bc_map, "0x00ff00");
+	mapannounce("bat_c02", _("Please be careful."), bc_map, "0x00ff00");
 	end;
 
 OnTimer55000:
-	mapannounce "bat_c02", "You will be sent back.",bc_map,"0x00ff00";
+	mapannounce("bat_c02", _("You will be sent back."), bc_map, "0x00ff00");
 	end;
 
 OnTimer60000:
@@ -387,16 +387,16 @@ bat_c02,51,130,5	script	KVM Officer#KVM02A	4_M_KY_HEAD,{
 		if( $@KvM02BG_Victory == Bat_Team )
 		{ // Victory
 			++kvm_point;
-			mes "[KVM Officer]";
-			mes "Good Game.";
-			mes "May the glory of KVM be with you.";
-			mes "You aquire the winning points: 1";
+			mes("[KVM Officer]");
+			mes("Good Game.");
+			mes("May the glory of KVM be with you.");
+			mes("You aquire the winning points: 1");
 			close2;
 		} else {
-			mes "[KVM Officer]";
-			mes "I am so sorry.";
-			mes "I wish you better luck next time.";
-			mes "You aquire the losing points: 0";
+			mes("[KVM Officer]");
+			mes("I am so sorry.");
+			mes("I wish you better luck next time.");
+			mes("You aquire the losing points: 0");
 			close2;
 		}
 		bg_leave;
@@ -413,16 +413,16 @@ bat_c02,148,53,1	script	KVM Officer#KVM02B	4_M_CRU_HEAD,{
 		if( $@KvM02BG_Victory == Bat_Team )
 		{ // Victory
 			++kvm_point;
-			mes "[KVM Officer]";
-			mes "Good Game.";
-			mes "May the glory of KVM be with you.";
-			mes "You aquire the winning points: 1";
+			mes("[KVM Officer]");
+			mes("Good Game.");
+			mes("May the glory of KVM be with you.");
+			mes("You aquire the winning points: 1");
 			close2;
 		} else {
-			mes "[KVM Officer]";
-			mes "I am so sorry.";
-			mes "I wish you better luck next time.";
-			mes "You aquire the losing points: 0";
+			mes("[KVM Officer]");
+			mes("I am so sorry.");
+			mes("I wish you better luck next time.");
+			mes("You aquire the losing points: 0");
 			close2;
 		}
 		bg_leave;

--- a/npc/battleground/kvm/kvm03.txt
+++ b/npc/battleground/kvm/kvm03.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Ai4rei
 //= Copyright (C)  L0ne_W0lf
 //=
@@ -40,7 +40,7 @@ bat_room,225,226,5	script	KVM Waiting Room#a3::KvM03R_Guillaume	4_M_KY_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station 5 Players",6,"KvM03_BG::OnGuillaumeJoin",1;
+	waitingroom(_("Battle Station 5 Players"), 6, "KvM03_BG::OnGuillaumeJoin", 1);
 	end;
 
 OnEnterBG:
@@ -54,7 +54,7 @@ bat_room,225,205,3	script	KVM Waiting Room#b3::KvM03R_Croix	4_M_CRU_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station 5 Players",6,"KvM03_BG::OnCroixJoin",1;
+	waitingroom(_("Battle Station 5 Players"), 6, "KvM03_BG::OnCroixJoin", 1);
 	end;
 
 OnEnterBG:
@@ -161,8 +161,8 @@ OnGuillaumeDie:
 		bg_updatescore "bat_c03",.Guillaume_Count,.Croix_Count;
 		if( .Guillaume_Count < 1 ) donpcevent "KvM03_BG::OnCroixWin";
 		else {
-			mapannounce "bat_c03", "The number of Guillaumes is "+.Guillaume_Count+".",bc_map,"0x00ff00";
-			mapannounce "bat_c03", "The number of Croixes is "+.Croix_Count+".",bc_map,"0x00ff00";
+			mapannounce("bat_c03", sprintf(_$("The number of Guillaumes is %d."), .Guillaume_Count), bc_map, "0x00ff00");
+			mapannounce("bat_c03", sprintf(_$("The number of Croixes is %d."), .Croix_Count), bc_map, "0x00ff00");
 		}
 	}
 	end;
@@ -175,8 +175,8 @@ OnCroixDie:
 		bg_updatescore "bat_c03",.Guillaume_Count,.Croix_Count;
 		if( .Croix_Count < 1 ) donpcevent "KvM03_BG::OnGuillaumeWin";
 		else {
-			mapannounce "bat_c03", "The number of Guillaumes is "+.Guillaume_Count+".",bc_map,"0x00ff00";
-			mapannounce "bat_c03", "The number of Croixes is "+.Croix_Count+".",bc_map,"0x00ff00";
+			mapannounce("bat_c03", sprintf(_$("The number of Guillaumes is %d."), .Guillaume_Count), bc_map, "0x00ff00");
+			mapannounce("bat_c03", sprintf(_$("The number of Croixes is %d."), .Croix_Count), bc_map, "0x00ff00");
 		}
 	}
 	end;
@@ -207,16 +207,16 @@ OnStart:
 	end;
 
 OnTimer1000:
-	mapannounce "bat_c03", "In 1 minute, KVM will start.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("In 1 minute, KVM will start."), bc_map, "0x00ff00");
 	end;
 
 OnTimer3000:
-	mapannounce "bat_c03", "The maximum time for a KVM battle is 5 minutes.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("The maximum time for a KVM battle is 5 minutes."), bc_map, "0x00ff00");
 	end;
 
 OnTimer6000:
-	mapannounce "bat_c03", "Please prepare for the KVM battle.",bc_map,"0x00ff00";
-	mapannounce "bat_c03", "You can buff your people.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("Please prepare for the KVM battle."), bc_map, "0x00ff00");
+	mapannounce("bat_c03", _("You can buff your people."), bc_map, "0x00ff00");
 	donpcevent "#A_camp_start03::OnEnable";
 	donpcevent "#B_camp_start03::OnEnable";
 	end;
@@ -227,26 +227,26 @@ OnTimer13000:
 	end;
 
 OnTimer30000:
-	mapannounce "bat_c03", "30 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("30 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer45000:
-	mapannounce "bat_c03", "15 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("15 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01One";
 	end;
 
 OnTimer50000:
-	mapannounce "bat_c03", "10 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("10 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01Two";
 	end;
 
 OnTimer55000:
-	mapannounce "bat_c03", "5 seconds remaining to start KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("5 seconds remaining to start KVM battle."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01One";
 	end;
 
 OnTimer59000:
-	mapannounce "bat_c03", "KVM is now commencing.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("KVM is now commencing."), bc_map, "0x00ff00");
 	donpcevent "::OnKvM01Two";
 	end;
 
@@ -258,7 +258,7 @@ OnTimer61000:
 	{
 		$@KvM03BG_Victory = 3;
 		$@KvM03BG = 3;
-		mapannounce "bat_c03","There are not enough players to start the battle",1,0xC0C0C0;
+		mapannounce("bat_c03", _("There are not enough players to start the battle"), bc_map, "0xC0C0C0");
 		stopnpctimer;
 		donpcevent "KvM03_BG::OnStop";
 		end;
@@ -269,27 +269,27 @@ OnTimer61000:
 	end;
 
 OnTimer300000:
-	mapannounce "bat_c03", "1 minute remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("1 minute remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer330000:
-	mapannounce "bat_c03", "30 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("30 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer345000:
-	mapannounce "bat_c03", "15 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("15 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer350000:
-	mapannounce "bat_c03", "10 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("10 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer355000:
-	mapannounce "bat_c03", "5 seconds remaining to finish the KVM battle.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("5 seconds remaining to finish the KVM battle."), bc_map, "0x00ff00");
 	end;
 
 OnTimer360000:
-	mapannounce "bat_c03", "KVM has ended.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("KVM has ended."), bc_map, "0x00ff00");
 	if( .Croix_Count > .Guillaume_Count )
 		donpcevent "KvM03_BG::OnCroixWin";
 	else if( .Croix_Count < .Guillaume_Count )
@@ -298,9 +298,9 @@ OnTimer360000:
 	{ // Draw Game
 		$@KvM03BG = 3;
 		$@KvM03BG_Victory = 3;
-		mapannounce "bat_c03", "The number of Guillaumes is "+.Guillaume_Count+".",bc_map,"0x00ff00";
-		mapannounce "bat_c03", "The number of Croixes is "+.Croix_Count+".",bc_map,"0x00ff00";
-		mapannounce "bat_c03", "This battle has ended in a draw.",bc_map,"0x00ff00";
+		mapannounce("bat_c03", sprintf(_$("The number of Guillaumes is %d."), .Guillaume_Count), bc_map, "0x00ff00");
+		mapannounce("bat_c03", sprintf(_$("The number of Croixes is %d."), .Croix_Count), bc_map, "0x00ff00");
+		mapannounce("bat_c03", _("This battle has ended in a draw."), bc_map, "0x00ff00");
 		donpcevent "KvM03_BG::OnStop";
 	}
 	end;
@@ -308,18 +308,18 @@ OnTimer360000:
 OnGuillaumeWin:
 	$@KvM03BG = 3;
 	$@KvM03BG_Victory = 1;
-	mapannounce "bat_c03", "Guillaume wins!",bc_map,"0x00ff00";
-	mapannounce "bat_c03", "Congratulations to Guillaume members.",bc_map,"0x00ff00";
-	mapannounce "bat_c03", "Everyone will be moved to the start point.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("Guillaume wins!"), bc_map, "0x00ff00");
+	mapannounce("bat_c03", _("Congratulations to Guillaume members."), bc_map, "0x00ff00");
+	mapannounce("bat_c03", _("Everyone will be moved to the start point."), bc_map, "0x00ff00");
 	donpcevent "KvM03_BG::OnStop";
 	end;
 
 OnCroixWin:
 	$@KvM03BG = 3;
 	$@KvM03BG_Victory = 2;
-	mapannounce "bat_c03", "Croix wins!",bc_map,"0x00ff00";
-	mapannounce "bat_c03", "Congratulations to Croix members.",bc_map,"0x00ff00";
-	mapannounce "bat_c03", "Everyone will be moved to the start point.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("Croix wins!"), bc_map, "0x00ff00");
+	mapannounce("bat_c03", _("Congratulations to Croix members."), bc_map, "0x00ff00");
+	mapannounce("bat_c03", _("Everyone will be moved to the start point."), bc_map, "0x00ff00");
 	donpcevent "KvM03_BG::OnStop";
 	end;
 
@@ -357,21 +357,21 @@ OnBegin:
 	end;
 
 OnTimer1000:
-	mapannounce "bat_c03", "Please apply with the Officer to acquire KVM points.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("Please apply with the Officer to acquire KVM points."), bc_map, "0x00ff00");
 	end;
 
 OnTimer3000:
-	mapannounce "bat_c03", "The Officer will grant you the points for 30 seconds.",bc_map,"0x00ff00";
-	mapannounce "bat_c03", "In 30 seconds, the Officer will be sent away.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("The Officer will grant you the points for 30 seconds."), bc_map, "0x00ff00");
+	mapannounce("bat_c03", _("In 30 seconds, the Officer will be sent away."), bc_map, "0x00ff00");
 	end;
 
 OnTimer5000:
-	mapannounce "bat_c03", "Unless you talk to the Officer, you cannot gain the points.",bc_map,"0x00ff00";
-	mapannounce "bat_c03", "Please be careful.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("Unless you talk to the Officer, you cannot gain the points."), bc_map, "0x00ff00");
+	mapannounce("bat_c03", _("Please be careful."), bc_map, "0x00ff00");
 	end;
 
 OnTimer55000:
-	mapannounce "bat_c03", "You will be sent back.",bc_map,"0x00ff00";
+	mapannounce("bat_c03", _("You will be sent back."), bc_map, "0x00ff00");
 	end;
 
 OnTimer60000:
@@ -387,17 +387,17 @@ bat_c03,51,130,5	script	KVM Officer#KVM03A	4_M_KY_HEAD,{
 		if( $@KvM03BG_Victory == Bat_Team )
 		{ // Victory
 			kvm_point += 2;
-			mes "[KVM Officer]";
-			mes "Good Game.";
-			mes "May the glory of KVM be with you.";
-			mes "You aquire the winning points: 2";
+			mes("[KVM Officer]");
+			mes("Good Game.");
+			mes("May the glory of KVM be with you.");
+			mes("You aquire the winning points: 2");
 			close2;
 		} else {
 			++kvm_point;
-			mes "[KVM Officer]";
-			mes "I am so sorry.";
-			mes "I wish you better luck next time.";
-			mes "You aquire the losing points: 1";
+			mes("[KVM Officer]");
+			mes("I am so sorry.");
+			mes("I wish you better luck next time.");
+			mes("You aquire the losing points: 1");
 			close2;
 		}
 		bg_leave;
@@ -414,17 +414,17 @@ bat_c03,148,53,1	script	KVM Officer#KVM03B	4_M_CRU_HEAD,{
 		if( $@KvM03BG_Victory == Bat_Team )
 		{ // Victory
 			kvm_point +=2;
-			mes "[KVM Officer]";
-			mes "Good Game.";
-			mes "May the glory of KVM be with you.";
-			mes "You aquire the winning points: 2";
+			mes("[KVM Officer]");
+			mes("Good Game.");
+			mes("May the glory of KVM be with you.");
+			mes("You aquire the winning points: 2");
 			close2;
 		} else {
 			++kvm_point;
-			mes "[KVM Officer]";
-			mes "I am so sorry.";
-			mes "I wish you better luck next time.";
-			mes "You aquire the losing points: 1";
+			mes("[KVM Officer]");
+			mes("I am so sorry.");
+			mes("I wish you better luck next time.");
+			mes("You aquire the losing points: 1");
 			close2;
 		}
 		bg_leave;

--- a/npc/battleground/kvm/kvm_enter.txt
+++ b/npc/battleground/kvm/kvm_enter.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  L0ne_W0lf
 //=
 //= Hercules is free software: you can redistribute it and/or modify
@@ -38,27 +38,27 @@ bat_room,164,178,5	script	KVM Mercenary Officer#1	4_M_KY_KNT,{
 	/*
 	.@kvm = questprogress(6026,PLAYTIME);
 	if (.@kvm == 1) {
-		mes "[Croix Mercenary Officer]";
-		mes "I know that you've already signed with the Croix. Go back and join their team. We will not accept traitors to fight for us.";
+		mes("[Croix Mercenary Officer]");
+		mes("I know that you've already signed with the Croix. Go back and join their team. We will not accept traitors to fight for us.");
 		close;
 	}
 	else if (.@kvm == 2) erasequest 6026;
 	*/
 	.@permit = questprogress(6025,PLAYTIME);
 	if (.@permit == 1) {
-		mes "[Guillaume Mercenary Officer]";
-		mes "It seems you have recently participated in a KVM battle. You must wait 5 minutes before signing up again.";
+		mes("[Guillaume Mercenary Officer]");
+		mes("It seems you have recently participated in a KVM battle. You must wait 5 minutes before signing up again.");
 		close;
 	}
 	else if (.@permit == 2) erasequest 6025;
-	mes "[Guillaume Mercenary Officer]";
-	mes "Let them know the real might of Guillaume!";
+	mes("[Guillaume Mercenary Officer]");
+	mes("Let them know the real might of Guillaume!");
 	next;
 	switch(select("I will fight with you.", "End Conversation.")) {
 	case 1:
-		mes "[Guillaume Mercenary Officer]";
-		mes "Show them how strong we are.";
-		mes "Today, everyone will hear the shout of triumph from Guillaume!";
+		mes("[Guillaume Mercenary Officer]");
+		mes("Show them how strong we are.");
+		mes("Today, everyone will hear the shout of triumph from Guillaume!");
 		close2;
 		//setquest 6025;
 		if (BaseLevel > 79)  warp "bat_room",169,223;
@@ -66,67 +66,67 @@ bat_room,164,178,5	script	KVM Mercenary Officer#1	4_M_KY_KNT,{
 		else warp "bat_room",225,223;
 		end;
 	case 2:
-		mes "[Guillaume Mercenary Officer]";
-		mes "We will win!";
+		mes("[Guillaume Mercenary Officer]");
+		mes("We will win!");
 		close;
 	}
 }
 
 //== Guillaume Knight - KvM ================================
 bat_room,167,178,5	script	Guillaume Knight#kvm	4_M_KY_SOLD,{
-	mes "[Guillaume Knight]";
-	mes "Hello.";
-	mes "What do you want to know?";
+	mes("[Guillaume Knight]");
+	mes("Hello.");
+	mes("What do you want to know?");
 	next;
 	switch(select("Apply for KVM.", "What is KVM?", "How do I participate in KVM?", "I want to know my Kreiger Points.")) {
 	case 1:
-		mes "[Guillaume Knight]";
-		mes "Applications are not available yet.";
-		mes "To apply, you need to go to a KVM Mercenary Officer.";
+		mes("[Guillaume Knight]");
+		mes("Applications are not available yet.");
+		mes("To apply, you need to go to a KVM Mercenary Officer.");
 		close;
 	case 2:
-		mes "[Guillaume Knight]";
-		mes "KVM is the abbreviation of Kreiger Von Midgard.";
-		mes "Adventurer, are you aware that the way to the new world has been opened?";
+		mes("[Guillaume Knight]");
+		mes("KVM is the abbreviation of Kreiger Von Midgard.");
+		mes("Adventurer, are you aware that the way to the new world has been opened?");
 		next;
-		mes "[Guillaume Knight]";
-		mes "We, the Guillaume Administration, have several plans to advance to the new world.";
-		mes "And KVM is one of them.";
+		mes("[Guillaume Knight]");
+		mes("We, the Guillaume Administration, have several plans to advance to the new world.");
+		mes("And KVM is one of them.");
 		next;
-		mes "[Guillaume Knight]";
-		mes "It means that we, one of many countries in the Midgard continent,";
-		mes "have decided to employ many adventurers for the immediate advance to the new world.";
+		mes("[Guillaume Knight]");
+		mes("It means that we, one of many countries in the Midgard continent,");
+		mes("have decided to employ many adventurers for the immediate advance to the new world.");
 		next;
-		mes "[Guillaume Knight]";
-		mes "Therefore, to select the best adventurers, we are holding the KVM.";
-		mes "We exspect responses from many adventurers.";
+		mes("[Guillaume Knight]");
+		mes("Therefore, to select the best adventurers, we are holding the KVM.");
+		mes("We exspect responses from many adventurers.");
 		next;
-		mes "[Guillaume Knight]";
-		mes "And we will give them rewards for their participation!";
-		mes "As for the rewards, please contact a KVM Logistic Officer.";
+		mes("[Guillaume Knight]");
+		mes("And we will give them rewards for their participation!");
+		mes("As for the rewards, please contact a KVM Logistic Officer.");
 		close;
 	case 3:
-		mes "[Guillaume Knight]";
-		mes "Basically, KVM is a 5 on 5 battle.";
-		mes "First, you apply with a KVM receptionist, in a group or individually.";
+		mes("[Guillaume Knight]");
+		mes("Basically, KVM is a 5 on 5 battle.");
+		mes("First, you apply with a KVM receptionist, in a group or individually.");
 		next;
-		mes "[Guillaume Knight]";
-		mes "Group applications are for when you intend to enter the KVM with your party members,";
-		mes "and a personal application is for when you intend to enter the KVM individually.";
+		mes("[Guillaume Knight]");
+		mes("Group applications are for when you intend to enter the KVM with your party members,");
+		mes("and a personal application is for when you intend to enter the KVM individually.");
 		next;
-		mes "[Guillaume Knight]";
-		mes "Please apply with a KVM officer, and he will contact you later when you are in Prontera.";
+		mes("[Guillaume Knight]");
+		mes("Please apply with a KVM officer, and he will contact you later when you are in Prontera.");
 		next;
-		mes "[Guillaume Knight]";
-		mes "Then you enter and follow the instructions in the battlefield.";
+		mes("[Guillaume Knight]");
+		mes("Then you enter and follow the instructions in the battlefield.");
 		next;
-		mes "[Guillaume Knight]";
-		mes "However, please be advised that unless you are in the KVM office, he cannot contact you.";
+		mes("[Guillaume Knight]");
+		mes("However, please be advised that unless you are in the KVM office, he cannot contact you.");
 		close;
 	case 4:
-		mes "[Guillaume Knight]";
-		mes "Your Kreiger Points are:";
-		mes ""+kvm_point+".";
+		mes("[Guillaume Knight]");
+		mes("Your Kreiger Points are:");
+		mesf("%d.", kvm_point);
 		close;
 	}
 }
@@ -136,27 +136,27 @@ bat_room,164,121,1	script	KVM Mercenary Officer#2	4_M_CRU_KNT,{
 	/*
 	.@kvm = questprogress(6025,PLAYTIME);
 	if (.@kvm == 1) {
-		mes "[Croix Mercenary Officer]";
-		mes "I know that you've already signed with the Guillaume. Go back and join their team. We will not accept traitors to fight for us.";
+		mes("[Croix Mercenary Officer]");
+		mes("I know that you've already signed with the Guillaume. Go back and join their team. We will not accept traitors to fight for us.");
 		close;
 	}
 	else if (.@kvm == 2) erasequest 6025;
 	*/
 	.@permit = questprogress(6025,PLAYTIME);
 	if (.@permit == 1) {
-		mes "[Croix Mercenary Officer]";
-		mes "It seems you have recently participated in a KVM battle. You must wait 5 minutes before signing up again.";
+		mes("[Croix Mercenary Officer]");
+		mes("It seems you have recently participated in a KVM battle. You must wait 5 minutes before signing up again.");
 		close;
 	}
 	else if (.@permit == 2) erasequest 6025;
-	mes "[Croix Mercenary Officer]";
-	mes "Let them know the real might of Croix!";
+	mes("[Croix Mercenary Officer]");
+	mes("Let them know the real might of Croix!");
 	next;
 	switch(select("I will fight with you.", "End Conversation.")) {
 	case 1:
-		mes "[Croix Mercenary Officer]";
-		mes "Show them how strong we are.";
-		mes "Today, everyone will hear the shout of triumph from Croix!";
+		mes("[Croix Mercenary Officer]");
+		mes("Show them how strong we are.");
+		mes("Today, everyone will hear the shout of triumph from Croix!");
 		close2;
 		//setquest 6026;
 		if (BaseLevel > 79) warp "bat_room",169,207;
@@ -164,67 +164,67 @@ bat_room,164,121,1	script	KVM Mercenary Officer#2	4_M_CRU_KNT,{
 		else warp "bat_room",225,207;
 		end;
 	case 2:
-		mes "[Croix Mercenary Officer]";
-		mes "We will win!";
+		mes("[Croix Mercenary Officer]");
+		mes("We will win!");
 		close;
 	}
 }
 
 //== Croix Knight - KvM ====================================
 bat_room,167,121,1	script	Croix Knight#kvm	4_M_CRU_SOLD,{
-	mes "[Croix Knight]";
-	mes "Hello.";
-	mes "What do you want to know?";
+	mes("[Croix Knight]");
+	mes("Hello.");
+	mes("What do you want to know?");
 	next;
 	switch(select("Apply for KVM.", "What is KVM?", "How do I participate in KVM?", "I want to know my Kreiger Points.")) {
 	case 1:
-		mes "[Croix Knight]";
-		mes "Applications are not available yet.";
-		mes "To apply, you need to go to a KVM Mercenary Officer.";
+		mes("[Croix Knight]");
+		mes("Applications are not available yet.");
+		mes("To apply, you need to go to a KVM Mercenary Officer.");
 		close;
 	case 2:
-		mes "[Croix Knight]";
-		mes "KVM is the abbreviation of Kreiger Von Midgard.";
-		mes "Adventurer, are you aware that the way to the new world has been opened?";
+		mes("[Croix Knight]");
+		mes("KVM is the abbreviation of Kreiger Von Midgard.");
+		mes("Adventurer, are you aware that the way to the new world has been opened?");
 		next;
-		mes "[Croix Knight]";
-		mes "We, the Croix Administration, have several plans to advance to the new world.";
-		mes "And KVM is one of them.";
+		mes("[Croix Knight]");
+		mes("We, the Croix Administration, have several plans to advance to the new world.");
+		mes("And KVM is one of them.");
 		next;
-		mes "[Croix Knight]";
-		mes "It means that we, one of many countries in the Midgard continent,";
-		mes "have decided to employ many adventurers for the immediate advance to the new world.";
+		mes("[Croix Knight]");
+		mes("It means that we, one of many countries in the Midgard continent,");
+		mes("have decided to employ many adventurers for the immediate advance to the new world.");
 		next;
-		mes "[Croix Knight]";
-		mes "Therefore, to select the best adventurers, we are holding the KVM.";
-		mes "We exspect responses from many adventurers.";
+		mes("[Croix Knight]");
+		mes("Therefore, to select the best adventurers, we are holding the KVM.");
+		mes("We exspect responses from many adventurers.");
 		next;
-		mes "[Croix Knight]";
-		mes "And we will give them rewards for their participation!";
-		mes "As for the rewards, please contact a KVM Logistic Officer.";
+		mes("[Croix Knight]");
+		mes("And we will give them rewards for their participation!");
+		mes("As for the rewards, please contact a KVM Logistic Officer.");
 		close;
 	case 3:
-		mes "[Croix Knight]";
-		mes "Basically, KVM is a 5 on 5 battle.";
-		mes "First, you apply with a KVM receptionist, in a group or individually.";
+		mes("[Croix Knight]");
+		mes("Basically, KVM is a 5 on 5 battle.");
+		mes("First, you apply with a KVM receptionist, in a group or individually.");
 		next;
-		mes "[Croix Knight]";
-		mes "Group applications are for when you intend to enter the KVM with your party members,";
-		mes "and a personal application is for when you intend to enter the KVM individually.";
+		mes("[Croix Knight]");
+		mes("Group applications are for when you intend to enter the KVM with your party members,");
+		mes("and a personal application is for when you intend to enter the KVM individually.");
 		next;
-		mes "[Croix Knight]";
-		mes "Please apply with a KVM officer, and he will contact you later when you are in Prontera.";
+		mes("[Croix Knight]");
+		mes("Please apply with a KVM officer, and he will contact you later when you are in Prontera.");
 		next;
-		mes "[Croix Knight]";
-		mes "Then you enter and follow the instructions in the battlefield.";
+		mes("[Croix Knight]");
+		mes("Then you enter and follow the instructions in the battlefield.");
 		next;
-		mes "[Croix Knight]";
-		mes "However, please be advised that unless you are in the KVM office, he cannot contact you.";
+		mes("[Croix Knight]");
+		mes("However, please be advised that unless you are in the KVM office, he cannot contact you.");
 		close;
 	case 4:
-		mes "[Croix Knight]";
-		mes "Your Kreiger Points are:";
-		mes ""+kvm_point+".";
+		mes("[Croix Knight]");
+		mes("Your Kreiger Points are:");
+		mesf("%d.", kvm_point);
 		close;
 	}
 }

--- a/npc/battleground/kvm/kvm_item_pay.txt
+++ b/npc/battleground/kvm/kvm_item_pay.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  L0ne_W0lf
 //=
 //= Hercules is free software: you can redistribute it and/or modify
@@ -41,69 +41,69 @@ bat_room,151,144,3	script	KVM Logistic Officer#a	4_M_JOB_KNIGHT2,{
 		.@pointstoadd = countitem(War_Badge);
 		delitem 7773,.@pointstoadd;
 		kvm_point += .@pointstoadd;
-		mes "[Logistics]";
-		mes "Are those "+getitemname(7773)+"s I see?";
-		mes "We no longer accept that currency,";
-		mes "but I can exchange those for you,";
-		mes "So you have "+.@pointstoadd+" "+getitemname(7773)+"s?";
-		mes "Alright, all set, you now have ^580080"+ kvm_point +"^000000 KVM Points.";
+		mes("[Logistics]");
+		mesf("Are those %ss I see?", getitemname(7773));
+		mes("We no longer accept that currency,\r"
+			"but I can exchange those for you.");
+		mesf("So you have %d %ss?", .@pointstoadd, getitemname(7773));
+		mesf("Alright, all set, you now have ^580080%d^000000 KVM Points.", kvm_point);
 		next;
 	}
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Logistics]";
-	mes "Hello?";
-	mes "I am in charge of distributing";
-	mes "reward items for KVM points. Any";
-	mes "wrong selection of items will not";
-	mes "be reversed. Please be carefull.";
-	mes "Select the next step please.";
+	mes("[Logistics]");
+	mes("Hello?");
+	mes("I am in charge of distributing\r"
+		"reward items for KVM points. Any\r"
+		"wrong selection of items will not\r"
+		"be reversed. Please be carefull.");
+	mes("Select the next step please.");
 	next;
 	.@name$ = strcharinfo(0);
 	switch(select("Read the KVM Catalogue.", "Purchase KVM Items.", "Confirm KVM Points.", "Explanation of KVM Rewards.", "Explanation of KVM Points.")) {
 	case 1:
-		mes "[Logistics]";
-		mes "Here is the catalogue of KVM items.";
-		mes "Each weapon requires 2,000 points";
-		mes "and each armor from 10 to 1,200";
-		mes "points. So, be carefull when";
-		mes "selecting a reward.";
+		mes("[Logistics]");
+		mes("Here is the catalogue of KVM items.");
+		mes("Each weapon requires 2,000 points\r"
+			"and each armor from 10 to 1,200\r"
+			"points. So, be carefull when\r"
+			"selecting a reward.");
 		close2;
 		readbook 11017,1;
 		end;
 	case 2:
-		mes "[Logistics]";
-		mes "Wich items do you want to see? As";
-		mes "for the detailed specification of";
-		mes "the items, please refer to the";
-		mes "^3131FFCatalogue^000000.";
+		mes("[Logistics]");
+		mes("Wich items do you want to see? As\r"
+			"for the detailed specification of\r"
+			"the items, please refer to the\r"
+			"^3131FFCatalogue^000000.");
 		next;
 		switch(select("Weapon", "Armor/Accessory", "Mass-Production Armor/Accessory", "Popularized Armor/Accessory")) {
 		case 1:
-			mes "[Logistics]";
-			mes "You have selected the Weapon Category.";
-			mes "Please select a sub-category.";
+			mes("[Logistics]");
+			mes("You have selected the Weapon Category.");
+			mes("Please select a sub-category.");
 			next;
 			switch(select("Dagger/Sword/Spear", "Staff/Mace/Axe/Shuriken", "Bow/Katar/Instrument/Whip", "Book/Knuckle", "Revolver/Rifle/Gun/Grenade Launcher")) {
 			case 1:
-				mes "[Logistics]";
-				mes "You have selected the Dagger/Sword/Spear category.";
-				mes "Please select a sub-category.";
+				mes("[Logistics]");
+				mes("You have selected the Dagger/Sword/Spear category.");
+				mes("Please select a sub-category.");
 				next;
 				switch(select("Dagger", "One-handed Sword", "Two-handed Sword", "One-handed Spear", "Two-handed Spear")) {
 				case 1: callsub PurchaseItem,13042,0,1; //Krieger_Dagger1
 				case 2:
-					mes "[Logistics]";
-					mes "You have selected the 'One-handed Sword' category.";
-					mes "There are 3 One-handed Swords: Glorious Flamberge, Glorious Rapier and Glorious Holy Avenger.";
-					mes "If you want their details, please refer to the KVM Catalogue.";
-					mes "Please select one of them.";
+					mes("[Logistics]");
+					mes("You have selected the 'One-handed Sword' category.");
+					mes("There are 3 One-handed Swords: Glorious Flamberge, Glorious Rapier and Glorious Holy Avenger.");
+					mes("If you want their details, please refer to the KVM Catalogue.");
+					mes("Please select one of them.");
 					next;
 					switch(select("Glorious Flamberge", "Glorious Rapier", "Glorious Holy Avenger")) {
 					case 1: callsub PurchaseItem,13416,0,0; //Krieger_Onehand_Sword1
@@ -115,17 +115,17 @@ bat_room,151,144,3	script	KVM Logistic Officer#a	4_M_JOB_KNIGHT2,{
 				case 5: callsub PurchaseItem,1486,0,1; //Krieger_Twohand_Spear1
 				}
 			case 2:
-				mes "[Logistics]";
-				mes "You have selected the 'Staff/Mace/Axe/Shuriken' category.";
-				mes "Please select a sub-category.";
+				mes("[Logistics]");
+				mes("You have selected the 'Staff/Mace/Axe/Shuriken' category.");
+				mes("Please select a sub-category.");
 				next;
 				switch(select("Staff", "Mace", "One-handed Axe", "Two-handed Axe", "Shuriken")) {
 				case 1:
-					mes "[Logistics]";
-					mes "You have selected the 'Staff' category.";
-					mes "There are 3 Staffs: a Two-handed Weapon Glorious Destruction Staff, a One-handed Glorious Arc Wand and a Glorious Healing Staff.";
-					mes "If you want their details, please refer to the KVM Catalogue.";
-					mes "Please select one of them.";
+					mes("[Logistics]");
+					mes("You have selected the 'Staff' category.");
+					mes("There are 3 Staffs: a Two-handed Weapon Glorious Destruction Staff, a One-handed Glorious Arc Wand and a Glorious Healing Staff.");
+					mes("If you want their details, please refer to the KVM Catalogue.");
+					mes("Please select one of them.");
 					next;
 					switch(select("Glorious Destruction Staff", "Glorious Arc Wand", "Glorious Healing Staff")) {
 					case 1: callsub PurchaseItem,2002,0,0; //Krieger_Twohand_Staff1
@@ -138,18 +138,18 @@ bat_room,151,144,3	script	KVM Logistic Officer#a	4_M_JOB_KNIGHT2,{
 				case 5: callsub PurchaseItem,13307,0,1; //Krieger_Huuma_Shuriken1
 				}
 			case 3:
-				mes "[Logistics]";
-				mes "You have selected the Bow/Katar/Instrument/Whip category.";
-				mes "Please select a sub-category.";
+				mes("[Logistics]");
+				mes("You have selected the Bow/Katar/Instrument/Whip category.");
+				mes("Please select a sub-category.");
 				next;
 				switch(select("Bow", "Katar", "Instrument", "Whip")) {
 				case 1: callsub PurchaseItem,1743,0,1; //Krieger_Bow1
 				case 2:
-					mes "[Logistics]";
-					mes "You have selected the 'Katar' category.";
-					mes "There are 2 Katars: Glorious Bloody Roar and Glorious Jamadhar.";
-					mes "If you want their details, please refer to the KVM Catalogue.";
-					mes "Please select one of them.";
+					mes("[Logistics]");
+					mes("You have selected the 'Katar' category.");
+					mes("There are 2 Katars: Glorious Bloody Roar and Glorious Jamadhar.");
+					mes("If you want their details, please refer to the KVM Catalogue.");
+					mes("Please select one of them.");
 					next;
 					switch(select("Glorious Bloody Roar", "Glorious Jamadhar")) {
 					case 1: callsub PurchaseItem,1281,0,0; //Krieger_Katar1
@@ -159,28 +159,28 @@ bat_room,151,144,3	script	KVM Logistic Officer#a	4_M_JOB_KNIGHT2,{
 				case 4: callsub PurchaseItem,1981,0,1; //Krieger_Whip1
 				}
 			case 4:
-				mes "[Logistics]";
-				mes "You have selected the Book/Knuckle category.";
-				mes "Please select a sub-category.";
+				mes("[Logistics]");
+				mes("You have selected the Book/Knuckle category.");
+				mes("Please select a sub-category.");
 				next;
 				switch(select("Book", "Knuckle")) {
 				case 1:
-					mes "[Logistics]";
-					mes "You have selected 'Book'.";
-					mes "There are 2 Books: Glorious Tablet and Glorious Apocalypse.";
-					mes "If you want their details, please refer to the KVM Catalogue.";
-					mes "Please select one of them.";
+					mes("[Logistics]");
+					mes("You have selected 'Book'.");
+					mes("There are 2 Books: Glorious Tablet and Glorious Apocalypse.");
+					mes("If you want their details, please refer to the KVM Catalogue.");
+					mes("Please select one of them.");
 					next;
 					switch(select("Glorious Tablet", "Glorious Apocalypse")) {
 					case 1: callsub PurchaseItem,1576,0,0; //Krieger_Book1
 					case 2: callsub PurchaseItem,1577,0,0; //Krieger_Book2
 					}
 				case 2:
-					mes "[Logistics]";
-					mes "You have selected the 'Knuckle' category.";
-					mes "There are 2 Knuckles: Glorious Claw and Glorious Fist.";
-					mes "If you want their details, please refer to the KVM Catalogue.";
-					mes "Please select one of them.";
+					mes("[Logistics]");
+					mes("You have selected the 'Knuckle' category.");
+					mes("There are 2 Knuckles: Glorious Claw and Glorious Fist.");
+					mes("If you want their details, please refer to the KVM Catalogue.");
+					mes("Please select one of them.");
 					next;
 					switch(select("Glorious Claw", "Glorious Fist")) {
 					case 1: callsub PurchaseItem,1826,0,0; //Krieger_Knuckle1
@@ -188,9 +188,9 @@ bat_room,151,144,3	script	KVM Logistic Officer#a	4_M_JOB_KNIGHT2,{
 					}
 				}
 			case 5:
-				mes "[Logistics]";
-				mes "You have selected the 'Revolver/Rifle/Gun/Grenade Launcher' category.";
-				mes "Please select a sub-category.";
+				mes("[Logistics]");
+				mes("You have selected the 'Revolver/Rifle/Gun/Grenade Launcher' category.");
+				mes("Please select a sub-category.");
 				next;
 				switch(select("Revolver", "Rifle", "Gatling Gun", "Shotgun", "Grenade Launcher")) {
 				case 1: callsub PurchaseItem,13110,0,1; //Krieger_Pistol1
@@ -201,9 +201,9 @@ bat_room,151,144,3	script	KVM Logistic Officer#a	4_M_JOB_KNIGHT2,{
 				}
 			}
 		case 2:
-			mes "[Logistics]";
-			mes "You have selected the 'Armor/Accessory' category.";
-			mes "Please select a sub-category.";
+			mes("[Logistics]");
+			mes("You have selected the 'Armor/Accessory' category.");
+			mes("Please select a sub-category.");
 			next;
 			switch(select("Armor", "Cloak", "Shoes", "Accessory")) {
 			case 1: callsub PurchaseItem,2394,1,2; //Krieger_Suit1
@@ -212,9 +212,9 @@ bat_room,151,144,3	script	KVM Logistic Officer#a	4_M_JOB_KNIGHT2,{
 			case 4: callsub PurchaseItem,2772,4,2; //Krieger_Ring1
 			}
 		case 3:
-			mes "[Logistics]";
-			mes "You have selected the 'Mass-Production Armor/Accessory' category.";
-			mes "Please select a sub-category.";
+			mes("[Logistics]");
+			mes("You have selected the 'Mass-Production Armor/Accessory' category.");
+			mes("Please select a sub-category.");
 			next;
 			switch(select("Mass-Production Armor", "Mass-Production Shoes", "Mass-Production Accessory")) {
 			case 1: callsub PurchaseItem,2395,5,3; //Krieger_Suit2
@@ -222,9 +222,9 @@ bat_room,151,144,3	script	KVM Logistic Officer#a	4_M_JOB_KNIGHT2,{
 			case 3: callsub PurchaseItem,2773,7,3; //Krieger_Ring2
 			}
 		case 4:
-			mes "[Logistics]";
-			mes "You have selected the 'Popularized Armor/Accessory' category.";
-			mes "Please select a sub-category.";
+			mes("[Logistics]");
+			mes("You have selected the 'Popularized Armor/Accessory' category.");
+			mes("Please select a sub-category.");
 			next;
 			switch(select("Popularized Armor", "Popularized Shoes", "Popularized Accessory")) {
 			case 1: callsub PurchaseItem,2396,8,4; //Krieger_Suit3
@@ -233,33 +233,33 @@ bat_room,151,144,3	script	KVM Logistic Officer#a	4_M_JOB_KNIGHT2,{
 			}
 		}
 	case 3:
-		mes "[Logistics]";
-		mes ""+ .@name$ +", your current points are ^580080"+ kvm_point +"^000000 KVM Points.";
+		mes("[Logistics]");
+		mesf("%s, your current points are ^580080%d^000000 KVM Points.", .@name$, kvm_point);
 		close;
 	case 4:
-		mes "[Logistics]";
-		mes "There are 3 categories in KVM Rewards: Weapon/Armor.Accessory.";
+		mes("[Logistics]");
+		mes("There are 3 categories in KVM Rewards: Weapon/Armor.Accessory.");
 		next;
-		mes "[Logistics]";
-		mes "Weapon rewards require 2,000 KVM points for each.";
-		mes "There are 3 types of Armor rewards and they require 840/630/580 KVM points fo each.";
-		mes "Accessory rewards require 1,200 KVM points for each.";
+		mes("[Logistics]");
+		mes("Weapon rewards require 2,000 KVM points for each.");
+		mes("There are 3 types of Armor rewards and they require 840/630/580 KVM points fo each.");
+		mes("Accessory rewards require 1,200 KVM points for each.");
 		next;
-		mes "[Logistics]";
-		mes "Kreiger Weapons are LV 4 Weapons, they can be upgraded and will have special effects: Slaughter, Destruction and Blessing.";
+		mes("[Logistics]");
+		mes("Kreiger Weapons are LV 4 Weapons, they can be upgraded and will have special effects: Slaughter, Destruction and Blessing.");
 		next;
-		mes "[Logistics]";
-		mes "When you can wear all 3 armors, you can have a special set of options.";
-		mes "Also, when Kreiger Accessory rewards are worn with medalsm it will bring you special set rewards.";
+		mes("[Logistics]");
+		mes("When you can wear all 3 armors, you can have a special set of options.");
+		mes("Also, when Kreiger Accessory rewards are worn with medalsm it will bring you special set rewards.");
 		next;
-		mes "[Logistics]";
-		mes "Finally, there are Mass-Production Armor and Accessory rewards.";
-		mes "Players whose Lvl is higher than 60 can equip Mass-Production Armors and there is a Lvl limit for Popularized Armor as well.";
+		mes("[Logistics]");
+		mes("Finally, there are Mass-Production Armor and Accessory rewards.");
+		mes("Players whose Lvl is higher than 60 can equip Mass-Production Armors and there is a Lvl limit for Popularized Armor as well.");
 		close;
 	case 5:
-		mes "[Logistics]";
-		mes "KVM Points are rewarded when you win, lose or draw in Kreiger Von Midgard (KVM).";
-		mes "You can have special Rewards by using these points.";
+		mes("[Logistics]");
+		mes("KVM Points are rewarded when you win, lose or draw in Kreiger Von Midgard (KVM).");
+		mes("You can have special Rewards by using these points.");
 		close;
 	}
 
@@ -267,64 +267,64 @@ PurchaseItem:
 	// Pricing for Weapon, Suit1, Muffler1, Shoes1, Ring1m Suit2, Shoes2, Ring2, Suit3, Shoes3, Ring3
 	setarray .@prices[0],2000,840,630,580,1200,120,70,200,15,10,30;
 
-	mes "[Logistics]";
+	mes("[Logistics]");
 
 	if (!getarg(2))
-		mes "You have selected ^ff0000"+getitemname(getarg(0))+"^000000.";
+		mesf("You have selected ^ff0000%s^000000.", getitemname(getarg(0)));
 	else if (getarg(2) == 1)
-		mes "There is only one "+callfunc("F_GetWeaponType",getarg(0))+": "+getitemname(getarg(0))+".";
+		mesf("There is only one %s: %s.", callfunc("F_GetWeaponType",getarg(0)), getitemname(getarg(0)));
 	else if (getarg(2) == 2) {
-		mes "You have selected '"+callfunc("F_GetArmorType",getarg(0))+"'.";
-		mes "The armor for one whose Lvl is more than 80 is: ^ff0000"+getitemname(getarg(0))+"^000000.";
+		mesf("You have selected '%s'.", callfunc("F_GetArmorType",getarg(0)));
+		mesf("The armor for one whose Lvl is more than 80 is: ^ff0000%s^000000.", getitemname(getarg(0)));
 	}
 	else if (getarg(2) == 3) {
-		mes "You have selected 'Mass-Production "+callfunc("F_GetArmorType",getarg(0))+"'.";
-		mes "There is only one Mass-Production "+callfunc("F_GetArmorType",getarg(0))+": ^ff0000"+getitemname(getarg(0))+"^000000.";
+		mesf("You have selected 'Mass-Production %s'.", callfunc("F_GetArmorType",getarg(0)));
+		mesf("There is only one Mass-Production %s: ^ff0000%s^000000.", callfunc("F_GetArmorType",getarg(0)), getitemname(getarg(0)));
 	}
 	else if (getarg(2) == 4) {
-		mes "You have selected 'Popularized "+callfunc("F_GetArmorType",getarg(0))+"'.";
-		mes "There is only one Popularized "+callfunc("F_GetArmorType",getarg(0))+": ^ff0000"+getitemname(getarg(0))+"^000000.";
+		mesf("You have selected 'Popularized %s'.", callfunc("F_GetArmorType",getarg(0)));
+		mesf("There is only one Popularized %s: ^ff0000%s^000000.", callfunc("F_GetArmorType",getarg(0)), getitemname(getarg(0)));
 	}
 
 	if (!getarg(1))
-		mes "It requires ^0000ff2,000^000000 KVM Points, and "+ .@name$ +", your points are: ^580080"+ kvm_point +"^000000.";
+		mesf("It requires ^0000ff2,000^000000 KVM Points, and %s, your points are: ^580080%d^000000.", .@name$, kvm_point);
 	else if (getarg(1) == 4)
-		mes "It requires ^0000ff1,200^000000 KVM Points, and "+ .@name$ +", your points are: ^580080"+ kvm_point +"^000000.";
+		mesf("It requires ^0000ff1,200^000000 KVM Points, and %s, your points are: ^580080%d^000000.", .@name$, kvm_point);
 	else
-		mes "It requires ^0000ff"+.@prices[getarg(1)]+"^000000 KVM Points, and "+ .@name$ +", your points are: ^580080"+ kvm_point +"^000000.";
+		mesf("It requires ^0000ff%d^000000 KVM Points, and %s, your points are: ^580080%d^000000.", .@prices[getarg(1)], .@name$, kvm_point);
 
-	mes "Are you sure you want this item?";
+	mes("Are you sure you want this item?");
 	next;
 	switch(select("No, I won't purchase it.", "Yes, I will purchase it.")) {
 	case 1:
-		mes "[Logistics]";
-		mes "You have selected 'I won't purchase it'.";
-		mes "When purchasing an item, please be careful there are no refunds.";
+		mes("[Logistics]");
+		mes("You have selected 'I won't purchase it'.");
+		mes("When purchasing an item, please be careful there are no refunds.");
 		break;
 	case 2:
 		if (kvm_point >= .@prices[getarg(1)]) {
 			kvm_point -= .@prices[getarg(1)];
 			getitem getarg(0),1;
-			mes "[Logistics]";
-			mes "You have purchased a "+getitemname(getarg(0))+".";
+			mes("[Logistics]");
+			mesf("You have purchased a %s.", getitemname(getarg(0)));
 			if (!getarg(1))
-				mes "Your KVM Points are reduced by ^0000ff"+getarg(1)+"^000000 points, your KVM Points are now ^580080"+kvm_point+"^000000.";
+				mesf("Your KVM Points are reduced by ^0000ff%d^000000 points, your KVM Points are now ^580080%d^000000.", getarg(1), kvm_point);
 			if (getarg(1) == 4)
-				mes "Your KVM Points are reduced by ^0000ff1,200^000000 points, your KVM Points are now ^580080"+kvm_point+"^000000.";
+				mesf("Your KVM Points are reduced by ^0000ff1,200^000000 points, your KVM Points are now ^580080%d^000000.", kvm_point);
 			else
-				mes "Your KVM Points are reduced by ^0000ff"+.@prices[getarg(1)]+"^000000 points, your KVM Points are now ^580080"+kvm_point+"^000000.";
+				mesf("Your KVM Points are reduced by ^0000ff%d^000000 points, your KVM Points are now ^580080%d^000000.", .@prices[getarg(1)], kvm_point);
 		}
 		else {
-			mes "[Logistics]";
+			mes("[Logistics]");
 			if (!getarg(1))
-				mes "You need ^0000ff2,000^000000 KVM Points to purchase this item.";
+				mes("You need ^0000ff2,000^000000 KVM Points to purchase this item.");
 			else if (getarg(1) == 4)
-				mes "You need ^0000ff1,200^000000 KVM Points to purchase this item.";
+				mes("You need ^0000ff1,200^000000 KVM Points to purchase this item.");
 			else
-				mes "You need ^0000ff"+.@prices[getarg(1)]+"^000000 KVM Points to purchase this item.";
-			mes "However, your KVM Points are now ^580080"+ kvm_point +"^000000.";
-			mes "Which are not enough to buy it.";
-			mes "When you get enough points, please come back again.";
+				mesf("You need ^0000ff%d^000000 KVM Points to purchase this item.", .@prices[getarg(1)]);
+			mesf("However, your KVM Points are now ^580080%d^000000.", kvm_point);
+			mes("Which are not enough to buy it.");
+			mes("When you get enough points, please come back again.");
 		}
 	}
 	close;

--- a/npc/battleground/tierra/tierra01.txt
+++ b/npc/battleground/tierra/tierra01.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Euphy
 //= Copyright (C)  Kisuka
 //= Copyright (C)  L0ne_W0lf
@@ -41,7 +41,7 @@ bat_room,57,227,5	script	Lieutenant Kalos	4_M_KY_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station",11,"start#bat_a01::OnReadyCheck",1,0,80;
+	waitingroom("Battle Station", 11, "start#bat_a01::OnReadyCheck", 1, 0, 80);
 	end;
 
 OnEnterBG:
@@ -53,7 +53,7 @@ bat_room,58,204,1	script	Lieutenant Eyor	4_M_CRU_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station",11,"start#bat_a01::OnReadyCheck",1,0,80;
+	waitingroom("Battle Station", 11, "start#bat_a01::OnReadyCheck", 1, 0, 80);
 	end;
 
 OnEnterBG:
@@ -168,7 +168,7 @@ OnTimer10000:
 
 bat_a01,15,16,3	script	OBJ#bat_a01_a	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@TierraBG1_id1,"bat_a01",177,345,"Food Storage",1909,"OBJ#bat_a01_a::OnMyMobDead";
+	bg_monster($@TierraBG1_id1, "bat_a01", 177, 345, _("Food Storage"), 1909, "OBJ#bat_a01_a::OnMyMobDead");
 	end;
 
 OnKill:
@@ -182,7 +182,7 @@ OnMyMobDead:
 		$@TierraBG1_Victory = 2;
 		enablenpc "Guillaume Vintenar#a01_a";
 		enablenpc "Croix Vintenar#a01_b";
-		mapannounce "bat_a01", "Croix Vintenar Swandery: We destroyed Guillaume's Food Storage. We won that! Wow!",bc_map,"0xFFCE00";
+		mapannounce("bat_a01", _("Croix Vintenar Swandery: We destroyed Guillaume's Food Storage. We won that! Wow!"), bc_map, "0xFFCE00");
 		bg_warp $@TierraBG1_id1,"bat_a01",50,374;
 		bg_warp $@TierraBG1_id2,"bat_a01",42,16;
 	}
@@ -191,7 +191,7 @@ OnMyMobDead:
 
 bat_a01,15,17,3	script	OBJ#bat_a01_b	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@TierraBG1_id2,"bat_a01",167,50,"Food Depot",1910,"OBJ#bat_a01_b::OnMyMobDead";
+	bg_monster($@TierraBG1_id2, "bat_a01", 167, 50, _("Food Depot"), 1910, "OBJ#bat_a01_b::OnMyMobDead");
 	end;
 
 OnKill:
@@ -205,7 +205,7 @@ OnMyMobDead:
 		$@TierraBG1_Victory = 1;
 		enablenpc "Guillaume Vintenar#a01_a";
 		enablenpc "Croix Vintenar#a01_b";
-		mapannounce "bat_a01", "Guillaume Vintenar Axl Rose : We destroyed Croix's Food Storage. We won that! Wow!",bc_map,"0xFFCE00";
+		mapannounce("bat_a01", _("Guillaume Vintenar Axl Rose : We destroyed Croix's Food Storage. We won that! Wow!"), bc_map, "0xFFCE00");
 		bg_warp $@TierraBG1_id1,"bat_a01",50,374;
 		bg_warp $@TierraBG1_id2,"bat_a01",42,16;
 	}
@@ -215,7 +215,7 @@ OnMyMobDead:
 bat_a01,15,18,3	script	barricade#bat_a01_a	CLEAR_NPC,{
 OnEnable:
 	for (.@i = 185; .@i < 202; ++.@i)
-		bg_monster $@TierraBG1_id1,"bat_a01",.@i,266,"Barricade",1906,"barricade#bat_a01_a::OnMyMobDead";
+		bg_monster($@TierraBG1_id1, "bat_a01", .@i, 266, _("Barricade"), 1906, "barricade#bat_a01_a::OnMyMobDead");
 	setwall "bat_a01",186,266,16,6,1,"bat_a01_c1";
 	end;
 
@@ -229,7 +229,7 @@ OnMyMobDead:
 		killmonster "bat_a01","barricade#bat_a01_a::OnMyMobDead";
 		delwall "bat_a01_c1";
 		enablenpc "Guillaume Blacksmith#a01";
-		mapannounce "bat_a01", "Guillaume Vintenar Axl Rose : The Barricade in the valley has been destroyed! Where's the Blacksmith? We need to rebuild the Barricade!",bc_map,"0xFFCE00";
+		mapannounce("bat_a01", _("Guillaume Vintenar Axl Rose : The Barricade in the valley has been destroyed! Where's the Blacksmith? We need to rebuild the Barricade!"), bc_map, "0xFFCE00");
 	}
 	end;
 }
@@ -237,7 +237,7 @@ OnMyMobDead:
 bat_a01,15,19,3	script	barricade#bat_a01_b	CLEAR_NPC,{
 OnEnable:
 	for (.@i = 169; .@i < 186; ++.@i)
-		bg_monster $@TierraBG1_id2,"bat_a01",.@i,129,"Barricade",1906,"barricade#bat_a01_b::OnMyMobDead";
+		bg_monster($@TierraBG1_id2, "bat_a01", .@i, 129, _("Barricade"), 1906, "barricade#bat_a01_b::OnMyMobDead");
 	setwall "bat_a01",170,129,16,6,1,"bat_a01_g1";
 	end;
 
@@ -251,14 +251,14 @@ OnMyMobDead:
 		killmonster "bat_a01","barricade#bat_a01_b::OnMyMobDead";
 		delwall "bat_a01_g1";
 		enablenpc "Croix Blacksmith#bat_a01";
-		mapannounce "bat_a01", "Croix Vintenar Swandery : The Barricade in the valley has been destroyed! Where's the Blacksmith? We need to rebuild the Barricade!",bc_map,"0xFFCE00";
+		mapannounce("bat_a01", _("Croix Vintenar Swandery : The Barricade in the valley has been destroyed! Where's the Blacksmith? We need to rebuild the Barricade!"), bc_map, "0xFFCE00");
 	}
 	end;
 }
 
 bat_a01,15,20,3	script	OBJ#bat_a01_n	CLEAR_NPC,{
 OnEnable:
-	monster "bat_a01",273,203,"Neutrality Flag",1911,1,"OBJ#bat_a01_n::OnMyMobDead";
+	monster("bat_a01", 273, 203, _("Neutrality Flag"), 1911, 1, "OBJ#bat_a01_n::OnMyMobDead");
 	end;
 
 OnKill:
@@ -270,11 +270,11 @@ OnMyMobDead:
 		bg_team_setxy getcharid(4),56,212;
 		if (getcharid(4) == $@TierraBG1_id1) {
 			donpcevent "NOBJ_mob#bat_a01_a::OnEnable";
-			mapannounce "bat_a01", "Guillaume captured a Neutrality Flag, so they have an advantage.",bc_map,"0xFFCE00";
+			mapannounce("bat_a01", _("Guillaume captured a Neutrality Flag, so they have an advantage."), bc_map, "0xFFCE00");
 		}
 		else {
 			donpcevent "NOBJ_mob#bat_a01_b::OnEnable";
-			mapannounce "bat_a01", "Croix captured a Neutrality Flag, so they have an advantage.",bc_map,"0xFFCE00";
+			mapannounce("bat_a01", _("Croix captured a Neutrality Flag, so they have an advantage."), bc_map, "0xFFCE00");
 		}
 	}
 	end;
@@ -283,9 +283,9 @@ OnMyMobDead:
 bat_a01,15,21,3	script	NOBJ_mob#bat_a01_a	CLEAR_NPC,{
 OnEnable:
 	donpcevent "NOBJ_mob#bat_a01_b::OnKill";
-	bg_monster $@TierraBG1_id1,"bat_a01",272,204,"Guillaume Camp Guardian",1949,"NOBJ_mob#bat_a01_a::OnMyMobDead";
-	bg_monster $@TierraBG1_id1,"bat_a01",272,213,"Guillaume Camp Guardian",1949,"NOBJ_mob#bat_a01_a::OnMyMobDead";
-	bg_monster $@TierraBG1_id1,"bat_a01",273,197,"Guillaume Camp Guardian",1950,"NOBJ_mob#bat_a01_a::OnMyMobDead";
+	bg_monster($@TierraBG1_id1, "bat_a01", 272, 204, _("Guillaume Camp Guardian"), 1949, "NOBJ_mob#bat_a01_a::OnMyMobDead");
+	bg_monster($@TierraBG1_id1, "bat_a01", 272, 213, _("Guillaume Camp Guardian"), 1949, "NOBJ_mob#bat_a01_a::OnMyMobDead");
+	bg_monster($@TierraBG1_id1, "bat_a01", 273, 197, _("Guillaume Camp Guardian"), 1950, "NOBJ_mob#bat_a01_a::OnMyMobDead");
 	end;
 
 OnKill:
@@ -299,9 +299,9 @@ OnMyMobDead:
 bat_a01,15,22,3	script	NOBJ_mob#bat_a01_b	CLEAR_NPC,{
 OnEnable:
 	donpcevent "NOBJ_mob#bat_a01_a::OnKill";
-	bg_monster $@TierraBG1_id2,"bat_a01",272,204,"Croix Camp Guardian",1949,"NOBJ_mob#bat_a01_a::OnMyMobDead";
-	bg_monster $@TierraBG1_id2,"bat_a01",272,213,"Croix Camp Guardian",1949,"NOBJ_mob#bat_a01_a::OnMyMobDead";
-	bg_monster $@TierraBG1_id2,"bat_a01",273,197,"Croix Camp Guardian",1950,"NOBJ_mob#bat_a01_a::OnMyMobDead";
+	bg_monster($@TierraBG1_id2, "bat_a01", 272, 204, _("Croix Camp Guardian"), 1949, "NOBJ_mob#bat_a01_a::OnMyMobDead");
+	bg_monster($@TierraBG1_id2, "bat_a01", 272, 213, _("Croix Camp Guardian"), 1949, "NOBJ_mob#bat_a01_a::OnMyMobDead");
+	bg_monster($@TierraBG1_id2, "bat_a01", 273, 197, _("Croix Camp Guardian"), 1950, "NOBJ_mob#bat_a01_a::OnMyMobDead");
 	end;
 
 OnKill:
@@ -314,56 +314,56 @@ OnMyMobDead:
 
 bat_a01,185,270,1	script	Guillaume Blacksmith#a01	4_M_REPAIR,{
 	if (getcharid(4) == $@TierraBG1_id1) {
-		mes "[Guillaume Blacksmith]";
-		mes "We are in urgency! The Barricade has been destroyed!";
-		mes "We can repair the Barricade with ^3131FF50 Stones, 3 Sinew of Bear, 500 Metal Fragments, 30 Rough Elunium and 100 Gold.^000000";
-		mes "We have it all except for the 50 Stones!";
+		mes("[Guillaume Blacksmith]");
+		mes("We are in urgency! The Barricade has been destroyed!");
+		mes("We can repair the Barricade with ^3131FF50 Stones, 3 Sinew of Bear, 500 Metal Fragments, 30 Rough Elunium and 100 Gold.^000000");
+		mes("We have it all except for the 50 Stones!");
 		next;
 		switch(select("Repair.", "Leave it.")) {
 		case 1:
 			if (countitem(Stone) > 49) {
-				mes "[Guillaume Blacksmith]";
-				mes "You brought enough stones! Let's go and repair.";
+				mes("[Guillaume Blacksmith]");
+				mes("You brought enough stones! Let's go and repair.");
 				next;
-				mes "..";
+				mes("..");
 				next;
-				mes "....";
+				mes("....");
 				next;
-				mes "......";
+				mes("......");
 				next;
-				mes "........";
+				mes("........");
 				next;
-				mes "..........";
+				mes("..........");
 				next;
-				mes "............";
+				mes("............");
 				next;
-				mes "..............";
+				mes("..............");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage.";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage.");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade.";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade.");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger.";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger.");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Now decorate with Metal Fragments.";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Now decorate with Metal Fragments.");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Decorate with Metal Fragments, and plait stones with Sinew of Bear!";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Decorate with Metal Fragments, and plait stones with Sinew of Bear!");
 				next;
-				mes "..............";
-				mes "..............";
-				mes "..............";
-				mes "..............";
-				mes "..............";
+				mes("..............");
+				mes("..............");
+				mes("..............");
+				mes("..............");
+				mes("..............");
 				next;
 				specialeffect EF_REPAIRWEAPON;
-				mes "[Guillaume Blacksmith]";
-				mes "Wow! It's done.";
-				mes "We are relieved.";
+				mes("[Guillaume Blacksmith]");
+				mes("Wow! It's done.");
+				mes("We are relieved.");
 				delitem Stone,50;
 				donpcevent "barricade#bat_a01_a::OnEnable";
 				close2;
@@ -371,23 +371,23 @@ bat_a01,185,270,1	script	Guillaume Blacksmith#a01	4_M_REPAIR,{
 				end;
 			}
 			else {
-				mes "[Guillaume Blacksmith]";
-				mes "You don't have enough Stones!";
+				mes("[Guillaume Blacksmith]");
+				mes("You don't have enough Stones!");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "^3131FFWe need 50 Stones.^000000";
-				mes "We are busy, so please hurry.";
+				mes("[Guillaume Blacksmith]");
+				mes("^3131FFWe need 50 Stones.^000000");
+				mes("We are busy, so please hurry.");
 				close;
 			}
 		case 2:
-			mes "[Guillaume Blacksmith]";
-			mes "There are enemies coming! Let's evacuate from here!";
+			mes("[Guillaume Blacksmith]");
+			mes("There are enemies coming! Let's evacuate from here!");
 			close;
 		}
 	}
 	else {
-		mes "[Guillaume Blacksmith]";
-		mes "There the enemy is coming!";
+		mes("[Guillaume Blacksmith]");
+		mes("There the enemy is coming!");
 		close;
 	}
 
@@ -398,56 +398,56 @@ OnInit:
 
 bat_a01,170,121,5	script	Croix Blacksmith#bat_a01	4_M_REPAIR,{
 	if (getcharid(4) == $@TierraBG1_id2) {
-		mes "[Croix Blacksmith]";
-		mes "We are in urgency! The Barricade has been destroyed!";
-		mes "We can repair the Barricade with ^3131FF50 Stones, 3 Sinew of Bear, 500 Metal Fragments, 30 Rough Elunium and 100 Gold.^000000";
-		mes "We have it all except for the 50 Stones!";
+		mes("[Croix Blacksmith]");
+		mes("We are in urgency! The Barricade has been destroyed!");
+		mes("We can repair the Barricade with ^3131FF50 Stones, 3 Sinew of Bear, 500 Metal Fragments, 30 Rough Elunium and 100 Gold.^000000");
+		mes("We have it all except for the 50 Stones!");
 		next;
 		switch(select("Repair.", "Leave it.")) {
 		case 1:
 			if (countitem(Stone) > 49) {
-				mes "[Croix Blacksmith]";
-				mes "You brought enough stones! Let's go and repair.";
+				mes("[Croix Blacksmith]");
+				mes("You brought enough stones! Let's go and repair.");
 				next;
-				mes "..";
+				mes("..");
 				next;
-				mes "....";
+				mes("....");
 				next;
-				mes "......";
+				mes("......");
 				next;
-				mes "........";
+				mes("........");
 				next;
-				mes "..........";
+				mes("..........");
 				next;
-				mes "............";
+				mes("............");
 				next;
-				mes "..............";
+				mes("..............");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage.";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage.");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade.";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade.");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger.";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger.");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Now decorate with Metal Fragments.";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Now decorate with Metal Fragments.");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Decorate with Metal Fragments, and plait stones with Sinew of Bear!";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Decorate with Metal Fragments, and plait stones with Sinew of Bear!");
 				next;
-				mes "..............";
-				mes "..............";
-				mes "..............";
-				mes "..............";
-				mes "..............";
+				mes("..............");
+				mes("..............");
+				mes("..............");
+				mes("..............");
+				mes("..............");
 				next;
 				specialeffect EF_REPAIRWEAPON;
-				mes "[Croix Blacksmith]";
-				mes "Wow! It's done.";
-				mes "We are relieved.";
+				mes("[Croix Blacksmith]");
+				mes("Wow! It's done.");
+				mes("We are relieved.");
 				delitem Stone,50;
 				donpcevent "barricade#bat_a01_b::OnEnable";
 				close2;
@@ -455,23 +455,23 @@ bat_a01,170,121,5	script	Croix Blacksmith#bat_a01	4_M_REPAIR,{
 				end;
 			}
 			else {
-				mes "[Croix Blacksmith]";
-				mes "You don't have enough Stones!";
+				mes("[Croix Blacksmith]");
+				mes("You don't have enough Stones!");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "^3131FFWe need 50 Stone.^000000";
-				mes "We are busy, so please hurry.";
+				mes("[Croix Blacksmith]");
+				mes("^3131FFWe need 50 Stone.^000000");
+				mes("We are busy, so please hurry.");
 				close;
 			}
 		case 2:
-			mes "[Croix Blacksmith]";
-			mes "There are enemies coming! Let's evacuate from here!";
+			mes("[Croix Blacksmith]");
+			mes("There are enemies coming! Let's evacuate from here!");
 			close;
 		}
 	}
 	else {
-		mes "[Croix Blacksmith]";
-		mes "There, the enemy is coming!";
+		mes("[Croix Blacksmith]");
+		mes("There, the enemy is coming!");
 		close;
 	}
 
@@ -482,10 +482,10 @@ OnInit:
 
 bat_a01,53,377,3	script	Battle Therapist#a01_a	4_F_SISTER,{
 	specialeffect2 EF_HEAL;
-	mes "[Battle Therapist]";
-	mes "Just close your eyes,";
-	mes "and take a deep breath.";
-	mes "You can be free from pain.";
+	mes("[Battle Therapist]");
+	mes("Just close your eyes,\r"
+		"and take a deep breath.");
+	mes("You can be free from pain.");
 	close;
 	end;
 
@@ -532,10 +532,10 @@ OnTouch_:
 
 bat_a01,45,19,3	script	Battle Therapist#a01_b	4_F_SISTER,{
 	specialeffect2 EF_HEAL;
-	mes "[Battle Therapist]";
-	mes "Just close your eyes,";
-	mes "and take a deep breath.";
-	mes "You can be free from pain.";
+	mes("[Battle Therapist]");
+	mes("Just close your eyes,\r"
+		"and take a deep breath.");
+	mes("You can be free from pain.");
 	close;
 	end;
 
@@ -582,8 +582,8 @@ OnTouch:
 
 bat_a01,60,216,3	script	Valley Ghost#bat_a01_n	4_GHOSTRING,{
 	specialeffect2 EF_HEAL;
-	mes "[Valley Ghost]";
-	mes "Boo...Boo...";
+	mes("[Valley Ghost]");
+	mes("Boo...Boo...");
 	close;
 
 OnInit:
@@ -700,18 +700,18 @@ bat_a01,53,377,3	script	Guillaume Vintenar#a01_a	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -720,18 +720,18 @@ bat_a01,53,377,3	script	Guillaume Vintenar#a01_a	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 0) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, and next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, and next time you will definitely win.");
 				close2;
 				getitem BF_Badge1,1;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, and next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, and next time you will definitely win.");
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -742,18 +742,18 @@ bat_a01,53,377,3	script	Guillaume Vintenar#a01_a	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 0) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, and next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, and next time you will definitely win.");
 				close2;
 				getitem BF_Badge1,1;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, and next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, and next time you will definitely win.");
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -762,18 +762,18 @@ bat_a01,53,377,3	script	Guillaume Vintenar#a01_a	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign of victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign of victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -794,18 +794,18 @@ bat_a01,45,19,3	script	Croix Vintenar#a01_b	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -814,18 +814,18 @@ bat_a01,45,19,3	script	Croix Vintenar#a01_b	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 0) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+" Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge1,1;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+" Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -836,18 +836,18 @@ bat_a01,45,19,3	script	Croix Vintenar#a01_b	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 0) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+" Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge1,1;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+" Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -856,18 +856,18 @@ bat_a01,45,19,3	script	Croix Vintenar#a01_b	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -892,31 +892,31 @@ OnStop:
 	end;
 
 OnTimer7000:
-	mapannounce "bat_a01", "Guillaume Vintenar Axl Rose : Let's attack to burn down Croix's Food Depot!",bc_map,"0xFF9900";
+	mapannounce("bat_a01", _("Guillaume Vintenar Axl Rose : Let's attack to burn down Croix's Food Depot!"), bc_map, "0xFF9900");
 	end;
 
 OnTimer8000:
-	mapannounce "bat_a01", "Croix Vintenar Swandery : Master of Valhalla! Let us be gifted with unfailing faith and courage!",bc_map,"0xFF99CC";
+	mapannounce("bat_a01", _("Croix Vintenar Swandery : Master of Valhalla! Let us be gifted with unfailing faith and courage!"), bc_map, "0xFF99CC");
 	end;
 
 OnTimer1800000:
-	mapannounce "bat_a01", "Marollo VII : Guillaume Marollo, Croix Marollo! Marollo followers!",bc_map,"0x99CC00";
+	mapannounce("bat_a01", _("Marollo VII : Guillaume Marollo, Croix Marollo! Marollo followers!"), bc_map, "0x99CC00");
 	end;
 
 OnTimer1803000:
-	mapannounce "bat_a01", "Marollo VII : Both camps are competitive, so no camp would be destroyed easily. That means the Marollo kingdoms will never be defeated!",bc_map,"0x99CC00";
+	mapannounce("bat_a01", _("Marollo VII : Both camps are competitive, so no camp would be destroyed easily. That means the Marollo kingdoms will never be defeated!"), bc_map, "0x99CC00");
 	end;
 
 OnTimer1808000:
-	mapannounce "bat_a01", "Marollo VII : I think we'd better terminate the battle, and call it a draw.",bc_map,"0x99CC00";
+	mapannounce("bat_a01", _("Marollo VII : I think we'd better terminate the battle, and call it a draw."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1822000:
-	mapannounce "bat_a01", "Marollo VII : Hold your royalty and faith for a moment, and let's settle up the battle of Tierra Gorge.",bc_map,"0x99CC00";
+	mapannounce("bat_a01", _("Marollo VII : Hold your royalty and faith for a moment, and let's settle up the battle of Tierra Gorge."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1825000:
-	mapannounce "bat_a01", "Axl Rose, Swandery : Yes sir.",bc_map,"0x99CC00";
+	mapannounce("bat_a01", _("Axl Rose, Swandery : Yes sir."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1830000:
@@ -927,12 +927,12 @@ OnTimer1830000:
 
 /*
 bat_a01,351,75,3	script	Croix Camp Soldier#bat_a01_guide	4_M_RASWORD,{
-	mes "Loading...";
+	mes("Loading...");
 	close;
 }
 
 bat_a01,356,326,3	script	Guillaume Camp Soldier#bat_a01_guide	4_M_RASWORD,{
-	mes "Loading...";
+	mes("Loading...");
 	close;
 }
 */
@@ -940,21 +940,21 @@ bat_a01,356,326,3	script	Guillaume Camp Soldier#bat_a01_guide	4_M_RASWORD,{
 bat_a01,1,1,3	script	Release all#a01	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
 	if (.@i == -1) {
-		mes "Cancelled.";
+		mes("Cancelled.");
 		close;
 	} else if (.@i == 0) {
 		end;
 	} else {
-		mes "May I help you?";
+		mes("May I help you?");
 		next;
 		switch(select("Release all.", "Cancel.")) {
 		case 1:
-			mes "Bye.";
+			mes("Bye.");
 			close2;
 			mapwarp "bat_a01","bat_room",154,150;
 			end;
 		case 2:
-			mes "Cancelled.";
+			mes("Cancelled.");
 			close;
 		}
 	}

--- a/npc/battleground/tierra/tierra02.txt
+++ b/npc/battleground/tierra/tierra02.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Euphy
 //= Copyright (C)  Kisuka
 //= Copyright (C)  L0ne_W0lf
@@ -41,7 +41,7 @@ bat_room,114,227,5	script	Lieutenant Rundel	4_M_KY_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station",11,"start#bat_a02::OnReadyCheck",1,0,80;
+	waitingroom("Battle Station", 11, "start#bat_a02::OnReadyCheck", 1, 0, 80);
 	end;
 
 OnEnterBG:
@@ -53,7 +53,7 @@ bat_room,114,204,1	script	Lieutenant Guerrit	4_M_CRU_KNT,{
 	end;
 
 OnInit:
-	waitingroom "Battle Station",11,"start#bat_a02::OnReadyCheck",1,0,80;
+	waitingroom("Battle Station", 11, "start#bat_a02::OnReadyCheck", 1, 0, 80);
 	end;
 
 OnEnterBG:
@@ -168,7 +168,7 @@ OnTimer10000:
 
 bat_a02,15,16,3	script	OBJ#bat_a02_a	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@TierraBG2_id1,"bat_a02",177,345,"Food Storage",1909,"OBJ#bat_a02_a::OnMyMobDead";
+	bg_monster($@TierraBG2_id1, "bat_a02", 177, 345, _("Food Storage"), 1909, "OBJ#bat_a02_a::OnMyMobDead");
 	end;
 
 OnKill:
@@ -182,7 +182,7 @@ OnMyMobDead:
 		$@TierraBG2_Victory = 2;
 		enablenpc "Guillaume Vintenar#a02_a";
 		enablenpc "Croix Vintenar#a02_b";
-		mapannounce "bat_a02", "Croix Vintenar Swandery: We destroyed Guillaume's Food Storage. We won that! Wow!",bc_map,"0xFFCE00";
+		mapannounce("bat_a02", _("Croix Vintenar Swandery: We destroyed Guillaume's Food Storage. We won that! Wow!"), bc_map, "0xFFCE00");
 		bg_warp $@TierraBG2_id1,"bat_a02",50,374;
 		bg_warp $@TierraBG2_id2,"bat_a02",42,16;
 	}
@@ -191,7 +191,7 @@ OnMyMobDead:
 
 bat_a02,15,17,3	script	OBJ#bat_a02_b	CLEAR_NPC,{
 OnEnable:
-	bg_monster $@TierraBG2_id2,"bat_a02",167,50,"Food Depot",1910,"OBJ#bat_a02_b::OnMyMobDead";
+	bg_monster($@TierraBG2_id2, "bat_a02", 167, 50, _("Food Depot"), 1910, "OBJ#bat_a02_b::OnMyMobDead");
 	end;
 
 OnKill:
@@ -205,7 +205,7 @@ OnMyMobDead:
 		$@TierraBG2_Victory = 1;
 		enablenpc "Guillaume Vintenar#a02_a";
 		enablenpc "Croix Vintenar#a02_b";
-		mapannounce "bat_a02", "Guillaume Vintenar Axl Rose : We destroyed Croix's Food Storage. We won that! Wow!",bc_map,"0xFFCE00";
+		mapannounce("bat_a02", _("Guillaume Vintenar Axl Rose : We destroyed Croix's Food Storage. We won that! Wow!"), bc_map, "0xFFCE00");
 		bg_warp $@TierraBG2_id1,"bat_a02",50,374;
 		bg_warp $@TierraBG2_id2,"bat_a02",42,16;
 	}
@@ -215,7 +215,7 @@ OnMyMobDead:
 bat_a02,15,18,3	script	barricade#bat_a02_a	CLEAR_NPC,{
 OnEnable:
 	for (.@i = 185; .@i < 202; ++.@i)
-		bg_monster $@TierraBG2_id1,"bat_a02",.@i,266,"Barricade",1906,"barricade#bat_a02_a::OnMyMobDead";
+		bg_monster($@TierraBG2_id1, "bat_a02", .@i, 266, _("Barricade"), 1906, "barricade#bat_a02_a::OnMyMobDead");
 	setwall "bat_a02",186,266,16,6,1,"bat_a02_c1";
 	end;
 
@@ -229,7 +229,7 @@ OnMyMobDead:
 		killmonster "bat_a02","barricade#bat_a02_a::OnMyMobDead";
 		delwall "bat_a02_c1";
 		enablenpc "Guillaume Blacksmith#a02";
-		mapannounce "bat_a02", "Guillaume Vintenar Axl Rose : The Barricade in the valley has been destroyed! Where's the Blacksmith? We need to rebuild the Barricade!",bc_map,"0xFFCE00";
+		mapannounce("bat_a02", _("Guillaume Vintenar Axl Rose : The Barricade in the valley has been destroyed! Where's the Blacksmith? We need to rebuild the Barricade!"), bc_map, "0xFFCE00");
 	}
 	end;
 }
@@ -237,7 +237,7 @@ OnMyMobDead:
 bat_a02,15,19,3	script	barricade#bat_a02_b	CLEAR_NPC,{
 OnEnable:
 	for (.@i = 169; .@i < 186; ++.@i)
-		bg_monster $@TierraBG2_id2,"bat_a02",.@i,129,"Barricade",1906,"barricade#bat_a02_b::OnMyMobDead";
+		bg_monster($@TierraBG2_id2, "bat_a02", .@i, 129, _("Barricade"), 1906, "barricade#bat_a02_b::OnMyMobDead");
 	setwall "bat_a02",170,129,16,6,1,"bat_a02_g1";
 	end;
 
@@ -251,14 +251,14 @@ OnMyMobDead:
 		killmonster "bat_a02","barricade#bat_a02_b::OnMyMobDead";
 		delwall "bat_a02_g1";
 		enablenpc "Croix Blacksmith#bat_a02";
-		mapannounce "bat_a02", "Croix Vintenar Swandery : The Barricade in the valley has been destroyed! Where's the Blacksmith? We need to rebuild the Barricade!",bc_map,"0xFFCE00";
+		mapannounce("bat_a02", _("Croix Vintenar Swandery : The Barricade in the valley has been destroyed! Where's the Blacksmith? We need to rebuild the Barricade!"), bc_map, "0xFFCE00");
 	}
 	end;
 }
 
 bat_a02,15,20,3	script	OBJ#bat_a02_n	CLEAR_NPC,{
 OnEnable:
-	monster "bat_a02",273,203,"Neutrality Flag",1911,1,"OBJ#bat_a02_n::OnMyMobDead";
+	monster("bat_a02", 273, 203, _("Neutrality Flag"), 1911, 1, "OBJ#bat_a02_n::OnMyMobDead");
 	end;
 
 OnKill:
@@ -270,11 +270,11 @@ OnMyMobDead:
 		bg_team_setxy getcharid(4),56,212;
 		if (getcharid(4) == $@TierraBG2_id1) {
 			donpcevent "NOBJ_mob#bat_a02_a::OnEnable";
-			mapannounce "bat_a02", "Guillaume captured a Neutrality Flag, so they have an advantage.",bc_map,"0xFFCE00";
+			mapannounce("bat_a02", _("Guillaume captured a Neutrality Flag, so they have an advantage."), bc_map, "0xFFCE00");
 		}
 		else {
 			donpcevent "NOBJ_mob#bat_a02_b::OnEnable";
-			mapannounce "bat_a02", "Croix captured a Neutrality Flag, so they have an advantage.",bc_map,"0xFFCE00";
+			mapannounce("bat_a02", _("Croix captured a Neutrality Flag, so they have an advantage."), bc_map, "0xFFCE00");
 		}
 	}
 	end;
@@ -283,9 +283,9 @@ OnMyMobDead:
 bat_a02,15,21,3	script	NOBJ_mob#bat_a02_a	CLEAR_NPC,{
 OnEnable:
 	donpcevent "NOBJ_mob#bat_a02_b::OnKill";
-	bg_monster $@TierraBG2_id1,"bat_a02",272,204,"Guillaume Camp Guardian",1949,"NOBJ_mob#bat_a02_a::OnMyMobDead";
-	bg_monster $@TierraBG2_id1,"bat_a02",272,213,"Guillaume Camp Guardian",1949,"NOBJ_mob#bat_a02_a::OnMyMobDead";
-	bg_monster $@TierraBG2_id1,"bat_a02",273,197,"Guillaume Camp Guardian",1950,"NOBJ_mob#bat_a02_a::OnMyMobDead";
+	bg_monster($@TierraBG2_id1, "bat_a02", 272, 204, _("Guillaume Camp Guardian"), 1949, "NOBJ_mob#bat_a02_a::OnMyMobDead");
+	bg_monster($@TierraBG2_id1, "bat_a02", 272, 213, _("Guillaume Camp Guardian"), 1949, "NOBJ_mob#bat_a02_a::OnMyMobDead");
+	bg_monster($@TierraBG2_id1, "bat_a02", 273, 197, _("Guillaume Camp Guardian"), 1950, "NOBJ_mob#bat_a02_a::OnMyMobDead");
 	end;
 
 OnKill:
@@ -299,9 +299,9 @@ OnMyMobDead:
 bat_a02,15,22,3	script	NOBJ_mob#bat_a02_b	CLEAR_NPC,{
 OnEnable:
 	donpcevent "NOBJ_mob#bat_a02_a::OnKill";
-	bg_monster $@TierraBG2_id2,"bat_a02",272,204,"Croix Camp Guardian",1949,"NOBJ_mob#bat_a02_a::OnMyMobDead";
-	bg_monster $@TierraBG2_id2,"bat_a02",272,213,"Croix Camp Guardian",1949,"NOBJ_mob#bat_a02_a::OnMyMobDead";
-	bg_monster $@TierraBG2_id2,"bat_a02",273,197,"Croix Camp Guardian",1950,"NOBJ_mob#bat_a02_a::OnMyMobDead";
+	bg_monster($@TierraBG2_id2, "bat_a02", 272, 204, _("Croix Camp Guardian"), 1949, "NOBJ_mob#bat_a02_a::OnMyMobDead");
+	bg_monster($@TierraBG2_id2, "bat_a02", 272, 213, _("Croix Camp Guardian"), 1949, "NOBJ_mob#bat_a02_a::OnMyMobDead");
+	bg_monster($@TierraBG2_id2, "bat_a02", 273, 197, _("Croix Camp Guardian"), 1950, "NOBJ_mob#bat_a02_a::OnMyMobDead");
 	end;
 
 OnKill:
@@ -314,56 +314,56 @@ OnMyMobDead:
 
 bat_a02,185,270,1	script	Guillaume Blacksmith#a02	4_M_REPAIR,{
 	if (getcharid(4) == $@TierraBG2_id1) {
-		mes "[Guillaume Blacksmith]";
-		mes "We are in urgency! The Barricade has been destroyed!";
-		mes "We can repair the Barricade with ^3131FF50 Stones, 3 Sinew of Bear, 500 Metal Fragments, 30 Rough Elunium and 100 Gold.^000000";
-		mes "We have it all except for the 50 Stones!";
+		mes("[Guillaume Blacksmith]");
+		mes("We are in urgency! The Barricade has been destroyed!");
+		mes("We can repair the Barricade with ^3131FF50 Stones, 3 Sinew of Bear, 500 Metal Fragments, 30 Rough Elunium and 100 Gold.^000000");
+		mes("We have it all except for the 50 Stones!");
 		next;
 		switch(select("Repair.", "Leave it.")) {
 		case 1:
 			if (countitem(Stone) > 49) {
-				mes "[Guillaume Blacksmith]";
-				mes "You brought enough stones! Let's go and repair.";
+				mes("[Guillaume Blacksmith]");
+				mes("You brought enough stones! Let's go and repair.");
 				next;
-				mes "..";
+				mes("..");
 				next;
-				mes "....";
+				mes("....");
 				next;
-				mes "......";
+				mes("......");
 				next;
-				mes "........";
+				mes("........");
 				next;
-				mes "..........";
+				mes("..........");
 				next;
-				mes "............";
+				mes("............");
 				next;
-				mes "..............";
+				mes("..............");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage.";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage.");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade.";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade.");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger.";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger.");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Now decorate with Metal Fragments.";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Now decorate with Metal Fragments.");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Decorate with Metal Fragments, and plait stones with Sinew of Bear!";
+				mes("[Guillaume Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Decorate with Metal Fragments, and plait stones with Sinew of Bear!");
 				next;
-				mes "..............";
-				mes "..............";
-				mes "..............";
-				mes "..............";
-				mes "..............";
+				mes("..............");
+				mes("..............");
+				mes("..............");
+				mes("..............");
+				mes("..............");
 				next;
 				specialeffect EF_REPAIRWEAPON;
-				mes "[Guillaume Blacksmith]";
-				mes "Wow! It's done.";
-				mes "We are relieved.";
+				mes("[Guillaume Blacksmith]");
+				mes("Wow! It's done.");
+				mes("We are relieved.");
 				delitem Stone,50;
 				donpcevent "barricade#bat_a02_a::OnEnable";
 				close2;
@@ -371,23 +371,23 @@ bat_a02,185,270,1	script	Guillaume Blacksmith#a02	4_M_REPAIR,{
 				end;
 			}
 			else {
-				mes "[Guillaume Blacksmith]";
-				mes "You don't have enough Stones!";
+				mes("[Guillaume Blacksmith]");
+				mes("You don't have enough Stones!");
 				next;
-				mes "[Guillaume Blacksmith]";
-				mes "^3131FFWe need 50 Stones.^000000";
-				mes "We are busy, so please hurry.";
+				mes("[Guillaume Blacksmith]");
+				mes("^3131FFWe need 50 Stones.^000000");
+				mes("We are busy, so please hurry.");
 				close;
 			}
 		case 2:
-			mes "[Guillaume Blacksmith]";
-			mes "There are enemies coming! Let's evacuate from here!";
+			mes("[Guillaume Blacksmith]");
+			mes("There are enemies coming! Let's evacuate from here!");
 			close;
 		}
 	}
 	else {
-		mes "[Guillaume Blacksmith]";
-		mes "There the enemy is coming!";
+		mes("[Guillaume Blacksmith]");
+		mes("There the enemy is coming!");
 		close;
 	}
 
@@ -398,56 +398,56 @@ OnInit:
 
 bat_a02,170,121,5	script	Croix Blacksmith#bat_a02	4_M_REPAIR,{
 	if (getcharid(4) == $@TierraBG2_id2) {
-		mes "[Croix Blacksmith]";
-		mes "We are in urgency! The Barricade has been destroyed!";
-		mes "We can repair the Barricade with ^3131FF50 Stones, 3 Sinew of Bear, 500 Metal Fragments, 30 Rough Elunium and 100 Gold.^000000";
-		mes "We have it all except for the 50 Stones!";
+		mes("[Croix Blacksmith]");
+		mes("We are in urgency! The Barricade has been destroyed!");
+		mes("We can repair the Barricade with ^3131FF50 Stones, 3 Sinew of Bear, 500 Metal Fragments, 30 Rough Elunium and 100 Gold.^000000");
+		mes("We have it all except for the 50 Stones!");
 		next;
 		switch(select("Repair.", "Leave it.")) {
 		case 1:
 			if (countitem(Stone) > 49) {
-				mes "[Croix Blacksmith]";
-				mes "You brought enough stones! Let's go and repair.";
+				mes("[Croix Blacksmith]");
+				mes("You brought enough stones! Let's go and repair.");
 				next;
-				mes "..";
+				mes("..");
 				next;
-				mes "....";
+				mes("....");
 				next;
-				mes "......";
+				mes("......");
 				next;
-				mes "........";
+				mes("........");
 				next;
-				mes "..........";
+				mes("..........");
 				next;
-				mes "............";
+				mes("............");
 				next;
-				mes "..............";
+				mes("..............");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage.";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage.");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade.";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade.");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger.";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger.");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Now decorate with Metal Fragments.";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Now decorate with Metal Fragments.");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Decorate with Metal Fragments, and plait stones with Sinew of Bear!";
+				mes("[Croix Blacksmith]");
+				mes("Combine Stones and Gold in the proper percentage and shape the Barricade, then add Rough Elunium to make it stronger. Decorate with Metal Fragments, and plait stones with Sinew of Bear!");
 				next;
-				mes "..............";
-				mes "..............";
-				mes "..............";
-				mes "..............";
-				mes "..............";
+				mes("..............");
+				mes("..............");
+				mes("..............");
+				mes("..............");
+				mes("..............");
 				next;
 				specialeffect EF_REPAIRWEAPON;
-				mes "[Croix Blacksmith]";
-				mes "Wow! It's done.";
-				mes "We are relieved.";
+				mes("[Croix Blacksmith]");
+				mes("Wow! It's done.");
+				mes("We are relieved.");
 				delitem Stone,50;
 				donpcevent "barricade#bat_a02_b::OnEnable";
 				close2;
@@ -455,23 +455,23 @@ bat_a02,170,121,5	script	Croix Blacksmith#bat_a02	4_M_REPAIR,{
 				end;
 			}
 			else {
-				mes "[Croix Blacksmith]";
-				mes "You don't have enough Stones!";
+				mes("[Croix Blacksmith]");
+				mes("You don't have enough Stones!");
 				next;
-				mes "[Croix Blacksmith]";
-				mes "^3131FFWe need 50 Stone.^000000";
-				mes "We are busy, so please hurry.";
+				mes("[Croix Blacksmith]");
+				mes("^3131FFWe need 50 Stone.^000000");
+				mes("We are busy, so please hurry.");
 				close;
 			}
 		case 2:
-			mes "[Croix Blacksmith]";
-			mes "There are enemies coming! Let's evacuate from here!";
+			mes("[Croix Blacksmith]");
+			mes("There are enemies coming! Let's evacuate from here!");
 			close;
 		}
 	}
 	else {
-		mes "[Croix Blacksmith]";
-		mes "There, the enemy is coming!";
+		mes("[Croix Blacksmith]");
+		mes("There, the enemy is coming!");
 		close;
 	}
 
@@ -482,10 +482,10 @@ OnInit:
 
 bat_a02,53,377,3	script	Battle Therapist#a02_a	4_F_SISTER,{
 	specialeffect2 EF_HEAL;
-	mes "[Battle Therapist]";
-	mes "Just close your eyes,";
-	mes "and take a deep breath.";
-	mes "You can be free from pain.";
+	mes("[Battle Therapist]");
+	mes("Just close your eyes,\r"
+		"and take a deep breath.");
+	mes("You can be free from pain.");
 	close;
 	end;
 
@@ -532,10 +532,10 @@ OnTouch_:
 
 bat_a02,45,19,3	script	Battle Therapist#a02_b	4_F_SISTER,{
 	specialeffect2 EF_HEAL;
-	mes "[Battle Therapist]";
-	mes "Just close your eyes,";
-	mes "and take a deep breath.";
-	mes "You can be free from pain.";
+	mes("[Battle Therapist]");
+	mes("Just close your eyes,\r"
+		"and take a deep breath.");
+	mes("You can be free from pain.");
 	close;
 	end;
 
@@ -582,8 +582,8 @@ OnTouch:
 
 bat_a02,60,216,3	script	Valley Ghost#bat_a02_n	4_GHOSTRING,{
 	specialeffect2 EF_HEAL;
-	mes "[Valley Ghost]";
-	mes "Boo...Boo...";
+	mes("[Valley Ghost]");
+	mes("Boo...Boo...");
 	close;
 
 OnInit:
@@ -700,18 +700,18 @@ bat_a02,53,377,3	script	Guillaume Vintenar#a02_a	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -720,18 +720,18 @@ bat_a02,53,377,3	script	Guillaume Vintenar#a02_a	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 0) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, and next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, and next time you will definitely win.");
 				close2;
 				getitem BF_Badge1,1;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, and next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, and next time you will definitely win.");
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -742,18 +742,18 @@ bat_a02,53,377,3	script	Guillaume Vintenar#a02_a	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 0) {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, and next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, and next time you will definitely win.");
 				close2;
 				getitem BF_Badge1,1;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "You lost, but you're dedicated to this battle.";
-				mes "This is a reward for your great dedication by Guillaume Marollo!";
-				mes "Just take this defeat as a lesson, and next time you will definitely win.";
+				mes("[Axl Rose]");
+				mes("You lost, but you're dedicated to this battle.");
+				mes("This is a reward for your great dedication by Guillaume Marollo!");
+				mes("Just take this defeat as a lesson, and next time you will definitely win.");
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -762,18 +762,18 @@ bat_a02,53,377,3	script	Guillaume Vintenar#a02_a	4_M_KY_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,3;
 			}
 			else {
-				mes "[Axl Rose]";
-				mes "Blessed Guillaume!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign of victory.";
+				mes("[Axl Rose]");
+				mes("Blessed Guillaume!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign of victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -794,18 +794,18 @@ bat_a02,45,19,3	script	Croix Vintenar#a02_b	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -814,18 +814,18 @@ bat_a02,45,19,3	script	Croix Vintenar#a02_b	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 0) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+" Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge1,1;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+" Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -836,18 +836,18 @@ bat_a02,45,19,3	script	Croix Vintenar#a02_b	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 0) {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+" Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge1,1;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Oh, "+strcharinfo(0)+" Don't be sad.";
-				mes "Even though we didn't win, we did our best.";
-				mes "This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.";
+				mes("[Swandery]");
+				mesf("Oh, %s Don't be sad.", strcharinfo(0));
+				mes("Even though we didn't win, we did our best.");
+				mes("This is a Royal gift from Croix, and please don't forget this battle. We will win the next one.");
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -856,18 +856,18 @@ bat_a02,45,19,3	script	Croix Vintenar#a02_b	4_M_CRU_HEAD,{
 			.@your_medal = countitem(BF_Badge1);
 			.@medal_gap = 500 - .@your_medal;
 			if (.@medal_gap > 2) {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,3;
 			}
 			else {
-				mes "[Swandery]";
-				mes "Blessed Croix!";
-				mes "Let's enjoy our glorious victory!";
-				mes ""+strcharinfo(0)+", it's a sign reflecting victory.";
+				mes("[Swandery]");
+				mes("Blessed Croix!");
+				mes("Let's enjoy our glorious victory!");
+				mesf("%s, it's a sign reflecting victory.", strcharinfo(0));
 				close2;
 				getitem BF_Badge1,.@medal_gap;
 			}
@@ -892,31 +892,31 @@ OnStop:
 	end;
 
 OnTimer7000:
-	mapannounce "bat_a02", "Guillaume Vintenar Axl Rose : Let's attack to burn down Croix's Food Depot!",bc_map,"0xFF9900";
+	mapannounce("bat_a02", _("Guillaume Vintenar Axl Rose : Let's attack to burn down Croix's Food Depot!"), bc_map, "0xFF9900");
 	end;
 
 OnTimer8000:
-	mapannounce "bat_a02", "Croix Vintenar Swandery : Master of Valhalla! Let us be gifted with unfailing faith and courage!",bc_map,"0xFF99CC";
+	mapannounce("bat_a02", _("Croix Vintenar Swandery : Master of Valhalla! Let us be gifted with unfailing faith and courage!"), bc_map, "0xFF99CC");
 	end;
 
 OnTimer1800000:
-	mapannounce "bat_a02", "Marollo VII : Guillaume Marollo, Croix Marollo! Marollo followers!",bc_map,"0x99CC00";
+	mapannounce("bat_a02", _("Marollo VII : Guillaume Marollo, Croix Marollo! Marollo followers!"), bc_map, "0x99CC00");
 	end;
 
 OnTimer1803000:
-	mapannounce "bat_a02", "Marollo VII : Both camps are competitive, so no camp would be destroyed easily. That means the Marollo kingdoms will never be defeated!",bc_map,"0x99CC00";
+	mapannounce("bat_a02", _("Marollo VII : Both camps are competitive, so no camp would be destroyed easily. That means the Marollo kingdoms will never be defeated!"), bc_map, "0x99CC00");
 	end;
 
 OnTimer1808000:
-	mapannounce "bat_a02", "Marollo VII : I think we'd better terminate the battle, and call it a draw.",bc_map,"0x99CC00";
+	mapannounce("bat_a02", _("Marollo VII : I think we'd better terminate the battle, and call it a draw."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1822000:
-	mapannounce "bat_a02", "Marollo VII : Hold your royalty and faith for a moment, and let's settle up the battle of Tierra Gorge.",bc_map,"0x99CC00";
+	mapannounce("bat_a02", _("Marollo VII : Hold your royalty and faith for a moment, and let's settle up the battle of Tierra Gorge."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1825000:
-	mapannounce "bat_a02", "Axl Rose, Swandery : Yes sir.",bc_map,"0x99CC00";
+	mapannounce("bat_a02", _("Axl Rose, Swandery : Yes sir."), bc_map, "0x99CC00");
 	end;
 
 OnTimer1830000:
@@ -927,12 +927,12 @@ OnTimer1830000:
 
 /*
 bat_a02,351,75,3	script	Croix Camp Soldier#bat_a02_guide	4_M_RASWORD,{
-	mes "Loading...";
+	mes("Loading...");
 	close;
 }
 
 bat_a02,356,326,3	script	Guillaume Camp Soldier#bat_a02_guide	4_M_RASWORD,{
-	mes "Loading...";
+	mes("Loading...");
 	close;
 }
 */
@@ -940,21 +940,21 @@ bat_a02,356,326,3	script	Guillaume Camp Soldier#bat_a02_guide	4_M_RASWORD,{
 bat_a02,1,1,3	script	Release all#a02	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
 	if (.@i == -1) {
-		mes "Cancelled.";
+		mes("Cancelled.");
 		close;
 	} else if (.@i == 0) {
 		end;
 	} else {
-		mes "May I help you?";
+		mes("May I help you?");
 		next;
 		switch(select("Release all.", "Cancel.")) {
 		case 1:
-			mes "Bye.";
+			mes("Bye.");
 			close2;
 			mapwarp "bat_a02","bat_room",154,150;
 			end;
 		case 2:
-			mes "Cancelled.";
+			mes("Cancelled.");
 			close;
 		}
 	}

--- a/npc/battleground/tierra/tierra_enter.txt
+++ b/npc/battleground/tierra/tierra_enter.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  L0ne_W0lf
 //=
 //= Hercules is free software: you can redistribute it and/or modify
@@ -35,59 +35,59 @@
 //== First Tierra Gorge Officers - Guillaume ===============
 bat_room,124,178,5	script	Tierra Gorge Officer#01a	4_M_KY_KNT,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Guillaume Army Officer]";
-	mes "Let's show the power of the Guillaume Army to those stinky Croixs!";
+	mes("[Guillaume Army Officer]");
+	mes("Let's show the power of the Guillaume Army to those stinky Croixs!");
 	next;
 	switch(select("I want to join your army!", "End Conversation")) {
 	case 1:
 		if ((Class == Job_Novice) || (BaseClass == Job_SuperNovice)) {
-			mes "[Guillaume Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Guillaume Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		if (BaseLevel < 80) {
-			mes "[Guillaume Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Guillaume Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		.@chk_urtime = questprogress(2069,PLAYTIME);
 		if (.@chk_urtime == 1) {
-			mes "[Guillaume Army Officer]";
-			mes "You seem to have just returned from the battlefield.";
-			mes "It's too early for you to go back. Go rest, and leave the enemies to us!";
+			mes("[Guillaume Army Officer]");
+			mes("You seem to have just returned from the battlefield.");
+			mes("It's too early for you to go back. Go rest, and leave the enemies to us!");
 			break;
 		}
 		if (.@chk_urtime == 2)
 			erasequest 2069;
 		if (getmapusers("bat_a01") > 0) {
-			mes "[Guillaume Army Officer]";
-			mes "I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Croixs already.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Guillaume Army Officer]");
+			mes("I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Croixs already.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
 		if ($@TierraBG1) {
-			mes "[Guillaume Army Officer]";
-			mes "An elite corps is already standing by to be dispatched to the battlefield.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Guillaume Army Officer]");
+			mes("An elite corps is already standing by to be dispatched to the battlefield.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
-		mes "[Guillaume Army Officer]";
-		mes "You definitely seem to be ready for battle!";
-		mes "Go show the Croixs what fear truly means!";
-		mes "Today, our cry of victory shall echo all over the battlefield!";
+		mes("[Guillaume Army Officer]");
+		mes("You definitely seem to be ready for battle!");
+		mes("Go show the Croixs what fear truly means!");
+		mes("Today, our cry of victory shall echo all over the battlefield!");
 		close2;
 		warp "bat_room",57,223;
 		end;
 	case 2:
-		mes "[Guillaume Army Officer]";
-		mes "Today, we shall be victorious!";
+		mes("[Guillaume Army Officer]");
+		mes("Today, we shall be victorious!");
 		break;
 	}
 	close;
@@ -95,216 +95,216 @@ bat_room,124,178,5	script	Tierra Gorge Officer#01a	4_M_KY_KNT,{
 
 bat_room,140,178,5	script	Tierra Gorge Officer#02a	4_M_KY_KNT,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Guillaume Army Officer]";
-	mes "Let's show the power of the Guillaume Army to those stinky Croixs!";
+	mes("[Guillaume Army Officer]");
+	mes("Let's show the power of the Guillaume Army to those stinky Croixs!");
 	next;
 	switch(select("I want to join your army!", "End Conversation")) {
 	case 1:
 		if ((Class == Job_Novice) || (BaseClass == Job_SuperNovice)) {
-			mes "[Guillaume Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Guillaume Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		if (BaseLevel < 80) {
-			mes "[Guillaume Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Guillaume Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		.@chk_urtime = questprogress(2069,PLAYTIME);
 		if (.@chk_urtime == 1) {
-			mes "[Guillaume Army Officer]";
-			mes "You seem to have just returned from the battlefield.";
-			mes "It's too early for you to go back. Go rest, and leave the enemies to us!";
+			mes("[Guillaume Army Officer]");
+			mes("You seem to have just returned from the battlefield.");
+			mes("It's too early for you to go back. Go rest, and leave the enemies to us!");
 			break;
 		}
 		if (.@chk_urtime == 2)
 			erasequest 2069;
 		if (getmapusers("bat_a02") > 0) {
-			mes "[Guillaume Army Officer]";
-			mes "I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Croixs already.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Guillaume Army Officer]");
+			mes("I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Croixs already.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
 		if ($@TierraBG2) {
-			mes "[Guillaume Army Officer]";
-			mes "An elite corps is already standing by to be dispatched to the battlefield.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Guillaume Army Officer]");
+			mes("An elite corps is already standing by to be dispatched to the battlefield.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
-		mes "[Guillaume Army Officer]";
-		mes "You definitely seem to be ready for battle!";
-		mes "Go show the Croixs what fear truly means!";
-		mes "Today, our cry of victory shall echo all over the battlefield!";
+		mes("[Guillaume Army Officer]");
+		mes("You definitely seem to be ready for battle!");
+		mes("Go show the Croixs what fear truly means!");
+		mes("Today, our cry of victory shall echo all over the battlefield!");
 		close2;
 		warp "bat_room",114,223;
 		end;
 	case 2:
-		mes "[Guillaume Army Officer]";
-		mes "Today, we shall be victorious!";
+		mes("[Guillaume Army Officer]");
+		mes("Today, we shall be victorious!");
 		break;
 	}
 	close;
 }
 
 bat_room,127,178,5	script	Guillaume Knight#1	4_M_KY_SOLD,{
-	mes "[Guillaume Knight]";
-	mes "Tierra Gorge consists of two steep sides placed vertically, and has ration depots for the Guillaume and Croix Armies at the 11 and 7 o'clock directions.";
+	mes("[Guillaume Knight]");
+	mes("Tierra Gorge consists of two steep sides placed vertically, and has ration depots for the Guillaume and Croix Armies at the 11 and 7 o'clock directions.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "The battle starts at your army's ship, and the goal is to advance and destroy your enemy's rations depot faster than they can destroy yours.";
+	mes("[Guillaume Knight]");
+	mes("The battle starts at your army's ship, and the goal is to advance and destroy your enemy's rations depot faster than they can destroy yours.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "The healer of the battlefield will resurrect soldiers once every 25 seconds so that they can rejoin the battle.";
-	mes "The army that captures the neutral flag in the center of the battlefield will be rewarded with extra regeneration points, meaning their soldiers will resurrect more than the other side, giving them an advantage.";
+	mes("[Guillaume Knight]");
+	mes("The healer of the battlefield will resurrect soldiers once every 25 seconds so that they can rejoin the battle.");
+	mes("The army that captures the neutral flag in the center of the battlefield will be rewarded with extra regeneration points, meaning their soldiers will resurrect more than the other side, giving them an advantage.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Those two rations depots are connected to each other through short and narrow paths, but the gates are blocked with barricades.";
-	mes "Think and move as quickly as you can. The victory of your army relies on your contribution.";
+	mes("[Guillaume Knight]");
+	mes("Those two rations depots are connected to each other through short and narrow paths, but the gates are blocked with barricades.");
+	mes("Think and move as quickly as you can. The victory of your army relies on your contribution.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Please remember: when you join a battle, you will receive a token which indicates the set duration for which you cannot participate in the same type of battle.";
-	mes "You may check the duration by pressing the Alt+U keys.";
+	mes("[Guillaume Knight]");
+	mes("Please remember: when you join a battle, you will receive a token which indicates the set duration for which you cannot participate in the same type of battle.");
+	mes("You may check the duration by pressing the Alt+U keys.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Are you ready to battle? Then apply with the recruiter next to me!";
+	mes("[Guillaume Knight]");
+	mes("Are you ready to battle? Then apply with the recruiter next to me!");
 	close;
 }
 
 bat_room,143,178,5	script	Guillaume Knight#2	4_M_KY_SOLD,{
-	mes "[Guillaume Knight]";
-	mes "Tierra Gorge consists of two steep sides placed vertically, and has ration depots for the Guillaume and Croix Armies at the 11 and 7 o'clock directions.";
+	mes("[Guillaume Knight]");
+	mes("Tierra Gorge consists of two steep sides placed vertically, and has ration depots for the Guillaume and Croix Armies at the 11 and 7 o'clock directions.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "The battle starts at your army's ship, and the goal is to advance and destroy your enemy's rations depot faster than they can destroy yours.";
+	mes("[Guillaume Knight]");
+	mes("The battle starts at your army's ship, and the goal is to advance and destroy your enemy's rations depot faster than they can destroy yours.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "The healer of the battlefield will resurrect soldiers once every 25 seconds so that they can rejoin the battle.";
-	mes "The army that captures the neutral flag in the center of the battlefield will be rewarded with extra regeneration points, meaning their soldiers will resurrect more than the other side, giving them an advantage.";
+	mes("[Guillaume Knight]");
+	mes("The healer of the battlefield will resurrect soldiers once every 25 seconds so that they can rejoin the battle.");
+	mes("The army that captures the neutral flag in the center of the battlefield will be rewarded with extra regeneration points, meaning their soldiers will resurrect more than the other side, giving them an advantage.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Those two rations depots are connected to each other through short and narrow paths, but the gates are blocked with barricades.";
-	mes "Think and move as quickly as you can. The victory of your army relies on your contribution.";
+	mes("[Guillaume Knight]");
+	mes("Those two rations depots are connected to each other through short and narrow paths, but the gates are blocked with barricades.");
+	mes("Think and move as quickly as you can. The victory of your army relies on your contribution.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Please remember: when you join a battle, you will receive a token which indicates the set duration for which you cannot participate in the same type of battle.";
-	mes "You may check the duration by pressing the Alt+U keys.";
+	mes("[Guillaume Knight]");
+	mes("Please remember: when you join a battle, you will receive a token which indicates the set duration for which you cannot participate in the same type of battle.");
+	mes("You may check the duration by pressing the Alt+U keys.");
 	next;
-	mes "[Guillaume Knight]";
-	mes "Are you ready to battle? Then apply with the recruiter next to me!";
+	mes("[Guillaume Knight]");
+	mes("Are you ready to battle? Then apply with the recruiter next to me!");
 	close;
 }
 
 bat_room,127,121,1	script	Croix Knight#1	4_M_CRU_SOLD,{
-	mes "[Croix Knight]";
-	mes "Tierra Gorge consists of two steep sides placed vertically, and has ration depots for the Guillaume and Croix Armies at the 11 and 7 o'clock directions.";
+	mes("[Croix Knight]");
+	mes("Tierra Gorge consists of two steep sides placed vertically, and has ration depots for the Guillaume and Croix Armies at the 11 and 7 o'clock directions.");
 	next;
-	mes "[Croix Knight]";
-	mes "The battle starts at your army's ship, and the goal is to advance and destroy your enemy's rations depot faster than they can destroy yours.";
+	mes("[Croix Knight]");
+	mes("The battle starts at your army's ship, and the goal is to advance and destroy your enemy's rations depot faster than they can destroy yours.");
 	next;
-	mes "[Croix Knight]";
-	mes "The healer of the battlefield will resurrect soldiers once every 25 seconds so that they can rejoin the battle.";
-	mes "The army that captures the neutral flag in the center of the battlefield will be rewarded with extra regeneration points, meaning their soldiers will resurrect more than the other side, giving them an advantage.";
+	mes("[Croix Knight]");
+	mes("The healer of the battlefield will resurrect soldiers once every 25 seconds so that they can rejoin the battle.");
+	mes("The army that captures the neutral flag in the center of the battlefield will be rewarded with extra regeneration points, meaning their soldiers will resurrect more than the other side, giving them an advantage.");
 	next;
-	mes "[Croix Knight]";
-	mes "Those two rations depots are connected to each other through short and narrow paths, but the gates are blocked with barricades.";
-	mes "Think and move as quickly as you can. The victory of your army relies on your contribution.";
+	mes("[Croix Knight]");
+	mes("Those two rations depots are connected to each other through short and narrow paths, but the gates are blocked with barricades.");
+	mes("Think and move as quickly as you can. The victory of your army relies on your contribution.");
 	next;
-	mes "[Croix Knight]";
-	mes "Please remember: when you join a battle, you will receive a token which indicates the set duration for which you cannot participate in the same type of battle.";
-	mes "You may check the duration by pressing the Alt+U keys.";
+	mes("[Croix Knight]");
+	mes("Please remember: when you join a battle, you will receive a token which indicates the set duration for which you cannot participate in the same type of battle.");
+	mes("You may check the duration by pressing the Alt+U keys.");
 	next;
-	mes "[Croix Knight]";
-	mes "Are you ready to battle? Then apply with the recruiter next to me!";
+	mes("[Croix Knight]");
+	mes("Are you ready to battle? Then apply with the recruiter next to me!");
 	close;
 }
 
 bat_room,143,121,1	script	Croix Knight#2	4_M_CRU_SOLD,{
-	mes "[Croix Knight]";
-	mes "Tierra Gorge consists of two steep sides placed vertically, and has ration depots for the Guillaume and Croix Armies at the 11 and 7 o'clock directions.";
+	mes("[Croix Knight]");
+	mes("Tierra Gorge consists of two steep sides placed vertically, and has ration depots for the Guillaume and Croix Armies at the 11 and 7 o'clock directions.");
 	next;
-	mes "[Croix Knight]";
-	mes "The battle starts at your army's ship, and the goal is to advance and destroy your enemy's rations depot faster than they can destroy yours.";
+	mes("[Croix Knight]");
+	mes("The battle starts at your army's ship, and the goal is to advance and destroy your enemy's rations depot faster than they can destroy yours.");
 	next;
-	mes "[Croix Knight]";
-	mes "The healer of the battlefield will resurrect soldiers once every 25 seconds so that they can rejoin the battle.";
-	mes "The army that captures the neutral flag in the center of the battlefield will be rewarded with extra regeneration points, meaning their soldiers will resurrect more than the other side, giving them an advantage.";
+	mes("[Croix Knight]");
+	mes("The healer of the battlefield will resurrect soldiers once every 25 seconds so that they can rejoin the battle.");
+	mes("The army that captures the neutral flag in the center of the battlefield will be rewarded with extra regeneration points, meaning their soldiers will resurrect more than the other side, giving them an advantage.");
 	next;
-	mes "[Croix Knight]";
-	mes "Those two rations depots are connected to each other through short and narrow paths, but the gates are blocked with barricades.";
-	mes "Think and move as quickly as you can. The victory of your army relies on your contribution.";
+	mes("[Croix Knight]");
+	mes("Those two rations depots are connected to each other through short and narrow paths, but the gates are blocked with barricades.");
+	mes("Think and move as quickly as you can. The victory of your army relies on your contribution.");
 	next;
-	mes "[Croix Knight]";
-	mes "Please remember: when you join a battle, you will receive a token which indicates the set duration for which you cannot participate in the same type of battle.";
-	mes "You may check the duration by pressing the Alt+U keys.";
+	mes("[Croix Knight]");
+	mes("Please remember: when you join a battle, you will receive a token which indicates the set duration for which you cannot participate in the same type of battle.");
+	mes("You may check the duration by pressing the Alt+U keys.");
 	next;
-	mes "[Croix Knight]";
-	mes "Are you ready to battle? Then apply with the recruiter next to me!";
+	mes("[Croix Knight]");
+	mes("Are you ready to battle? Then apply with the recruiter next to me!");
 	close;
 }
 
 //== Second Tierra Gorge Officers - Croix ==================
 bat_room,125,121,1	script	Tierra Gorge Officer#01b	4_M_CRU_KNT,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Croix Army Officer]";
-	mes "Let's show the power of the Croix Army to those stinky Guillaumes!";
+	mes("[Croix Army Officer]");
+	mes("Let's show the power of the Croix Army to those stinky Guillaumes!");
 	next;
 	switch(select("I want to join your army!", "End Conversation")) {
 	case 1:
 		if ((Class == Job_Novice) || (BaseClass == Job_SuperNovice)) {
-			mes "[Croix Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Croix Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		if (BaseLevel < 80) {
-			mes "[Croix Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Croix Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		.@chk_urtime = questprogress(2069,PLAYTIME);
 		if (.@chk_urtime == 1) {
-			mes "[Croix Army Officer]";
-			mes "You seem to have just returned from the battlefield.";
-			mes "It's too early for you to go back. Go rest, and leave the enemies to us!";
+			mes("[Croix Army Officer]");
+			mes("You seem to have just returned from the battlefield.");
+			mes("It's too early for you to go back. Go rest, and leave the enemies to us!");
 			break;
 		}
 		if (.@chk_urtime == 2)
 			erasequest 2069;
 		if (getmapusers("bat_a02") > 0) {
-			mes "[Croix Army Officer]";
-			mes "I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Guillaume already.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Croix Army Officer]");
+			mes("I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Guillaume already.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
 		if ($@TierraBG1) {
-			mes "[Croix Army Officer]";
-			mes "An elite corps is already standing by to be dispatched to the battlefield.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Croix Army Officer]");
+			mes("An elite corps is already standing by to be dispatched to the battlefield.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
-		mes "[Croix Army Officer]";
-		mes "You definitely seem to be ready for battle!";
-		mes "Go show the Guillaumes what fear truly means!";
-		mes "Today, our cry of victory shall echo all over the battlefield!";
+		mes("[Croix Army Officer]");
+		mes("You definitely seem to be ready for battle!");
+		mes("Go show the Guillaumes what fear truly means!");
+		mes("Today, our cry of victory shall echo all over the battlefield!");
 		close2;
 		warp "bat_room",57,207;
 		end;
 	case 2:
-		mes "[Croix Army Officer]";
-		mes "Today, we shall be victorious!";
+		mes("[Croix Army Officer]");
+		mes("Today, we shall be victorious!");
 		break;
 	}
 	close;
@@ -312,59 +312,59 @@ bat_room,125,121,1	script	Tierra Gorge Officer#01b	4_M_CRU_KNT,{
 
 bat_room,140,121,1	script	Tierra Gorge Officer#02b	4_M_CRU_KNT,{
 	if (checkweight(Knife,1) == 0) {
-		mes "- Wait a minute !! -";
-		mes "- Currently you're carrying -";
-		mes "- too many items with you. -";
-		mes "- Please try again -";
-		mes "- after you loose some weight. -";
+		mes("- Wait a minute !! -");
+		mes("- Currently you're carrying -");
+		mes("- too many items with you. -");
+		mes("- Please try again -");
+		mes("- after you loose some weight. -");
 		close;
 	}
-	mes "[Croix Army Officer]";
-	mes "Let's show the power of the Croix Army to those stinky Guillaumes!";
+	mes("[Croix Army Officer]");
+	mes("Let's show the power of the Croix Army to those stinky Guillaumes!");
 	next;
 	switch(select("I want to join your army!", "End Conversation")) {
 	case 1:
 		if ((Class == Job_Novice) || (BaseClass == Job_SuperNovice)) {
-			mes "[Croix Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Croix Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		if (BaseLevel < 80) {
-			mes "[Croix Army Officer]";
-			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
+			mes("[Croix Army Officer]");
+			mes("I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.");
 			break;
 		}
 		.@chk_urtime = questprogress(2069,PLAYTIME);
 		if (.@chk_urtime == 1) {
-			mes "[Croix Army Officer]";
-			mes "You seem to have just returned from the battlefield.";
-			mes "It's too early for you to go back. Go rest, and leave the enemies to us!";
+			mes("[Croix Army Officer]");
+			mes("You seem to have just returned from the battlefield.");
+			mes("It's too early for you to go back. Go rest, and leave the enemies to us!");
 			break;
 		}
 		if (.@chk_urtime == 2)
 			erasequest 2069;
 		if (getmapusers("bat_a02") > 0) {
-			mes "[Croix Army Officer]";
-			mes "I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Guillaume already.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Croix Army Officer]");
+			mes("I've received a report informing me that an elite corps has been dispatched to the battlefield fighting the Guillaume already.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
 		if ($@TierraBG2) {
-			mes "[Croix Army Officer]";
-			mes "An elite corps is already standing by to be dispatched to the battlefield.";
-			mes "Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.";
+			mes("[Croix Army Officer]");
+			mes("An elite corps is already standing by to be dispatched to the battlefield.");
+			mes("Why don't you go wait for a while? I suggest you sharpen your weapons and prepare your supplies until then.");
 			break;
 		}
-		mes "[Croix Army Officer]";
-		mes "You definitely seem to be ready for battle!";
-		mes "Go show the Guillaumes what fear truly means!";
-		mes "Today, our cry of victory shall echo all over the battlefield!";
+		mes("[Croix Army Officer]");
+		mes("You definitely seem to be ready for battle!");
+		mes("Go show the Guillaumes what fear truly means!");
+		mes("Today, our cry of victory shall echo all over the battlefield!");
 		close2;
 		warp "bat_room",114,207;
 		end;
 	case 2:
-		mes "[Croix Army Officer]";
-		mes "Today, we shall be victorious!";
+		mes("[Croix Army Officer]");
+		mes("Today, we shall be victorious!");
 		break;
 	}
 	close;

--- a/npc/jobs/2-2/alchemist.txt
+++ b/npc/jobs/2-2/alchemist.txt
@@ -9,7 +9,7 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2012-2015  Hercules Dev Team
+//= Copyright (C) 2012-2016  Hercules Dev Team
 //= Copyright (C)  Kisuka
 //= Copyright (C)  L0ne_W0lf
 //= Copyright (C)  Vicious
@@ -131,7 +131,7 @@ alde_alche,27,185,5	script	Alchemist Guildsman#am	4_F_ALCHE,{
 			next;
 			mes "[Parmy Gianino]";
 			mes "Whether or not you try to become an Alchemist is your decision. The road to becoming an "
-				"Alchemist is very challenging, and you'll need to focus on experimentation and"
+				"Alchemist is very challenging, and you'll need to focus on experimentation and "
 				"research, instead of commerce.";
 			close;
 		case 2:
@@ -951,7 +951,7 @@ alde_alche,13,15,7	script	Studying Man#am	4_M_ALCHE_C,{
 		mes "......";
 		mes "Who is it...?";
 		next;
-		monster "alde_alche",13,15,"Wolf",1013,1;
+		monster("alde_alche", 13, 15, getmonsterinfo(WOLF, MOB_NAME), WOLF, 1);
 		killmonsterall "alde_alche";
 		mes "[Darwin]";
 		mes "A wolf?";

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -816,6 +816,7 @@ struct script_interface {
 	unsigned short (*mapindexname2id) (struct script_state *st, const char* name);
 	int (*string_dup) (char *str);
 	void (*load_translations) (void);
+	bool (*load_translation_addstring) (const char *file, uint8 lang_id, const char *msgctxt, const struct script_string_buf *msgid, const struct script_string_buf *msgstr);
 	int (*load_translation) (const char *file, uint8 lang_id);
 	int (*translation_db_destroyer) (union DBKey key, struct DBData *data, va_list ap);
 	void (*clear_translations) (bool reload);

--- a/src/plugins/generate-translations.c
+++ b/src/plugins/generate-translations.c
@@ -24,6 +24,7 @@
 #include "common/memmgr.h"
 #include "common/showmsg.h"
 #include "common/strlib.h"
+#include "common/sysinfo.h"
 #include "map/atcommand.h"
 #include "map/map.h"
 #include "map/script.h"
@@ -67,6 +68,8 @@ CMDLINEARG(generatetranslations)
 		time_t t = time(NULL);
 		struct tm *lt = localtime(&t);
 		int year = lt->tm_year+1900;
+		char timestring[128] = "";
+		strftime(timestring, sizeof(timestring), "%Y-%m-%d %H:%M:%S%z", lt);
 		fprintf(lang_export_fp,
 				"# This file is part of Hercules.\n"
 				"# http://herc.ws - http://github.com/HerculesWS/Hercules\n"
@@ -84,8 +87,22 @@ CMDLINEARG(generatetranslations)
 				"# GNU General Public License for more details.\n"
 				"#\n"
 				"# You should have received a copy of the GNU General Public License\n"
-				"# along with this program.  If not, see <http://www.gnu.org/licenses/>.\n",
-				year);
+				"# along with this program.  If not, see <http://www.gnu.org/licenses/>.\n\n"
+
+				"#,fuzzy\n"
+				"msgid \"\"\n"
+				"msgstr \"\"\n"
+				"\"Project-Id-Version: %s\\n\"\n"
+				"\"Report-Msgid-Bugs-To: dev@herc.ws\\n\"\n"
+				"\"POT-Creation-Date: %s\\n\"\n"
+				"\"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n\"\n"
+				"\"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n\"\n"
+				"\"Language-Team: LANGUAGE <LL@li.org>\\n\"\n"
+				"\"Language: \\n\"\n"
+				"\"MIME-Version: 1.0\\n\"\n"
+				"\"Content-Type: text/plain; charset=ISO-8859-1\\n\"\n"
+				"\"Content-Transfer-Encoding: 8bit\\n\"\n\n",
+				year, sysinfo->vcsrevision_scripts(), timestring);
 	}
 	generating_translations = true;
 	return true;

--- a/src/plugins/generate-translations.c
+++ b/src/plugins/generate-translations.c
@@ -48,6 +48,7 @@ FILE *lang_export_fp;
 char *lang_export_file;/* for lang_export_fp */
 struct script_string_buf lang_export_line_buf;
 struct script_string_buf lang_export_escaped_buf;
+int lang_export_stringcount;
 
 /// Whether the translations template generator will automatically run.
 bool generating_translations = false;
@@ -187,6 +188,7 @@ void script_add_translatable_string_posthook(const struct script_string_buf *str
 				script->parser_current_npc_name ? script->parser_current_npc_name : "Unknown NPC",
 				VECTOR_DATA(lang_export_escaped_buf)
 		);
+		lang_export_stringcount++;
 		VECTOR_TRUNCATE(lang_export_line_buf);
 		VECTOR_TRUNCATE(lang_export_escaped_buf);
 	}
@@ -232,6 +234,7 @@ bool msg_config_read_posthook(bool retVal, const char *cfg_name, bool allow_over
 					"msgstr \"\"\n",
 					atcommand->msg_table[0][i]
 			       );
+			lang_export_stringcount++;
 		}
 	}
 
@@ -248,6 +251,7 @@ HPExport void server_preinit(void)
 	addHookPre(script, parse, parse_script_prehook);
 	addHookPost(script, parser_clean_leftovers, script_parser_clean_leftovers_posthook);
 	addHookPost(atcommand, msg_read, msg_config_read_posthook);
+	lang_export_stringcount = 0;
 }
 
 HPExport void plugin_init(void)
@@ -257,7 +261,7 @@ HPExport void plugin_init(void)
 HPExport void server_online(void)
 {
 	if (generating_translations && lang_export_fp != NULL) {
-		ShowInfo("Lang exported to '%s'\n", lang_export_file);
+		ShowInfo("Translations template exported to '%s' with %d strings.\n", lang_export_file, lang_export_stringcount);
 		fclose(lang_export_fp);
 		lang_export_fp = NULL;
 	}


### PR DESCRIPTION
- Added support for concatenated strings in the .po files, as described in the [gettext documentation](https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html):

```
msgid ""
"Here is an example of how one might continue a very long string\n"
"for the common case the string represents multi-line output.\n"
```

- Added header to the generated .pot file (improves compatibility with online translation services such as transifex)

- Converted npc/airports/ and npc/battleground/ to a HULD-compliant format (simplifies translation, especially to languages that have different sentence order or are much more terse than English, as per HULD best practices)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1351)
<!-- Reviewable:end -->
