### PR TITLE
allow checkoption et al to check another player

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3950,17 +3950,18 @@ things might in some cases be required.
 
 ---------------------------------------
 
-*checkoption(<option number>)
-*checkoption1(<option number>)
-*checkoption2(<option number>)
-*setoption(<option number>{, <flag>});
+*checkoption(<option number>{, <account id>})
+*checkoption1(<option number>{, <account id>})
+*checkoption2(<option number>{, <account id>})
+*setoption(<option number>{, <flag>{, <account id>}});
 
 The setoption() series of functions check for a so-called option that is
 set on the invoking character. 'Options' are used to store status 
 conditions and a lot of other non-permanent character data of the yes-no 
 kind. For most common cases, it is better to use checkcart(),
 checkfalcon(), checkmount() and other similar functions, but there are
-some options which you cannot get at this way.
+some options which you cannot get at this way. If <account id> is given,
+this player will be used instead of the invoking character.
 
 Option numbers valid for the first (option) version of this command are:
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9950,7 +9950,13 @@ BUILDIN(end) {
 BUILDIN(checkoption)
 {
 	int option;
-	struct map_session_data *sd = script->rid2sd(st);
+	struct map_session_data *sd;
+
+	if (script_hasdata(st, 3))
+		sd = map->id2sd(script_getnum(st, 3));
+	else
+		sd = script->rid2sd(st);
+
 	if (sd == NULL)
 		return true;// no player attached, report source
 
@@ -9969,7 +9975,13 @@ BUILDIN(checkoption)
 BUILDIN(checkoption1)
 {
 	int opt1;
-	struct map_session_data *sd = script->rid2sd(st);
+	struct map_session_data *sd;
+
+	if (script_hasdata(st, 3))
+		sd = map->id2sd(script_getnum(st, 3));
+	else
+		sd = script->rid2sd(st);
+
 	if (sd == NULL)
 		return true;// no player attached, report source
 
@@ -9988,7 +10000,13 @@ BUILDIN(checkoption1)
 BUILDIN(checkoption2)
 {
 	int opt2;
-	struct map_session_data *sd = script->rid2sd(st);
+	struct map_session_data *sd;
+
+	if (script_hasdata(st, 3))
+		sd = map->id2sd(script_getnum(st, 3));
+	else
+		sd = script->rid2sd(st);
+
 	if (sd == NULL)
 		return true;// no player attached, report source
 
@@ -10012,7 +10030,13 @@ BUILDIN(setoption)
 {
 	int option;
 	int flag = 1;
-	struct map_session_data *sd = script->rid2sd(st);
+	struct map_session_data *sd;
+
+	if (script_hasdata(st, 4))
+		sd = map->id2sd(script_getnum(st, 4));
+	else
+		sd = script->rid2sd(st);
+
 	if (sd == NULL)
 		return true;// no player attached, report source
 
@@ -23190,8 +23214,8 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(setgroupid, "i?"),
 		BUILDIN_DEF(getgroupid,""),
 		BUILDIN_DEF(end,""),
-		BUILDIN_DEF(checkoption,"i"),
-		BUILDIN_DEF(setoption,"i?"),
+		BUILDIN_DEF(checkoption,"i?"),
+		BUILDIN_DEF(setoption,"i??"),
 		BUILDIN_DEF(setcart,"?"),
 		BUILDIN_DEF(checkcart,""),
 		BUILDIN_DEF(setfalcon,"?"),
@@ -23341,8 +23365,8 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(setnpcdir,"*"), // [4144]
 		BUILDIN_DEF(getnpcclass,"?"), // [4144]
 		BUILDIN_DEF(getmapxy,"rrri?"), //by Lorky [Lupus]
-		BUILDIN_DEF(checkoption1,"i"),
-		BUILDIN_DEF(checkoption2,"i"),
+		BUILDIN_DEF(checkoption1,"i?"),
+		BUILDIN_DEF(checkoption2,"i?"),
 		BUILDIN_DEF(guildgetexp,"i"),
 		BUILDIN_DEF(guildchangegm,"is"),
 		BUILDIN_DEF(logmes,"s"), //this command actls as MES but rints info into LOG file either SQL/TXT [Lupus]


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
* add optional parameter `<account id>` to the following buildins:
    * `checkoption()`
    * `checkoption1()`
    * `checkoption2()`
    * `setoption()`

**Affected Branches:** `master`

**Issues addressed:** *(none)*

- - -
I really only need this to check `Option_Invisible` on another player.

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
