### PR TITLE
Fix map-server crash when using npcspeed on a npc not on a map

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -15203,21 +15203,24 @@ BUILDIN(npctalk)
 }
 
 // change npc walkspeed [Valaris]
-BUILDIN(npcspeed) {
-	struct npc_data* nd;
-	int speed;
-
-	speed = script_getnum(st,2);
-	nd = map->id2nd(st->oid);
+static BUILDIN(npcspeed)
+{
+	struct npc_data *nd = map->id2nd(st->oid);
+	int speed = script_getnum(st, 2);
 
 	if (nd != NULL) {
 		unit->bl2ud2(&nd->bl); // ensure nd->ud is safe to edit
+		if (nd->ud == NULL) {
+			ShowWarning("buildin_npcspeed: Floating NPC don't have unit data.\n");
+			return false;
+		}
 		nd->speed = speed;
 		nd->ud->state.speed_changed = 1;
 	}
 
 	return true;
 }
+
 // make an npc walk to a position [Valaris]
 BUILDIN(npcwalkto)
 {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Check for unit data `(nd->ud != NULL)` before adjust the NPC speed. 
Throw warnings if `nd->ud == NULL`.

**Issues addressed:** <!-- Write here the issue number, if any. -->
Prevent map-server from crashing when adjust the NPC speed.

Sample NPC Script:
```
-	script	dummynpc	-1,{
	OnInit:
		debugmes "set speed to 100";
		npcspeed 100;
		debugmes "set speed done";
		end;
}
```
Result:
![sample](https://i.imgur.com/cY72hDz.png)

After fixed:  throw warnings but didnt crash map-server
![sample2](https://i.imgur.com/oh9hn2p.png)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
