### PR TITLE
Fixes error when skill is used on traps

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -12156,7 +12156,7 @@ int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *bl, int6
 	struct skill_unit_group *sg;
 	struct block_list *ss;
 	struct map_session_data *tsd;
-	struct status_data *tstatus, *bst;
+	struct status_data *tstatus;
 	struct status_change *tsc, *ssc;
 	struct skill_unit_group_tickset *ts;
 	enum sc_type type;
@@ -12181,8 +12181,6 @@ int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *bl, int6
 
 	tstatus = status->get_status_data(bl);
 	nullpo_ret(tstatus);
-	bst = status->get_base_status(bl);
-	nullpo_ret(bst);
 	type = status->skill2sc(sg->skill_id);
 	skill_id = sg->skill_id;
 
@@ -12858,6 +12856,8 @@ int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *bl, int6
 			if (tsc && (tsc->data[SC_HALLUCINATIONWALK] || tsc->data[SC_VACUUM_EXTREME])) {
 				return 0;
 			} else {
+				struct status_data *bst = status->get_base_status(bl);
+				nullpo_ret(bst);
 				sg->limit -= 1000 * bst->str/20;
 				sc_start(ss, bl, SC_VACUUM_EXTREME, 100, sg->skill_lv, sg->limit);
 


### PR DESCRIPTION
Fixed assert report when arrow shower(skill) was used on traps.
Fixes #1676

### Pull Request Prelude


- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

scope of bst variable is reduced to only UNT_VACUUM_EXTREME case, so other traps aren't affected if bst is NULL.

**Affected Branches:** 

master

**Issues addressed:**

#1676 

### Known Issues and TODO List
None