### PR TITLE
Corrected the showscript packet

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -17747,7 +17747,7 @@ void clif_ShowScript(struct block_list *bl, const char *message)
 	WBUFW(buf,2) = len+8;
 	WBUFL(buf,4) = bl->id;
 	safestrncpy(WBUFP(buf,8),message,len);
-	clif->send(buf,WBUFW(buf,2),bl,ALL_CLIENT);
+	clif->send(buf,WBUFW(buf,2),bl,AREA);
 }
 
 void clif_status_change_end(struct block_list *bl, int tid, enum send_target target, int type) {


### PR DESCRIPTION
The showscript packet was being sent to all players logged in which can be
network intensive.
Thanks to @Tokeiburu & aleos89!
Based on https://github.com/rathena/rathena/commit/47a69c082a9520f14b19ebfd335c4956d0c5a13b

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1401)
<!-- Reviewable:end -->
