### PR TITLE
Update Duel System Cooldown

### DIFF
--- a/conf/map/battle/misc.conf
+++ b/conf/map/battle/misc.conf
@@ -101,7 +101,7 @@ duel_allow_teleport: false
 // Autoleave duel when die
 duel_autoleave_when_die: true
 
-// Delay between using @duel in minutes
+// Delay between using @duel in seconds
 duel_time_interval: 60
 
 // Restrict duel usage to same map

--- a/conf/messages.conf
+++ b/conf/messages.conf
@@ -368,7 +368,7 @@
 353: Duel: The Player is in the duel already.
 354: Duel: Invitation has been sent.
 355: Duel: You can't use @duel without @reject.
-356: Duel: You can take part in duel once per %d minutes.
+356: Duel: You can take part in duel again after %d seconds.
 357: Duel: Invalid value.
 358: Duel: You can't use @leave. You aren't a duelist.
 359: Duel: You've left the duel.

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -8048,10 +8048,11 @@ ACMD(duel)
 		return false;
 	}
 
-	if (!duel->checktime(sd)) {
+	int64 diff = duel->difftime(sd);
+	if (diff > 0) {
 		char output[CHAT_SIZE_MAX];
-		// "Duel: You can take part in duel only one time per %d minutes."
-		sprintf(output, msg_fd(fd,356), battle_config.duel_time_interval);
+		// "Duel: You can take part in duel again after %d secconds."
+		sprintf(output, msg_fd(fd,356), (int)diff);
 		clif->message(fd, output);
 		return false;
 	}
@@ -8101,10 +8102,11 @@ ACMD(leave)
 
 ACMD(accept)
 {
-	if (!duel->checktime(sd)) {
+	int64 diff = duel->difftime(sd);
+	if (diff > 0) {
 		char output[CHAT_SIZE_MAX];
-		// "Duel: You can take part in duel only one time per %d minutes."
-		sprintf(output, msg_fd(fd,356), battle_config.duel_time_interval);
+		// "Duel: You can take part in duel again after %d seconds."
+		sprintf(output, msg_fd(fd,356), (int)diff);
 		clif->message(fd, output);
 		return false;
 	}

--- a/src/map/duel.c
+++ b/src/map/duel.c
@@ -41,27 +41,12 @@ struct duel_interface *duel;
  *------------------------------------------*/
 static void duel_savetime(struct map_session_data *sd)
 {
-	time_t clock;
-	struct tm *t;
-
-	time(&clock);
-	t = localtime(&clock);
-
-	pc_setglobalreg(sd, script->add_variable("PC_LAST_DUEL_TIME"), t->tm_mday*24*60 + t->tm_hour*60 + t->tm_min);
+	pc_setglobalreg(sd, script->add_variable("PC_LAST_DUEL_TIME"), (int)time(NULL));
 }
 
-static int duel_checktime(struct map_session_data *sd)
+static int64 duel_difftime(struct map_session_data *sd)
 {
-	int diff;
-	time_t clock;
-	struct tm *t;
-
-	time(&clock);
-	t = localtime(&clock);
-
-	diff = t->tm_mday*24*60 + t->tm_hour*60 + t->tm_min - pc_readglobalreg(sd, script->add_variable("PC_LAST_DUEL_TIME") );
-
-	return !(diff >= 0 && diff < battle_config.duel_time_interval);
+	return (pc_readglobalreg(sd, script->add_variable("PC_LAST_DUEL_TIME")) + battle_config.duel_time_interval - (int)time(NULL));
 }
 
 static int duel_showinfo_sub(struct map_session_data *sd, va_list va)
@@ -233,7 +218,7 @@ void duel_defaults(void)
 	duel->reject = duel_reject;
 	duel->leave = duel_leave;
 	duel->showinfo = duel_showinfo;
-	duel->checktime = duel_checktime;
+	duel->difftime = duel_difftime;
 
 	duel->init = do_init_duel;
 	duel->final = do_final_duel;

--- a/src/map/duel.h
+++ b/src/map/duel.h
@@ -52,7 +52,7 @@ struct duel_interface {
 	void (*reject) (const unsigned int did, struct map_session_data* sd);
 	void (*leave) (const unsigned int did, struct map_session_data* sd);
 	void (*showinfo) (const unsigned int did, struct map_session_data* sd);
-	int (*checktime) (struct map_session_data* sd);
+	int64 (*difftime) (struct map_session_data* sd);
 
 	void (*init) (bool minimal);
 	void (*final) (void);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -2844,8 +2844,8 @@ typedef void (*HPMHOOK_pre_duel_leave) (const unsigned int *did, struct map_sess
 typedef void (*HPMHOOK_post_duel_leave) (const unsigned int did, struct map_session_data *sd);
 typedef void (*HPMHOOK_pre_duel_showinfo) (const unsigned int *did, struct map_session_data **sd);
 typedef void (*HPMHOOK_post_duel_showinfo) (const unsigned int did, struct map_session_data *sd);
-typedef int (*HPMHOOK_pre_duel_checktime) (struct map_session_data **sd);
-typedef int (*HPMHOOK_post_duel_checktime) (int retVal___, struct map_session_data *sd);
+typedef int64 (*HPMHOOK_pre_duel_difftime) (struct map_session_data **sd);
+typedef int64 (*HPMHOOK_post_duel_difftime) (int64 retVal___, struct map_session_data *sd);
 typedef void (*HPMHOOK_pre_duel_init) (bool *minimal);
 typedef void (*HPMHOOK_post_duel_init) (bool minimal);
 typedef void (*HPMHOOK_pre_duel_final) (void);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -2422,8 +2422,8 @@ struct {
 	struct HPMHookPoint *HP_duel_leave_post;
 	struct HPMHookPoint *HP_duel_showinfo_pre;
 	struct HPMHookPoint *HP_duel_showinfo_post;
-	struct HPMHookPoint *HP_duel_checktime_pre;
-	struct HPMHookPoint *HP_duel_checktime_post;
+	struct HPMHookPoint *HP_duel_difftime_pre;
+	struct HPMHookPoint *HP_duel_difftime_post;
 	struct HPMHookPoint *HP_duel_init_pre;
 	struct HPMHookPoint *HP_duel_init_post;
 	struct HPMHookPoint *HP_duel_final_pre;
@@ -9267,8 +9267,8 @@ struct {
 	int HP_duel_leave_post;
 	int HP_duel_showinfo_pre;
 	int HP_duel_showinfo_post;
-	int HP_duel_checktime_pre;
-	int HP_duel_checktime_post;
+	int HP_duel_difftime_pre;
+	int HP_duel_difftime_post;
 	int HP_duel_init_pre;
 	int HP_duel_init_post;
 	int HP_duel_final_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -1241,7 +1241,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(duel->reject, HP_duel_reject) },
 	{ HP_POP(duel->leave, HP_duel_leave) },
 	{ HP_POP(duel->showinfo, HP_duel_showinfo) },
-	{ HP_POP(duel->checktime, HP_duel_checktime) },
+	{ HP_POP(duel->difftime, HP_duel_difftime) },
 	{ HP_POP(duel->init, HP_duel_init) },
 	{ HP_POP(duel->final, HP_duel_final) },
 /* elemental_interface */

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -31601,14 +31601,14 @@ void HP_duel_showinfo(const unsigned int did, struct map_session_data *sd) {
 	}
 	return;
 }
-int HP_duel_checktime(struct map_session_data *sd) {
+int64 HP_duel_difftime(struct map_session_data *sd) {
 	int hIndex = 0;
-	int retVal___ = 0;
-	if (HPMHooks.count.HP_duel_checktime_pre > 0) {
-		int (*preHookFunc) (struct map_session_data **sd);
+	int64 retVal___ = 0;
+	if (HPMHooks.count.HP_duel_difftime_pre > 0) {
+		int64 (*preHookFunc) (struct map_session_data **sd);
 		*HPMforce_return = false;
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_duel_checktime_pre; hIndex++) {
-			preHookFunc = HPMHooks.list.HP_duel_checktime_pre[hIndex].func;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_duel_difftime_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_duel_difftime_pre[hIndex].func;
 			retVal___ = preHookFunc(&sd);
 		}
 		if (*HPMforce_return) {
@@ -31617,12 +31617,12 @@ int HP_duel_checktime(struct map_session_data *sd) {
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.duel.checktime(sd);
+		retVal___ = HPMHooks.source.duel.difftime(sd);
 	}
-	if (HPMHooks.count.HP_duel_checktime_post > 0) {
-		int (*postHookFunc) (int retVal___, struct map_session_data *sd);
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_duel_checktime_post; hIndex++) {
-			postHookFunc = HPMHooks.list.HP_duel_checktime_post[hIndex].func;
+	if (HPMHooks.count.HP_duel_difftime_post > 0) {
+		int64 (*postHookFunc) (int64 retVal___, struct map_session_data *sd);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_duel_difftime_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_duel_difftime_post[hIndex].func;
 			retVal___ = postHookFunc(retVal___, sd);
 		}
 	}


### PR DESCRIPTION
- Able to set cooldown in `seconds` format.
- New `duel_time_interval` value will be applied to any existing cooldown
  if new value is reloaded in-game using `@reloadbattleconf`.
- Display the cooldown tick before can create new duel.
## Example:

![image](https://cloud.githubusercontent.com/assets/1075099/19774554/14380034-9ca0-11e6-9b4f-29f4e8846f41.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1495)

<!-- Reviewable:end -->
