### PR TITLE
Fixes to Doctor Quest, Crazy Uproar Quest, Kafra HQ's Potato Trader

### DIFF
--- a/npc/cities/aldebaran.txt
+++ b/npc/cities/aldebaran.txt
@@ -36,7 +36,7 @@
 //================= Description ===========================================
 //= Aldebaran Town NPCs
 //================= Current Version =======================================
-//= 2.3
+//= 2.4
 //=========================================================================
 
 //== Aldebaran =============================================
@@ -1098,7 +1098,7 @@ aldeba_in,79,161,6	script	Kafra#04	4_F_KAFRA3,{
 		.@list$ = "";
 		.@numitemchoices = 0;
 		for (.@i = 0; .@i < getarraysize(.@choices) - 3; .@i += 3) { // Skip the last entry as it's handled separately
-			.@list$ += .@choices[i] + "- " + getitemname(.@choices[.@i+1]) + " " + .@choices[.@i+2] + " ea:";
+			.@list$ += .@choices[.@i] + "- " + getitemname(.@choices[.@i+1]) + " " + .@choices[.@i+2] + " ea:";
 			++.@numitemchoices;
 		}
 		.@list$ += .@choices[.@i] + "- " + .@ordinal$ + " Lottery Chance!:" + .@changepage$ +":Cancel";
@@ -1111,7 +1111,7 @@ aldeba_in,79,161,6	script	Kafra#04	4_F_KAFRA3,{
 				continue;
 			}
 			RESRVPTS -= .@choices[.@chosen * 3];
-			if (.@chosen < .@numitemchances) {
+			if (.@chosen < .@numitemchoices) {
 				// Item
 				mes "[Kafra]";
 				mes "Here you are.";

--- a/npc/quests/quests_louyang.txt
+++ b/npc/quests/quests_louyang.txt
@@ -1429,6 +1429,7 @@ lou_in02,265,69,5	script	Doctor#lyang	4_F_CHNDOCTOR,{
 		mes "^3355FF10 Sprout^000000 and";
 		mes "^3355FF5 Honey Pot^000000.";
 		ch_par = 17;
+		changequest 11056,11057;
 		close;
 	}
 	else if (ch_par == 17) {

--- a/npc/quests/skills/merchant_skills.txt
+++ b/npc/quests/skills/merchant_skills.txt
@@ -36,7 +36,7 @@
 //================= Description ===========================================
 //= Quests for skills: Crazy Uproar, Change Cart, Cart Revolution
 //================= Current Version =======================================
-//= 1.8
+//= 1.9
 //=========================================================================
 
 alberta,83,96,5	script	Necko	4W_M_02,7,7,{
@@ -65,7 +65,7 @@ alberta,83,96,5	script	Necko	4W_M_02,7,7,{
 			mes "Ppyakikakikakakakakakakaka!!";
 			close;
 		}
-		else if (JobLevel < 15) {
+		else if (BaseJob == Job_Merchant && JobLevel < 15) {
 			mes "[Necko]";
 			mes "Oh, did you come because";
 			mes "you are infatuated with my voice?";
@@ -86,7 +86,7 @@ alberta,83,96,5	script	Necko	4W_M_02,7,7,{
 			mes "Kyukwakakakakakakakakakaka!";
 			close;
 		}
-		else if ((countitem(Scarlet_Jewel) > 6) && (countitem(Banana_Juice) > 0) && (countitem(Mushroom_Spore) > 49) && (JobLevel >= 15 || (BaseJob == Job_Blacksmith || BaseJob == Job_Alchemist))) {
+		else if ((countitem(Scarlet_Jewel) > 6) && (countitem(Banana_Juice) > 0) && (countitem(Mushroom_Spore) > 49)) {
 			mes "[Necko]";
 			mes "Oh! You!";
 			mes "You are qualified to learn how to shout!";


### PR DESCRIPTION
This request includes 3 fixes to quite old NPCs.
Luyoang Doctor Quest: Questlog being not cleared fixed.
Crazy Uproar Quest: Fixed requirements. (Blacksmiths & Alchemists needed Job Level 15 or higher, which is wrong)
Kafra Headquarter's Potato Trader: Fixed the menu being displayed incorrectly as well him entering you always into the lottery, without caring for your selection.

All tested(except Crazy Uproar Quest Fix) and working nicely on OriginsRO. ~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1392)
<!-- Reviewable:end -->
