### PR TITLE
Script commands Update

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6312,11 +6312,14 @@ Examples:
 
 Okay, these commands should be fairly self explaining.
 For the emotions, you can look in db/constants.conf for prefixes with e_
-PS: unittalk can receive a third parameter:
+
+PS: unittalk() can receive a third parameter:
+
 	Show_UnitName:
 		1: true (default) - Shows Unit name like (UnitName : Message)
 		0: false - Hides Unit name
-PS2: unitwarp() supports a <GID> of zero, which causes the executor of the
+
+unitwarp() supports a <GID> of zero, which causes the executor of the
 script to be affected. This can be used with OnTouchNPC to warp
 monsters:
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3225,10 +3225,10 @@ Return true if successful, otherwise it will return false.
 
 ---------------------------------------
 
-*getgroupid()
+*getgroupid({<account ID>|<character ID>|<character name>})
 
-This function will return the id of player group the account to which the 
-invoking player belongs.
+This function will return the id of player group the account to which the
+given player belongs. If no parameter is given this function will return the group id of invoking player.
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6316,8 +6316,8 @@ For the emotions, you can look in db/constants.conf for prefixes with e_
 PS: unittalk() can receive a third parameter:
 
 	Show_UnitName:
-		1: true (default) - Shows Unit name like (UnitName : Message)
-		0: false - Hides Unit name
+		true: Shows Unit name like "UnitName : Message" (default)
+		false: Hides Unit name
 
 unitwarp() supports a <GID> of zero, which causes the executor of the
 script to be affected. This can be used with OnTouchNPC to warp
@@ -6436,8 +6436,8 @@ A debug message also shows on the console when no events are triggered.
 *npctalk("<message>"{, "<npc name>"{, <show_npcname>}})
 
 show_npcname values:
-	1: true (default) - shows npc name
-	0: false - hide npc name
+	true: shows npc name (default)
+	false: hide npc name
 
 This command will display a message to the surrounding area as if the NPC 
 object running it was a player talking - that is, above their head and in 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6307,12 +6307,16 @@ Examples:
 *unitwarp(<GID>, <Mapname>, <x>, <y>)
 *unitattack(<GID>, <Target ID>)
 *unitstop(<GID>)
-*unittalk(<GID>, <Text>)
+*unittalk(<GID>, <Text>{, <Show_UnitName>})
 *unitemote(<GID>, <Emote>)
 
 Okay, these commands should be fairly self explaining.
 For the emotions, you can look in db/constants.conf for prefixes with e_
-PS: unitwarp() supports a <GID> of zero, which causes the executor of the
+PS: unittalk can receive a third parameter:
+	Show_UnitName:
+		1: true (default) - Shows Unit name like (UnitName : Message)
+		0: false - Hides Unit name
+PS2: unitwarp() supports a <GID> of zero, which causes the executor of the
 script to be affected. This can be used with OnTouchNPC to warp
 monsters:
 
@@ -6426,12 +6430,16 @@ A debug message also shows on the console when no events are triggered.
 
 ---------------------------------------
 
-*npctalk("<message>"{, "<npc name>"})
+*npctalk("<message>"{, "<npc name>"{, <show_npcname>}})
+
+show_npcname values:
+	1: true (default) - shows npc name
+	0: false - hide npc name
 
 This command will display a message to the surrounding area as if the NPC 
 object running it was a player talking - that is, above their head and in 
-the chat window. The display name of the NPC will get appended in front of 
-the message to complete the effect.
+the chat window. If display is false the name of the NPC will get appended in front of 
+the message to complete the effect otherwise the npc name will not be shown.
 
 	// This will make everyone in the area see the NPC greet the character
 	// who just invoked it.

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3229,6 +3229,7 @@ Return true if successful, otherwise it will return false.
 
 This function will return the id of player group the account to which the
 given player belongs. If no parameter is given this function will return the group id of invoking player.
