### PR TITLE
Reduce the amount of gitlab-ci pipeline jobs by half

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables: &base_vars
 
 # Compilers
 
-pre_re:clang-3.9:
+clang-3.9:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
@@ -44,20 +44,10 @@ pre_re:clang-3.9:
   script:
     - ./tools/ci/travis.sh build CC=clang-3.9 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:clang-3.9:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: primary
-  image: debian:stretch
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: clang-3.9 mariadb-client libmariadbclient-dev-compat
-  script:
     - ./tools/ci/travis.sh build CC=clang-3.9 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:clang-4.0:
+clang-4.0:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
@@ -68,20 +58,10 @@ pre_re:clang-4.0:
   script:
     - ./tools/ci/travis.sh build CC=clang-4.0 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:clang-4.0:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: primary
-  image: debian:unstable
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: clang-4.0 mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build CC=clang-4.0 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-4.6:
+gcc-4.6:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
@@ -92,20 +72,10 @@ pre_re:gcc-4.6:
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:gcc-4.6:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: secondary
-  image: debian:wheezy
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-4.6 mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build CC=gcc-4.6 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-4.7:
+gcc-4.7:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
@@ -116,20 +86,10 @@ pre_re:gcc-4.7:
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.7 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:gcc-4.7:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: secondary
-  image: debian:wheezy
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-4.7 mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build CC=gcc-4.7 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-4.8:
+gcc-4.8:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
@@ -140,20 +100,10 @@ pre_re:gcc-4.8:
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.8 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:gcc-4.8:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: primary
-  image: debian:jessie
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-4.8 mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build CC=gcc-4.8 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-4.9:
+gcc-4.9:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
@@ -164,20 +114,10 @@ pre_re:gcc-4.9:
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.9 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:gcc-4.9:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: primary
-  image: debian:jessie
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-4.9 mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build CC=gcc-4.9 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-5:
+gcc-5:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
@@ -188,20 +128,10 @@ pre_re:gcc-5:
   script:
     - ./tools/ci/travis.sh build CC=gcc-5 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:gcc-5:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: secondary
-  image: debian:unstable
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-5 mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build CC=gcc-5 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-6:
+gcc-6:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
@@ -212,20 +142,10 @@ pre_re:gcc-6:
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:gcc-6:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: primary
-  image: debian:stretch
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
-  script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-6_i386:
+gcc-6_i386:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
@@ -236,20 +156,10 @@ pre_re:gcc-6_i386:
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:gcc-6_i386:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: primary
-  image: vicamo/debian:sid-i386
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-6 mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-6_sanitize:
+gcc-6_sanitize:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
@@ -260,20 +170,10 @@ pre_re:gcc-6_sanitize:
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal --disable-manager --enable-sanitize=full
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:gcc-6_sanitize:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: secondary
-  image: debian:stretch
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
-  script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-manager --enable-sanitize=full
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-6_i386_sanitize:
+gcc-6_i386_sanitize:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
@@ -284,20 +184,10 @@ pre_re:gcc-6_i386_sanitize:
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal --disable-manager --enable-sanitize=full
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:gcc-6_i386_sanitize:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: secondary
-  image: vicamo/debian:sid-i386
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-6 mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-manager --enable-sanitize=full
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:gcc-6_cov:
+gcc-6_cov:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
@@ -311,20 +201,6 @@ pre_re:gcc-6_cov:
     - gcovr -r . --gcov-executable=gcov-6 -o gcov_pre.txt
     - gcovr -r . --gcov-executable=gcov-6 --html -o gcov_pre.html
     - cat gcov_pre.txt
-  artifacts:
-    paths:
-      - gcov_pre.*
-    when: on_success
-
-re:gcc-6_cov:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: secondary
-  image: debian:stretch
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc-6 gcovr mariadb-client libmariadbclient-dev-compat
-  script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot CFLAGS="-coverage" LDFLAGS="-coverage"
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
     - gcovr -r . --gcov-executable=gcov-6 -o gcov_re.txt
@@ -332,12 +208,13 @@ re:gcc-6_cov:
     - cat gcov_re.txt
   artifacts:
     paths:
+      - gcov_pre.*
       - gcov_re.*
     when: on_success
 
 # Distributions
 
-pre_re:debian-oldstable:
+debian-oldstable:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
@@ -348,20 +225,10 @@ pre_re:debian-oldstable:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:debian-oldstable:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: platforms
-  image: debian:oldstable
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:debian-stable:
+debian-stable:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
@@ -372,20 +239,10 @@ pre_re:debian-stable:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:debian-stable:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: platforms
-  image: debian:stable
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:debian-testing:
+debian-testing:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
@@ -396,20 +253,10 @@ pre_re:debian-testing:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:debian-testing:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: platforms
-  image: debian:testing
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:centos-previous:
+centos-previous:
   <<: *branch_exceptions
   stage: platforms
   image: centos:6
