### PR TITLE
Fixes for npc_removed_list and map_removed

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -3996,7 +3996,7 @@ bool map_config_read_map_list(const char *filename, struct config_t *config, boo
 	nullpo_retr(false, filename);
 	nullpo_retr(false, config);
 
-	deleted_maps = strdb_alloc(DB_OPT_DUP_KEY|DB_OPT_RELEASE_KEY|DB_OPT_ALLOW_NULL_DATA, MAP_NAME_LENGTH);
+	deleted_maps = strdb_alloc(DB_OPT_DUP_KEY|DB_OPT_ALLOW_NULL_DATA, MAP_NAME_LENGTH);
 
 	// Remove maps
 	if ((setting = libconfig->lookup(config, "map_configuration/map_removed")) != NULL) {
@@ -4136,9 +4136,9 @@ bool map_read_npclist(const char *filename, bool imported)
 	if (!libconfig->load_file(&config, filename))
 		return false;
 
-	deleted_npcs = strdb_alloc(DB_OPT_DUP_KEY|DB_OPT_RELEASE_KEY, MAP_NAME_LENGTH);
+	deleted_npcs = strdb_alloc(DB_OPT_DUP_KEY|DB_OPT_ALLOW_NULL_DATA, MAP_NAME_LENGTH);
 
-	// Remove maps
+	// Remove NPCs
 	if ((setting = libconfig->lookup(&config, "npc_removed_list")) != NULL) {
 		int i, del_count = libconfig->setting_length(setting);
 		for (i = 0; i < del_count; i++) {
@@ -4149,7 +4149,7 @@ bool map_read_npclist(const char *filename, bool imported)
 
 			strdb_put(deleted_npcs, scriptname, NULL);
 
-			if (imported) // Map list is empty on the first run, only do this for imported files.
+			if (imported) // NPC list is empty on the first run, only do this for imported files.
 				npc->delsrcfile(scriptname);
 		}
 	}

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -4212,7 +4212,7 @@ bool map_read_npclist(const char *filename, bool imported)
 void map_reloadnpc(bool clear) {
 	int i;
 	if (clear)
-		npc->addsrcfile("clear"); // this will clear the current script list
+		npc->clearsrcfile();
 
 #ifdef RENEWAL
 	map->read_npclist("npc/re/scripts_main.conf", false);

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -4128,6 +4128,7 @@ bool map_read_npclist(const char *filename, bool imported)
 	struct config_setting_t *setting = NULL;
 	const char *import = NULL;
 	bool retval = true;
+	bool remove_all = false;
 
 	struct DBMap *deleted_npcs;
 
@@ -4147,10 +4148,13 @@ bool map_read_npclist(const char *filename, bool imported)
 			if ((scriptname = libconfig->setting_get_string_elem(setting, i)) == NULL || scriptname[0] == '\0')
 				continue;
 
-			strdb_put(deleted_npcs, scriptname, NULL);
-
-			if (imported) // NPC list is empty on the first run, only do this for imported files.
+			if (strcmp(scriptname, "all") == 0) {
+				remove_all = true;
+				npc->clearsrcfile();
+			} else {
+				strdb_put(deleted_npcs, scriptname, NULL);
 				npc->delsrcfile(scriptname);
+			}
 		}
 	}
 
@@ -4168,7 +4172,7 @@ bool map_read_npclist(const char *filename, bool imported)
 			if ((scriptname = libconfig->setting_get_string_elem(setting, i)) == NULL || scriptname[0] == '\0')
 				continue;
 
-			if (strdb_exists(deleted_npcs, scriptname))
+			if (remove_all || strdb_exists(deleted_npcs, scriptname))
 				continue;
 
 			npc->addsrcfile(scriptname);

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -2464,24 +2464,21 @@ void npc_addsrcfile(const char* name)
 		file_prev->next = file;
 }
 
-/// Removes a npc source file (or all)
-void npc_delsrcfile(const char* name)
+/**
+ * Removes a npc source file.
+ *
+ * @param name The file name to remove.
+ */
+void npc_delsrcfile(const char *name)
 {
 	struct npc_src_list* file = npc->src_files;
 	struct npc_src_list* file_prev = NULL;
 
 	nullpo_retv(name);
-	if( strcmpi(name, "all") == 0 )
-	{
-		npc->clearsrcfile();
-		return;
-	}
 
-	while( file != NULL )
-	{
-		if( strcmp(file->name, name) == 0 )
-		{
-			if( npc->src_files == file )
+	while (file != NULL) {
+		if (strcmp(file->name, name) == 0) {
+			if (npc->src_files == file)
 				npc->src_files = file->next;
 			else
 				file_prev->next = file->next;

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -2432,24 +2432,22 @@ void npc_clearsrcfile(void)
 	npc->src_files = NULL;
 }
 
-/// Adds a npc source file (or removes all)
-void npc_addsrcfile(const char* name)
+/**
+ * Adds a npc source file.
+ *
+ * @param name The file name to add.
+ */
+void npc_addsrcfile(const char *name)
 {
 	struct npc_src_list* file;
 	struct npc_src_list* file_prev = NULL;
 
 	nullpo_retv(name);
-	if( strcmpi(name, "clear") == 0 )
-	{
-		npc->clearsrcfile();
-		return;
-	}
 
 	// prevent multiple insert of source files
 	file = npc->src_files;
-	while( file != NULL )
-	{
-		if( strcmp(name, file->name) == 0 )
+	while (file != NULL) {
+		if (strcmp(name, file->name) == 0)
 			return;// found the file, no need to insert it again
 		file_prev = file;
 		file = file->next;


### PR DESCRIPTION
Fixed various issues in the functions that process npc_removed_list and map_removed

- Corrected DBMap options
- Re-implemented (and optimized) handling of "all" in npc_removed_list
- Removed the now useless special handling of `npc->addsrcfile("clear")` and `npc->delsrcfile("all")`, both superseded by `npc->clearsrcfile()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1435)
<!-- Reviewable:end -->
