### PR TITLE
fix for #1592 (getvariableofpc)

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18176,7 +18176,6 @@ BUILDIN(getvariableofpc)
 
 	switch (*name)
 	{
-	case '#':
 	case '$':
 	case '.':
 	case '\'':

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -672,10 +672,12 @@ struct script_interface {
 	struct script_data* (*push_val)(struct script_stack* stack, enum c_op type, int64 val, struct reg_db *ref);
 	struct script_data *(*get_val) (struct script_state* st, struct script_data* data);
 	char* (*get_val_ref_str) (struct script_state* st, struct reg_db *n, struct script_data* data);
+	char* (*get_val_pc_ref_str) (struct script_state* st, struct reg_db *n, struct script_data* data);
 	char* (*get_val_scope_str) (struct script_state* st, struct reg_db *n, struct script_data* data);
 	char* (*get_val_npc_str) (struct script_state* st, struct reg_db *n, struct script_data* data);
 	char* (*get_val_instance_str) (struct script_state* st, const char* name, struct script_data* data);
 	int (*get_val_ref_num) (struct script_state* st, struct reg_db *n, struct script_data* data);
+	int (*get_val_pc_ref_num) (struct script_state* st, struct reg_db *n, struct script_data* data);
 	int (*get_val_scope_num) (struct script_state* st, struct reg_db *n, struct script_data* data);
 	int (*get_val_npc_num) (struct script_state* st, struct reg_db *n, struct script_data* data);
 	int (*get_val_instance_num) (struct script_state* st, const char* name, struct script_data* data);
@@ -755,10 +757,12 @@ struct script_interface {
 	void (*errorwarning_sub) (StringBuf *buf, const char *src, const char *file, int start_line, const char *error_msg, const char *error_pos);
 	int (*set_reg) (struct script_state *st, struct map_session_data *sd, int64 num, const char *name, const void *value, struct reg_db *ref);
 	void (*set_reg_ref_str) (struct script_state* st, struct reg_db *n, int64 num, const char* name, const char *str);
+	void (*set_reg_pc_ref_str) (struct script_state* st, struct reg_db *n, int64 num, const char* name, const char *str);
 	void (*set_reg_scope_str) (struct script_state* st, struct reg_db *n, int64 num, const char* name, const char *str);
 	void (*set_reg_npc_str) (struct script_state* st, struct reg_db *n, int64 num, const char* name, const char *str);
 	void (*set_reg_instance_str) (struct script_state* st, int64 num, const char* name, const char *str);
 	void (*set_reg_ref_num) (struct script_state* st, struct reg_db *n, int64 num, const char* name, int val);
+	void (*set_reg_pc_ref_num) (struct script_state* st, struct reg_db *n, int64 num, const char* name, int val);
 	void (*set_reg_scope_num) (struct script_state* st, struct reg_db *n, int64 num, const char* name, int val);
 	void (*set_reg_npc_num) (struct script_state* st, struct reg_db *n, int64 num, const char* name, int val);
 	void (*set_reg_instance_num) (struct script_state* st, int64 num, const char* name, int val);


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
It seems that when we tested #1592 we only tested `@` variables (temp PC vars). For those variables it is suitable to use the generic `set_reg_ref_` because they store the absolute value (`char*` or `int`), but all other PC variables (`#`, `##` and no prefix) store a full `script_reg_` struct so they need a custom getter & setter.

**Affected Branches:** `master`

**Issues addressed:**
- added `get_val_pc_ref_str` and `get_val_pc_ref_num` to get the other types of PC vars
- added `set_reg_pc_ref_str` and `set_reg_pc_ref_num` to set the other types of PC vars
- fixed `getvariableofpc` so that it doesn't classify `#` and `##` vars as illegal scope (I had an extraneous `case` in the `switch`)

<br>

**Type:** *bug*
**Severity:** *medium*~*high*


[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
