### PR TITLE
 Add support for new drop packet 0xadd for zero clients

### DIFF
--- a/db/pre-re/item_db.conf
+++ b/db/pre-re/item_db.conf
@@ -95,6 +95,8 @@ item_db: (
 	Delay: Delay to use item      (int, defaults to 0)
 	KeepAfterUse: true/false      (boolean, defaults to false)
 	DropAnnounce: true/false      (boolean, defaults to false)
+	ShowDropEffect: true/false    (boolean, defaults to false)
+	DropEffectMode: Effect Type   (int, default to 0)
 	Trade: {                      (defaults to no restrictions)
 		override: GroupID             (int, defaults to 100)
 		nodrop: true/false            (boolean, defaults to false)

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -95,6 +95,8 @@ item_db: (
 	Delay: Delay to use item      (int, defaults to 0)
 	KeepAfterUse: true/false      (boolean, defaults to false)
 	DropAnnounce: true/false      (boolean, defaults to false)
+	ShowDropEffect: true/false    (boolean, defaults to false)
+	DropEffectMode: Effect Type   (int, default to 0)
 	Trade: {                      (defaults to no restrictions)
 		override: GroupID             (int, defaults to 100)
 		nodrop: true/false            (boolean, defaults to false)

--- a/doc/item_db.txt
+++ b/doc/item_db.txt
@@ -73,6 +73,8 @@ item_db: (
 	Delay: Delay to use item      (int, defaults to 0)
 	KeepAfterUse: true/false      (boolean, defaults to false)
 	DropAnnounce: true/false      (boolean, defaults to false)
+	ShowDropEffect: true/false    (boolean, defaults to false)
+	DropEffectMode: Effect Type   (int, default to 0)
 	Trade: {                      (defaults to no restrictions)
 		override: GroupID             (int, defaults to 100)
 		nodrop: true/false            (boolean, defaults to false)
@@ -368,3 +370,12 @@ OnUnequipScript: Script to execute when the item is unequipped.
 Inherit: This can be used only in item_db2.conf, and if set to true, and the
          item already exists in item_db.conf, all the missing fields will be
          inherited from there rather than using their default values.
+
+ShowDropEffect: Allow showing an effect when the item dropped by a monster. [ZERO client only]
+DropEffectMode: Set attribute for ShowDropEffect. [ZERO client only]
+				0 - Client Based (itemInfo EffectID)
+				1 - White effect
+				2 - Blue effect
+				3 - Yellow effect
+				4 - Purple effect
+				5 - Orange effect

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -5457,7 +5457,7 @@ void atcommand_getring(struct map_session_data* sd) {
 
 	if((flag = pc->additem(sd,&item_tmp,1,LOG_TYPE_COMMAND))) {
 		clif->additem(sd,0,0,flag);
-		map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+		map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 	}
 }
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -796,7 +796,15 @@ void clif_dropflooritem(struct flooritem_data* fitem) {
 	p.subX = fitem->subx;
 	p.subY = fitem->suby;
 	p.count = fitem->item_data.amount;
-
+#ifdef PACKETVER_ZERO
+	if (fitem->showdropeffect) {
+		p.showdropeffect = itemdb_showdropeffect(fitem->item_data.nameid);
+		p.dropeffectmode = itemdb_dropeffectmode(fitem->item_data.nameid);
+	} else {
+		p.showdropeffect = 0;
+		p.dropeffectmode = 0;
+	}
+#endif
 	clif->send(&p, sizeof(p), &fitem->bl, AREA);
 }
 

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -2070,6 +2070,12 @@ int itemdb_readdb_libconfig_sub(struct config_setting_t *it, int n, const char *
 	if ((t = libconfig->setting_get_member(it, "DisableOptions")))
 		id.flag.no_options = libconfig->setting_get_bool(t) ? 1 : 0;
 
+	if ((t = libconfig->setting_get_member(it, "ShowDropEffect")))
+		id.flag.showdropeffect = libconfig->setting_get_bool(t) ? 1 : 0;
+
+	if (itemdb->lookup_const(it, "DropEffectMode", &i32) && i32 >= 0)
+		id.dropeffectmode = i32;
+
 	if (itemdb->lookup_const(it, "ViewSprite", &i32) && i32 >= 0)
 		id.view_sprite = i32;
 

--- a/src/map/itemdb.h
+++ b/src/map/itemdb.h
@@ -472,6 +472,7 @@ struct item_data {
 	int view_id;
 	int matk;
 	int elvmax;/* maximum level for this item */
+	int dropeffectmode;
 
 	int delay;
 	uint64 class_base[3]; ///< Specifies if the base can wear this item (split in 3 indexes per type: 1-1, 2-1, 2-2)
@@ -495,6 +496,7 @@ struct item_data {
 		unsigned force_serial : 1;
 		unsigned no_options: 1; // < disallows use of item options on the item. (non-equippable items are automatically flagged) [Smokexyz]
 		unsigned drop_announce : 1; // Official Drop Announce [Jedzkie]
+		unsigned showdropeffect: 1; // < Allow showing effect on item drop [Asheraf]
 	} flag;
 	struct {// item stacking limitation
 		unsigned short amount;
@@ -538,6 +540,8 @@ struct item_data {
 #define itemdb_value_sell(n)  (itemdb->search(n)->value_sell)
 #define itemdb_canrefine(n)   (!itemdb->search(n)->flag.no_refine)
 #define itemdb_allowoption(n) (!itemdb->search(n)->flag.no_options)
+#define itemdb_showdropeffect(n) (itemdb->search(n)->flag.showdropeffect)
+#define itemdb_dropeffectmode(n) (itemdb->search(n)->dropeffectmode)
 
 #define itemdb_is_element(n)     ((n) >= ITEMID_SCARLET_PTS && (n) <= ITEMID_LIME_GREEN_PTS)
 #define itemdb_is_spellbook(n)   ((n) >= ITEMID_MAGIC_BOOK_FB && (n) <= ITEMID_MAGIC_BOOK_DL)

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -1694,8 +1694,9 @@ bool map_closest_freecell(int16 m, const struct block_list *bl, int16 *x, int16 
  * @m, @x, @y mapid,x,y
  * @first_charid, @second_charid, @third_charid, looting priority
  * @flag: &1 MVP item. &2 do stacking check.
+ * @showdropeffect: show effect when the item is dropped.
  *------------------------------------------*/
-int map_addflooritem(const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags)
+int map_addflooritem(const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags, bool showdropeffect)
 {
 	int r;
 	struct flooritem_data *fitem=NULL;
@@ -1714,6 +1715,7 @@ int map_addflooritem(const struct block_list *bl, struct item *item_data, int am
 	fitem->bl.x = x;
 	fitem->bl.y = y;
 	fitem->bl.id = map->get_new_object_id();
+	fitem->showdropeffect = showdropeffect;
 	if(fitem->bl.id==0){
 		ers_free(map->flooritem_ers, fitem);
 		return 0;

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -531,6 +531,7 @@ struct flooritem_data {
 	int first_get_charid,second_get_charid,third_get_charid;
 	int64 first_get_tick,second_get_tick,third_get_tick;
 	struct item item_data;
+	bool showdropeffect;
 };
 
 enum status_point_types { //we better clean up this enum and change it name [Hemagx]
@@ -1208,7 +1209,7 @@ END_ZEROED_BLOCK;
 	int (*clearflooritem_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*removemobs_timer) (int tid, int64 tick, int id, intptr_t data);
 	void (*clearflooritem) (struct block_list* bl);
-	int (*addflooritem) (const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags);
+	int (*addflooritem) (const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags, bool showdropeffect);
 	// player to map session
 	void (*addnickdb) (int charid, const char* nick);
 	void (*delnickdb) (int charid, const char* nick);

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -1873,7 +1873,7 @@ int mob_delay_item_drop(int tid, int64 tick, int id, intptr_t data) {
 		struct item_drop *ditem_prev;
 		map->addflooritem(NULL, &ditem->item_data,ditem->item_data.amount,
 		                  list->m,list->x,list->y,
-		                  list->first_charid,list->second_charid,list->third_charid,0);
+		                  list->first_charid,list->second_charid,list->third_charid,0,true);
 		ditem_prev = ditem;
 		ditem = ditem->next;
 		ers_free(item_drop_ers, ditem_prev);
@@ -2586,7 +2586,7 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type) {
 
 					if((temp = pc->additem(mvp_sd,&item,1,LOG_TYPE_PICKDROP_PLAYER)) != 0) {
 						clif->additem(mvp_sd,0,0,temp);
-						map->addflooritem(&md->bl, &item, 1, mvp_sd->bl.m, mvp_sd->bl.x, mvp_sd->bl.y, mvp_sd->status.char_id, (second_sd?second_sd->status.char_id : 0), (third_sd ? third_sd->status.char_id : 0), 1);
+						map->addflooritem(&md->bl, &item, 1, mvp_sd->bl.m, mvp_sd->bl.x, mvp_sd->bl.y, mvp_sd->status.char_id, (second_sd?second_sd->status.char_id : 0), (third_sd ? third_sd->status.char_id : 0), 1, true);
 					}
 
 					//Logs items, MVP prizes [Lupus]

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -1838,11 +1838,13 @@ int mob_ai_hard(int tid, int64 tick, int id, intptr_t data) {
 /*==========================================
  * Initializes the delay drop structure for mob-dropped items.
  *------------------------------------------*/
-struct item_drop* mob_setdropitem(int nameid, int qty, struct item_data *data) {
+struct item_drop* mob_setdropitem(int nameid, int qty, struct item_data *data)
+{
 	struct item_drop *drop = ers_alloc(item_drop_ers, struct item_drop);
 	drop->item_data.nameid = nameid;
 	drop->item_data.amount = qty;
 	drop->item_data.identify = data ? itemdb->isidentified2(data) : itemdb->isidentified(nameid);
+	drop->showdropeffect = true;
 	drop->next = NULL;
 	return drop;
 }
@@ -1857,6 +1859,7 @@ struct item_drop* mob_setlootitem(struct item* item)
 	nullpo_retr(NULL, item);
 	drop = ers_alloc(item_drop_ers, struct item_drop);
 	memcpy(&drop->item_data, item, sizeof(struct item));
+	drop->showdropeffect = false;
 	drop->next = NULL;
 	return drop;
 }
@@ -1864,7 +1867,8 @@ struct item_drop* mob_setlootitem(struct item* item)
 /*==========================================
  * item drop with delay (timer function)
  *------------------------------------------*/
-int mob_delay_item_drop(int tid, int64 tick, int id, intptr_t data) {
+int mob_delay_item_drop(int tid, int64 tick, int id, intptr_t data)
+{
 	struct item_drop_list *list;
 	struct item_drop *ditem;
 	list=(struct item_drop_list *)data;
@@ -1872,8 +1876,9 @@ int mob_delay_item_drop(int tid, int64 tick, int id, intptr_t data) {
 	while (ditem) {
 		struct item_drop *ditem_prev;
 		map->addflooritem(NULL, &ditem->item_data,ditem->item_data.amount,
-		                  list->m,list->x,list->y,
-		                  list->first_charid,list->second_charid,list->third_charid,0,true);
+		    list->m,list->x,list->y,
+		    list->first_charid,list->second_charid,list->third_charid,0,
+		    ditem->showdropeffect);
 		ditem_prev = ditem;
 		ditem = ditem->next;
 		ers_free(item_drop_ers, ditem_prev);

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -406,6 +406,7 @@ enum mob_id {
 // The data structures for storing delayed item drops
 struct item_drop {
 	struct item item_data;
+	bool showdropeffect;
 	struct item_drop* next;
 };
 struct item_drop_list {

--- a/src/map/packets_struct.h
+++ b/src/map/packets_struct.h
@@ -191,7 +191,9 @@ enum packet_headers {
 	skill_entryType = 0x9ca,
 #endif
 	graffiti_entryType = 0x1c9,
-#if PACKETVER > 20130000 /* not sure date */
+#ifdef PACKETVER_ZERO
+	dropflooritemType = 0xadd,
+#elif PACKETVER > 20130000 /* not sure date */
 	dropflooritemType = 0x84b,
 #else
 	dropflooritemType = 0x9e,
@@ -495,6 +497,10 @@ struct packet_dropflooritem {
 	uint8 subX;
 	uint8 subY;
 	int16 count;
+#ifdef PACKETVER_ZERO
+	int8 showdropeffect;
+	int16 dropeffectmode;
+#endif
 } __attribute__((packed));
 struct packet_idle_unit2 {
 #if PACKETVER < 20091103

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -4781,7 +4781,7 @@ int pc_dropitem(struct map_session_data *sd,int n,int amount)
 		return 0;
 	}
 
-	if (!map->addflooritem(&sd->bl, &sd->status.inventory[n], amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 2))
+	if (!map->addflooritem(&sd->bl, &sd->status.inventory[n], amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 2, false))
 		return 0;
 
 	pc->delitem(sd, n, amount, 1, DELITEM_NORMAL, LOG_TYPE_PICKDROP_PLAYER);
@@ -7962,7 +7962,7 @@ int pc_dead(struct map_session_data *sd,struct block_list *src) {
 		item_tmp.card[1]=0;
 		item_tmp.card[2]=GetWord(sd->status.char_id,0); // CharId
 		item_tmp.card[3]=GetWord(sd->status.char_id,1);
-		map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+		map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 	}
 
 	// activate Steel body if a super novice dies at 99+% exp [celest]

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -325,7 +325,7 @@ int pet_return_egg(struct map_session_data *sd, struct pet_data *pd)
 	tmp_item.card[3] = pd->pet.rename_flag;
 	if((flag = pc->additem(sd,&tmp_item,1,LOG_TYPE_EGG))) {
 		clif->additem(sd,0,0,flag);
-		map->addflooritem(&sd->bl, &tmp_item, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+		map->addflooritem(&sd->bl, &tmp_item, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 	}
 	pd->pet.incubate = 1;
 	unit->free(&pd->bl,CLR_OUTSIGHT);
@@ -610,7 +610,7 @@ bool pet_get_egg(int account_id, short pet_class, int pet_id ) {
 	tmp_item.card[3] = 0; //New pets are not named.
 	if((ret = pc->additem(sd,&tmp_item,1,LOG_TYPE_PICKDROP_PLAYER))) {
 		clif->additem(sd,0,0,ret);
-		map->addflooritem(&sd->bl, &tmp_item, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+		map->addflooritem(&sd->bl, &tmp_item, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 	}
 
 	return true;
@@ -751,7 +751,7 @@ int pet_unequipitem(struct map_session_data *sd, struct pet_data *pd) {
 	tmp_item.identify = 1;
 	if((flag = pc->additem(sd,&tmp_item,1,LOG_TYPE_CONSUME))) {
 		clif->additem(sd,0,0,flag);
-		map->addflooritem(&sd->bl, &tmp_item, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+		map->addflooritem(&sd->bl, &tmp_item, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 	}
 	if( battle_config.pet_equip_required )
 	{ // Skotlex: halt support timers if needed
@@ -1026,7 +1026,7 @@ int pet_delay_item_drop(int tid, int64 tick, int id, intptr_t data) {
 		struct item_drop *ditem_prev;
 		map->addflooritem(NULL, &ditem->item_data, ditem->item_data.amount,
 			list->m, list->x, list->y,
-			list->first_charid, list->second_charid, list->third_charid, 0);
+			list->first_charid, list->second_charid, list->third_charid, 0, false);
 		ditem_prev = ditem;
 		ditem = ditem->next;
 		ers_free(pet->item_drop_ers, ditem_prev);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -7923,7 +7923,7 @@ BUILDIN(getitem) {
 			if ((flag = pc->additem(sd, &it, get_count, LOG_TYPE_SCRIPT))) {
 				clif->additem(sd, 0, 0, flag);
 				if( pc->candrop(sd,&it) )
-					map->addflooritem(&sd->bl, &it, get_count, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+					map->addflooritem(&sd->bl, &it, get_count, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 			}
 		}
 	}
@@ -8031,7 +8031,7 @@ BUILDIN(getitem2)
 				if ((flag = pc->additem(sd, &item_tmp, get_count, LOG_TYPE_SCRIPT))) {
 					clif->additem(sd, 0, 0, flag);
 					if( pc->candrop(sd,&item_tmp) )
-						map->addflooritem(&sd->bl, &item_tmp, get_count, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+						map->addflooritem(&sd->bl, &item_tmp, get_count, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 				}
 			}
 		}
@@ -8224,7 +8224,7 @@ BUILDIN(makeitem)
 	item_tmp.nameid = nameid;
 	item_tmp.identify=1;
 
-	map->addflooritem(NULL, &item_tmp, amount, m, x, y, 0, 0, 0, 0);
+	map->addflooritem(NULL, &item_tmp, amount, m, x, y, 0, 0, 0, 0, false);
 
 	return true;
 }
@@ -8308,7 +8308,7 @@ BUILDIN(makeitem2)
 	item_tmp.card[2] = (short)script_getnum(st, 9);
 	item_tmp.card[3] = (short)script_getnum(st, 10);
 
-	map->addflooritem(NULL, &item_tmp, amount, m, x, y, 0, 0, 0, 0);
+	map->addflooritem(NULL, &item_tmp, amount, m, x, y, 0, 0, 0, 0, false);
 
 	return true;
 }
@@ -13576,7 +13576,7 @@ BUILDIN(successremovecards)
 
 			if ((flag = pc->additem(sd, &item_tmp, 1, LOG_TYPE_SCRIPT))) {
 				clif->additem(sd, 0, 0, flag);
-				map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+				map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 			}
 		}
 	}
@@ -13634,7 +13634,7 @@ BUILDIN(failedremovecards)
 
 				if ((flag = pc->additem(sd, &item_tmp, 1, LOG_TYPE_SCRIPT))) {
 					clif->additem(sd, 0, 0, flag);
-					map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+					map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 				}
 			}
 		}
@@ -22171,7 +22171,7 @@ BUILDIN(getrandgroupitem)
 				if ((flag = pc->additem(sd, &it, get_count, LOG_TYPE_SCRIPT))) {
 					clif->additem(sd, 0, 0, flag);
 					if( pc->candrop(sd,&it) )
-						map->addflooritem(&sd->bl, &it, get_count, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+						map->addflooritem(&sd->bl, &it, get_count, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 				}
 			}
 		}

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -5207,7 +5207,7 @@ int skill_castend_damage_id(struct block_list* src, struct block_list *bl, uint1
 						item_tmp.nameid = sg->item_id ? sg->item_id : ITEMID_BOOBY_TRAP;
 						item_tmp.identify = 1;
 						if( item_tmp.nameid )
-							map->addflooritem(bl, &item_tmp, 1, bl->m, bl->x, bl->y, 0, 0, 0, 0);
+							map->addflooritem(bl, &item_tmp, 1, bl->m, bl->x, bl->y, 0, 0, 0, 0, false);
 					}
 					skill->delunit(su);
 				}
@@ -7452,7 +7452,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 				eflag = pc->additem(sd,&item_tmp,1,LOG_TYPE_PRODUCE);
 				if(eflag) {
 					clif->additem(sd,0,0,eflag);
-					map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+					map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 				}
 			}
 			break;
@@ -8176,7 +8176,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 									item_tmp.identify = 1;
 									if ((success = pc->additem(sd, &item_tmp, amount, LOG_TYPE_SKILL)) != 0) {
 										clif->additem(sd,0,0,success);
-										map->addflooritem(&sd->bl, &item_tmp, amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+										map->addflooritem(&sd->bl, &item_tmp, amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 									}
 								}
 							}
@@ -8188,7 +8188,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 							item_tmp.identify = 1;
 							if (item_tmp.nameid && (flag=pc->additem(sd,&item_tmp,1,LOG_TYPE_SKILL)) != 0) {
 								clif->additem(sd,0,0,flag);
-								map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+								map->addflooritem(&sd->bl, &item_tmp, 1, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 							}
 						}
 					}
@@ -17502,7 +17502,7 @@ int skill_unit_timer_sub(union DBKey key, struct DBData *data, va_list ap)
 					memset(&item_tmp,0,sizeof(item_tmp));
 					item_tmp.nameid = group->item_id ? group->item_id : ITEMID_BOOBY_TRAP;
 					item_tmp.identify = 1;
-					map->addflooritem(bl, &item_tmp, 1, bl->m, bl->x, bl->y, 0, 0, 0, 0);
+					map->addflooritem(bl, &item_tmp, 1, bl->m, bl->x, bl->y, 0, 0, 0, 0, false);
 				}
 				skill->delunit(su);
 			}
@@ -18457,7 +18457,7 @@ int skill_produce_mix(struct map_session_data *sd, uint16 skill_id, int nameid, 
 							tmp_item.amount = qty * skill->dbs->changematerial_db[i].qty[j];
 							if((flag = pc->additem(sd,&tmp_item,tmp_item.amount,LOG_TYPE_PRODUCE))) {
 								clif->additem(sd,0,0,flag);
-								map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+								map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 							}
 							k++;
 						}
@@ -18471,7 +18471,7 @@ int skill_produce_mix(struct map_session_data *sd, uint16 skill_id, int nameid, 
 		} else if (tmp_item.amount) { //Success
 			if((flag = pc->additem(sd,&tmp_item,tmp_item.amount,LOG_TYPE_PRODUCE))) {
 				clif->additem(sd,0,0,flag);
-				map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+				map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 			}
 			if( skill_id == GN_MIX_COOKING || skill_id == GN_MAKEBOMB || skill_id ==  GN_S_PHARMACY )
 				clif->msgtable_skill(sd, skill_id, MSG_SKILL_SUCCESS);
@@ -18531,7 +18531,7 @@ int skill_produce_mix(struct map_session_data *sd, uint16 skill_id, int nameid, 
 					tmp_item.identify = 1;
 					if( pc->additem(sd,&tmp_item,tmp_item.amount,LOG_TYPE_PRODUCE) ) {
 						clif->additem(sd,0,0,flag);
-						map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+						map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 					}
 					clif->msgtable_skill(sd, skill_id, MSG_SKILL_FAILURE);
 				}
@@ -18588,7 +18588,7 @@ int skill_arrow_create (struct map_session_data *sd, int nameid)
 			continue;
 		if((flag = pc->additem(sd,&tmp_item,tmp_item.amount,LOG_TYPE_PRODUCE))) {
 			clif->additem(sd,0,0,flag);
-			map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+			map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 		}
 	}
 
@@ -18843,7 +18843,7 @@ int skill_elementalanalysis(struct map_session_data *sd, uint16 skill_lv, const 
 			int flag = pc->additem(sd,&tmp_item,tmp_item.amount,LOG_TYPE_CONSUME);
 			if (flag) {
 				clif->additem(sd,0,0,flag);
-				map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0);
+				map->addflooritem(&sd->bl, &tmp_item, tmp_item.amount, sd->bl.m, sd->bl.x, sd->bl.y, 0, 0, 0, 0, false);
 			}
 		}
 

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -3984,8 +3984,8 @@ typedef int (*HPMHOOK_pre_map_removemobs_timer) (int *tid, int64 *tick, int *id,
 typedef int (*HPMHOOK_post_map_removemobs_timer) (int retVal___, int tid, int64 tick, int id, intptr_t data);
 typedef void (*HPMHOOK_pre_map_clearflooritem) (struct block_list **bl);
 typedef void (*HPMHOOK_post_map_clearflooritem) (struct block_list *bl);
-typedef int (*HPMHOOK_pre_map_addflooritem) (const struct block_list **bl, struct item **item_data, int *amount, int16 *m, int16 *x, int16 *y, int *first_charid, int *second_charid, int *third_charid, int *flags);
-typedef int (*HPMHOOK_post_map_addflooritem) (int retVal___, const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags);
+typedef int (*HPMHOOK_pre_map_addflooritem) (const struct block_list **bl, struct item **item_data, int *amount, int16 *m, int16 *x, int16 *y, int *first_charid, int *second_charid, int *third_charid, int *flags, bool *showdropeffect);
+typedef int (*HPMHOOK_post_map_addflooritem) (int retVal___, const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags, bool showdropeffect);
 typedef void (*HPMHOOK_pre_map_addnickdb) (int *charid, const char **nick);
 typedef void (*HPMHOOK_post_map_addnickdb) (int charid, const char *nick);
 typedef void (*HPMHOOK_pre_map_delnickdb) (int *charid, const char **nick);

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -41256,15 +41256,15 @@ void HP_map_clearflooritem(struct block_list *bl) {
 	}
 	return;
 }
-int HP_map_addflooritem(const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags) {
+int HP_map_addflooritem(const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags, bool showdropeffect) {
 	int hIndex = 0;
 	int retVal___ = 0;
 	if (HPMHooks.count.HP_map_addflooritem_pre > 0) {
-		int (*preHookFunc) (const struct block_list **bl, struct item **item_data, int *amount, int16 *m, int16 *x, int16 *y, int *first_charid, int *second_charid, int *third_charid, int *flags);
+		int (*preHookFunc) (const struct block_list **bl, struct item **item_data, int *amount, int16 *m, int16 *x, int16 *y, int *first_charid, int *second_charid, int *third_charid, int *flags, bool *showdropeffect);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_map_addflooritem_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_map_addflooritem_pre[hIndex].func;
-			retVal___ = preHookFunc(&bl, &item_data, &amount, &m, &x, &y, &first_charid, &second_charid, &third_charid, &flags);
+			retVal___ = preHookFunc(&bl, &item_data, &amount, &m, &x, &y, &first_charid, &second_charid, &third_charid, &flags, &showdropeffect);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -41272,13 +41272,13 @@ int HP_map_addflooritem(const struct block_list *bl, struct item *item_data, int
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.map.addflooritem(bl, item_data, amount, m, x, y, first_charid, second_charid, third_charid, flags);
+		retVal___ = HPMHooks.source.map.addflooritem(bl, item_data, amount, m, x, y, first_charid, second_charid, third_charid, flags, showdropeffect);
 	}
 	if (HPMHooks.count.HP_map_addflooritem_post > 0) {
-		int (*postHookFunc) (int retVal___, const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags);
+		int (*postHookFunc) (int retVal___, const struct block_list *bl, struct item *item_data, int amount, int16 m, int16 x, int16 y, int first_charid, int second_charid, int third_charid, int flags, bool showdropeffect);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_map_addflooritem_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_map_addflooritem_post[hIndex].func;
-			retVal___ = postHookFunc(retVal___, bl, item_data, amount, m, x, y, first_charid, second_charid, third_charid, flags);
+			retVal___ = postHookFunc(retVal___, bl, item_data, amount, m, x, y, first_charid, second_charid, third_charid, flags, showdropeffect);
 		}
 	}
 	return retVal___;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR adds support for new drop packet with ability to set effect on item drop.
![example](http://imgc1.gnjoy.com/ufile/ro/2017/11/22/SRBP5Z1JTO2H9UEAP390.gif) 

[//]: # (Describe at length, the changes that this pull request makes.)

**Affected Branches:** 
- master

[//]: # (Master? Slave?)

[//]: # (Issue Tracker Number if any.)

### Known Issues and TODO List
- Official behavior uses the count of random options on drop as DropEffectMode for equipments.

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
