### PR TITLE
Pre-Renewal instances cooldown mode

### DIFF
--- a/conf/map/battle/feature.conf
+++ b/conf/map/battle/feature.conf
@@ -55,4 +55,11 @@ features: {
 	// Requires: 2014-10-22bRagexe or later
 	// Disabled by default while test version is out; enable at your own risk -- the mean dev.
 	roulette: false
+
+	// Pre-Renewal instances cooldown mode
+	// Fixes entrance exploits and changes behavior of instances cooldown with this values:
+	// 0 - Classic behaviour with exploit entrance (not recommended)
+	// 1 - Classic behaviour without exploit entrance (default)
+	// 2 - Updated behaviour to disable re-entrance on same instance
+	pre_re_instance_mode: 1
 }

--- a/npc/instances/EndlessTower.txt
+++ b/npc/instances/EndlessTower.txt
@@ -312,6 +312,33 @@ L_Enter:
 		mes "The party leader did not generate the dungeon yet.";
 		close;
 	} else {
+		switch (getbattleflag("features/pre_re_instance_mode")) {
+		case 0:
+			break;
+		case 1:
+			.@instance = has_instance2("1@tower");
+			instance_attach(.@instance);
+			if (!'ins_etower_id) {
+				$@ins_etower_id[.@instance] = gettimetick(2);
+				'ins_etower_id = $@ins_etower_id[.@instance];
+			}
+			if (!questprogress(60200,PLAYTIME))
+				ins_etower_id = 'ins_etower_id;
+			if (ins_etower_id == 'ins_etower_id)
+				break;
+			// fall through
+		case 2:
+			.@dun_ent_t = ((etower_timer+604800) - gettimetick(2));
+			.@dun_h = (.@dun_ent_t / 3600);
+			.@dun_m = (.@dun_ent_t - (.@dun_h * 3600)) / 60;
+			.@dun_s = .@dun_ent_t - ((.@dun_h * 3600) + (.@dun_m * 60));
+			mesf("Due to the tower's aftereffects, you cannot enter the dungeon right now, %d hours %d minutes %d seconds left to enter the next dungeon.", .@dun_h, .@dun_m, .@dun_s);
+			next;
+			mes "It is dangerous here. Let me move you to Alberta.";
+			close2;
+			warp "alberta",223,36;
+			end;
+		}
 		mapannounce "e_tower", strcharinfo(PC_NAME)+" of the party, " +getarg(3)+", is entering the dungeon, Endless Tower.",bc_map,"0x00ff99",FW_NORMAL,12;
 		if (getarg(1)) {
 			etower_timer = gettimetick(2);

--- a/npc/instances/NydhoggsNest.txt
+++ b/npc/instances/NydhoggsNest.txt
@@ -224,6 +224,26 @@ L_Enter:
 		mes "You did not request for entrance. Please let your leader request entrance.";
 		close;
 	} else {
+		switch (getbattleflag("features/pre_re_instance_mode")) {
+		case 0:
+			break;
+		case 1:
+			.@instance = has_instance2("1@nyd");
+			instance_attach(.@instance);
+			if (!'ins_nyd_id) {
+				$@ins_nyd_id[.@instance] = gettimetick(2);
+				'ins_nyd_id = $@ins_nyd_id[.@instance];
+			}
+			if (!questprogress(3135,PLAYTIME))
+				ins_nyd_id = 'ins_nyd_id;
+			if (ins_nyd_id == 'ins_nyd_id)
+				break;
+			// fall through
+		case 2:
+			mes "[Yggdrasil Gatekeeper]";
+			mes "The time limit to enter the dungeon has expired. You must wait for the World Tree to stabilize its power before trying to re-enter.";
+			close;
+		}
 		mapannounce "nyd_dun02", getpartyname(getcharid(CHAR_ID_PARTY))+"'s party member "+strcharinfo(PC_NAME)+" has entered Nidhoggur's Nest.",bc_map,"0x00ff99";
 		if (!questprogress(3135)) setquest 3135;
 		if (!questprogress(3136)) setquest 3136;

--- a/npc/instances/OrcsMemory.txt
+++ b/npc/instances/OrcsMemory.txt
@@ -107,6 +107,26 @@ gef_fild10,242,202,0	script	Dimensional Gorge Piece	2_MONEMUS,{
 		mes "If your dungeon has been destroyed you must wait 7 days before re-entering.";
 		close;
 	}
+	switch (getbattleflag("features/pre_re_instance_mode")) {
+	case 0:
+		break;
+	case 1:
+		.@instance = has_instance2("1@orcs");
+		instance_attach(.@instance);
+		if (!'ins_orc_id) {
+			$@ins_orc_id[.@instance] = gettimetick(2);
+			'ins_orc_id = $@ins_orc_id[.@instance];
+		}
+		if (!questprogress(12059,PLAYTIME))
+			ins_orc_id = 'ins_orc_id;
+		if (ins_orc_id == 'ins_orc_id)
+			break;
+		// fall through
+	case 2:
+		// custom message
+		mes "Your dungeon has expired. You must wait before trying to re-enter.";
+		close;
+	}
 
 	mapannounce "gef_fild10", strcharinfo(PC_NAME) + " of the party, " + .@p_name$ + " is entering the "+.@md_name$+".",bc_map,"0x00ff99";
 	if (!questprogress(12059)) setquest 12059;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7321,6 +7321,7 @@ static const struct battle_data {
 	{ "player_warp_keep_direction",         &battle_config.player_warp_keep_direction,      0,      0,      1,              },
 	{ "atcommand_levelup_events",	        &battle_config.atcommand_levelup_events,	    0,      0,      1,				},
 	{ "max_summoner_parameter",             &battle_config.max_summoner_parameter,          120,    10,     10000,          },
+	{ "features/pre_re_instance_mode",      &battle_config.pre_re_instance_mode,            1,      0,      2,              },
 };
 #ifndef STATS_OPT_OUT
 /**

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -547,6 +547,8 @@ struct Battle_Config {
 	int atcommand_levelup_events;	// Enable atcommands trigger level up events for NPCs
 
 	int max_summoner_parameter; // Summoner Max Stats
+	
+	int pre_re_instance_mode;	// Pre-Renewal instances entrance mode
 };
 
 /* criteria for battle_config.idletime_critera */


### PR DESCRIPTION
Fixes entrance exploits and changes behavior of instances cooldown with this values:
0 - Classic behaviour with exploit entrance (not recommended)
1 - Classic behaviour without exploit entrance (default)
2 - Updated behaviour to disable re-entrance on same instance
Fixes #732 #1582