### PR TITLE
Fix an incorrect null check in BUILDIN(logmes)

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -15866,11 +15866,12 @@ enum logmes_type {
 /*==========================================
  * Allows player to write logs (i.e. Bank NPC, etc) [Lupus]
  *------------------------------------------*/
-BUILDIN(logmes) {
+BUILDIN(logmes)
+{
 	const char *str = script_getstr(st, 2);
 	struct map_session_data *sd = script->rid2sd(st);
 	enum logmes_type type = LOGMES_NPC;
-	nullpo_retr(sd, false);
+	nullpo_retr(false, sd);
 
 	if (script_hasdata(st, 3)) {
 		type = script_getnum(st, 3);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR fixes an incorrect null check in `BUILDIN(logmes)` (inverted order of arguments in a `nullpo_retr` call).

The incorrect check would cause the `logmes()` script command to never log to database (but rather output a backtrace to the console).

Issue detected by coverity.

Note: From this point onward, we're going to manually run a coverity scan before each release is merged  to the stable branch, so that this kind of errors won't get noticed too late.

**Affected Branches:** 

- master
- stable
- tagged release `v2017-10-22`

**Issues addressed:**

- Coverity CID 168499

### Known Issues and TODO List

We'll probably need a .1 release for this.

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
