### PR TITLE
new buildin: getdatatype()

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8334,6 +8334,30 @@ Example:
 
 ---------------------------------------
 
+*getdatatype(<argument>)
+
+This command returns the raw type of the given <argument>. Unlike
+isstr, this command does not evaluate the argument. The returned type
+is bitmasked.
+
+types include:
+
+	DATATYPE_NIL
+	DATATYPE_STR
+	DATATYPE_INT
+	DATATYPE_CONST
+	DATATYPE_PARAM
+	DATATYPE_VAR
+	DATATYPE_LABEL
+
+Example:
+
+	getdatatype() // DATATYPE_NIL
+	getdatatype("foo") // DATATYPE_STR
+	getdatatype(@foo$) // (DATATYPE_VAR | DATATYPE_STR)
+
+---------------------------------------
+
 *charisalpha("<string>", <position>)
 
 This function will return true if the character number Position in the given

--- a/npc/dev/test.txt
+++ b/npc/dev/test.txt
@@ -9,8 +9,8 @@
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2013-2015  Hercules Dev Team
-//= Copyright (C) 2013-2015  Haru
+//= Copyright (C) 2013-2017  Hercules Dev Team
+//= Copyright (C) 2013-2017  Haru
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -742,6 +742,19 @@ function	script	HerculesSelfTestHelper	{
 	callsub(OnCheckStr, "sprintf (positional)", sprintf("'%2$+05d'", 5, 6), "'+0006'");
 	callsub(OnCheckStr, "sprintf (positional)", sprintf("'%2$s' '%1$c'", "First", "Second"), "'Second' 'F'");
 
+	callsub(OnCheck, "Getdatatype (integer)",              getdatatype(5), DATATYPE_INT);
+	callsub(OnCheck, "Getdatatype (constant string)",      getdatatype("foo"), DATATYPE_STR | DATATYPE_CONST);
+	callsub(OnCheck, "Getdatatype (parameter)",            getdatatype(Hp), DATATYPE_INT | DATATYPE_PARAM);
+	callsub(OnCheck, "Getdatatype (numeric variable)",     getdatatype(.@x), DATATYPE_INT | DATATYPE_VAR);
+	callsub(OnCheck, "Getdatatype (string variable)",      getdatatype(.@x$), DATATYPE_STR | DATATYPE_VAR);
+	callsub(OnCheck, "Getdatatype (label)",                getdatatype(OnTestGetdatatype), DATATYPE_LABEL);
+	//callsub(OnCheck, "Getdatatype (constant)",             getdatatype(DATATYPE_CONST), DATATYPE_CONST); // FIXME
+	callsub(OnCheck, "Getdatatype (returned integer)",     getdatatype(callsub(OnTestReturnValue, 5)), DATATYPE_INT);
+	callsub(OnCheck, "Getdatatype (returned string)",      getdatatype(callsub(OnTestReturnValue, "foo")), DATATYPE_STR | DATATYPE_CONST);
+	callsub(OnCheck, "Getdatatype (getarg default value)", callsub(OnTestGetdatatypeDefault), DATATYPE_INT);
+	callsub(OnCheck, "Getdatatype (getarg integer value)", callsub(OnTestGetdatatype, 5), DATATYPE_INT);
+	callsub(OnCheck, "Getdatatype (getarg string)",        callsub(OnTestGetdatatype, "foo"), DATATYPE_STR | DATATYPE_CONST);
+
 	if (.errors) {
 		debugmes "Script engine self-test   [ \033[0;31mFAILED\033[0m ]";
 		debugmes "**** The test was completed with " + .errors + " errors. ****";
@@ -785,6 +798,12 @@ OnTestScopeArrays:
 
 OnTestVarOfAnotherNPC:
 	return getvariableofnpc(.x, getarg(0));
+
+OnTestGetdatatypeDefault:
+	return getdatatype(getarg(0, 0));
+
+OnTestGetdatatype:
+	return getdatatype(getarg(0));
 
 OnReportError:
 	.@msg$ = getarg(0,"Unknown Error");


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

New buildin: `getdatatype()`. Currently isstr() returns if the data evaluates to a string or not, but there is no way to know what type the original data (prior to get_val) was. This new buildin fills that gap.

<br>

### Known Issues

For some reason when passing a constant it treats it as an integer:
```c
getdatatype(3); // DATATYPE_INT
getdatatype(Zeny); // (DATATYPE_PARAM | DATATYPE_INT)
getdatatype(ZENY); // (DATATYPE_VAR | DATATYPE_INT)
getdatatype(ZENY$); // (DATATYPE_VAR | DATATYPE_STR)
getdatatype(CHAR_ID_ACCOUNT); // DATATYPE_INT <= not detected as const!
```
All other C_NAME types (variables, params) are recognized properly. And it's not a problem with my implementation; doing `data->type` returns `C_INT` with constants. This also means that `script->reportdata()` probably never even worked as intended, along with a bunch of other functions.

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
