### PR TITLE
Fix re-equip & misceffect in Set Item Option

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -14218,6 +14218,8 @@ BUILDIN(setequipoption)
 			ShowError("buildin_setequipotion: Option value %d exceeds maximum limit (%d to %d) for type!\n", value, -INT16_MAX, INT16_MAX);
 			return false;
 		}
+		/* Store equip info */
+		int ep = sd->status.inventory[i].equip;
 		/* Add Option Index */
 		sd->status.inventory[i].option[slot-1].index = ito->index;
 		/* Add Option Value */
@@ -14233,8 +14235,8 @@ BUILDIN(setequipoption)
 		clif->additem(sd, i, 1, 0); // notify client to simulate item addition.
 		/* Log addition of the item. */
 		logs->pick_pc(sd, LOG_TYPE_SCRIPT, 1, &sd->status.inventory[i], sd->inventory_data[i]);
-		pc->equipitem(sd, i, sd->status.inventory[i].equip); // force equip the item at the original position.
-		clif->misceffect(&sd->bl, 2); // show effect
+		pc->equipitem(sd, i, ep); // force equip the item at the original position.
+		clif->misceffect(&sd->bl, 3); // show effect
 	}
 
 	script_pushint(st, 1);


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix re-equip & misceffect in Set Item Option:
- When setequipotion is successful, item is not re-equipped.
- Wrong value in misceffect, it shows failed refinement.

[//]: # (Describe at length, the changes that this pull request makes.)

**Affected Branches:** 

[//]: # (Master? Slave?)

- [x] Master

**Issues addressed:**

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