@@ -429,29 +276,10 @@ pre_re:centos-previous:
   script:
     - scl enable devtoolset-3 './tools/ci/travis.sh build CFLAGS="-Wno-cast-qual" --enable-debug --enable-Werror --enable-buildbot --disable-renewal'
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:centos-previous:
-  <<: *branch_exceptions
-  stage: platforms
-  image: centos:6
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - yum -y update
-    - yum install -y make mysql-devel pcre-devel git zlib-devel mysql
-    - yum install -y centos-release-scl
-    - yum install -y yum install devtoolset-3-toolchain
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mysql
-    - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mysql:latest
-  variables:
-    <<: *base_vars
-  script:
     - scl enable devtoolset-3  './tools/ci/travis.sh build CFLAGS="-Wno-cast-qual" --enable-debug --enable-Werror --enable-buildbot'
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:centos-current:
+centos-current:
   <<: *branch_exceptions
   stage: platforms
   image: centos:7
@@ -469,27 +297,10 @@ pre_re:centos-current:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:centos-current:
-  <<: *branch_exceptions
-  stage: platforms
-  image: centos:7
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - yum -y update
-    - yum install -y gcc make mysql-devel pcre-devel git zlib-devel mysql
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mysql
-    - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mysql:latest
-  variables:
-    <<: *base_vars
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:ubuntu-xenial:
+ubuntu-xenial:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
@@ -502,24 +313,12 @@ pre_re:ubuntu-xenial:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:ubuntu-xenial:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: platforms
-  image: ubuntu:16.04
-  services:
-    - mysql:latest
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
 # SQL servers
 
-pre_re:mysql-5.5:
+mysql-5.5:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
@@ -532,22 +331,10 @@ pre_re:mysql-5.5:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:mysql-5.5:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: platforms
-  image: debian:jessie
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mysql-client-5.5 libmysqlclient-dev
-  services:
-    - mysql:5.5
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:mysql-5.6:
+mysql-5.6:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
@@ -560,22 +347,10 @@ pre_re:mysql-5.6:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:mysql-5.6:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: platforms
-  image: debian:jessie
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
-  services:
-    - mysql:5.6
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:mysql-5.7:
+mysql-5.7:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
@@ -588,22 +363,10 @@ pre_re:mysql-5.7:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
-
-re:mysql-5.7:
-  <<: *branch_exceptions
-  <<: *prerequisites
-  stage: platforms
-  image: debian:unstable
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mysql-client-5.7 libmysqlclient-dev
-  services:
-    - mysql:5.7
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
 
-pre_re:mariadb-10.0:
+mariadb-10.0:
   <<: *branch_exceptions
   stage: platforms
   image: debian:jessie
@@ -622,28 +385,10 @@ pre_re:mariadb-10.0:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mariadb
-
-re:mariadb-10.0:
-  <<: *branch_exceptions
-  stage: platforms
-  image: debian:jessie
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mariadb-client-10.0 libmysqlclient-dev
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - ./tools/ci/retry.sh apt-get update
-    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mariadb
-    - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mariadb:10.0
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mariadb
 
-pre_re:mariadb-latest:
+mariadb-latest:
   <<: *branch_exceptions
   stage: platforms
   image: debian:unstable
@@ -662,28 +407,10 @@ pre_re:mariadb-latest:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mariadb
-
-re:mariadb-latest:
-  <<: *branch_exceptions
-  stage: platforms
-  image: debian:unstable
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mariadb-client-10.1 libmariadbclient-dev-compat
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - ./tools/ci/retry.sh apt-get update
-    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mariadb
-    - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mariadb:latest
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mariadb
 
-pre_re:percona:
+percona:
   <<: *branch_exceptions
   stage: platforms
   image: debian:jessie
@@ -702,24 +429,6 @@ pre_re:percona:
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok percona
-
-re:percona:
-  <<: *branch_exceptions
-  stage: platforms
-  image: debian:jessie
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - ./tools/ci/retry.sh apt-get update
-    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok percona
-    - ./tools/ci/travis.sh getplugins || true
-  services:
-    - percona:latest
-  script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok percona
 
@@ -742,8 +451,7 @@ pages:
     - mv gcov_*.* public/
     - cp tools/doxygen/pages_index.html public/index.html
   dependencies:
-    - re:gcc-6_cov
-    - pre_re:gcc-6_cov
+    - gcc-6_cov
   artifacts:
     paths:
       - public

--- a/tools/ci/travis.sh
+++ b/tools/ci/travis.sh
@@ -145,6 +145,7 @@ case "$MODE" in
 	build)
 		(cd tools && ./validateinterfaces.py silent) || aborterror "Interface validation error."
 		./configure $@ || (cat config.log && aborterror "Configure error, aborting build.")
+		make clean || aborterror "Build failed."
 		make -j3 || aborterror "Build failed."
 		make plugins -j3 || aborterror "Build failed."
 		make plugin.script_mapquit -j3 || aborterror "Build failed."


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Pre-renewal and renewal builds for each configuration are now built as part of the same job.
This should reduce the burden on the gitlab-ci infrastructure, and will become necessary when the changes discussed on https://gitlab.com/gitlab-com/infrastructure/issues/2885 will take place.

**Affected Branches:** 

- master
- stable

**Issues addressed:**

https://gitlab.com/gitlab-com/infrastructure/issues/2885

### Known Issues and TODO List

- [ ] This currently reduces the number of jobs from 49 to 25, which is still larger than the planned maximum limit. Further changes will be necessary.


[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
