### PR TITLE
Change skill_init_unit_layout to report skill id instead of index

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -18984,7 +18984,8 @@ void skill_init_unit_layout (void)
 
 void skill_init_unit_layout_unknown(int skill_idx)
 {
-	ShowError("unknown unit layout at skill %d\n", skill_idx);
+	Assert_retv(skill_idx >= 0 && skill_idx < MAX_SKILL_DB);
+	ShowError("unknown unit layout at skill %d\n", skill->dbs->db[skill_idx].nameid);
 }
 
 int skill_block_check(struct block_list *bl, sc_type type , uint16 skill_id)


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Reporting the index to the user when there is a mistake in the database is not helpful and could be confusing sometimes as the user might search for an id that does not exist.




[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
