### PR TITLE
Fix handling of the special case of SplashRange < 0 meaning AREA_SIZE

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -231,17 +231,20 @@ int skill_get_range(int skill_id, int skill_lv)
 
 int skill_get_splash(int skill_id, int skill_lv)
 {
-	int idx;
+	int idx, val;
 	if (skill_id == 0)
 		return 0;
 	idx = skill->get_index(skill_id);
 	Assert_ret(idx != 0);
 	Assert_ret(skill_lv > 0);
+	val = skill->dbs->db[idx].splash[skill_get_lvl_idx(skill_lv)];
+	if (val < 0) {
+		val = AREA_SIZE;
+	}
 	if (skill_lv > MAX_SKILL_LEVEL) {
-		int val = skill->dbs->db[idx].splash[skill_get_lvl_idx(skill_lv)];
 		return skill_adjust_over_level(val, skill_lv, skill->dbs->db[idx].max);
 	}
-	return skill->dbs->db[idx].splash[skill_get_lvl_idx(skill_lv)];
+	return val;
 }
 
 int skill_get_hp(int skill_id, int skill_lv)


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This restores the behavior that was broken in 2b4bfa5d0.

Fixes #1911

**Affected Branches:** 

- master
- stable (v2017.11.19, v2017.11.19-1)

**Issues addressed:**

- #1911 

### Known Issues and TODO List

N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
