### PR TITLE
Optimisation of char_memitemdata_to_sql()

### DIFF
--- a/src/char/char.h
+++ b/src/char/char.h
@@ -139,7 +139,8 @@ struct char_interface {
 	void (*set_all_offline_sql) (void);
 	struct DBData (*create_charstatus) (union DBKey key, va_list args);
 	int (*mmo_char_tosql) (int char_id, struct mmo_charstatus* p);
-	int (*memitemdata_to_sql) (const struct item items[], int max, int id, int tableswitch);
+	int (*getitemdata_from_sql) (struct item *items, int max, int guid, enum inventory_table_type table);
+	int (*memitemdata_to_sql) (const struct item items[], int id, enum inventory_table_type table);
 	int (*mmo_gender) (const struct char_session_data *sd, const struct mmo_charstatus *p, char sex);
 	int (*mmo_chars_fromsql) (struct char_session_data* sd, uint8* buf);
 	int (*mmo_char_fromsql) (int char_id, struct mmo_charstatus* p, bool load_everything);

--- a/src/char/int_storage.c
+++ b/src/char/int_storage.c
@@ -238,7 +238,7 @@ int inter_storage_fromsql(int account_id, struct storage_data *p)
 int inter_storage_guild_storage_tosql(int guild_id, const struct guild_storage *p)
 {
 	nullpo_ret(p);
-	chr->memitemdata_to_sql(p->items, MAX_GUILD_STORAGE, guild_id, TABLE_GUILD_STORAGE);
+	chr->memitemdata_to_sql(p->items, guild_id, TABLE_GUILD_STORAGE);
 	ShowInfo ("guild storage save to DB - guild: %d\n", guild_id);
 	return 0;
 }

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -380,8 +380,10 @@ typedef struct DBData (*HPMHOOK_pre_chr_create_charstatus) (union DBKey *key, va
 typedef struct DBData (*HPMHOOK_post_chr_create_charstatus) (struct DBData retVal___, union DBKey key, va_list args);
 typedef int (*HPMHOOK_pre_chr_mmo_char_tosql) (int *char_id, struct mmo_charstatus **p);
 typedef int (*HPMHOOK_post_chr_mmo_char_tosql) (int retVal___, int char_id, struct mmo_charstatus *p);
-typedef int (*HPMHOOK_pre_chr_memitemdata_to_sql) (const struct item *items[], int *max, int *id, int *tableswitch);
-typedef int (*HPMHOOK_post_chr_memitemdata_to_sql) (int retVal___, const struct item items[], int max, int id, int tableswitch);
+typedef int (*HPMHOOK_pre_chr_getitemdata_from_sql) (struct item **items, int *max, int *guid, enum inventory_table_type *table);
+typedef int (*HPMHOOK_post_chr_getitemdata_from_sql) (int retVal___, struct item *items, int max, int guid, enum inventory_table_type table);
+typedef int (*HPMHOOK_pre_chr_memitemdata_to_sql) (const struct item *items[], int *id, enum inventory_table_type *table);
+typedef int (*HPMHOOK_post_chr_memitemdata_to_sql) (int retVal___, const struct item items[], int id, enum inventory_table_type table);
 typedef int (*HPMHOOK_pre_chr_mmo_gender) (const struct char_session_data **sd, const struct mmo_charstatus **p, char *sex);
 typedef int (*HPMHOOK_post_chr_mmo_gender) (int retVal___, const struct char_session_data *sd, const struct mmo_charstatus *p, char sex);
 typedef int (*HPMHOOK_pre_chr_mmo_chars_fromsql) (struct char_session_data **sd, uint8 **buf);

--- a/src/plugins/HPMHooking/HPMHooking_char.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_char.HPMHooksCore.inc
@@ -62,6 +62,8 @@ struct {
 	struct HPMHookPoint *HP_chr_create_charstatus_post;
 	struct HPMHookPoint *HP_chr_mmo_char_tosql_pre;
 	struct HPMHookPoint *HP_chr_mmo_char_tosql_post;
+	struct HPMHookPoint *HP_chr_getitemdata_from_sql_pre;
+	struct HPMHookPoint *HP_chr_getitemdata_from_sql_post;
 	struct HPMHookPoint *HP_chr_memitemdata_to_sql_pre;
 	struct HPMHookPoint *HP_chr_memitemdata_to_sql_post;
 	struct HPMHookPoint *HP_chr_mmo_gender_pre;
@@ -1547,6 +1549,8 @@ struct {
 	int HP_chr_create_charstatus_post;
 	int HP_chr_mmo_char_tosql_pre;
 	int HP_chr_mmo_char_tosql_post;
+	int HP_chr_getitemdata_from_sql_pre;
+	int HP_chr_getitemdata_from_sql_post;
 	int HP_chr_memitemdata_to_sql_pre;
 	int HP_chr_memitemdata_to_sql_post;
 	int HP_chr_mmo_gender_pre;

--- a/src/plugins/HPMHooking/HPMHooking_char.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_char.HookingPoints.inc
@@ -46,6 +46,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(chr->set_all_offline_sql, HP_chr_set_all_offline_sql) },
 	{ HP_POP(chr->create_charstatus, HP_chr_create_charstatus) },
 	{ HP_POP(chr->mmo_char_tosql, HP_chr_mmo_char_tosql) },
+	{ HP_POP(chr->getitemdata_from_sql, HP_chr_getitemdata_from_sql) },
 	{ HP_POP(chr->memitemdata_to_sql, HP_chr_memitemdata_to_sql) },
 	{ HP_POP(chr->mmo_gender, HP_chr_mmo_gender) },
 	{ HP_POP(chr->mmo_chars_fromsql, HP_chr_mmo_chars_fromsql) },

--- a/src/plugins/HPMHooking/HPMHooking_char.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_char.Hooks.inc
@@ -528,15 +528,15 @@ int HP_chr_mmo_char_tosql(int char_id, struct mmo_charstatus *p) {
 	}
 	return retVal___;
 }
-int HP_chr_memitemdata_to_sql(const struct item items[], int max, int id, int tableswitch) {
+int HP_chr_getitemdata_from_sql(struct item *items, int max, int guid, enum inventory_table_type table) {
 	int hIndex = 0;
 	int retVal___ = 0;
-	if (HPMHooks.count.HP_chr_memitemdata_to_sql_pre > 0) {
-		int (*preHookFunc) (const struct item *items[], int *max, int *id, int *tableswitch);
+	if (HPMHooks.count.HP_chr_getitemdata_from_sql_pre > 0) {
+		int (*preHookFunc) (struct item **items, int *max, int *guid, enum inventory_table_type *table);
 		*HPMforce_return = false;
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_chr_memitemdata_to_sql_pre; hIndex++) {
-			preHookFunc = HPMHooks.list.HP_chr_memitemdata_to_sql_pre[hIndex].func;
-			retVal___ = preHookFunc(&items, &max, &id, &tableswitch);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_chr_getitemdata_from_sql_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_chr_getitemdata_from_sql_pre[hIndex].func;
+			retVal___ = preHookFunc(&items, &max, &guid, &table);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -544,13 +544,40 @@ int HP_chr_memitemdata_to_sql(const struct item items[], int max, int id, int ta
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.chr.memitemdata_to_sql(items, max, id, tableswitch);
+		retVal___ = HPMHooks.source.chr.getitemdata_from_sql(items, max, guid, table);
+	}
+	if (HPMHooks.count.HP_chr_getitemdata_from_sql_post > 0) {
+		int (*postHookFunc) (int retVal___, struct item *items, int max, int guid, enum inventory_table_type table);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_chr_getitemdata_from_sql_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_chr_getitemdata_from_sql_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, items, max, guid, table);
+		}
+	}
+	return retVal___;
+}
+int HP_chr_memitemdata_to_sql(const struct item items[], int id, enum inventory_table_type table) {
+	int hIndex = 0;
+	int retVal___ = 0;
+	if (HPMHooks.count.HP_chr_memitemdata_to_sql_pre > 0) {
+		int (*preHookFunc) (const struct item *items[], int *id, enum inventory_table_type *table);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_chr_memitemdata_to_sql_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_chr_memitemdata_to_sql_pre[hIndex].func;
+			retVal___ = preHookFunc(&items, &id, &table);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.chr.memitemdata_to_sql(items, id, table);
 	}
 	if (HPMHooks.count.HP_chr_memitemdata_to_sql_post > 0) {
-		int (*postHookFunc) (int retVal___, const struct item items[], int max, int id, int tableswitch);
+		int (*postHookFunc) (int retVal___, const struct item items[], int id, enum inventory_table_type table);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_chr_memitemdata_to_sql_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_chr_memitemdata_to_sql_post[hIndex].func;
-			retVal___ = postHookFunc(retVal___, items, max, id, tableswitch);
+			retVal___ = postHookFunc(retVal___, items, id, table);
 		}
 	}
 	return retVal___;


### PR DESCRIPTION
Implements the storage saving algorithm for inventory, cart and guild storage tables.
Total queries to a table in any call would be no more than 4 per call, replacing the original algorithm that could make a lot more through single update queries per call. This significantly reduces the run time speed for saving/loading of item data from the game server.

[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Optimisation of char_memitemdata_to_sql()
    Implements the storage saving algorithm for inventory, cart and guild storage tables.
    Total queries to a table in any call would be no more than 4 per call, replacing the original algorithm that could make a lot more through single update queries per call. This significantly reduces the run time speed for saving/loading of item data from the game server.

**Affected Branches:** master

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
