### PR TITLE
Fixes a minor typo in buildin_setequipoption

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -13979,8 +13979,8 @@ BUILDIN(getequipoption)
 BUILDIN(setequipoption)
 {
 	int equip_index = script_getnum(st, 2);
-	int slot = script_getnum(st, 4);
-	int opt_index = script_getnum(st, 3);
+	int slot = script_getnum(st, 3);
+	int opt_index = script_getnum(st, 4);
 	int value = script_getnum(st, 5);
 	int i = -1;
 	


### PR DESCRIPTION
Related to the order of the arguments.

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes the order of the arguments of *setequipoption(<equip_index>,<slot>,<opt_index>,<value>);
I had forgotten to interchange <slot> and <opt_index>.

**Affected Branches:** Master

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
