### PR TITLE
Made prevent_logout effect on log-in optional

### DIFF
--- a/conf/map/battle/player.conf
+++ b/conf/map/battle/player.conf
@@ -140,6 +140,15 @@ max_cart_weight: 8000
 // Prevent logout of players after being hit for how long (in ms, 0 disables)?
 prevent_logout: 10000
 
+// When should the server prevent a player from logging out? Have no effect if prevent_logout is disabled. (Note 3)
+// Official servers prevent players from logging out after attacking, casting skills, and taking damage.
+// 0 = Players can always logout
+// 1 = Prevent logout on login
+// 2 = Prevent logout after attacking
+// 4 = Prevent logout after casting skill
+// 8 = Prevent logout after being hit
+prevent_logout_trigger: 14
+
 // Display the drained hp/sp values from normal attacks? (Ie: Hunter Fly card)
 show_hp_sp_drain: false
 

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7333,6 +7333,7 @@ static const struct battle_data {
 	{ "max_summoner_parameter",             &battle_config.max_summoner_parameter,          120,    10,     10000,          },
 	{ "mvp_exp_reward_message",             &battle_config.mvp_exp_reward_message,          0,      0,      1,              },
 	{ "monster_eye_range_bonus",            &battle_config.mob_eye_range_bonus,             0,      0,      10,             },
+	{ "prevent_logout_trigger",             &battle_config.prevent_logout_trigger,          0xE,    0,      0xF,            }
 };
 #ifndef STATS_OPT_OUT
 /**

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -552,6 +552,8 @@ struct Battle_Config {
 	int mvp_exp_reward_message;
 
 	int mob_eye_range_bonus; //Vulture's Eye and Snake's Eye range bonus
+
+	int prevent_logout_trigger;
 };
 
 /* criteria for battle_config.idletime_critera */

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -741,7 +741,8 @@ int pc_setnewpc(struct map_session_data *sd, int account_id, int char_id, int lo
 	sd->client_tick  = client_tick;
 	sd->state.active = 0; //to be set to 1 after player is fully authed and loaded.
 	sd->bl.type      = BL_PC;
-	sd->canlog_tick  = timer->gettick();
+	if (battle_config.prevent_logout_trigger & PLT_LOGIN)
+		sd->canlog_tick = timer->gettick();
 	//Required to prevent homunculus copuing a base speed of 0.
 	sd->battle_status.speed = sd->base_status.speed = DEFAULT_WALK_SPEED;
 	sd->state.warp_clean = 1;
@@ -7703,7 +7704,8 @@ void pc_damage(struct map_session_data *sd,struct block_list *src,unsigned int h
 	if( sd->status.ele_id > 0 )
 		elemental->set_target(sd,src);
 
-	sd->canlog_tick = timer->gettick();
+	if (battle_config.prevent_logout_trigger & PLT_DAMAGE)
+		sd->canlog_tick = timer->gettick();
 }
 
 /*==========================================

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -73,6 +73,14 @@ enum equip_index {
 	EQI_MAX
 };
 
+enum prevent_logout_trigger {
+	PLT_NONE   = 0x0,
+	PLT_LOGIN  = 0x1,
+	PLT_ATTACK = 0x2,
+	PLT_SKILL  = 0x4,
+	PLT_DAMAGE = 0x8
+};
+
 enum pc_unequipitem_flag {
 	PCUNEQUIPITEM_NONE   = 0x0, ///< Just unequip
 	PCUNEQUIPITEM_RECALC = 0x1, ///< Recalculate status after unequipping

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1667,6 +1667,9 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 	} else
 		skill->castend_id(ud->skilltimer,tick,src->id,0);
 
+	if (sd != NULL && battle_config.prevent_logout_trigger & PLT_SKILL)
+		sd->canlog_tick = timer->gettick();
+
 	return 1;
 }
 
@@ -1813,6 +1816,10 @@ int unit_skilluse_pos2( struct block_list *src, short skill_x, short skill_y, ui
 		ud->skilltimer = INVALID_TIMER;
 		skill->castend_pos(ud->skilltimer,tick,src->id,0);
 	}
+
+	if (sd != NULL && battle_config.prevent_logout_trigger & PLT_SKILL)
+		sd->canlog_tick = timer->gettick();
+
 	return 1;
 }
 
@@ -2252,6 +2259,9 @@ int unit_attack_timer_sub(struct block_list* src, int tid, int64 tick)
 			pc->update_idle_time(sd, BCIDLE_ATTACK);
 		ud->attacktimer = timer->add(ud->attackabletime,unit->attack_timer,src->id,0);
 	}
+
+	if (sd != NULL && battle_config.prevent_logout_trigger & PLT_ATTACK)
+		sd->canlog_tick = timer->gettick();
 
 	return 1;
 }


### PR DESCRIPTION
kRO does not prevent players from logging out after connecting to its zone servers.

Credits to @secretdataz of rAthena

[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)

**Affected Branches:** master

[//]: # (Master? Slave?)

**Issues addressed:**
https://github.com/HerculesWS/Hercules/issues/981

[//]: # (Issue Tracker Number if any.)

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
