### PR TITLE
Implemented official Giant Fly Wing Effect

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2687,7 +2687,7 @@ Example 2: check party count (with a next() pause), before warping to event
 	}
 	
 	// Finally, it's safe to start the event!
-	warpparty("event_map", 0, 0, getcharid(CHAR_ID_PARTY));
+	warpparty("event_map", 0, 0, getcharid(CHAR_ID_PARTY), true);
 
 ---------------------------------------
 
@@ -4355,7 +4355,7 @@ See also warp().
 
 ---------------------------------------
 
-*warpparty("<to_mapname>", <x>, <y>, <party_id>, {"<from_mapname>"})
+*warpparty("<to_mapname>", <x>, <y>, <party_id>, "<from_mapname>", <include_leader>)
 
 Warps a party to specified map and coordinate given the party ID, which 
 you can get with getcharid(CHAR_ID_PARTY). You can also request another party id given 
@@ -4375,13 +4375,15 @@ Leader:       All party members are warped to the leader's position. The
 If you specify a from_mapname, warpparty() will only affect those on
 that map.
 
+You can exclude Party leader from warping, by keeping include_leader option as false.
+
 Example:
 
 	mes("[Party Warper]");
 	mes("Here you go!");
 	close2();
 	.@id = getcharid(CHAR_ID_PARTY);
-	warpparty("prontera", 150, 100, .@id);
+	warpparty("prontera", 150, 100, .@id, true);
 	close();
 
 ---------------------------------------

