### PR TITLE
Adds GvG2 zone to WoE:SE maps

### DIFF
--- a/npc/mapflag/zone.txt
+++ b/npc/mapflag/zone.txt
@@ -137,3 +137,15 @@ umbala	mapflag	zone	Towns
 veins	mapflag	zone	Towns
 xmas	mapflag	zone	Towns
 yuno	mapflag	zone	Towns
+
+// WoE SE
+arug_cas01	mapflag	zone	GvG2
+arug_cas02	mapflag	zone	GvG2
+arug_cas03	mapflag	zone	GvG2
+arug_cas04	mapflag	zone	GvG2
+arug_cas05	mapflag	zone	GvG2
+schg_cas01	mapflag	zone	GvG2
+schg_cas02	mapflag	zone	GvG2
+schg_cas03	mapflag	zone	GvG2
+schg_cas04	mapflag	zone	GvG2
+schg_cas05	mapflag	zone	GvG2


### PR DESCRIPTION
WoE:SE maps were missing GvG2 zone, allowing use of Leap/High Jump.
Fixes #1391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1565)
<!-- Reviewable:end -->
