### PR TITLE
Fix cases were player were executed

### DIFF
--- a/npc/cities/jawaii.txt
+++ b/npc/cities/jawaii.txt
@@ -862,7 +862,7 @@ jawaii_in,28,124,0	script	Bartender#jaw	1_ETC_01,{
 		mes "["+strcharinfo(PC_NAME)+"]";
 		mes "Thank you.";
 		close2;
-		percentheal -100,0;
+		unitkill getcharid(CHAR_ID_ACCOUNT);
 		end;
 	}
 	while (1) {
@@ -893,7 +893,7 @@ jawaii_in,28,124,0	script	Bartender#jaw	1_ETC_01,{
 				mes "Thank you...";
 				mes "So much...";
 				close2;
-				percentheal -100,0;
+				unitkill getcharid(CHAR_ID_ACCOUNT);
 				end;
 			}
 			if (Zeny > 99) Zeny -= 100;
@@ -1103,7 +1103,7 @@ S_KillChar:
 		mes "Thank you...";
 		mes "Mr. Bartender...";
 		close2;
-		percentheal -100,0;
+		unitkill getcharid(CHAR_ID_ACCOUNT);
 		end;
 	}
 	if (Zeny > 99) Zeny -= 100;
@@ -1154,8 +1154,9 @@ jawaii_in,43,115,0	script	Customer#jaw_1	4W_M_01,{
 		mes "the one who laughs last!";
 		next;
 		mes "^3355FFYou drank to your fill.^000000";
-		close;
-		percentheal -100,0;
+		close2;
+		unitkill getcharid(CHAR_ID_ACCOUNT);
+		end;
 	}
 	mes "[Buchi]";
 	mes "You look happy...";

--- a/npc/cities/umbala.txt
+++ b/npc/cities/umbala.txt
@@ -1021,7 +1021,7 @@ umbala,140,197,1	script	Bungee Jump	FAKE_NPC,0,0,{
 OnTouch:
 	switch(rand(1,3)) {
 	case 1:
-		percentheal -100,0;
+		Hp = 1;
 		mapannounce "umbala","Bungee Jump: "+strcharinfo(PC_NAME)+" : Kyaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~~~~~~~",bc_map;
 		end;
 	case 2:
@@ -1030,7 +1030,7 @@ OnTouch:
 		end;
 	case 3:
 		if (rand(1,2) == 2) {
-			percentheal -99,0;
+			Hp = 1;
 			warp "nif_in",69,15;
 		}
 		end;

--- a/npc/custom/etc/monster_arena.txt
+++ b/npc/custom/etc/monster_arena.txt
@@ -724,7 +724,8 @@ L_Heal:
 
 function	script	illegalkill	{
 	announce "Illegal Kill by " + strcharinfo(PC_NAME) + " Detected",1;
-	percentheal -100,-100;
+	Sp = 0;
+	unitkill getcharid(CHAR_ID_ACCOUNT);
 	end;
 }
 

--- a/npc/custom/etc/rpsroulette.txt
+++ b/npc/custom/etc/rpsroulette.txt
@@ -96,7 +96,8 @@ cmd_in02,182,126,2	script	Crazy Boris	4_M_03,{
 			mes "*^0000FFClick^000000* *^FF0000BANG^000000*";
 			mes "You're dead!";
 			emotion e_gg;
-			percentheal -100,-100;
+			Sp = 0;
+			unitkill getcharid(CHAR_ID_ACCOUNT);
 			close;
 		}
 		specialeffect EF_SUI_EXPLOSION;

--- a/npc/other/divorce.txt
+++ b/npc/other/divorce.txt
@@ -211,7 +211,8 @@ nif_in,190,112,5	script	Deviruchi#divorce	4_DEVIRUCHI,{
 		specialeffect2 EF_DEVIL;
 		wedding_sign = 0;
 		Zeny -= 2500000;
-		percentheal -100,-100;
+		Sp = 0;
+		Hp = 1;
 		divorce;
 		mes "[Deviruchi]";
 		mes "Bwahhahahaha~!";

--- a/npc/quests/eye_of_hellion.txt
+++ b/npc/quests/eye_of_hellion.txt
@@ -395,7 +395,7 @@ morocc_in,116,101,3	script	Old Scholar Tyus#hellion	4_M_JOB_WIZARD,3,3,{
 		mes "you now before you are";
 		mes "consumed by its darkness!";
 		close2;
-		percentheal -100,0;
+		unitkill getcharid(CHAR_ID_ACCOUNT);
 		end;
 	}
 	else if (HELLIONQ > 57 && HELLIONQ < 66) {
@@ -435,7 +435,7 @@ morocc_in,116,101,3	script	Old Scholar Tyus#hellion	4_M_JOB_WIZARD,3,3,{
 		mes "you now before you are";
 		mes "consumed by its darkness!";
 		close;
-		percentheal -100,0;
+		unitkill getcharid(CHAR_ID_ACCOUNT);
 		end;
 	}
 	else if (HELLIONQ == 67) {
@@ -1853,7 +1853,7 @@ pay_arche,142,28,0	script	Buddha Statue#paypuzz6	HIDDEN_NPC,5,5,{
 			mes "to your answer. However...";
 			mes "You have chosen poorly.";
 			close2;
-			percentheal -100,0;
+			unitkill getcharid(CHAR_ID_ACCOUNT);
 			end;
 		case 2:
 			mes "[Echoing Voice]";
@@ -1863,7 +1863,7 @@ pay_arche,142,28,0	script	Buddha Statue#paypuzz6	HIDDEN_NPC,5,5,{
 			mes "where is the respect for your";
 			mes "own life? If you are that willing to throw it away, you are no hero.";
 			close2;
-			percentheal -100,0;
+			unitkill getcharid(CHAR_ID_ACCOUNT);
 			end;
 		case 3:
 			mes "[Echoing Voice]";
@@ -1889,7 +1889,7 @@ pay_arche,142,28,0	script	Buddha Statue#paypuzz6	HIDDEN_NPC,5,5,{
 			mes "your own cowardice. You have";
 			mes "chosen extremely poorly...";
 			close2;
-			percentheal -100,0;
+			unitkill getcharid(CHAR_ID_ACCOUNT);
 			end;
 		}
 	}

