### PR TITLE
Adoption Fixes and some new commands

### DIFF
--- a/conf/messages.conf
+++ b/conf/messages.conf
@@ -696,7 +696,15 @@
 
 // @jobchange
 923: You can not change to this job by command.
-//924-979 FREE
+
+// @adopt
+924: Baby already adopted or is in the process of being adopted.
+925: You need to be married and in a party with your partner and the Baby to adopt.
+926: Both parents need to have their wedding rings equipped.
+927: The Baby is not a Novice.
+928: A parent or Baby was not found.
+
+//929-979 FREE
 
 // @kami
 980: Please enter a message (usage: @kami <message>).

--- a/db/constants.conf
+++ b/db/constants.conf
@@ -3872,4 +3872,15 @@ constants_db: {
 	UDT_STATADD:         54
 	UDT_ROBE:            55
 	UDT_BODY2:           56
+
+	comment__: "Adoption Types"
+	ADOPT_ALLOWED:             0
+	ADOPT_ALREADY_ADOPTED:     1
+	ADOPT_MARRIED_AND_PARTY:   2
+	ADOPT_EQUIP_RINGS:         3
+	ADOPT_NOT_NOVICE:          4
+	ADOPT_CHARACTER_NOT_FOUND: 5	
+	ADOPT_MORE_CHILDREN:       6
+	ADOPT_LEVEL_70:            7
+	ADOPT_MARRIED:             8
 }

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -15833,9 +15833,9 @@ void clif_parse_cashshop_buy(int fd, struct map_session_data *sd)
 /// Adoption message (ZC_BABYMSG).
 /// 0216 <msg>.L
 /// msg:
