### PR TITLE
Overflow correction in visual function bg_message

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -16533,6 +16533,9 @@ void clif_bg_message(struct battleground_data *bgd, int src_id, const char *name
 		return;
 
 	len = (int)strlen(mes);
+#if PACKETVER <= 20120716
+	len += 1;
+#endif
 	Assert_retv(len <= INT16_MAX - NAME_LENGTH - 8);
 	buf = (unsigned char*)aMalloc((len + NAME_LENGTH + 8)*sizeof(unsigned char));
 


### PR DESCRIPTION
### Changes Proposed
Correction of the problem mentioned [IN THIS TOPIC.](http://herc.ws/board/topic/15409-bug-bg_message/)
Apparently there was a memory leak in the dynamic allocation. I compared previous versions of the emulator and found that the message size was received as a parameter, and that all entries per parameter were +1 the original size of the string.
I kept the length definition inside the function and incremented the variable. I have run the tests and the messages are now displayed normally.

[//]: # (Describe at length, the changes that this pull request makes.)

**Affected Branches:** 
Master


