### PR TITLE
Add clang 4.0 and 5.0 builds to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,24 @@ matrix:
         - libxml-sax-perl
         - libxml-parser-perl
   - compiler: clang
+    env: CONFIGURE_FLAGS="--enable-debug CC=clang-5.0 --enable-Werror --enable-buildbot"
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-trusty-5.0
+        - ubuntu-toolchain-r-test
+        packages:
+        - clang-5.0
+  - compiler: clang
+    env: CONFIGURE_FLAGS="--enable-debug CC=clang-5.0 --disable-renewal --enable-Werror --enable-buildbot"
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-trusty-5.0
+        - ubuntu-toolchain-r-test
+        packages:
+        - clang-5.0
+  - compiler: clang
     env: CONFIGURE_FLAGS="--enable-debug --enable-Werror --enable-buildbot"
   - compiler: clang
     env: CONFIGURE_FLAGS="--enable-debug --disable-renewal --enable-Werror --enable-buildbot"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,24 @@ matrix:
         packages:
         - clang-5.0
   - compiler: clang
+    env: CONFIGURE_FLAGS="--enable-debug CC=clang-4.0 --enable-Werror --enable-buildbot"
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-trusty-4.0
+        - ubuntu-toolchain-r-test
+        packages:
+        - clang-4.0
+  - compiler: clang
+    env: CONFIGURE_FLAGS="--enable-debug CC=clang-4.0 --disable-renewal --enable-Werror --enable-buildbot"
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-trusty-4.0
+        - ubuntu-toolchain-r-test
+        packages:
+        - clang-4.0
+  - compiler: clang
     env: CONFIGURE_FLAGS="--enable-debug --enable-Werror --enable-buildbot"
   - compiler: clang
     env: CONFIGURE_FLAGS="--enable-debug --disable-renewal --enable-Werror --enable-buildbot"


### PR DESCRIPTION
the inclusion of `ubuntu-toolchain-r-test` is for `libstdc++6`, which is required by `clang-5.0`