### PR TITLE
Fixed announces from Koschei the Immortal (Moscovia Quests)

### DIFF
--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -7350,15 +7350,15 @@ OnDisable:
 	end;
 
 OnTimer3000:
-	announce "Koshei, the Immortal : I will kill all who disturb me!! Cry in terror weak humans!!!",bc_map,0xCE3131;
+	mapannounce "mosk_dun01","Koshei, the Immortal : I will kill all who disturb me!! Cry in terror weak humans!!!",bc_map,0xCE3131;
 	end;
 
 OnTimer63000:
-	announce "Koshei, the Immortal : You worms, you mere monsters... I will curse all who are in my way!!",bc_map,0xCE3131;
+	mapannounce "mosk_dun01","Koshei, the Immortal : You worms, you mere monsters... I will curse all who are in my way!!",bc_map,0xCE3131;
 	end;
 
 OnTimer150000:
-	announce "Koshei, the Immortal : Mankind! Cry in terror!! Hahahahahahahhahahah!!!",bc_map,0xCE3131;
+	mapannounce "mosk_dun01","Koshei, the Immortal : Mankind! Cry in terror!! Hahahahahahahhahahah!!!",bc_map,0xCE3131;
 	end;
 
 OnTimer300000:


### PR DESCRIPTION
Some ancient typo, which results in `script_rid2sd: fatal error ! player not attached!` and never showing those messages.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1542)
<!-- Reviewable:end -->
