### PR TITLE
Req. Weapon Class Correction for Spiral Pierce

### DIFF
--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -11750,6 +11750,8 @@ skill_db: (
 			Lv10: 45
 		}
 		WeaponTypes: {
+			1HSwords: true
+			2HSwords: true
 			1HSpears: true
 			2HSpears: true
 		}


### PR DESCRIPTION
Hi,

According to RateMyServer and iRO Wiki, the Req. Weapon Class for Spiral Pierce is One-handed Sword,  Two-handed Sword, One-handed Spear or Two-handed Spear