### PR TITLE
Unequip arrows when a bow is unequipped. (RE only)

### DIFF
--- a/conf/map/battle/items.conf
+++ b/conf/map/battle/items.conf
@@ -114,3 +114,7 @@ item_enabled_npc: true
 // 2 : disabled equipments are nullify, disabled cards will caused the equipment to unequip
 // 3 : disabled equipments are unequip, disabled cards will caused the equipment to unequip (1+2)
 unequip_restricted_equipment: 0
+
+// When unequip a bow with arrow equipped, it also unequip the arrow?
+// Default: true (Official behavior, applies only in Renewal)
+bow_unequip_arrow: true

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7320,6 +7320,7 @@ static const struct battle_data {
 	{ "save_body_style",                    &battle_config.save_body_style,                 0,      0,      1,              },
 	{ "player_warp_keep_direction",         &battle_config.player_warp_keep_direction,      0,      0,      1,              },
 	{ "atcommand_levelup_events",	        &battle_config.atcommand_levelup_events,	    0,      0,      1,				},
+	{ "bow_unequip_arrow",                  &battle_config.bow_unequip_arrow,               1,      0,      1,              },
 	{ "max_summoner_parameter",             &battle_config.max_summoner_parameter,          120,    10,     10000,          },
 };
 #ifndef STATS_OPT_OUT

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -545,6 +545,8 @@ struct Battle_Config {
 	int player_warp_keep_direction;
 
 	int atcommand_levelup_events;	// Enable atcommands trigger level up events for NPCs
+	
+	int bow_unequip_arrow;
 
 	int max_summoner_parameter; // Summoner Max Stats
 };

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -10036,6 +10036,11 @@ int pc_unequipitem(struct map_session_data *sd,int n,int flag)
 		status_change_end(&sd->bl, SC_ARMOR_RESIST, INVALID_TIMER);
 	}
 
+#ifdef RENEWAL
+	if (battle->bc->bow_unequip_arrow && pos&EQP_ARMS && sd->equip_index[EQI_AMMO] > 0)
+		pc->unequipitem(sd, sd->equip_index[EQI_AMMO], PCUNEQUIPITEM_FORCE);
+#endif
+
 	if( sd->state.autobonus&pos )
 		sd->state.autobonus &= ~sd->status.inventory[n].equip; //Check for activated autobonus [Inkfish]
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Forces the un-equipment of arrows when a bow is unequipped.
Also adds a configuration to disable this setting.
In either case (on or off) it works only when compiled in renewal.

**Affected Branches:** 

- [x] Master

**Issues addressed:** #745 

Based on original PR by @Jedzkie in #1079 

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
