### PR TITLE
allow the PC timer buildins to run on another player

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6475,15 +6475,16 @@ Size is 0 = normal 1 = small 2 = big.
 //=====================================
 ---------------------------------------
 
-*addtimer(<ticks>, "NPC::OnLabel")
-*deltimer("NPC::OnLabel")
-*addtimercount("NPC::OnLabel", <ticks>)
+*addtimer(<ticks>, "NPC::OnLabel"{, <account id>})
+*deltimer("NPC::OnLabel"{, <account id>})
+*addtimercount("NPC::OnLabel", <ticks>{, <account id>})
 
 These commands will create, destroy, and delay a countdown timer - 
 addtimer() to create, deltimer() to destroy and addtimercount() to delay
 it by the specified number of ticks. For all three cases, the event label 
 given is the identifier of that timer. The timer runs on the character 
-object that is attached to the script, and can have multiple instances. 
+object that is attached to the script, and can have multiple instances.
+If <acccount id> is passed, this player will be used instead.
 When the label is run, it is run as if the player that the timer runs on 
 has clicked the NPC.
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10790,7 +10790,11 @@ BUILDIN(addtimer)
 	struct map_session_data *sd;
 
 	script->check_event(st, event);
-	sd = script->rid2sd(st);
+
+	if (script_hasdata(st, 4))
+		sd = map->id2sd(script_getnum(st, 4));
+	else
+		sd = script->rid2sd(st);
 
 	if (sd == NULL) {
 		script_pushint(st, 0);
@@ -21092,7 +21096,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(clone,"siisi????"),
 		BUILDIN_DEF(doevent,"s"),
 		BUILDIN_DEF(donpcevent,"s"),
-		BUILDIN_DEF(addtimer,"is"),
+		BUILDIN_DEF(addtimer,"is?"),
 		BUILDIN_DEF(deltimer,"s"),
 		BUILDIN_DEF(addtimercount,"si"),
 		BUILDIN_DEF(initnpctimer,"??"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10841,7 +10841,11 @@ BUILDIN(addtimercount)
 
 	event = script_getstr(st, 2);
 	tick = script_getnum(st, 3);
-	sd = script->rid2sd(st);
+
+	if (script_hasdata(st, 4))
+		sd = map->id2sd(script_getnum(st, 4));
+	else
+		sd = script->rid2sd(st);
 
 	if (sd == NULL)
 		return true;
@@ -21104,7 +21108,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(donpcevent,"s"),
 		BUILDIN_DEF(addtimer,"is?"),
 		BUILDIN_DEF(deltimer,"s?"),
-		BUILDIN_DEF(addtimercount,"si"),
+		BUILDIN_DEF(addtimercount,"si?"),
 		BUILDIN_DEF(initnpctimer,"??"),
 		BUILDIN_DEF(stopnpctimer,"??"),
 		BUILDIN_DEF(startnpctimer,"??"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10819,11 +10819,12 @@ BUILDIN(deltimer)
 
 	event=script_getstr(st, 2);
 	sd = script->rid2sd(st);
-	if( sd == NULL )
+
+	if (sd == NULL)
 		return true;
 
 	script->check_event(st, event);
-	pc->deleventtimer(sd,event);
+	pc->deleventtimer(sd, event);
 	return true;
 }
 /*==========================================

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10839,14 +10839,15 @@ BUILDIN(addtimercount)
 	int tick;
 	struct map_session_data *sd;
 
-	event=script_getstr(st, 2);
-	tick=script_getnum(st,3);
+	event = script_getstr(st, 2);
+	tick = script_getnum(st, 3);
 	sd = script->rid2sd(st);
-	if( sd == NULL )
+
+	if (sd == NULL)
 		return true;
 
 	script->check_event(st, event);
-	pc->addeventtimercount(sd,event,tick);
+	pc->addeventtimercount(sd, event, tick);
 	return true;
 }
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10818,7 +10818,11 @@ BUILDIN(deltimer)
 	struct map_session_data *sd;
 
 	event=script_getstr(st, 2);
-	sd = script->rid2sd(st);
+
+	if (script_hasdata(st, 3))
+		sd = map->id2sd(script_getnum(st, 3));
+	else
+		sd = script->rid2sd(st);
 
 	if (sd == NULL)
 		return true;
@@ -21098,7 +21102,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(doevent,"s"),
 		BUILDIN_DEF(donpcevent,"s"),
 		BUILDIN_DEF(addtimer,"is?"),
-		BUILDIN_DEF(deltimer,"s"),
+		BUILDIN_DEF(deltimer,"s?"),
 		BUILDIN_DEF(addtimercount,"si"),
 		BUILDIN_DEF(initnpctimer,"??"),
 		BUILDIN_DEF(stopnpctimer,"??"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10792,14 +10792,18 @@ BUILDIN(addtimer)
 	script->check_event(st, event);
 	sd = script->rid2sd(st);
 
-	if (sd == NULL)
-		return true;
-
-	if (!pc->addeventtimer(sd, tick, event)) {
-		ShowWarning("script:addtimer: Event timer is full, can't add new event timer. (cid:%d timer:%s)\n", sd->status.char_id, event);
+	if (sd == NULL) {
+		script_pushint(st, 0);
 		return false;
 	}
 
+	if (!pc->addeventtimer(sd, tick, event)) {
+		ShowWarning("script:addtimer: Event timer is full, can't add new event timer. (cid:%d timer:%s)\n", sd->status.char_id, event);
+		script_pushint(st, 0);
+		return false;
+	}
+
+	script_pushint(st, 1);
 	return true;
 }
 /*==========================================

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10785,19 +10785,21 @@ BUILDIN(donpcevent)
  *------------------------------------------*/
 BUILDIN(addtimer)
 {
-	int tick = script_getnum(st,2);
+	int tick = script_getnum(st, 2);
 	const char* event = script_getstr(st, 3);
 	struct map_session_data *sd;
 
 	script->check_event(st, event);
 	sd = script->rid2sd(st);
-	if( sd == NULL )
+
+	if (sd == NULL)
 		return true;
 
-	if (!pc->addeventtimer(sd,tick,event)) {
-		ShowWarning("buildin_addtimer: Event timer is full, can't add new event timer. (cid:%d timer:%s)\n",sd->status.char_id,event);
+	if (!pc->addeventtimer(sd, tick, event)) {
+		ShowWarning("script:addtimer: Event timer is full, can't add new event timer. (cid:%d timer:%s)\n", sd->status.char_id, event);
 		return false;
 	}
+
 	return true;
 }
 /*==========================================


### PR DESCRIPTION
### Pull Request Prelude
- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- add a new parameter to `addtimer`, `addtimercount`, and `deltimer` to make them usable on another player
- ~~~add new buildin: `areatimer("map", x1, y1, x2, y2, tick, "npc::event")`~~~

**Affected Branches:** `master`

**Issues addressed:** (none)

### Known Issues
(none)

### TODO
- [x] update documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1610)
<!-- Reviewable:end -->
