### PR TITLE
patch for readparam()

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2451,7 +2451,7 @@ arrays:
 
 ---------------------------------------
 
-*readparam(<parameter number>)
+*readparam(<parameter number>{, "<player name>"})
 
 This function will return the basic stats of an invoking character, 
 referred to by the parameter number. Instead of a number, you can use a 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -8568,20 +8568,26 @@ BUILDIN(disableitemuse)
 BUILDIN(readparam) {
 	int type;
 	struct map_session_data *sd;
+	struct script_data *data = script_getdata(st, 2);
 
-	type=script_getnum(st,2);
-	if (script_hasdata(st,3))
-		sd = script->nick2sd(st, script_getstr(st,3));
-	else
-		sd=script->rid2sd(st);
+	if (reference_toparam(data)) {
+		type = reference_getparamtype(data);
+	} else {
+		type = script->conv_num(st, data);
+	}
+
+	if (script_hasdata(st, 3)) {
+		sd = script->nick2sd(st, script_getstr(st, 3));
+	} else {
+		sd = script->rid2sd(st);
+	}
 
 	if (sd == NULL) {
-		script_pushint(st,-1);
+		script_pushint(st, -1);
 		return true;
 	}
 
-	script_pushint(st,pc->readparam(sd,type));
-
+	script_pushint(st, pc->readparam(sd, type));
 	return true;
 }
 


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

* Allow passing params to `readparam`
    * you can still pass integers and constants like before
* Add missing `<player name>` parameter to the documentation of `readparam`

<br>

As @AnnieRuru pointed out in #840, doing the following:
```c
debugmes(sprintf("%d - %d", Hp, readparam(Hp)));
```
Will print, for example, `40 - 0`. This is because `readparam` only takes integers (or constants) and does not take params. This PR remedies to this situation, and allows to do things like the following:
```c
debugmes(Hp); // print our own hp
debugmes(readparam(Hp, "another player")); // print the hp of someone else
```

<br><br>

**Affected Branches:** `master`
**Related issues:** #840 
**Type:** [enhancement](https://github.com/HerculesWS/Hercules/labels/type%3Aenhancement)
**Compopents:** [script engine](https://github.com/HerculesWS/Hercules/labels/component%3Acore%3Ascriptengine), [documentation](https://github.com/HerculesWS/Hercules/labels/component%3Adocumentation)

closes #840

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