-///     0 = "You cannot adopt more than 1 child."
-///     1 = "You must be at least character level 70 in order to adopt someone."
-///     2 = "You cannot adopt a married person."
+///     ADOPT_REPLY_MORE_CHILDREN = "You cannot adopt more than 1 child."
+///     ADOPT_REPLY_LEVEL_70 = "You must be at least character level 70 in order to adopt someone."
+///     ADOPT_REPLY_MARRIED = "You cannot adopt a married person."
 void clif_Adopt_reply(struct map_session_data *sd, int type)
 {
 	int fd;
@@ -15870,7 +15870,7 @@ void clif_parse_Adopt_request(int fd, struct map_session_data *sd) __attribute__
 void clif_parse_Adopt_request(int fd, struct map_session_data *sd) {
 	struct map_session_data *tsd = map->id2sd(RFIFOL(fd,2)), *p_sd = map->charid2sd(sd->status.partner_id);
 
-	if( pc->can_Adopt(sd, p_sd, tsd) ) {
+	if (pc->can_adopt(sd, p_sd, tsd) == ADOPT_ALLOWED) {
 		tsd->adopt_invite = sd->status.account_id;
 		clif->adopt_request(tsd, sd, p_sd->status.account_id);
 	}

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -573,6 +573,15 @@ enum CZ_CONFIG {
 	CZ_CONFIG_HOMUNCULUS_AUTOFEEDING = 3,
 };
 /**
+ * Adoption
+ **/
+enum e_adopt_reply {
+	ADOPT_REPLY_MORE_CHILDREN = 0,
+	ADOPT_REPLY_LEVEL_70,
+	ADOPT_REPLY_MARRIED,
+};
+
+/**
  * Structures
  **/
 typedef void (*pFunc)(int, struct map_session_data *); //cant help but put it first

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -803,6 +803,22 @@ enum pc_skill_flag {
 };
 
 /**
+ * Flag values for pc->can_adopt
+ */
+ 
+enum adopt_responses {
+	ADOPT_ALLOWED = 0,
+	ADOPT_ALREADY_ADOPTED,
+	ADOPT_MARRIED_AND_PARTY,
+	ADOPT_EQUIP_RINGS,
+	ADOPT_NOT_NOVICE,
+	ADOPT_CHARACTER_NOT_FOUND,
+	ADOPT_MORE_CHILDREN,
+	ADOPT_LEVEL_70,
+	ADOPT_MARRIED,
+};
+
+/**
  * Used to temporarily remember vending data
  **/
 struct autotrade_vending {
@@ -915,7 +931,7 @@ END_ZEROED_BLOCK; /* End */
 	int (*dropitem) (struct map_session_data *sd,int n,int amount);
 
 	bool (*isequipped) (struct map_session_data *sd, int nameid);
-	bool (*can_Adopt) (struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd);
+	enum adopt_responses (*can_adopt) (struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd);
 	bool (*adoption) (struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd);
 
 	int (*updateweightstatus) (struct map_session_data *sd);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -5404,8 +5404,8 @@ typedef int (*HPMHOOK_pre_pc_dropitem) (struct map_session_data **sd, int *n, in
 typedef int (*HPMHOOK_post_pc_dropitem) (int retVal___, struct map_session_data *sd, int n, int amount);
 typedef bool (*HPMHOOK_pre_pc_isequipped) (struct map_session_data **sd, int *nameid);
 typedef bool (*HPMHOOK_post_pc_isequipped) (bool retVal___, struct map_session_data *sd, int nameid);
-typedef bool (*HPMHOOK_pre_pc_can_Adopt) (struct map_session_data **p1_sd, struct map_session_data **p2_sd, struct map_session_data **b_sd);
-typedef bool (*HPMHOOK_post_pc_can_Adopt) (bool retVal___, struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd);
+typedef enum adopt_responses (*HPMHOOK_pre_pc_can_adopt) (struct map_session_data **p1_sd, struct map_session_data **p2_sd, struct map_session_data **b_sd);
+typedef enum adopt_responses (*HPMHOOK_post_pc_can_adopt) (enum adopt_responses retVal___, struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd);
 typedef bool (*HPMHOOK_pre_pc_adoption) (struct map_session_data **p1_sd, struct map_session_data **p2_sd, struct map_session_data **b_sd);
 typedef bool (*HPMHOOK_post_pc_adoption) (bool retVal___, struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd);
 typedef int (*HPMHOOK_pre_pc_updateweightstatus) (struct map_session_data **sd);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -4158,8 +4158,8 @@ struct {
 	struct HPMHookPoint *HP_pc_dropitem_post;
 	struct HPMHookPoint *HP_pc_isequipped_pre;
 	struct HPMHookPoint *HP_pc_isequipped_post;
-	struct HPMHookPoint *HP_pc_can_Adopt_pre;
-	struct HPMHookPoint *HP_pc_can_Adopt_post;
+	struct HPMHookPoint *HP_pc_can_adopt_pre;
+	struct HPMHookPoint *HP_pc_can_adopt_post;
 	struct HPMHookPoint *HP_pc_adoption_pre;
 	struct HPMHookPoint *HP_pc_adoption_post;
 	struct HPMHookPoint *HP_pc_updateweightstatus_pre;
@@ -10367,8 +10367,8 @@ struct {
 	int HP_pc_dropitem_post;
 	int HP_pc_isequipped_pre;
 	int HP_pc_isequipped_post;
-	int HP_pc_can_Adopt_pre;
-	int HP_pc_can_Adopt_post;
+	int HP_pc_can_adopt_pre;
+	int HP_pc_can_adopt_post;
 	int HP_pc_adoption_pre;
 	int HP_pc_adoption_post;
 	int HP_pc_updateweightstatus_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -2134,7 +2134,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(pc->takeitem, HP_pc_takeitem) },
 	{ HP_POP(pc->dropitem, HP_pc_dropitem) },
 	{ HP_POP(pc->isequipped, HP_pc_isequipped) },
-	{ HP_POP(pc->can_Adopt, HP_pc_can_Adopt) },
+	{ HP_POP(pc->can_adopt, HP_pc_can_adopt) },
 	{ HP_POP(pc->adoption, HP_pc_adoption) },
 	{ HP_POP(pc->updateweightstatus, HP_pc_updateweightstatus) },
 	{ HP_POP(pc->addautobonus, HP_pc_addautobonus) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -55332,14 +55332,15 @@ bool HP_pc_isequipped(struct map_session_data *sd, int nameid) {
 	}
 	return retVal___;
 }
-bool HP_pc_can_Adopt(struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd) {
+enum adopt_responses HP_pc_can_adopt(struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd) {
+/* Unknown return type 'enum adopt_responses'. Initializing to '0'. */
 	int hIndex = 0;
-	bool retVal___ = false;
-	if (HPMHooks.count.HP_pc_can_Adopt_pre > 0) {
-		bool (*preHookFunc) (struct map_session_data **p1_sd, struct map_session_data **p2_sd, struct map_session_data **b_sd);
+	enum adopt_responses retVal___ = 0;
+	if (HPMHooks.count.HP_pc_can_adopt_pre > 0) {
+		enum adopt_responses (*preHookFunc) (struct map_session_data **p1_sd, struct map_session_data **p2_sd, struct map_session_data **b_sd);
 		*HPMforce_return = false;
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_can_Adopt_pre; hIndex++) {
-			preHookFunc = HPMHooks.list.HP_pc_can_Adopt_pre[hIndex].func;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_can_adopt_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_pc_can_adopt_pre[hIndex].func;
 			retVal___ = preHookFunc(&p1_sd, &p2_sd, &b_sd);
 		}
 		if (*HPMforce_return) {
@@ -55348,12 +55349,12 @@ bool HP_pc_can_Adopt(struct map_session_data *p1_sd, struct map_session_data *p2
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.pc.can_Adopt(p1_sd, p2_sd, b_sd);
+		retVal___ = HPMHooks.source.pc.can_adopt(p1_sd, p2_sd, b_sd);
 	}
-	if (HPMHooks.count.HP_pc_can_Adopt_post > 0) {
-		bool (*postHookFunc) (bool retVal___, struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd);
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_can_Adopt_post; hIndex++) {
-			postHookFunc = HPMHooks.list.HP_pc_can_Adopt_post[hIndex].func;
+	if (HPMHooks.count.HP_pc_can_adopt_post > 0) {
+		enum adopt_responses (*postHookFunc) (enum adopt_responses retVal___, struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_can_adopt_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_pc_can_adopt_post[hIndex].func;
 			retVal___ = postHookFunc(retVal___, p1_sd, p2_sd, b_sd);
 		}
 	}


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)
Changes the behavior when adding skills via `skill()` script command. When sending the packet `0x111` with wedding skills, it tells the client to enable the adoption option when right clicking and with all the other required stuff in order to enable it.
Adds support to adoption via @atcommands and script_commands.
Fixes #1440

**Affected Branches:** 

[//]: # (Master? Slave?)
Master

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)
#1440 

### Credits
rAthena - the whole concept for commands
@Asheraf - By figuring out the relation between the packet `0x0111` and the Adoption Bug.