### PR TITLE
Fix i386 CI builds

### DIFF
--- a/tools/ci/travis.sh
+++ b/tools/ci/travis.sh
@@ -207,7 +207,7 @@ EOF
 			echo "Disable leak dection on travis"
 			export ASAN_OPTIONS=detect_leaks=0:detect_stack_use_after_return=true:strict_init_order=true
 		else
-			export ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=true:strict_init_order=true
+			export ASAN_OPTIONS=detect_stack_use_after_return=true:strict_init_order=true
 		fi
 		# run_test spinlock # Not running the spinlock test for the time being (too time consuming)
 		run_test libconfig


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The address sanitizer's leak detector isn't supported on i386, so it can't be forced to be enabled in the travis.sh script.

Related to #1949 

**Affected Branches:** 

- master

**Issues addressed:**

N/A

### Known Issues and TODO List

N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
