### PR TITLE
use mediumint for equip_locations in item_db.sql & item_db_re.sql

### DIFF
--- a/src/plugins/db2sql.c
+++ b/src/plugins/db2sql.c
@@ -457,7 +457,7 @@ void itemdb2sql_tableheader(void)
 			"  `equip_jobs` bigint(20) UNSIGNED DEFAULT NULL,\n"
 			"  `equip_upper` tinyint(8) UNSIGNED DEFAULT NULL,\n"
 			"  `equip_genders` tinyint(2) UNSIGNED DEFAULT NULL,\n"
-			"  `equip_locations` smallint(4) UNSIGNED DEFAULT NULL,\n"
+			"  `equip_locations` mediumint(8) UNSIGNED DEFAULT NULL,\n"
 			"  `weapon_level` tinyint(2) UNSIGNED DEFAULT NULL,\n"
 			"  `equip_level_min` smallint(5) UNSIGNED DEFAULT NULL,\n"
 			"  `equip_level_max` smallint(5) UNSIGNED DEFAULT NULL,\n"


### PR DESCRIPTION
Trying to fix this error when importing `item_db_re.sql`.

```
ERROR 1264 (22003) at line 9768: Out of range value for column 'equip_locations' at row 1
```
Seems we are trying to insert `65536` to an `unsigned smallint` which could only handle `65535`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1451)
<!-- Reviewable:end -->
