### PR TITLE
fix setting pc var on another pc

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -7038,6 +7038,7 @@ BUILDIN(__setr)
 	int64 num;
 	const char* name;
 	char prefix;
+	struct reg_db *ref;
 
 	data = script_getdata(st,2);
 	//datavalue = script_getdata(st,3);
@@ -7050,11 +7051,11 @@ BUILDIN(__setr)
 
 	num = reference_getuid(data);
 	name = reference_getname(data);
+	ref = reference_getref(data);
 	prefix = *name;
 
 	if (not_server_variable(prefix)) {
-		sd = script->rid2sd(st);
-		if (sd == NULL) {
+		if (ref == NULL && (sd = script->rid2sd(st)) == NULL) {
 			ShowError("script:set: no player attached for player variable '%s'\n", name);
 			return true;
 		}
@@ -7102,9 +7103,9 @@ BUILDIN(__setr)
 	}
 
 	if (is_string_variable(name))
-		script->set_reg(st, sd, num, name, script_getstr(st, 3), script_getref(st, 2));
+		script->set_reg(st, sd, num, name, script_getstr(st, 3), ref);
 	else
-		script->set_reg(st, sd, num, name, (const void *)h64BPTRSIZE(script_getnum(st, 3)), script_getref(st, 2));
+		script->set_reg(st, sd, num, name, (const void *)h64BPTRSIZE(script_getnum(st, 3)), ref);
 
 	return true;
 }


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Reading a player variable with `getvariableofpc()` works just fine without attached player, but it can't be passed to `set()` if there is no attached player (triggers `script:set: no player attached for player variable`). This PR fixes this. It also fixes the loss of reference, akin to #1765.