--- a/npc/quests/okolnir.txt
+++ b/npc/quests/okolnir.txt
@@ -44,7 +44,7 @@ function	script	F_Okolnir	{
 -	script	Guide#gq_main	FAKE_NPC,{
 	.@sub$ = callfunc("F_Okolnir");
 	.@GID = getcastledata(strnpcinfo(NPC_MAP),1);
-	if (getcharid(2) == .@GID) {
+	if (getcharid(CHAR_ID_GUILD) == .@GID) {
 		if (getd("$siz_"+.@sub$+"_on") == 0) {
 			mes "[Guide]";
 			mes "This castle has a hidden secret.";
@@ -192,7 +192,7 @@ que_qsch05,345,23,0	warp	Gate02#gq_sch05	1,1,schg_cas05,369,306
 	.@sub$ = callfunc("F_Okolnir");
 	.@t$ = ((compare(strnpcinfo(NPC_MAP),"aru"))?"arug_cas0":"schg_cas0")+(charat(strnpcinfo(NPC_MAP),getstrlen(strnpcinfo(NPC_MAP))-1));
 	.@GID = getcastledata(.@t$,1);
-	if (getcharid(2) == .@GID) {
+	if (getcharid(CHAR_ID_GUILD) == .@GID) {
 		cutin "wish_maiden31",1;
 		if (strcharinfo(PC_NAME) == getguildmaster(.@GID)) {
 			mes "[Wish Maiden]";
@@ -358,7 +358,7 @@ que_qsch05,345,23,0	warp	Gate02#gq_sch05	1,1,schg_cas05,369,306
 		mes "[Wish Maiden]";
 		mes "...You are not qualified.";
 		close2;
-		percentheal -100,0;
+		unitkill getcharid(CHAR_ID_ACCOUNT);
 		cutin "wish_maiden11",255;
 		end;
 	}
@@ -2161,7 +2161,7 @@ que_qsch05,251,255,3	duplicate(Wish Maiden#main_boss)	Wish Maiden#sch05_boss	WIS
 	.@sub$ = callfunc("F_Okolnir");
 	.@t$ = ((compare(strnpcinfo(NPC_MAP),"aru"))?"arug_cas0":"schg_cas0")+(charat(strnpcinfo(NPC_MAP),getstrlen(strnpcinfo(NPC_MAP))-1));
 	.@GID = getcastledata(.@t$,1);
-	if (getcharid(2) == .@GID) {
+	if (getcharid(CHAR_ID_GUILD) == .@GID) {
 		if (strcharinfo(PC_NAME) == getguildmaster(.@GID)) {
 			if (compare(.@sub$,"aru")) {
 				setarray .@n, 7835,1,7836,1,7837,1,7838,1,2513,1,7291,10,7293,10,7063,100,985,20;

--- a/npc/quests/quests_13_1.txt
+++ b/npc/quests/quests_13_1.txt
@@ -13912,7 +13912,7 @@ que_dan02,115,53,3	script	Man#moc2_crazyR01	4_M_DSTMAN,{
 		mes "Are you his enemy?";
 		mes "DIE!";
 		close2;
-		percentheal -100,0;
+		unitkill getcharid(CHAR_ID_ACCOUNT);
 		end;
 	}
 	cutin "mocseal_kid01",255;

--- a/npc/quests/quests_ayothaya.txt
+++ b/npc/quests/quests_ayothaya.txt
@@ -1947,7 +1947,7 @@ ayo_dun01,272,26,0	duplicate(AyoTrap1)	 #th_dun1_1_4	HIDDEN_NPC
 
 ayo_dun01,26,27,0	script	 #th_dun1_1::AyoTrap2	FAKE_NPC,1,1,{
 OnTouch:
-	percentheal -100,0;
+	unitkill getcharid(CHAR_ID_ACCOUNT);
 	end;
 }
 

--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -8624,10 +8624,10 @@ OnTouch:
 			mes "- You hear a splashing as -";
 			mes "- something gleaming -";
 			mes "- seems to stare at you!! -";
-			next;
+			close2;
 			specialeffect2 EF_FLASHER;
-			percentheal -100,0;
-			close;
+			unitkill getcharid(CHAR_ID_ACCOUNT);
+			end;
 		}
 	} else if (rhea_rus_hair > 2 && rhea_rus_hair < 7) {
 		mes "[Lusalka's Voice]";
@@ -8646,9 +8646,10 @@ OnTouch:
 				close;
 			}
 			mes "-You seem to hear the splash but something gleaming raids on you!!-";
+			close2;
 			specialeffect2 EF_FLASHER;
-			percentheal -100,0;
-			close;
+			unitkill getcharid(CHAR_ID_ACCOUNT);
+			end;
 		}
 	} else if (rhea_rus_hair == 8) {
 		mes "["+ strcharinfo(PC_NAME) +"]";
@@ -8884,10 +8885,11 @@ mosk_fild02,124,202,3	script	Lusalka#rus23	4_F_RUSGREEN,{
 		end;
 	}
 	mes "-When Lusalka watches you, you are blacked out-";
+	close2;
 	specialeffect2 EF_FLASHER;
-	percentheal -100,0;
+	unitkill getcharid(CHAR_ID_ACCOUNT);
 	donpcevent "Lusalka#rus23::OnDisable";
-	close;
+	end;
 
 OnInit:
 	disablenpc "Lusalka#rus23";

--- a/npc/quests/seals/megingard_seal.txt
+++ b/npc/quests/seals/megingard_seal.txt
@@ -1859,7 +1859,7 @@ morocc_in,146,179,0	script	Employee#megin1	1_F_01,{
 							mes "^3355FFThe Inn Employee";
 							mes "knocks you out~^000000";
 							close2;
-							percentheal -100,0;
+							unitkill getcharid(CHAR_ID_ACCOUNT);
 							end;
 						}
 						else {
@@ -1897,7 +1897,8 @@ morocc_in,146,179,0	script	Employee#megin1	1_F_01,{
 							mes "^3355FFThe Inn Employee";
 							mes "knocks you out~^000000";
 							close2;
-							percentheal -100,0;
+							unitkill getcharid(CHAR_ID_ACCOUNT);
+							end;
 						}
 						else {
 							mes "[Ms. Scary Inn Employee]";
@@ -1937,7 +1938,7 @@ morocc_in,146,179,0	script	Employee#megin1	1_F_01,{
 							mes "^3355FFThe Inn Employee";
 							mes "knocks you out~^000000";
 							close2;
-							percentheal -100,0;
+							unitkill getcharid(CHAR_ID_ACCOUNT);
 							end;
 						}
 						else {

--- a/npc/quests/the_sign_quest.txt
+++ b/npc/quests/the_sign_quest.txt
@@ -4484,9 +4484,8 @@ cmd_in02,88,51,4	script	Strange Guy#sign	1_M_SIGNART,{
 				mes "I'll freakin' beat you to near";
 				mes "freakin' death! Bam bam bam!";
 				close2;
-				percentheal -100,0;
 				soundeffect "effect\\sign_noise.wav",1;
-				percentheal -99,0;
+				Hp = 1;
 				warp "comodo",122,100;
 				end;
 			case 2:
@@ -6837,7 +6836,7 @@ yuno,330,100,4	script	Knight#ss	4_M_JOB_KNIGHT2,{
 			}
 		}
 		else {
-			.@signid = getcharid(0,strcharinfo(PC_NAME));
+			.@signid = getcharid(CHAR_ID_CHAR,strcharinfo(PC_NAME));
 			.@sign3 = .@signid & 65535;
 			.@sign4 = .@signid >> 16;
 			.@sign1 = 254;
@@ -10764,7 +10763,7 @@ que_sign01,45,227,4	script	Queen of the Dead	2_F_SIGN1,{
 		mes "invitation? Insolent mortal!";
 		mes "Go back to where you belong!^000000";
 		close2;
-		percentheal -100,0;
+		unitkill getcharid(CHAR_ID_ACCOUNT);
 		end;
 	}
 	else if (sign_q == 117) {
@@ -12202,7 +12201,7 @@ que_sign01,46,56,0	script	Fountain#sign	HIDDEN_NPC,{
 		case 1:
 			mes "...";
 			close2;
-			percentheal -100,0;
+			unitkill getcharid(CHAR_ID_ACCOUNT);
 			end;
 		case 2:
 			mes "...";


### PR DESCRIPTION
Fixes #1176

On Aegis players set their HP to 0 by script are still alive. Since we don't want to copy this, scripts that set HP to 0 and expects the player to stay alive are changed.
Additionally some scripts where changed where the HP were set to 1% instead to 1 HP and also the percentheal -100 with intended death set into close2. In megingard_seal.txt a end; was missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1473)
<!-- Reviewable:end -->
