### PR TITLE
Ignore hidden units in the cell stack limit checks

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -447,6 +447,11 @@ int map_count_oncell(int16 m, int16 x, int16 y, int type, int flag) {
 					struct status_change *sc = status->get_sc(bl);
 					if (sc && (sc->option&OPTION_INVISIBLE))
 						continue;
+					if (bl->type == BL_NPC) {
+						const struct npc_data *nd = BL_UCCAST(BL_NPC, bl);
+						if (nd->class_ == FAKE_NPC || nd->class_ == HIDDEN_WARP_CLASS)
+							continue;
+					}
 				}
 				if (flag&0x1) {
 					struct unit_data *ud = unit->bl2ud(bl);

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -1354,7 +1354,7 @@ int mob_unlocktarget(struct mob_data *md, int64 tick) {
 		md->ud.target_to = 0;
 		unit->set_target(&md->ud, 0);
 	}
-	if(battle_config.official_cell_stack_limit && map->count_oncell(md->bl.m, md->bl.x, md->bl.y, BL_CHAR|BL_NPC, 1) > battle_config.official_cell_stack_limit) {
+	if(battle_config.official_cell_stack_limit && map->count_oncell(md->bl.m, md->bl.x, md->bl.y, BL_CHAR|BL_NPC, 0x1 | 0x2) > battle_config.official_cell_stack_limit) {
 		unit->walktoxy(&md->bl, md->bl.x, md->bl.y, 8);
 	}
 

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -474,7 +474,7 @@ int unit_walktoxy_timer(int tid, int64 tick, int id, intptr_t data)
 		ud->to_x = bl->x;
 		ud->to_y = bl->y;
 
-		if(battle_config.official_cell_stack_limit && map->count_oncell(bl->m, x, y, BL_CHAR|BL_NPC, 1) > battle_config.official_cell_stack_limit) {
+		if (battle_config.official_cell_stack_limit && map->count_oncell(bl->m, x, y, BL_CHAR|BL_NPC, 0x1 | 0x2) > battle_config.official_cell_stack_limit) {
 			//Walked on occupied cell, call unit_walktoxy again
 			if(ud->steptimer != INVALID_TIMER) {
 				//Execute step timer on next step instead


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Invisible NPCs (including those with `FAKE_NPC` and `HIDDEN_WARP_CLASS` sprites) will be ignored for the purpose of cell stack counting.
This improves the Dancer Quest experience as well as other cases of hidden NPCs blocking off certain cells.

**Issues addressed:**

- Fixes #1135

### Known Issues and TODO List

This has been used in a production server for a while, as mentioned in the linked issue. No known problems as of now.

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
