### PR TITLE
Fix unterminated strings in ZC_BATTLEFIELD_CHAT

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -16566,18 +16566,15 @@ void clif_bg_message(struct battleground_data *bgd, int src_id, const char *name
 		return;
 
 	len = (int)strlen(mes);
-#if PACKETVER <= 20120716
-	len += 1;
-#endif
-	Assert_retv(len <= INT16_MAX - NAME_LENGTH - 8);
-	buf = (unsigned char*)aMalloc((len + NAME_LENGTH + 8)*sizeof(unsigned char));
+	Assert_retv(len <= INT16_MAX - NAME_LENGTH - 9);
+	buf = (unsigned char *)aCalloc(len + NAME_LENGTH + 9, sizeof(unsigned char));
 
-	WBUFW(buf,0) = 0x2dc;
-	WBUFW(buf,2) = len + NAME_LENGTH + 8;
-	WBUFL(buf,4) = src_id;
-	memcpy(WBUFP(buf,8), name, NAME_LENGTH);
-	memcpy(WBUFP(buf,32), mes, len); // [!] no NUL terminator
-	clif->send(buf,WBUFW(buf,2), &sd->bl, BG);
+	WBUFW(buf, 0) = 0x2dc;
+	WBUFW(buf, 2) = len + NAME_LENGTH + 9;
+	WBUFL(buf, 4) = src_id;
+	safestrncpy(WBUFP(buf, 8), name, NAME_LENGTH);
+	safestrncpy(WBUFP(buf, 32), mes, len + 1);
+	clif->send(buf, WBUFW(buf, 2), &sd->bl, BG);
 
 	aFree(buf);
 }


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This extends the changes from #1890, targeting the clients that were excluded.

The unterminated string could cause client crashes or trailing garbage to be displayed when receiving a battlegrounds chat message, on various client versions.

Regardless of whether each client version requires that a string NUL terminator is present in the packet, the client is able to properly handle its presence. As a safety measure, this patch always appends a NUL terminator to the message, regardless of client version, to fix the issues described in the comments of PR #1890.

This has been double-checked on the following clients, to ensure that the NUL terminator doesn't cause display glitches:

- 2010-07-30aRagexe
- 2013-08-07aRagexe
- 2018-01-24bRagexeRE

**Affected Branches:** 

- master
- stable

**Issues addressed:**

Comments of #1890 

### Known Issues and TODO List

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
