### PR TITLE
Fix a race condition when saving the storage on logout

### DIFF
--- a/src/char/char.c
+++ b/src/char/char.c
@@ -288,15 +288,11 @@ void char_set_char_offline(int char_id, int account_id)
 	else
 	{
 		struct mmo_charstatus* cp = (struct mmo_charstatus*) idb_get(chr->char_db_,char_id);
-		struct storage_data *stor = (struct storage_data *) idb_get(inter_storage->account_storage, account_id);
 
 		inter_guild->CharOffline(char_id, cp?cp->guild_id:-1);
 
 		if (cp)
 			idb_remove(chr->char_db_,char_id);
-
-		if (stor) /* Remove inter-storage data. */
-			inter_storage->delete_account_storage(account_id);
 
 		if( SQL_ERROR == SQL->Query(inter->sql_handle, "UPDATE `%s` SET `online`='0' WHERE `char_id`='%d' LIMIT 1", char_db, char_id) )
 			Sql_ShowDebug(inter->sql_handle);

--- a/src/char/int_storage.h
+++ b/src/char/int_storage.h
@@ -31,20 +31,13 @@ struct guild_storage;
  * inter_storage interface
  **/
 struct inter_storage_interface {
-	/* */
-	struct DBMap *account_storage;
-	/* */
-	/* */
-	struct DBData (*ensure_account_storage) (union DBKey key, va_list args);
-	int (*clear_account_storage) (union DBKey key, struct DBData *data, va_list args);
-	int (*tosql) (int account_id, struct storage_data *cp, const struct storage_data *p);
+	int (*tosql) (int account_id, const struct storage_data *p);
 	int (*fromsql) (int account_id, struct storage_data *p);
 	int (*guild_storage_tosql) (int guild_id, const struct guild_storage *p);
 	int (*guild_storage_fromsql) (int guild_id, struct guild_storage* p);
 	int (*sql_init) (void);
 	void (*sql_final) (void);
 	int (*delete_) (int account_id);
-	void (*delete_account_storage) (int account_id);
 	int (*guild_storage_delete) (int guild_id);
 	int (*parse_frommap) (int fd);
 };


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The storage data is no longer cached in the char server. This removal
doesn't cause any performance loss, since the cached data was refreshed
(loaded from the database) after every save operation. This commit
moves the load at the beginning of the save rather than at the end, and
discars the cached copy after the save is completed.

**Issues addressed:**

Fixes #1754, related to #1752 and #1756

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
