### PR TITLE
fix for #1761

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -17032,6 +17032,7 @@ BUILDIN(swap)
 {
 	struct map_session_data *sd = NULL;
 	struct script_data *data1, *data2;
+	struct reg_db *ref1, *ref2;
 	const char *varname1, *varname2;
 	int64 uid1, uid2;
 
@@ -17072,6 +17073,8 @@ BUILDIN(swap)
 
 	uid1 = reference_getuid(data1);
 	uid2 = reference_getuid(data2);
+	ref1 = reference_getref(data1);
+	ref2 = reference_getref(data2);
 
 	if (is_string_variable(varname1)) {
 		const char *value1, *value2;
@@ -17080,8 +17083,8 @@ BUILDIN(swap)
 		value2 = script_getstr(st,3);
 
 		if (strcmpi(value1, value2)) {
-			script->set_reg(st, sd, uid1, varname1, value2, script_getref(st,3));
-			script->set_reg(st, sd, uid2, varname2, value1, script_getref(st,2));
+			script->set_reg(st, sd, uid1, varname1, value2, ref1);
+			script->set_reg(st, sd, uid2, varname2, value1, ref2);
 		}
 	}
 	else {
@@ -17091,8 +17094,8 @@ BUILDIN(swap)
 		value2 = script_getnum(st,3);
 
 		if (value1 != value2) {
-			script->set_reg(st, sd, uid1, varname1, (const void *)h64BPTRSIZE(value2), script_getref(st,3));
-			script->set_reg(st, sd, uid2, varname2, (const void *)h64BPTRSIZE(value1), script_getref(st,2));
+			script->set_reg(st, sd, uid1, varname1, (const void *)h64BPTRSIZE(value2), ref1);
+			script->set_reg(st, sd, uid2, varname2, (const void *)h64BPTRSIZE(value1), ref2);
 		}
 	}
 	return true;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
For some reason the reference is lost right after the `conv_num` or `conv_str`. See https://github.com/HerculesWS/Hercules/issues/1761#issuecomment-306341881

**Affected Branches:** `master`
**Issues addressed:** #1761

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
