### PR TITLE
Update *waitingroom script document

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6854,7 +6854,7 @@ The maximum length of a chat room name is 60 letters.
 The limit is the maximum number of people allowed to enter the chat room. 
 The attached NPC is included in this count. If the optional event and 
 trigger parameters are given, the event label 
-("<NPC object name>::<label name>") will be invoked as if with a doevent()
+("<NPC object name>::<label name>") will be invoked as if with a donpcevent()
 upon the number of people in the chat room reaching the given triggering 
 amount.
 


### PR DESCRIPTION
When trigger event label, it run as `donpcevent` not `doevent`, no player are attached to the script when it's triggering the event. 
No RID are attached to script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1537)
<!-- Reviewable:end -->