--- a/npc/other/CashShop_Functions.txt
+++ b/npc/other/CashShop_Functions.txt
@@ -56,10 +56,14 @@ function	script	F_CashStore	{
 // - Summons Party members on party leader map to that location.
 // - No arguments.
 function	script	F_CashPartyCall	{
-	warp "Random",0,0;
-	if (getpartyleader(getcharid(CHAR_ID_PARTY),2) == getcharid(CHAR_ID_CHAR)) {
-		getmapxy(.@mapl$, .@xl, .@yl, UNITTYPE_PC);
-		warpparty .@mapl$, .@xl, .@yl, getcharid(CHAR_ID_PARTY), .@mapl$;
+	warp "Random", 0, 0;
+	if (getpartyleader(getcharid(CHAR_ID_PARTY), 2) == getcharid(CHAR_ID_CHAR)) {
+		getmapxy(.@map$, .@x, .@y, UNITTYPE_PC);
+		do {
+			.@x2 = .@x + rand(-2, 2);
+			.@y2 = .@y + rand(-2, 2);
+		} while (checkcell(.@map$, .@x2, .@y2, cell_chknopass));
+		warpparty(.@map$, .@x2, .@y2, getcharid(CHAR_ID_PARTY), .@map$, false);
 	}
 	return;
 }

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -358,30 +358,32 @@ typedef enum useskill_fail_cause { // clif_skill_fail
 }useskill_fail_cause;
 
 enum clif_messages {
-	MSG_ITEM_CANT_OBTAIN_WEIGHT  = 0x034, ///< You cannot carry more items because you are overweight.
-	MSG_ITEM_NEED_STANDING       = 0x297, ///< You cannot use this item while sitting.
-	MSG_MERCENARY_EXPIRED        = 0x4f2, ///< The mercenary contract has expired.
-	MSG_MERCENARY_DIED           = 0x4f3, ///< The mercenary has died.
-	MSG_MERCENARY_RELEASED       = 0x4f4, ///< You have released the mercenary.
-	MSG_MERCENARY_ESCAPED        = 0x4f5, ///< The mercenary has run away.
-	MSG_SKILL_CANT_USE_AREA      = 0x536, ///< This skill cannot be used within this area
-	MSG_ITEM_CANT_USE_AREA       = 0x537, ///< This item cannot be used within this area.
-	MSG_EQUIP_NOT_PUBLIC         = 0x54d, ///< This character's equipment information is not open to the public.
-	MSG_ITEM_NEED_MADO           = 0x59b, ///< Item can only be used when Mado Gear is mounted.
-	MSG_ITEM_NEED_CART           = 0x5ef, ///< Usable only when cart is put on
-	MSG_RUNE_STONE_MAX_AMOUNT    = 0x61b, ///< Cannot create Rune stone more than the maximum amount.
-	MSG_SKILL_POINTS_LEFT_JOB1   = 0x61e, ///< You must consume all '%d' remaining points in your 1st Job tab.
-	MSG_SKILL_POINTS_LEFT_JOB2   = 0x61f, ///< You must consume all '%d' remaining points in your 2nd Job tab. 1st Tab is already done.
-	MSG_SKILL_ITEM_NOT_FOUND     = 0x623, // FIXME[Haru]: This seems to be 0x622 in the msgstringtable files I found.
-	MSG_SKILL_SUCCESS            = 0x627, // FIXME[Haru]: This seems to be 0x626 in the msgstringtable files I found.
-	MSG_SKILL_FAILURE            = 0x628, // FIXME[Haru]: This seems to be 0x627 in the msgstringtable files I found.
-	MSG_SKILL_ITEM_NEED_IDENTIFY = 0x62d, ///< Unable to use unchecked items as materials.
-	MSG_ITEM_CANT_EQUIP_LVL      = 0x6ed, // FIXME[Haru]: This seems to be 0x6ee in the msgstringtable files I found.
-	MSG_ITEM_CANT_USE_LVL        = 0x6ee, // FIXME[Haru]: This seems to be 0x6ef in the msgstringtable files I found.
-	MSG_COOKING_LIST_FAIL        = 0x625, // FIXME[Haru]: This might be a wrong message ID. Not sure what it should be.
-	MSG_SECONDS_UNTIL_USE        = 0x746, ///< %d seconds left until you can use
-	MSG_NPC_WORK_IN_PROGRESS     = 0x783, // FIXME[Haru]: This seems to be 0x784 in the msgstringtable files I found.
-	MSG_REINS_CANT_USE_MOUNTED   = 0x78b, // FIXME[Haru]: This seems to be 0x785 in the msgstringtalbe files I found.
+	MSG_ITEM_CANT_OBTAIN_WEIGHT    = 0x034, ///< You cannot carry more items because you are overweight.
+	MSG_ITEM_NEED_STANDING         = 0x297, ///< You cannot use this item while sitting.
+	MSG_MERCENARY_EXPIRED          = 0x4f2, ///< The mercenary contract has expired.
+	MSG_MERCENARY_DIED             = 0x4f3, ///< The mercenary has died.
+	MSG_MERCENARY_RELEASED         = 0x4f4, ///< You have released the mercenary.
+	MSG_MERCENARY_ESCAPED          = 0x4f5, ///< The mercenary has run away.
+	MSG_PARTY_MEMBER_NOT_SUMMONED  = 0x4c5, ///< The party member was not summoned because you are not the party leader.
+	MSG_PARTY_NO_MEMBER_IN_MAP     = 0x4c6, ///< There is no party member to summon in the current map.
+	MSG_SKILL_CANT_USE_AREA        = 0x536, ///< This skill cannot be used within this area
+	MSG_ITEM_CANT_USE_AREA         = 0x537, ///< This item cannot be used within this area.
+	MSG_EQUIP_NOT_PUBLIC           = 0x54d, ///< This character's equipment information is not open to the public.
+	MSG_ITEM_NEED_MADO             = 0x59b, ///< Item can only be used when Mado Gear is mounted.
+	MSG_ITEM_NEED_CART             = 0x5ef, ///< Usable only when cart is put on
+	MSG_RUNE_STONE_MAX_AMOUNT      = 0x61b, ///< Cannot create Rune stone more than the maximum amount.
+	MSG_SKILL_POINTS_LEFT_JOB1     = 0x61e, ///< You must consume all '%d' remaining points in your 1st Job tab.
+	MSG_SKILL_POINTS_LEFT_JOB2     = 0x61f, ///< You must consume all '%d' remaining points in your 2nd Job tab. 1st Tab is already done.
+	MSG_SKILL_ITEM_NOT_FOUND       = 0x623, // FIXME[Haru]: This seems to be 0x622 in the msgstringtable files I found.
+	MSG_SKILL_SUCCESS              = 0x627, // FIXME[Haru]: This seems to be 0x626 in the msgstringtable files I found.
+	MSG_SKILL_FAILURE              = 0x628, // FIXME[Haru]: This seems to be 0x627 in the msgstringtable files I found.
+	MSG_SKILL_ITEM_NEED_IDENTIFY   = 0x62d, ///< Unable to use unchecked items as materials.
+	MSG_ITEM_CANT_EQUIP_LVL        = 0x6ed, // FIXME[Haru]: This seems to be 0x6ee in the msgstringtable files I found.
+	MSG_ITEM_CANT_USE_LVL          = 0x6ee, // FIXME[Haru]: This seems to be 0x6ef in the msgstringtable files I found.
+	MSG_COOKING_LIST_FAIL          = 0x625, // FIXME[Haru]: This might be a wrong message ID. Not sure what it should be.
+	MSG_SECONDS_UNTIL_USE          = 0x746, ///< %d seconds left until you can use
+	MSG_NPC_WORK_IN_PROGRESS       = 0x783, // FIXME[Haru]: This seems to be 0x784 in the msgstringtable files I found.
+	MSG_REINS_CANT_USE_MOUNTED     = 0x78b, // FIXME[Haru]: This seems to be 0x785 in the msgstringtalbe files I found.
 };
 
 /**

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -4847,10 +4847,40 @@ int pc_isUseitem(struct map_session_data *sd,int n)
 			if( pc_issit(sd) )
 				return 0;
 			break;
+
+		case ITEMID_GIANT_FLY_WING: {
+			struct party_data *p;
+
+			if (!sd->status.party_id) {
+				clif->msgtable(sd, MSG_PARTY_MEMBER_NOT_SUMMONED);
+				break;
+			}
+
+			if ((p = party->search(sd->status.party_id)) != NULL) {
+				int i;
+				int16 m;
+
+				ARR_FIND(0, MAX_PARTY, i, p->data[i].sd == sd);
+
+				if (i == MAX_PARTY || !p->party.member[i].leader) {
+					clif->msgtable(sd, MSG_PARTY_MEMBER_NOT_SUMMONED);
+					break;
+				}
+
+				m = sd->bl.m;
+
+				ARR_FIND(0, MAX_PARTY, i, p->data[i].sd && p->data[i].sd != sd && p->data[i].sd->bl.m == m);
+
+				if (i == MAX_PARTY || pc_isdead(p->data[i].sd)) {
+					clif->msgtable(sd, MSG_PARTY_NO_MEMBER_IN_MAP);
+					break;
+				}
+			}
+		}
+		FALLTHROUGH
 		case ITEMID_WING_OF_FLY:
-		case ITEMID_GIANT_FLY_WING:
-			if( map->list[sd->bl.m].flag.noteleport || map_flag_gvg2(sd->bl.m) ) {
-				clif->skill_mapinfomessage(sd,0);
+			if (map->list[sd->bl.m].flag.noteleport || map_flag_gvg2(sd->bl.m)) {
+				clif->skill_mapinfomessage(sd, 0);
 				return 0;
 			}
 			/* Fall through */

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -6690,9 +6690,10 @@ BUILDIN(warpchar) {
 	return true;
 }
 /*==========================================
- * Warpparty - [Fredzilla] [Paradox924X]
- * Syntax: warpparty "to_mapname",x,y,Party_ID,{"from_mapname"};
+ * Warpparty - [Fredzilla] [Paradox924X] [Jedzkie] [Dastgir]
+ * Syntax: warpparty("<to_mapname>", <x>, <y>, <party_id>, "<from_mapname>", <include_leader>)
  * If 'from_mapname' is specified, only the party members on that map will be warped
+ * If 'include_leader' option is set to false, the leader will be warped too.
  *------------------------------------------*/
 BUILDIN(warpparty)
 {
@@ -6702,78 +6703,84 @@ BUILDIN(warpparty)
 	int type;
 	int map_index;
 	int i;
+	bool include_leader = true;
 
-	const char* str = script_getstr(st,2);
-	int x = script_getnum(st,3);
-	int y = script_getnum(st,4);
-	int p_id = script_getnum(st,5);
+	const char* str = script_getstr(st, 2);
+	int x = script_getnum(st, 3);
+	int y = script_getnum(st, 4);
+	int p_id = script_getnum(st, 5);
 	const char* str2 = NULL;
-	if ( script_hasdata(st,6) )
-		str2 = script_getstr(st,6);
+
+	if (script_hasdata(st, 6))
+		str2 = script_getstr(st, 6);
+	if (script_hasdata(st, 7))
+		include_leader = script_getnum(st, 7);
 
 	p = party->search(p_id);
-	if(!p)
+
+	if (p == NULL)
 		return true;
 
-	type = ( strcmp(str,"Random")==0 ) ? 0
-	: ( strcmp(str,"SavePointAll")==0 ) ? 1
-	: ( strcmp(str,"SavePoint")==0 ) ? 2
-	: ( strcmp(str,"Leader")==0 ) ? 3
+	type = (strcmp(str, "Random") == 0) ? 0
+	: (strcmp(str, "SavePointAll") == 0) ? 1
+	: (strcmp(str, "SavePoint") == 0) ? 2
+	: (strcmp(str, "Leader") == 0) ? 3
 	: 4;
 
-	switch (type)
-	{
-		case 3:
-			for(i = 0; i < MAX_PARTY && !p->party.member[i].leader; i++);
-			if (i == MAX_PARTY || !p->data[i].sd) //Leader not found / not online
-				return true;
-			pl_sd = p->data[i].sd;
-			map_index = pl_sd->mapindex;
-			x = pl_sd->bl.x;
-			y = pl_sd->bl.y;
-			break;
-		case 4:
-			map_index = script->mapindexname2id(st,str);
-			break;
-		case 2:
-			//"SavePoint" uses save point of the currently attached player
-			if (( sd = script->rid2sd(st) ) == NULL )
-				return true;
-			/* Fall through */
-		default:
-			map_index = 0;
-			break;
+	switch (type) {
+	case 3:
+		ARR_FIND(0, MAX_PARTY, i, p->party.member[i].leader);
+		if (i == MAX_PARTY || !p->data[i].sd) // Leader not found / not online
+			return true;
+		pl_sd = p->data[i].sd;
+		map_index = pl_sd->mapindex;
+		x = pl_sd->bl.x;
+		y = pl_sd->bl.y;
+		break;
+	case 4:
+		map_index = script->mapindexname2id(st, str);
+		break;
+	case 2:
+		// "SavePoint" uses save point of the currently attached player
+		if ((sd = script->rid2sd(st)) == NULL)
+			return true;
+		/* Fall through */
+	default:
+		map_index = 0;
+		break;
 	}
 
 	for (i = 0; i < MAX_PARTY; i++) {
-		if( !(pl_sd = p->data[i].sd) || pl_sd->status.party_id != p_id )
+		if (!(pl_sd = p->data[i].sd) || pl_sd->status.party_id != p_id)
 			continue;
 
-		if( str2 && strcmp(str2, map->list[pl_sd->bl.m].name) != 0 )
+		if (str2 && strcmp(str2, map->list[pl_sd->bl.m].name) != 0)
 			continue;
 
-		if( pc_isdead(pl_sd) )
+		if (pc_isdead(pl_sd))
 			continue;
 
-		switch( type )
-		{
-			case 0: // Random
-				if(!map->list[pl_sd->bl.m].flag.nowarp)
-					pc->randomwarp(pl_sd,CLR_TELEPORT);
-				break;
-			case 1: // SavePointAll
-				if(!map->list[pl_sd->bl.m].flag.noreturn)
-					pc->setpos(pl_sd,pl_sd->status.save_point.map,pl_sd->status.save_point.x,pl_sd->status.save_point.y,CLR_TELEPORT);
-				break;
-			case 2: // SavePoint
-				if(!map->list[pl_sd->bl.m].flag.noreturn)
-					pc->setpos(pl_sd,sd->status.save_point.map,sd->status.save_point.x,sd->status.save_point.y,CLR_TELEPORT);
-				break;
-			case 3: // Leader
-			case 4: // m,x,y
-				if(!map->list[pl_sd->bl.m].flag.noreturn && !map->list[pl_sd->bl.m].flag.nowarp)
-					pc->setpos(pl_sd,map_index,x,y,CLR_TELEPORT);
-				break;
+		if (include_leader == false && p->party.member[i].leader)
+			continue;
+
+		switch( type ) {
+		case 0: // Random
+			if (!map->list[pl_sd->bl.m].flag.nowarp)
+				pc->randomwarp(pl_sd, CLR_TELEPORT);
+			break;
+		case 1: // SavePointAll
+			if (!map->list[pl_sd->bl.m].flag.noreturn)
+				pc->setpos(pl_sd, pl_sd->status.save_point.map, pl_sd->status.save_point.x, pl_sd->status.save_point.y, CLR_TELEPORT);
+			break;
+		case 2: // SavePoint
+			if (!map->list[pl_sd->bl.m].flag.noreturn)
+				pc->setpos(pl_sd, sd->status.save_point.map, sd->status.save_point.x, sd->status.save_point.y, CLR_TELEPORT);
+			break;
+		case 3: // Leader
+		case 4: // m,x,y
+			if (!map->list[pl_sd->bl.m].flag.noreturn && !map->list[pl_sd->bl.m].flag.nowarp)
+				pc->setpos(pl_sd, map_index, x, y, CLR_TELEPORT);
+			break;
 		}
 	}
 
@@ -21524,7 +21531,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(warp,"sii?"),
 		BUILDIN_DEF(areawarp,"siiiisii??"),
 		BUILDIN_DEF(warpchar,"siii"), // [LuzZza]
-		BUILDIN_DEF(warpparty,"siii?"), // [Fredzilla] [Paradox924X]
+		BUILDIN_DEF(warpparty,"siii??"), // [Fredzilla] [Paradox924X] [Jedzkie] [Dastgir]
 		BUILDIN_DEF(warpguild,"siii?"), // [Fredzilla]
 		BUILDIN_DEF(setlook,"ii"),
 		BUILDIN_DEF(changelook,"ii"), // Simulates but don't Store it


### PR DESCRIPTION
Update the *warpparty script commmand, credits to Dastgir
Coding-style fixes & whitespace adjustments in warpparty part in script.c

[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)

**Affected Branches:** master

[//]: # (Master? Slave?)

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)

### Known Issues and TODO List
Our current implementation of Giant Fly Wing is when you use the item, the positions of the characters are only in the same cell where the leader is, But in kRO, if you use the item, the positions of the characters are randomized within 3x3 range excluding the leader. The leader warps always at the center of the 3x3 cell.

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
