### PR TITLE
Enable @b/joblvl trigger OnPCLvUpEvent

### DIFF
--- a/conf/battle/gm.conf
+++ b/conf/battle/gm.conf
@@ -35,3 +35,8 @@ atcommand_mobinfo_type: 0
 // Set the minimum group id to ignore invalid cells when warping.
 // Default group is 2. Use 100 to disable this setting.
 gm_ignore_warpable_area: 2
+
+// Should atcommands trigger level up events for NPCs? (Note 1)
+// This option is for @baselevelup and @joblevelup
+// Default: no
+atcommand_levelup_events: no

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -1398,6 +1398,7 @@ ACMD(baselevelup)
 		sd->status.base_level -= level;
 		clif->message(fd, msg_fd(fd,22)); // Base level lowered.
 		status_calc_pc(sd, SCO_FORCE);
+		level *= -1;
 	}
 	sd->status.base_exp = 0;
 	clif->updatestatus(sd, SP_STATUSPOINT);
@@ -1407,7 +1408,9 @@ ACMD(baselevelup)
 	pc->baselevelchanged(sd);
 	if(sd->status.party_id)
 		party->send_levelup(sd);
-	npc->script_event(sd, NPCE_BASELVUP); // Trigger OnPCBaseLvUpEvent
+	
+	if (level > 0 && battle_config.atcommand_levelup_events)
+		npc->script_event(sd, NPCE_BASELVUP); // Trigger OnPCBaseLvUpEvent
 
 	return true;
 }
@@ -1450,6 +1453,7 @@ ACMD(joblevelup)
 		else
 			sd->status.skill_point -= level;
 		clif->message(fd, msg_fd(fd,25)); // Job level lowered.
+		level *= -1;
 	}
 	sd->status.job_exp = 0;
 	clif->updatestatus(sd, SP_JOBLEVEL);
@@ -1457,7 +1461,9 @@ ACMD(joblevelup)
 	clif->updatestatus(sd, SP_NEXTJOBEXP);
 	clif->updatestatus(sd, SP_SKILLPOINT);
 	status_calc_pc(sd, SCO_FORCE);
-	npc->script_event(sd, NPCE_JOBLVUP); // Trigger OnPCJobLvUpEvent
+
+	if (level > 0 && battle_config.atcommand_levelup_events)
+		npc->script_event(sd, NPCE_JOBLVUP); // Trigger OnPCJobLvUpEvent
 
 	return true;
 }

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -1407,6 +1407,8 @@ ACMD(baselevelup)
 	pc->baselevelchanged(sd);
 	if(sd->status.party_id)
 		party->send_levelup(sd);
+	npc->script_event(sd, NPCE_BASELVUP); // Trigger OnPCBaseLvUpEvent
+
 	return true;
 }
 
@@ -1455,6 +1457,7 @@ ACMD(joblevelup)
 	clif->updatestatus(sd, SP_NEXTJOBEXP);
 	clif->updatestatus(sd, SP_SKILLPOINT);
 	status_calc_pc(sd, SCO_FORCE);
+	npc->script_event(sd, NPCE_JOBLVUP); // Trigger OnPCJobLvUpEvent
 
 	return true;
 }

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7248,6 +7248,7 @@ static const struct battle_data {
 	{ "max_body_style",                     &battle_config.max_body_style,                  4,      0,      SHRT_MAX,       },
 	{ "save_body_style",                    &battle_config.save_body_style,                 0,      0,      1,              },
 	{ "player_warp_keep_direction",         &battle_config.player_warp_keep_direction,      0,      0,      1,              },
+	{ "atcommand_levelup_events",	        &battle_config.atcommand_levelup_events,	    0,      0,      1,				},
 };
 #ifndef STATS_OPT_OUT
 /**

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -542,6 +542,8 @@ struct Battle_Config {
 
 	// Warp Face Direction
 	int player_warp_keep_direction;
+
+	int atcommand_levelup_events;	// Enable atcommands trigger level up events for NPCs
 };
 
 /* criteria for battle_config.idletime_critera */


### PR DESCRIPTION
- OnPCBaseLvUpEvent
- OnPCJobLvUpEvent

Useful when debug `OnPCBaseLvUpEvent` / `OnPCJobLvUpEvent` script. 
Especially in a low rate server, you don't have to kill hundred of mob to gain a level to trigger the event to test the script you want to build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1396)
<!-- Reviewable:end -->
