### PR TITLE
Monster Vulture's Eye and Snake's Eye removed.

### DIFF
--- a/conf/map/battle/monster.conf
+++ b/conf/map/battle/monster.conf
@@ -259,3 +259,9 @@ mob_size_influence: false
 // Default (most official): mob - 220, boss - 1
 mob_icewall_walk_block: 220
 boss_icewall_walk_block: 1
+
+// Which level of of Vulture's Eye and Snake's Eye should monsters have learned?
+// Officially monsters don't have these skills learned, so their ranged skills
+// only have a range of 9. If you put a number higher than 0, their range will
+// be increased by that number.
+monster_eye_range_bonus: 0

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7332,6 +7332,7 @@ static const struct battle_data {
 	{ "bow_unequip_arrow",                  &battle_config.bow_unequip_arrow,               1,      0,      1,              },
 	{ "max_summoner_parameter",             &battle_config.max_summoner_parameter,          120,    10,     10000,          },
 	{ "mvp_exp_reward_message",             &battle_config.mvp_exp_reward_message,          0,      0,      1,              },
+	{ "monster_eye_range_bonus",            &battle_config.mob_eye_range_bonus,             0,      0,      10,             },
 };
 #ifndef STATS_OPT_OUT
 /**

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -550,6 +550,8 @@ struct Battle_Config {
 
 	int max_summoner_parameter; // Summoner Max Stats
 	int mvp_exp_reward_message;
+
+	int mob_eye_range_bonus; //Vulture's Eye and Snake's Eye range bonus
 };
 
 /* criteria for battle_config.idletime_critera */

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -303,7 +303,7 @@ int skill_get_range2(struct block_list *bl, uint16 skill_id, uint16 skill_lv)
 			if (sd != NULL)
 				range += pc->checkskill(sd, AC_VULTURE);
 			else
-				range += 10; //Assume level 10?
+				range += battle->bc->mob_eye_range_bonus;
 			break;
 		// added to allow GS skills to be effected by the range of Snake Eyes [Reddozen]
 		case GS_RAPIDSHOWER:
@@ -314,7 +314,7 @@ int skill_get_range2(struct block_list *bl, uint16 skill_id, uint16 skill_lv)
 			if (sd != NULL)
 				range += pc->checkskill(sd, GS_SNAKEEYE);
 			else
-				range += 10; //Assume level 10?
+				range += battle->bc->mob_eye_range_bonus;
 			break;
 		case NJ_KIRIKAGE:
 			if (sd != NULL)


### PR DESCRIPTION
### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Original PR #1148 by @SamuelHercules committed on 8 Feb 2016
* Monsters no longer have Vulture's Eye level 10 and Snake's Eye level 10 learned by default
* When you tank Cecil Damon from 10-14 cells away, she will no longer use her target skills
* Added a configuration with which you can set the level of Vulture's Eye and Snake's Eye that monsters have learned
Merged rathena/rathena@cccd1496f716fe02a3db20780b6e52b3c33391b4
Credit: Playtester

**Affected Branches:** Master 
**Issues addressed:** #1148 

### Known Issues and TODO List
- [ ] Verify validity of information and intended effects on RE / PRE-RE.
 
[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
