### PR TITLE
Fix various warnings on Visual Studio 2017

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -4868,21 +4868,19 @@ ACMD(undisguiseguild)
  *------------------------------------------*/
 ACMD(exp)
 {
-	char output[CHAT_SIZE_MAX];
-	double nextb, nextj;
-
-	memset(output, '\0', sizeof(output));
+	double percentb = 0.0, percentj = 0.0;
+	uint64 nextb, nextj;
 
 	nextb = pc->nextbaseexp(sd);
-	if (nextb)
-		nextb = sd->status.base_exp*100.0/nextb;
+	if (nextb != 0)
+		percentb = sd->status.base_exp * 100.0 / nextb;
 
 	nextj = pc->nextjobexp(sd);
-	if (nextj)
-		nextj = sd->status.job_exp*100.0/nextj;
+	if (nextj != 0)
+		percentj = sd->status.job_exp * 100.0 / nextj;
 
-	sprintf(output, msg_fd(fd,1148), sd->status.base_level, nextb, sd->status.job_level, nextj); // Base Level: %d (%.3f%%) | Job Level: %d (%.3f%%)
-	clif->message(fd, output);
+	sprintf(atcmd_output, msg_fd(fd,1148), sd->status.base_level, percentb, sd->status.job_level, percentj); // Base Level: %d (%.3f%%) | Job Level: %d (%.3f%%)
+	clif->message(fd, atcmd_output);
 	return true;
 }
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -8332,7 +8332,7 @@ int pc_setparam(struct map_session_data *sd, int type, int64 val)
 		if (val >= sd->status.job_level) {
 			if (val > pc->maxjoblv(sd))
 				val = pc->maxjoblv(sd);
-			sd->status.skill_point += val - sd->status.job_level;
+			sd->status.skill_point += (int)val - sd->status.job_level;
 			clif->updatestatus(sd, SP_SKILLPOINT);
 		}
 		sd->status.job_level = (int32)val;
@@ -8413,28 +8413,28 @@ int pc_setparam(struct map_session_data *sd, int type, int64 val)
 		}
 		break;
 	case SP_STR:
-		sd->status.str = cap_value(val, 1, pc_maxparameter(sd));
+		sd->status.str = cap_value((int)val, 1, pc_maxparameter(sd));
 		break;
 	case SP_AGI:
-		sd->status.agi = cap_value(val, 1, pc_maxparameter(sd));
+		sd->status.agi = cap_value((int)val, 1, pc_maxparameter(sd));
 		break;
 	case SP_VIT:
-		sd->status.vit = cap_value(val, 1, pc_maxparameter(sd));
+		sd->status.vit = cap_value((int)val, 1, pc_maxparameter(sd));
 		break;
 	case SP_INT:
-		sd->status.int_ = cap_value(val, 1, pc_maxparameter(sd));
+		sd->status.int_ = cap_value((int)val, 1, pc_maxparameter(sd));
 		break;
 	case SP_DEX:
-		sd->status.dex = cap_value(val, 1, pc_maxparameter(sd));
+		sd->status.dex = cap_value((int)val, 1, pc_maxparameter(sd));
 		break;
 	case SP_LUK:
-		sd->status.luk = cap_value(val, 1, pc_maxparameter(sd));
+		sd->status.luk = cap_value((int)val, 1, pc_maxparameter(sd));
 		break;
 	case SP_KARMA:
-		sd->status.karma = val;
+		sd->status.karma = (int)val;
 		break;
 	case SP_MANNER:
-		sd->status.manner = val;
+		sd->status.manner = (int)val;
 		if( val < 0 )
 			sc_start(NULL, &sd->bl, SC_NOCHAT, 100, 0, 0);
 		else {


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This aims to fix the type conversion warnings described in #1867 and related to the changes from uint32 to uint64 of the Exp-related variables.

**Affected Branches:** 

- master
- stable

**Issues addressed:**

- #1867 

### Known Issues and TODO List

- [ ] To be tested on MSVC

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
