### PR TITLE
Fix wrong skill name used to increase damage

### DIFF
--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -124966,13 +124966,12 @@ item_db: (
 	EquipLv: 102
 	View: 8
 	Script: <"
-		if(getrefine()>=6) {
-			bonus2 bSkillAtk,GN_CRAZYWEED,20+((getrefine()-5)*2);
-			bonus2 bSkillAtk,GN_DEMONIC_FIRE,20+((getrefine()-5)*2);
-		}
-		else {
-			bonus2 bSkillAtk,GN_CRAZYWEED,20;
-			bonus2 bSkillAtk,GN_DEMONIC_FIRE,20;
+		if (getrefine() >= 6) {
+			bonus2 bSkillAtk, GN_CRAZYWEED_ATK, 20 + ((getrefine()-5)*2);
+			bonus2 bSkillAtk, GN_DEMONIC_FIRE, 20 + ((getrefine()-5)*2);
+		} else {
+			bonus2 bSkillAtk, GN_CRAZYWEED_ATK, 20;
+			bonus2 bSkillAtk, GN_DEMONIC_FIRE, 20;
 		}
 	">
 },
@@ -135651,19 +135650,21 @@ item_db: (
 	EquipLv: 100
 	View: 912
 	Script: <"
-		bonus2 bSkillAtk,WL_CRIMSONROCK,5;
-		bonus2 bSkillAtk,WL_JACKFROST,5;
-		bonus2 bSkillAtk,WL_EARTHSTRAIN,5;
-		bonus2 bSkillAtk,WL_CHAINLIGHTNING,5;
-		bonus2 bIgnoreMdefRate,RC_NonBoss,10;
-		bonus2 bIgnoreMdefRate,RC_NonBoss,getrefine()*2;
-		if(getrefine()>6) {
-			bonus2 bSkillAtk,WL_CRIMSONROCK,5;
-			bonus2 bSkillAtk,WL_JACKFROST,5;
-			bonus2 bSkillAtk,WL_EARTHSTRAIN,5;
-			bonus2 bSkillAtk,WL_CHAINLIGHTNING,5;
+		bonus2 bSkillAtk, WL_CRIMSONROCK, 5;
+		bonus2 bSkillAtk, WL_JACKFROST, 5;
+		bonus2 bSkillAtk, WL_EARTHSTRAIN, 5;
+		bonus2 bSkillAtk, WL_CHAINLIGHTNING_ATK, 5;
+		bonus2 bIgnoreMdefRate, RC_NonBoss, 10;
+		bonus2 bIgnoreMdefRate, RC_NonBoss, getrefine() * 2;
+		if (getrefine() > 6) {
+			bonus2 bSkillAtk, WL_CRIMSONROCK, 5;
+			bonus2 bSkillAtk, WL_JACKFROST, 5;
+			bonus2 bSkillAtk, WL_EARTHSTRAIN, 5;
+			bonus2 bSkillAtk, WL_CHAINLIGHTNING_ATK, 5;
 		}
-		if(getrefine()>8) { bonus bMatkRate,5; }
+		if (getrefine() > 8) {
+			bonus bMatkRate, 5; 
+		}
 	">
 },
 {


### PR DESCRIPTION
This fix for 
GN_CRAZYWEED and WL_CHAINLIGHTNING
should be
GN_CRAZYWEED_ATK
WL_CHAINLIGHTNING_ATK

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1487)

<!-- Reviewable:end -->
