### PR TITLE
allow strcharinfo() and strnpcinfo() to take a GID

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2341,7 +2341,7 @@ deleted.
 //=====================================
 ---------------------------------------
 
-*strcharinfo(<type>)
+*strcharinfo(<type>{, <default value>{, <GID>}})
 
 This function will return either the name, party name or guild name for 
 the invoking character. Whatever it returns is determined by type.
@@ -2349,6 +2349,10 @@ the invoking character. Whatever it returns is determined by type.
 (1) PC_PARTY	- The name of the party they're in if any.
 (2) PC_GUILD	- The name of the guild they're in if any.
 (3) PC_MAP		- The name of the map the character is in.
+
+If <GID> is passed, it will return the value of the specified player instead
+the attached player. If the player is not found, it will return
+<default value>, if any, or else return an empty string.
  
 If a character is not a member of any party or guild, an empty string will 
 be returned when requesting that information.
@@ -2358,7 +2362,7 @@ using only numbers reduces script readability
 
 ---------------------------------------
 
-*strnpcinfo(<type>)
+*strnpcinfo(<type>{, <default value>{, <GID>}})
 
 This function will return the various parts of the name of the calling NPC.
 Whatever it returns is determined by type.
@@ -2368,6 +2372,10 @@ Whatever it returns is determined by type.
 (2) NPC_NAME_HIDDEN  - The hidden part of the NPC's display name
 (3) NPC_NAME_UNIQUE  - The NPC's unique name (::name)
 (4) NPC_MAP		    - The name of the map the NPC is in.
