### PR TITLE
Fixes Range Exploit

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1460,7 +1460,7 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 		} else if( src->type == BL_MER && skill_id == MA_REMOVETRAP ) {
 			if( !battle->check_range(battle->get_master(src), target, range + 1) )
 				return 0; // Aegis calc remove trap based on Master position, ignoring mercenary O.O
-		} else if( !battle->check_range(src, target, range + (skill_id == RG_CLOSECONFINE?0:2)) ) {
+		} else if (!battle->check_range(src, target, range)) {
 			return 0; // Arrow-path check failed.
 		}
 	}


### PR DESCRIPTION
issue #841
[Original Commit by Playtester on rAthena](https://github.com/rathena/rathena/commit/6f74f67da060a063183e1147dfc893c9454af853)
- Players will no longer get +2 range server-sided when using a target spell
- This will prevent players from modifying the client to get extra range

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1457)

<!-- Reviewable:end -->