+Returns -1 if no player was found.
 
 ---------------------------------------
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9688,10 +9688,23 @@ BUILDIN(setgroupid) {
 
 /// Returns the group ID of the player.
 ///
-/// getgroupid() -> <int>
+/// getgroupid({<account ID>/<character ID>/<character name>})
 BUILDIN(getgroupid)
 {
-	struct map_session_data *sd = script->rid2sd(st);
+	struct map_session_data *sd = NULL;
+
+	/* check if a character name is specified */
+	if (script_hasdata(st, 2)) {
+		if (script_isstringtype(st, 2)) {
+			sd = map->nick2sd(script_getstr(st, 2));
+		} else {
+			int id = script_getnum(st, 2);
+			sd = (map->id2sd(id) ? map->id2sd(id) : map->charid2sd(id));
+		}
+	} else {
+		sd = script->rid2sd(st);
+	}
+
 	if (sd == NULL)
 		return true; // no player attached, report source
 	script_pushint(st, pc_get_group_id(sd));
@@ -20894,7 +20907,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(basicskillcheck,""),
 		BUILDIN_DEF(getgmlevel,""),
 		BUILDIN_DEF(setgroupid, "i?"),
-		BUILDIN_DEF(getgroupid,""),
+		BUILDIN_DEF(getgroupid,"?"),
 		BUILDIN_DEF(end,""),
 		BUILDIN_DEF(checkoption,"i"),
 		BUILDIN_DEF(setoption,"i?"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -14549,8 +14549,8 @@ BUILDIN(message)
  * npctalk (sends message to surrounding area)
  * usage: npctalk "<message>"{,"<npc name>"{,<show_npcname>}};
  *  <show_npcname>:
- *      1: shows npc name like "Npc : message"
- *      0: hide npc name
+ *      true: shows npc name like "Npc : message" (default)
+ *      false: hide npc name
  *------------------------------------------*/
 BUILDIN(npctalk)
 {
@@ -14572,13 +14572,10 @@ BUILDIN(npctalk)
 		char name[NAME_LENGTH], message[256];
 		safestrncpy(name, nd->name, sizeof(name));
 		strtok(name, "#"); // discard extra name identifier if present
-		switch (show_npcname) {
-			default:
-				ShowWarning("script: buildin_npctalk: Invalid value for 'show_npcname'. Using default.\n");
-				//fall through
-			case 1: safesnprintf(message, sizeof(message), "%s : %s", name, str); break;
-			case 0: safesnprintf(message, sizeof(message), "%s", str); break;
-		}
+		if (show_npcname)
+			safesnprintf(message, sizeof(message), "%s", str);
+		else
+			safesnprintf(message, sizeof(message), "%s : %s", name, str);
 		clif->disp_overhead(&nd->bl, message);
 	}
 
@@ -17290,13 +17287,10 @@ BUILDIN(unittalk) {
 		safestrncpy(blname, clif->get_bl_name(bl), sizeof(blname));
 		if(bl->type == BL_NPC)
 			strtok(blname, "#");
-		switch (show_unitname) {
-			default:
-				ShowWarning("script: buildin_unittalk: Invalid value for 'show_unitname'. Using default.\n");
-				//fall through
-			case 1: StrBuf->Printf(&sbuf, "%s : %s", blname, message); break;
-			case 0: StrBuf->Printf(&sbuf, "%s", message); break;
-		}
+		if (show_unitname)
+			StrBuf->Printf(&sbuf, "%s : %s", blname, message);
+		else
+			StrBuf->Printf(&sbuf, "%s", message);
 		clif->disp_overhead(bl, StrBuf->Value(&sbuf));
 		StrBuf->Destroy(&sbuf);
 	}

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9705,8 +9705,10 @@ BUILDIN(getgroupid)
 		sd = script->rid2sd(st);
 	}
 
-	if (sd == NULL)
+	if (sd == NULL) {
+		script_pushint(st, -1); // Failure, no player found.
 		return true; // no player attached, report source
+	}
 	script_pushint(st, pc_get_group_id(sd));
 
 	return true;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -14574,10 +14574,11 @@ BUILDIN(npctalk)
 		char name[NAME_LENGTH], message[256];
 		safestrncpy(name, nd->name, sizeof(name));
 		strtok(name, "#"); // discard extra name identifier if present
-		if (show_npcname)
+		if (show_npcname) {
 			safesnprintf(message, sizeof(message), "%s", str);
-		else
+		} else {
 			safesnprintf(message, sizeof(message), "%s : %s", name, str);
+		}
 		clif->disp_overhead(&nd->bl, message);
 	}
 
@@ -17270,7 +17271,8 @@ BUILDIN(unitstop) {
 /// Makes the unit say the message
 ///
 /// unittalk <unit_id>,"<message>"{, show_unitname};
-BUILDIN(unittalk) {
+BUILDIN(unittalk)
+{
 	int unit_id, show_unitname = 1;
 	const char* message;
 	struct block_list* bl;
@@ -17287,12 +17289,14 @@ BUILDIN(unittalk) {
 		char blname[NAME_LENGTH];
 		StrBuf->Init(&sbuf);
 		safestrncpy(blname, clif->get_bl_name(bl), sizeof(blname));
-		if(bl->type == BL_NPC)
+		if(bl->type == BL_NPC) {
 			strtok(blname, "#");
-		if (show_unitname)
+		}
+		if (show_unitname) {
 			StrBuf->Printf(&sbuf, "%s : %s", blname, message);
-		else
+		} else {
 			StrBuf->Printf(&sbuf, "%s", message);
+		}
 		clif->disp_overhead(bl, StrBuf->Value(&sbuf));
 		StrBuf->Destroy(&sbuf);
 	}

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -14549,13 +14549,13 @@ BUILDIN(message)
  * npctalk (sends message to surrounding area)
  * usage: npctalk "<message>"{,"<npc name>"{,<show_npcname>}};
  *  <show_npcname>:
- *      0: shows npc name like "Npc : message"
- *      1: hide npc name
+ *      1: shows npc name like "Npc : message"
+ *      0: hide npc name
  *------------------------------------------*/
 BUILDIN(npctalk)
 {
 	struct npc_data* nd;
-	int show_npcname = 0;
+	int show_npcname = 1;
 	const char *str = script_getstr(st,2);
 
 	if (script_hasdata(st, 3)) {
@@ -14573,8 +14573,11 @@ BUILDIN(npctalk)
 		safestrncpy(name, nd->name, sizeof(name));
 		strtok(name, "#"); // discard extra name identifier if present
 		switch (show_npcname) {
-			case 0: safesnprintf(message, sizeof(message), "%s", str); break;
+			default:
+				ShowWarning("script: buildin_npctalk: Invalid value for 'show_npcname'. Using default.\n");
+				//fall through
 			case 1: safesnprintf(message, sizeof(message), "%s : %s", name, str); break;
+			case 0: safesnprintf(message, sizeof(message), "%s", str); break;
 		}
 		clif->disp_overhead(&nd->bl, message);
 	}
@@ -17288,6 +17291,9 @@ BUILDIN(unittalk) {
 		if(bl->type == BL_NPC)
 			strtok(blname, "#");
 		switch (show_unitname) {
+			default:
+				ShowWarning("script: buildin_unittalk: Invalid value for 'show_unitname'. Using default.\n");
+				//fall through
 			case 1: StrBuf->Printf(&sbuf, "%s : %s", blname, message); break;
 			case 0: StrBuf->Printf(&sbuf, "%s", message); break;
 		}

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -17269,7 +17269,7 @@ BUILDIN(unitstop) {
 ///
 /// unittalk <unit_id>,"<message>"{, show_unitname};
 BUILDIN(unittalk) {
-	int unit_id, show_unitname;
+	int unit_id, show_unitname = 1;
 	const char* message;
 	struct block_list* bl;
 


### PR DESCRIPTION
## Updated _getgroupid_ script command

- [x] Added an extra optional parameter which lets you specify a player to get his/her groupid you can use the account_id, char_id or character name.

## Updated _npctalk_ and _unittalk_ script commands

- [x] Added an extra optional parameter to show/hide npc/unit name. By default unit/npc names will be shown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1571)
<!-- Reviewable:end -->