+
+If <GID> is passed, it will return the value of the specified NPC instead of
+the attached NPC. If the NPC is not found, it will return <default value>,
+if any, or else return an empty string.
 
 ---------------------------------------
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -8685,39 +8685,48 @@ BUILDIN(getguildmember)
  *------------------------------------------*/
 BUILDIN(strcharinfo)
 {
-	int num;
 	struct guild* g;
 	struct party_data* p;
-	struct map_session_data *sd = script->rid2sd(st);
-	if (sd == NULL) //Avoid crashing....
-		return true;
+	struct map_session_data *sd;
 
-	num=script_getnum(st,2);
-	switch(num) {
-		case 0:
-			script_pushstrcopy(st,sd->status.name);
-			break;
-		case 1:
-			if( ( p = party->search(sd->status.party_id) ) != NULL ) {
-				script_pushstrcopy(st,p->party.name);
-			} else {
-				script_pushconststr(st,"");
-			}
-			break;
-		case 2:
-			if( ( g = sd->guild ) != NULL ) {
-				script_pushstrcopy(st,g->name);
-			} else {
-				script_pushconststr(st,"");
-			}
-			break;
-		case 3:
-			script_pushconststr(st,map->list[sd->bl.m].name);
-			break;
-		default:
-			ShowWarning("buildin_strcharinfo: unknown parameter.\n");
-			script_pushconststr(st,"");
-			break;
+	if (script_hasdata(st, 4))
+		sd = map->id2sd(script_getnum(st, 4));
+	else
+		sd = script->rid2sd(st);
+
+	if (sd == NULL) {
+		if(script_hasdata(st, 3)) {
+			script_pushcopy(st, 3);
+		} else {
+			script_pushconststr(st, "");
+		}
+		return true;
+	}
+
+	switch (script_getnum(st, 2)) {
+	case 0:
+		script_pushstrcopy(st, sd->status.name);
+		break;
+	case 1:
+		if ((p = party->search(sd->status.party_id)) != NULL) {
+			script_pushstrcopy(st, p->party.name);
+		} else {
+			script_pushconststr(st, "");
+		}
+		break;
+	case 2:
+		if ((g = sd->guild) != NULL) {
+			script_pushstrcopy(st, g->name);
+		} else {
+			script_pushconststr(st, "");
+		}
+		break;
+	case 3:
+		script_pushconststr(st, map->list[sd->bl.m].name);
+		break;
+	default:
+		ShowWarning("script:strcharinfo: unknown parameter.\n");
+		script_pushconststr(st, "");
 	}
 
 	return true;
@@ -8734,41 +8743,51 @@ BUILDIN(strcharinfo)
  *------------------------------------------*/
 BUILDIN(strnpcinfo)
 {
-	int num;
 	char *buf,*name=NULL;
-	struct npc_data *nd = map->id2nd(st->oid);
+	struct npc_data *nd;
+
+	if (script_hasdata(st, 4))
+		nd = map->id2nd(script_getnum(st, 4));
+	else
+		nd = map->id2nd(st->oid);
+
 	if (nd == NULL) {
-		script_pushconststr(st, "");
+		if (script_hasdata(st, 3)) {
+			script_pushcopy(st, 3);
+		} else {
+			script_pushconststr(st, "");
+		}
 		return true;
 	}
 
-	num = script_getnum(st,2);
-	switch(num) {
-		case 0: // display name
+	switch (script_getnum(st,2)) {
+	case 0: // display name
+		name = aStrdup(nd->name);
+		break;
+	case 1: // visible part of display name
+		if ((buf = strchr(nd->name,'#')) != NULL) {
 			name = aStrdup(nd->name);
-			break;
-		case 1: // visible part of display name
-			if((buf = strchr(nd->name,'#')) != NULL)
-			{
-				name = aStrdup(nd->name);
-				name[buf - nd->name] = 0;
-			} else // Return the name, there is no '#' present
-				name = aStrdup(nd->name);
-			break;
-		case 2: // # fragment
-			if((buf = strchr(nd->name,'#')) != NULL)
-				name = aStrdup(buf+1);
-			break;
-		case 3: // unique name
-			name = aStrdup(nd->exname);
-			break;
-		case 4: // map name
-			if( nd->bl.m >= 0 ) // Only valid map indexes allowed (issue:8034)
-				name = aStrdup(map->list[nd->bl.m].name);
-			break;
+			name[buf - nd->name] = 0;
+		} else { // Return the name, there is no '#' present
+			name = aStrdup(nd->name);
+		}
+		break;
+	case 2: // # fragment
+		if ((buf = strchr(nd->name,'#')) != NULL) {
+			name = aStrdup(buf+1);
+		}
+		break;
+	case 3: // unique name
+		name = aStrdup(nd->exname);
+		break;
+	case 4: // map name
+		if (nd->bl.m >= 0) { // Only valid map indexes allowed (issue:8034)
+			name = aStrdup(map->list[nd->bl.m].name);
+		}
+		break;
 	}
 
-	if(name)
+	if (name)
 		script_pushstr(st, name);
 	else
 		script_pushconststr(st, "");
@@ -20881,8 +20900,8 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(getguildmaster,"i"),
 		BUILDIN_DEF(getguildmasterid,"i"),
 		BUILDIN_DEF(getguildmember,"i?"),
-		BUILDIN_DEF(strcharinfo,"i"),
-		BUILDIN_DEF(strnpcinfo,"i"),
+		BUILDIN_DEF(strcharinfo,"i??"),
+		BUILDIN_DEF(strnpcinfo,"i??"),
 		BUILDIN_DEF(charid2rid,"i"),
 		BUILDIN_DEF(getequipid,"i"),
 		BUILDIN_DEF(getequipname,"i"),


### PR DESCRIPTION
`strcharinfo()` and `strnpcinfo()` can now work without an attached rid, and can get details from another GID than the attached pc/npc. It can also return a default value if the attached or target gid is not found.

* `strcharinfo(0)` will return the name of the attached player, or an empty string if there is no attached player
* `strcharinfo(0, "foobar")` will return the name of the attached player, or `foobar` if there is no attached player
* `strcharinfo(0, "foobar", id)` will return the name of the player with account id `id`, or `foobar` if the player could not be found

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1589)
<!-- Reviewable:end -->
