### PR TITLE
Fixes named items having their names changed when near other players

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -1077,9 +1077,11 @@ void clif_set_unit_idle(struct block_list* bl, struct map_session_data *tsd, enu
 #endif
 #if PACKETVER >= 20150513
 	p.body = vd->body_style;
+#endif
+/* Might be earlier, this is when the named item bug began */
+#if PACKETVER >= 20131223
 	safestrncpy(p.name, clif->get_bl_name(bl), NAME_LENGTH);
 #endif
-
 	clif->send(&p,sizeof(p),tsd?&tsd->bl:bl,target);
 
 	if (clif->isdisguised(bl)) {
@@ -1220,6 +1222,9 @@ void clif_spawn_unit(struct block_list* bl, enum send_target target) {
 #endif
 #if PACKETVER >= 20150513
 	p.body = vd->body_style;
+#endif
+/* Might be earlier, this is when the named item bug began */
+#if PACKETVER >= 20131223
 	safestrncpy(p.name, clif->get_bl_name(bl), NAME_LENGTH);
 #endif
 	if (clif->isdisguised(bl)) {
@@ -1262,7 +1267,7 @@ void clif_set_unit_walking(struct block_list* bl, struct map_session_data *tsd, 
 #endif
 #if PACKETVER >= 20131223
 	p.AID = bl->id;
-	p.GID = (tsd) ? tsd->status.char_id : 0; // CCODE
+	p.GID = (sd) ? sd->status.char_id : 0; // CCODE
 #else
 	p.GID = bl->id;
 #endif
@@ -1312,6 +1317,9 @@ void clif_set_unit_walking(struct block_list* bl, struct map_session_data *tsd, 
 #endif
 #if PACKETVER >= 20150513
 	p.body = vd->body_style;
+#endif
+/* Might be earlier, this is when the named item bug began */
+#if PACKETVER >= 20131223
 	safestrncpy(p.name, clif->get_bl_name(bl), NAME_LENGTH);
 #endif
 

--- a/src/map/packets_struct.h
+++ b/src/map/packets_struct.h
@@ -589,6 +589,9 @@ struct packet_spawn_unit {
 #endif
 #if PACKETVER >= 20150513
 	int16 body;
+#endif
+/* Might be earlier, this is when the named item bug began */
+#if PACKETVER >= 20131223
 	char name[NAME_LENGTH];
 #endif
 } __attribute__((packed));
@@ -657,6 +660,9 @@ struct packet_unit_walking {
 #endif
 #if PACKETVER >= 20150513
 	int16 body;
+#endif
+/* Might be earlier, this is when the named item bug began */
+#if PACKETVER >= 20131223
 	char name[NAME_LENGTH];
 #endif
 } __attribute__((packed));
@@ -723,6 +729,9 @@ struct packet_idle_unit {
 #endif
 #if PACKETVER >= 20150513
 	int16 body;
+#endif
+/* Might be earlier, this is when the named item bug began */
+#if PACKETVER >= 20131223
 	char name[NAME_LENGTH];
 #endif
 } __attribute__((packed));


### PR DESCRIPTION
Fixes named items having their names changed when near other players/name's owner. Fixes #1206 when merged.

There was 2 issues there:
- first: item name disappeared, because the client needs the character name when it's near
- second: name changing to another player, that's because when the player wich name is on the item walked near the one who had the item, unit_walking was sending the GID of the one who had the item instead of the one walking near, thus changing the name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1567)
<!-- Reviewable:end -->
