### PR TITLE
Fix wrong order of dialogue at Crusader Jobchange Quest.

### DIFF
--- a/npc/jobs/2-2/crusader.txt
+++ b/npc/jobs/2-2/crusader.txt
@@ -210,6 +210,7 @@ prt_castle,45,169,5	script	Senior Crusader	4_M_CRU_OLD,{
 		mes "Have you proven your determination with the task I have given you, or do you possess the items proving that you have received your calling?";
 		next;
 		if (countitem(Patriotism_Marks) >= 1 && countitem(Sacred_Marks) >= 1) {
+			mes "[Michael Halig]";
 			mes "Ah...";
 			mes "I see that you have been called to become a Crusader. We are assured of your will, but now we must test your capabilities.";
 			next;

--- a/npc/jobs/2-2/crusader.txt
+++ b/npc/jobs/2-2/crusader.txt
@@ -78,20 +78,6 @@ prt_castle,45,169,5	script	Senior Crusader	4_M_CRU_OLD,{
 		mes "As it happened one thousand years ago, evil forces will one day attack in droves in an attempt to take over the world once again.";
 		close;
 	}
-	else if(CRUS_Q <= 3 && countitem(Patriotism_Marks) && countitem(Sacred_Marks)) {
-		mes "Ah...";
-		mes "I see that you have been called to become a Crusader. We are assured of your will, but now we must test your capabilities.";
-		next;
-		mes "[Michael Halig]";
-		mes "Meet with Moorenak Miyol who is training in the underground dungeon of the Prontera Castle. Go, and speak with him first.";
-		next;
-		delitem 1004, 1;
-		delitem 1009, 1;
-		CRUS_Q = 4;
-		mes "[Michael Halig]";
-		mes "Moorenak and others like him will test the limits of your capabilities and help you find your path. Return to me after you have completed their tests...";
-		close;
-	}
 	else if(CRUS_Q == 0) {
 		mes "We are Crusaders, warriors preparing for the Holy War.";
 		mes "What brings you";
@@ -223,6 +209,27 @@ prt_castle,45,169,5	script	Senior Crusader	4_M_CRU_OLD,{
 	else if(CRUS_Q >= 1 && CRUS_Q <= 3) {
 		mes "Have you proven your determination with the task I have given you, or do you possess the items proving that you have received your calling?";
 		next;
+		if (countitem(Patriotism_Marks) >= 1 && countitem(Sacred_Marks) >= 1) {
+			mes "Ah...";
+			mes "I see that you have been called to become a Crusader. We are assured of your will, but now we must test your capabilities.";
+			next;
+			mes "[Michael Halig]";
+			mes "Meet with Moorenak Miyol who is training in the underground dungeon of the Prontera Castle. Go, and speak with him first.";
+			next;
+			delitem Patriotism_Marks, 1;
+			delitem Sacred_Marks, 1;
+			CRUS_Q = 4;
+			if (questprogress(3006)) {
+				changequest 3006,3009;
+			} else if (questprogress(3007)) {
+				changequest 3007,3009;
+			} else {
+				changequest 3008,3009;
+			}
+			mes "[Michael Halig]";
+			mes "Moorenak and others like him will test the limits of your capabilities and help you find your path. Return to me after you have completed their tests...";
+			close;
+		}
 		switch(CRUS_Q) {
 		case 1:
 			.@item1 = 957;


### PR DESCRIPTION
## Pull Request Prelude

### Current Behavior
If a player has Patriotism_Marks and Sacred_Marks before starting the quest, he'll skip the introductionary dialogue of the Crusader automatically.
(This actually irritated a player of mine heavily, making him believe the quest is bugged.)

### Expected Behavior
He does his introduction and when you're willing to become Crusader, you'll be able to use your 2 Items to skip the Item Gathering part.

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

## Changes Proposed
I moved one of the alternative first quest parts to the part where the player already has accepted the Item Gathering part. This is exactly at the location where it is in the original aegis script.
This also makes the 2nd very same code-part not obsolete anymore.

**Affected Branches: Master** 

**Issues addressed: None**

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/herculesws/hercules/1637)
<!-- Reviewable:end -->
