### PR TITLE
Fixes getbattleflag on npc/other/auction.txt

### DIFF
--- a/npc/other/auction.txt
+++ b/npc/other/auction.txt
@@ -113,7 +113,7 @@ auction_02,43,17,0	warp	auction_enterance_lhz	1,1,lighthalzen,209,169
 	next;
 	if (select("Yes", "No") == 1) {
 		mes "[Auction Broker]";
-		if ( getbattleflag( "feature.auction" ) ) {
+		if (getbattleflag("features/auction")) {
 			mes "Very well.";
 			mes "Please take";
 			mes "a look, and see";


### PR DESCRIPTION
getbattleflag was using a wrong string for feature confs, I believe this was caused when battle folder was converted into libconfig, as `feature.*` became `features/*` and this script wasn't updated. I checked the entire script folder and couldn't find any other `feature.*` to update.

Fixes #1580 as merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1581)
<!-- Reviewable:end -->
