### PR TITLE
remove hardcoded chat area size

### DIFF
--- a/conf/map/battle/client.conf
+++ b/conf/map/battle/client.conf
@@ -69,6 +69,9 @@ pet_hair_style: 100
 // Visible area size (how many squares away from a player can they see)
 area_size: 14
 
+// Chat area size (how many squares away from a player can they chat)
+chat_area_size: 9
+
 // Maximum walk path (how many cells a player can walk going to cursor)
 // default: 17(official)
 max_walk_path: 17
@@ -107,7 +110,7 @@ save_body_style: false
 
 // Do not display cloth colors for the wedding costume?
 // Note: Both save_clothcolor and wedding_modifydisplay have to be enabled
-// for this option to take effect. Set this to true if your cloth palettes 
+// for this option to take effect. Set this to true if your cloth palettes
 // pack doesn't has wedding palettes (or has less than the other jobs)
 wedding_ignorepalette: false
 

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7167,6 +7167,7 @@ static const struct battle_data {
 	{ "castrate_dex_scale",                 &battle_config.castrate_dex_scale,              150,    1,      INT_MAX,        },
 	{ "vcast_stat_scale",                   &battle_config.vcast_stat_scale,                530,    1,      INT_MAX,        },
 	{ "area_size",                          &battle_config.area_size,                       14,     0,      INT_MAX,        },
+	{ "chat_area_size",                     &battle_config.chat_area_size,                  9,      0,      INT_MAX,        },
 	{ "zeny_from_mobs",                     &battle_config.zeny_from_mobs,                  0,      0,      1,              },
 	{ "mobs_level_up",                      &battle_config.mobs_level_up,                   0,      0,      1,              },
 	{ "mobs_level_up_exp_rate",             &battle_config.mobs_level_up_exp_rate,          1,      1,      INT_MAX,        },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -362,6 +362,7 @@ struct Battle_Config {
 
 	int castrate_dex_scale; // added by [MouseJstr]
 	int area_size; // added by [MouseJstr]
+	int chat_area_size; // added by [gumi]
 
 	int max_def, over_def_bonus; //added by [Skotlex]
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -451,8 +451,8 @@ bool clif_send(const void* buf, int len, struct block_list* bl, enum send_target
 			break;
 		case AREA_CHAT_WOC:
 			nullpo_retr(true, bl);
-			map->foreachinarea(clif->send_sub, bl->m, bl->x-(AREA_SIZE-5), bl->y-(AREA_SIZE-5),
-			                   bl->x+(AREA_SIZE-5), bl->y+(AREA_SIZE-5), BL_PC, buf, len, bl, AREA_WOC);
+			map->foreachinarea(clif->send_sub, bl->m, bl->x-CHAT_AREA_SIZE, bl->y-CHAT_AREA_SIZE,
+			                   bl->x+CHAT_AREA_SIZE, bl->y+CHAT_AREA_SIZE, BL_PC, buf, len, bl, AREA_WOC);
 			break;
 
 		case CHAT:

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -47,6 +47,7 @@ enum E_MAPSERVER_ST {
 
 #define MAX_NPC_PER_MAP 512
 #define AREA_SIZE (battle->bc->area_size)
+#define CHAT_AREA_SIZE (battle->bc->chat_area_size)
 #define DAMAGELOG_SIZE 30
 #define LOOTITEM_SIZE 10
 #define MAX_MOBSKILL 50


### PR DESCRIPTION
This patch removes the hardcoded chat area size and instead reads it from battle.conf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1562)
<!-- Reviewable:end -->
