### PR TITLE
Fix boss flag and add 2017-10-25 client packets

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -189,6 +189,7 @@ There are two optional fields for monster size and AI. Size can be 0
 
 Alternately, a monster spawned using 'boss_monster' instead of 'monster' is able to be
 detected on the map with the SC_CASH_BOSS_ALARM status (used by Convex Mirror, item ID# 12214).
+A monster spawned using 'miniboss_monster' is spawn monster as mini boss view.
 
 ** NPC names
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -1067,14 +1067,17 @@ void clif_set_unit_idle(struct block_list* bl, struct map_session_data *tsd, enu
 #endif
 #if PACKETVER >= 20120221
 	if (battle_config.show_monster_hp_bar && bl->type == BL_MOB && status_get_hp(bl) < status_get_max_hp(bl)) {
-		const struct mob_data *md = BL_UCCAST(BL_MOB, bl);
 		p.maxHP = status_get_max_hp(bl);
 		p.HP = status_get_hp(bl);
-		p.isBoss = (md->spawn != NULL && md->spawn->state.boss) ? 1 : 0;
 	} else {
 		p.maxHP = -1;
 		p.HP = -1;
-		p.isBoss = 0;
+	}
+	if (bl->type == BL_MOB) {
+		const struct mob_data *md = BL_UCCAST(BL_MOB, bl);
+		p.isBoss = (md->spawn != NULL) ? md->spawn->state.boss : BTYPE_NONE;
+	} else {
+		p.isBoss = BTYPE_NONE;
 	}
 #endif
 #if PACKETVER >= 20150513
@@ -1216,14 +1219,17 @@ void clif_spawn_unit(struct block_list* bl, enum send_target target) {
 #endif
 #if PACKETVER >= 20120221
 	if (battle_config.show_monster_hp_bar && bl->type == BL_MOB && status_get_hp(bl) < status_get_max_hp(bl)) {
-		const struct mob_data *md = BL_UCCAST(BL_MOB, bl);
 		p.maxHP = status_get_max_hp(bl);
 		p.HP = status_get_hp(bl);
-		p.isBoss = (md->spawn != NULL && md->spawn->state.boss) ? 1 : 0;
 	} else {
 		p.maxHP = -1;
 		p.HP = -1;
-		p.isBoss = 0;
+	}
+	if (bl->type == BL_MOB) {
+		const struct mob_data *md = BL_UCCAST(BL_MOB, bl);
+		p.isBoss = (md->spawn != NULL) ? md->spawn->state.boss : BTYPE_NONE;
+	} else {
+		p.isBoss = BTYPE_NONE;
 	}
 #endif
 #if PACKETVER >= 20150513
@@ -1315,14 +1321,17 @@ void clif_set_unit_walking(struct block_list* bl, struct map_session_data *tsd, 
 #endif
 #if PACKETVER >= 20120221
 	if (battle_config.show_monster_hp_bar && bl->type == BL_MOB && status_get_hp(bl) < status_get_max_hp(bl)) {
-		const struct mob_data *md = BL_UCCAST(BL_MOB, bl);
 		p.maxHP = status_get_max_hp(bl);
 		p.HP = status_get_hp(bl);
-		p.isBoss = (md->spawn != NULL && md->spawn->state.boss) ? 1 : 0;
 	} else {
 		p.maxHP = -1;
 		p.HP = -1;
-		p.isBoss = 0;
+	}
+	if (bl->type == BL_MOB) {
+		const struct mob_data *md = BL_UCCAST(BL_MOB, bl);
+		p.isBoss = (md->spawn != NULL) ? md->spawn->state.boss : BTYPE_NONE;
+	} else {
+		p.isBoss = BTYPE_NONE;
 	}
 #endif
 #if PACKETVER >= 20150513

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -1840,7 +1840,7 @@ void map_addiddb(struct block_list *bl)
 		struct mob_data *md = BL_UCAST(BL_MOB, bl);
 		idb_put(map->mobid_db,bl->id,bl);
 
-		if( md->state.boss )
+		if (md->state.boss == BTYPE_MVP)
 			idb_put(map->bossid_db, bl->id, bl);
 	}
 

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -519,7 +519,7 @@ struct spawn_data {
 		//0: Normal mob | 1: Standard summon, attacks mobs
 		//2: Alchemist Marine Sphere | 3: Alchemist Summon Flora | 4: Summon Zanzou
 		unsigned int dynamic : 1; ///< Whether this data is indexed by a map's dynamic mob list
-		unsigned int boss : 1;    ///< 0: Non-boss monster | 1: Boss monster
+		uint8 boss;    ///< 0: Non-boss monster | 1: Boss monster | 2: MVP
 	} state;
 	char name[NAME_LENGTH], eventname[EVENT_NAME_LENGTH]; //Name/event
 };

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2686,7 +2686,7 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type) {
 		return 5; // Note: Actually, it's 4. Oh well...
 
 	// MvP tomb [GreenBox]
-	if (battle_config.mvp_tomb_enabled && md->spawn->state.boss && map->list[md->bl.m].flag.notomb != 1)
+	if (battle_config.mvp_tomb_enabled && md->spawn->state.boss == BTYPE_MVP && map->list[md->bl.m].flag.notomb != 1)
 		mob->mvptomb_create(md, mvp_sd ? mvp_sd->status.name : NULL, time(NULL));
 
 	if( !rebirth ) {

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -69,6 +69,12 @@ struct hplugin_data_store;
 // Disable this to make monsters not do any path search when looking for a target (old behavior).
 #define ACTIVEPATHSEARCH
 
+enum e_bosstype {
+	BTYPE_NONE = 0,
+	BTYPE_BOSS = 1,
+	BTYPE_MVP = 2,
+};
+
 //Mob skill states.
 enum MobSkillState {
 	MSS_ANY = -1,
@@ -181,10 +187,10 @@ struct mob_data {
 		unsigned int spotted: 1;
 		unsigned int npc_killmonster: 1; //for new killmonster behavior
 		unsigned int rebirth: 1; // NPC_Rebirth used
-		unsigned int boss : 1;
 		enum MobSkillState skillstate;
 		unsigned char steal_flag; //number of steal tries (to prevent steal exploit on mobs with few items) [Lupus]
 		unsigned char attacked_count; //For rude attacked.
+		uint8 boss;
 		int provoke_flag; // Celest
 	} state;
 	struct guardian_data* guardian_data;

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -3843,7 +3843,12 @@ const char *npc_parse_mob(const char *w1, const char *w2, const char *w3, const 
 
 	memset(&mobspawn, 0, sizeof(struct spawn_data));
 
-	mobspawn.state.boss = (strcmp(w2,"boss_monster") == 0 ? 1 : 0);
+	if (strcmp(w2, "boss_monster") == 0)
+		mobspawn.state.boss = BTYPE_MVP;
+	else if (strcmp(w2, "miniboss_monster") == 0)
+		mobspawn.state.boss = BTYPE_BOSS;
+	else
+		mobspawn.state.boss = BTYPE_NONE;
 
 	// w1=<map name>,<x>,<y>,<xs>,<ys>
 	// w3=<mob name>{,<mob level>}
@@ -4662,7 +4667,7 @@ int npc_parsesrcfile(const char* filepath, bool runOnInit) {
 		{
 			p = npc->parse_duplicate(w1,w2,w3,w4, p, buffer, filepath, (runOnInit?NPO_ONINIT:NPO_NONE), &success);
 		}
-		else if( (strcmp(w2,"monster") == 0 || strcmp(w2,"boss_monster") == 0) )
+		else if (strcmp(w2,"monster") == 0 || strcmp(w2,"boss_monster") == 0 || strcmp(w2,"miniboss_monster") == 0)
 		{
 			p = npc->parse_mob(w1, w2, w3, w4, p, buffer, filepath, &success);
 		}

--- a/src/map/packets.h
+++ b/src/map/packets.h
@@ -10669,4 +10669,78 @@ packet(0x96e,-1,clif->ackmergeitems);
 	packet(0x096a,6,clif->pGetCharNameRequest,2);  // CZ_REQNAME
 #endif
 
+// 2017-10-25eRagexeRE
+#if PACKETVER == 20171025
+// shuffle packets
+	packet(0x0202,5,clif->pChangeDir,2,4);  // CZ_CHANGE_DIRECTION
+	packet(0x022d,19,clif->pWantToConnection,2,6,10,14,18);  // CZ_ENTER
+	packet(0x023b,26,clif->pFriendsListAdd,2);  // CZ_ADD_FRIENDS
+	packet(0x0281,-1,clif->pItemListWindowSelected,2,4,8);  // CZ_ITEMLISTWIN_RES
+	packet(0x035f,6,clif->pTickSend,2);  // CZ_REQUEST_TIME
+	packet(0x0360,6,clif->pReqClickBuyingStore,2);  // CZ_REQ_CLICK_TO_BUYING_STORE
+	packet(0x0361,5,clif->pHomMenu,2,4);  // CZ_COMMAND_MER
+	packet(0x0362,6,clif->pDropItem,2,4);  // CZ_ITEM_THROW
+	packet(0x0363,8,clif->pDull/*,XXX*/);  // CZ_JOIN_BATTLE_FIELD
+	packet(0x0364,8,clif->pMoveFromKafra,2,4);  // CZ_MOVE_ITEM_FROM_STORE_TO_BODY
+	packet(0x0365,18,clif->pPartyBookingRegisterReq,2,4);  // CZ_PARTY_BOOKING_REQ_REGISTER
+	packet(0x0366,90,clif->pUseSkillToPosMoreInfo,2,4,6,8,10);  // CZ_USE_SKILL_TOGROUND_WITHTALKBOX
+	packet(0x0368,6,clif->pSolveCharName,2);  // CZ_REQNAME_BYGID
+	packet(0x0369,7,clif->pActionRequest,2,6);  // CZ_REQUEST_ACT
+	packet(0x0436,4,clif->pDull/*,XXX*/);  // CZ_GANGSI_RANK
+	packet(0x0437,5,clif->pWalkToXY,2);  // CZ_REQUEST_MOVE
+	packet(0x0438,10,clif->pUseSkillToPos,2,4,6,8);  // CZ_USE_SKILL_TOGROUND
+	packet(0x07e4,6,clif->pTakeItem,2);  // CZ_ITEM_PICKUP
+	packet(0x07ec,8,clif->pMoveToKafra,2,4);  // CZ_MOVE_ITEM_FROM_BODY_TO_STORE
+	packet(0x0802,26,clif->pPartyInvite2,2);  // CZ_PARTY_JOIN_REQ
+	packet(0x0811,-1,clif->pReqTradeBuyingStore,2,4,8,12);  // CZ_REQ_TRADE_BUYING_STORE
+	packet(0x0815,-1,clif->pReqOpenBuyingStore,2,4,8,9,89);  // CZ_REQ_OPEN_BUYING_STORE
+	packet(0x0817,2,clif->pReqCloseBuyingStore,0);  // CZ_REQ_CLOSE_BUYING_STORE
+	packet(0x0819,-1,clif->pSearchStoreInfo,2,4,5,9,13,14,15);  // CZ_SEARCH_STORE_INFO
+	packet(0x0835,2,clif->pSearchStoreInfoNextPage,0);  // CZ_SEARCH_STORE_INFO_NEXT_PAGE
+	packet(0x0838,12,clif->pSearchStoreInfoListItemClick,2,6,10);  // CZ_SSILIST_ITEM_CLICK
+	packet(0x083c,10,clif->pUseSkillToId,2,4,6);  // CZ_USE_SKILL
+	packet(0x08a2,36,clif->pStoragePassword,0);  // CZ_ACK_STORE_PASSWORD
+	packet(0x096a,6,clif->pGetCharNameRequest,2);  // CZ_REQNAME
+#endif
+
+// 2017-11-01bRagexeRE
+#if PACKETVER == 20171101
+// shuffle packets
+	packet(0x022d,36,clif->pStoragePassword,0);  // CZ_ACK_STORE_PASSWORD
+	packet(0x0368,19,clif->pWantToConnection,2,6,10,14,18);  // CZ_ENTER
+	packet(0x0369,-1,clif->pSearchStoreInfo,2,4,5,9,13,14,15);  // CZ_SEARCH_STORE_INFO
+	packet(0x0438,6,clif->pTickSend,2);  // CZ_REQUEST_TIME
+	packet(0x0835,6,clif->pDropItem,2,4);  // CZ_ITEM_THROW
+	packet(0x085b,5,clif->pHomMenu,2,4);  // CZ_COMMAND_MER
+	packet(0x0860,6,clif->pGetCharNameRequest,2);  // CZ_REQNAME
+	packet(0x086c,10,clif->pUseSkillToId,2,4,6);  // CZ_USE_SKILL
+	packet(0x0872,26,clif->pFriendsListAdd,2);  // CZ_ADD_FRIENDS
+	packet(0x0876,5,clif->pChangeDir,2,4);  // CZ_CHANGE_DIRECTION
+	packet(0x0886,8,clif->pDull/*,XXX*/);  // CZ_JOIN_BATTLE_FIELD
+	packet(0x088e,6,clif->pReqClickBuyingStore,2);  // CZ_REQ_CLICK_TO_BUYING_STORE
+	packet(0x0890,2,clif->pSearchStoreInfoNextPage,0);  // CZ_SEARCH_STORE_INFO_NEXT_PAGE
+	packet(0x0895,4,clif->pDull/*,XXX*/);  // CZ_GANGSI_RANK
+	packet(0x0899,26,clif->pPartyInvite2,2);  // CZ_PARTY_JOIN_REQ
+	packet(0x089b,-1,clif->pReqOpenBuyingStore,2,4,8,9,89);  // CZ_REQ_OPEN_BUYING_STORE
+	packet(0x089c,18,clif->pPartyBookingRegisterReq,2,4);  // CZ_PARTY_BOOKING_REQ_REGISTER
+	packet(0x08a0,8,clif->pMoveFromKafra,2,4);  // CZ_MOVE_ITEM_FROM_STORE_TO_BODY
+	packet(0x08ab,-1,clif->pItemListWindowSelected,2,4,8);  // CZ_ITEMLISTWIN_RES
+	packet(0x08ad,12,clif->pSearchStoreInfoListItemClick,2,6,10);  // CZ_SSILIST_ITEM_CLICK
+	packet(0x091b,8,clif->pMoveToKafra,2,4);  // CZ_MOVE_ITEM_FROM_BODY_TO_STORE
+	packet(0x0939,5,clif->pWalkToXY,2);  // CZ_REQUEST_MOVE
+	packet(0x094a,2,clif->pReqCloseBuyingStore,0);  // CZ_REQ_CLOSE_BUYING_STORE
+	packet(0x094d,6,clif->pSolveCharName,2);  // CZ_REQNAME_BYGID
+	packet(0x0952,90,clif->pUseSkillToPosMoreInfo,2,4,6,8,10);  // CZ_USE_SKILL_TOGROUND_WITHTALKBOX
+	packet(0x0957,7,clif->pActionRequest,2,6);  // CZ_REQUEST_ACT
+	packet(0x095a,-1,clif->pReqTradeBuyingStore,2,4,8,12);  // CZ_REQ_TRADE_BUYING_STORE
+	packet(0x0962,6,clif->pTakeItem,2);  // CZ_ITEM_PICKUP
+	packet(0x0966,10,clif->pUseSkillToPos,2,4,6,8);  // CZ_USE_SKILL_TOGROUND
+#endif
+
+// 2017-11-01bRagexeRE
+#if PACKETVER >= 20171101
+// new packets
+	packet(0x0ae1,28);
+#endif
+
 #endif /* MAP_PACKETS_H */

--- a/src/map/packets_keys.h
+++ b/src/map/packets_keys.h
@@ -2,7 +2,7 @@
  * This file is part of Hercules.
  * http://herc.ws - http://github.com/HerculesWS/Hercules
  *
- * Copyright (C) 2013-2015  Hercules Dev Team
+ * Copyright (C) 2013-2017  Hercules Dev Team
  *
  * Hercules is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2057,7 +2057,7 @@
 	packetKeys(0x03FA5A97,0x20B802D5,0x339F1977);
 #endif
 
-// 2017-06-07bRagexeRE
+// 2017-06-07bRagexeRE, 2017-06-07cRagexeRE
 #if PACKETVER == 20170607
 	packetKeys(0x50564ACD,0x79CA4E15,0x405F4894);
 #endif
@@ -2150,6 +2150,16 @@
 // 2017-10-18aRagexeRE
 #if PACKETVER == 20171018
 	packetKeys(0x2CAA109C,0x158C1EC2,0x7A5E58F3);
+#endif
+
+// 2017-10-25bRagexeRE, 2017-10-25cRagexeRE, 2017-10-25dRagexeRE, 2017-10-25eRagexeRE
+#if PACKETVER == 20171025
+	packetKeys(0x165C565C,0x565C565C,0x565C565C);
+#endif
+
+// 2017-11-01bRagexeRE
+#if PACKETVER == 20171101
+	packetKeys(0x7056317F,0x7EEE0589,0x02672373);
 #endif
 
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add spawn flag miniboss_monster for spawn mini boss monsters. Old clients see mini bosses as boss/mvp.
Add support for 2017-10-25 clients.
