### PR TITLE
Updated *warpguild() script command.

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -4292,7 +4292,7 @@ Example:
 
 ---------------------------------------
 
-*warpguild("<mapname>", <x>, <y>, <guild_id>)
+*warpguild("<mapname>", <x>, <y>, <guild_id>, {"<from_mapname>"})
 
 Warps a guild to specified map and coordinate given the guild id, which 
 you can get with getcharid(CHAR_ID_GUILD). You can also request another guild id given 
@@ -4305,10 +4305,13 @@ SavePointAll: All guild members are warped to their respective save point.
 SavePoint:    All guild members are warped to the save point of the 
               currently attached player (will fail if there's no player 
               attached).
+			  
+If you specify a from_mapname, warpguild() will only affect those on that map.
 
 Example:
 
 	warpguild("prontera", x, y, Guild_ID);
+	warpguild("prontera", x, y, Guild_ID, "payon"); // warp member from Payon map only.
 
 ---------------------------------------
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -6607,61 +6607,66 @@ BUILDIN(warpparty)
 }
 /*==========================================
  * Warpguild - [Fredzilla]
- * Syntax: warpguild "mapname",x,y,Guild_ID;
+ * Syntax: warpguild "mapname",x,y,Guild_ID,{"from_mapname"};
  *------------------------------------------*/
 BUILDIN(warpguild)
 {
 	struct map_session_data *sd = NULL;
-	struct map_session_data *pl_sd;
 	struct guild* g;
-	struct s_mapiterator* iter;
 	int type;
+	int i;
+	int16 map_index = -1;
 
-	const char* str = script_getstr(st,2);
-	int x           = script_getnum(st,3);
-	int y           = script_getnum(st,4);
-	int gid         = script_getnum(st,5);
+	const char *str  = script_getstr(st, 2);
+	int x            = script_getnum(st, 3);
+	int y            = script_getnum(st, 4);
+	int gid          = script_getnum(st, 5);
+
+	if (script_hasdata(st, 6)) {
+		map_index = map->mapname2mapid(script_getstr(st, 6));
+	}
 
 	g = guild->search(gid);
-	if( g == NULL )
+	if(g == NULL)
 		return true;
 
-	type = ( strcmp(str,"Random")==0 ) ? 0
-	: ( strcmp(str,"SavePointAll")==0 ) ? 1
-	: ( strcmp(str,"SavePoint")==0 ) ? 2
+	type = (strcmp(str, "Random") == 0) ? 0
+	: (strcmp(str, "SavePointAll") == 0) ? 1
+	: (strcmp(str, "SavePoint") == 0) ? 2
 	: 3;
 
-	if( type == 2 && ( sd = script->rid2sd(st) ) == NULL )
+	if (type == 2 && (sd = script->rid2sd(st)) == NULL)
 	{// "SavePoint" uses save point of the currently attached player
 		return true;
 	}
 
-	iter = mapit_getallusers();
-	for (pl_sd = BL_UCAST(BL_PC, mapit->first(iter)); mapit->exists(iter); pl_sd = BL_UCAST(BL_PC, mapit->next(iter))) {
-		if( pl_sd->status.guild_id != gid )
-			continue;
+	for (i = 0; i < MAX_GUILD; i++) {
+		if (g->member[i].online && g->member[i].sd != NULL) {
 
-		switch( type )
-		{
+			if (map_index >= 0 && map_index != g->member[i].sd->bl.m)
+				continue;
+
+			switch (type)
+			{
 			case 0: // Random
-				if(!map->list[pl_sd->bl.m].flag.nowarp)
-					pc->randomwarp(pl_sd,CLR_TELEPORT);
+				if (!map->list[g->member[i].sd->bl.m].flag.nowarp)
+					pc->randomwarp(g->member[i].sd, CLR_TELEPORT);
 				break;
 			case 1: // SavePointAll
-				if(!map->list[pl_sd->bl.m].flag.noreturn)
-					pc->setpos(pl_sd,pl_sd->status.save_point.map,pl_sd->status.save_point.x,pl_sd->status.save_point.y,CLR_TELEPORT);
+				if (!map->list[g->member[i].sd->bl.m].flag.noreturn)
+					pc->setpos(g->member[i].sd, g->member[i].sd->status.save_point.map, g->member[i].sd->status.save_point.x, g->member[i].sd->status.save_point.y, CLR_TELEPORT);
 				break;
 			case 2: // SavePoint
-				if(!map->list[pl_sd->bl.m].flag.noreturn)
-					pc->setpos(pl_sd,sd->status.save_point.map,sd->status.save_point.x,sd->status.save_point.y,CLR_TELEPORT);
+				if (!map->list[g->member[i].sd->bl.m].flag.noreturn)
+					pc->setpos(g->member[i].sd, sd->status.save_point.map, sd->status.save_point.x, sd->status.save_point.y, CLR_TELEPORT);
 				break;
 			case 3: // m,x,y
-				if(!map->list[pl_sd->bl.m].flag.noreturn && !map->list[pl_sd->bl.m].flag.nowarp)
-					pc->setpos(pl_sd,script->mapindexname2id(st,str),x,y,CLR_TELEPORT);
+				if (!map->list[g->member[i].sd->bl.m].flag.noreturn && !map->list[g->member[i].sd->bl.m].flag.nowarp)
+					pc->setpos(g->member[i].sd, script->mapindexname2id(st, str), x, y, CLR_TELEPORT);
 				break;
+			}
 		}
 	}
-	mapit->free(iter);
 
 	return true;
 }
@@ -20730,7 +20735,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(areawarp,"siiiisii??"),
 		BUILDIN_DEF(warpchar,"siii"), // [LuzZza]
 		BUILDIN_DEF(warpparty,"siii?"), // [Fredzilla] [Paradox924X]
-		BUILDIN_DEF(warpguild,"siii"), // [Fredzilla]
+		BUILDIN_DEF(warpguild,"siii?"), // [Fredzilla]
 		BUILDIN_DEF(setlook,"ii"),
 		BUILDIN_DEF(changelook,"ii"), // Simulates but don't Store it
 		BUILDIN_DEF2(__setr,"set","rv"),


### PR DESCRIPTION
- Added optional parameter to warp member from target map.
- Update to loop guild member using `g->member[]` data.

Sample Script:

```
prontera,155,181,5  script  NPC_1   757,{
    npctalk "warp from here to here.";
    warpguild( "prontera", 155, 170, getcharid(2) );
    end;
}
```

```
prontera,155,171,5  script  NPC_2   757,{
    npctalk "warp from payon to here.";
    warpguild( "prontera", 155, 170, getcharid(2),"payon" );
    end;
}
```

```
prontera,155,161,5  script  NPC_3   757,{
    npctalk "warp from prontera to here.";
    warpguild( "prontera", 155, 170, getcharid(2),"prontera" );
    end;
}
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1496)

<!-- Reviewable:end -->
