### PR TITLE
Add proper MySQL Lib/Header checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1500,18 +1500,21 @@ fi
 
 MYSQL_OLD_LIBS="$LIBS" ; LIBS="$LIBS $MYSQL_LIBS"
 MYSQL_OLD_CPPFLAGS="$CPPFLAGS" ; CPPFLAGS="$CPPFLAGS $MYSQL_CFLAGS"
-AC_CHECK_FUNC([mysql_init], [HAVE_MYSQL="yes"])
-AC_CHECK_HEADER([mysql.h], [], [HAVE_MYSQL=""])
+# Note that for AC_CHECK_FUNC to succeed, LIBS has to be correctly defined.
+AC_CHECK_FUNC(mysql_init, [
+		HAVE_MYSQL="yes"
+	], [
+		AC_MSG_ERROR([MySQL Library not found or incompatible])
+		HAVE_MYSQL=""
+	])
+AC_CHECK_HEADER([mysql/mysql.h], [
+		HAVE_MYSQL="$HAVE_MYSQL"
+	], [ 
+		AC_MSG_ERROR([MySQL Header not found.])
+		HAVE_MYSQL=""
+	])
 CPPFLAGS="$MYSQL_OLD_CPPFLAGS"
 LIBS="$MYSQL_OLD_LIBS"
-
-AC_MSG_CHECKING([MySQL library (required)])
-if test "$HAVE_MYSQL" = "yes" ; then
-	AC_MSG_RESULT([yes ($MYSQL_VERSION)])
-else
-	AC_MSG_RESULT([no])
-	AC_MSG_ERROR([MySQL not found or incompatible])
-fi
 
 AC_SUBST([HAVE_MYSQL])
 AC_SUBST([MYSQL_VERSION])


### PR DESCRIPTION
Updated configure.ac with better mysql checks library and header file checks.

[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)

**Affected Branches:** master

[//]: # (Master? Slave?)

**Issues addressed:** 
Fixes a compile issue in macOS High Sierra when searching for mysql header files.

[//]: # (Issue Tracker Number if any.)

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)
- [x] test cross-compatibility through travis etc.

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
