### PR TITLE
Fix HPMHooking compilation when sprintf() is a macro

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -5625,7 +5625,7 @@ const char *script_getfuncname(struct script_state *st) {
  *                   already initialized)
  * @retval false if an error occurs.
  */
-bool script_sprintf(struct script_state *st, int start, struct StringBuf *out)
+bool script_sprintf_helper(struct script_state *st, int start, struct StringBuf *out)
 {
 	const char *format = NULL;
 	const char *p = NULL, *np = NULL;
@@ -5678,7 +5678,7 @@ bool script_sprintf(struct script_state *st, int start, struct StringBuf *out)
 		}
 		// placeholder = "%n" ; (ignored)
 		if (*np == 'n') {
-			ShowWarning("script_sprintf: Format %%n not supported! Skipping...\n");
+			ShowWarning("script_sprintf_helper: Format %%n not supported! Skipping...\n");
 			script->reportsrc(st);
 			lastarg = nextarg;
 			p = np + 1;
@@ -5881,7 +5881,7 @@ BUILDIN(mesf)
 
 	StrBuf->Init(&buf);
 
-	if (!script_sprintf(st, 2, &buf)) {
+	if (!script->sprintf_helper(st, 2, &buf)) {
 		StrBuf->Destroy(&buf);
 		return false;
 	}
@@ -16793,7 +16793,7 @@ BUILDIN(sprintf)
 	struct StringBuf buf;
 	StrBuf->Init(&buf);
 
-	if (!script_sprintf(st, 2, &buf)) {
+	if (!script->sprintf_helper(st, 2, &buf)) {
 		StrBuf->Destroy(&buf);
 		script_pushconststr(st, "");
 		return false;
@@ -25180,7 +25180,7 @@ void script_defaults(void)
 	script->search_str = script_search_str;
 	script->setd_sub = setd_sub;
 	script->attach_state = script_attach_state;
-	script->sprintf = script_sprintf;
+	script->sprintf_helper = script_sprintf_helper;
 
 	script->queue = script_hqueue_get;
 	script->queue_add = script_hqueue_add;

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -909,7 +909,7 @@ struct script_interface {
 	int (*buildin_mobuseskill_sub) (struct block_list *bl, va_list ap);
 	int (*cleanfloor_sub) (struct block_list *bl, va_list ap);
 	int (*run_func) (struct script_state *st);
-	bool (*sprintf) (struct script_state *st, int start, struct StringBuf *out);
+	bool (*sprintf_helper) (struct script_state *st, int start, struct StringBuf *out);
 	const char *(*getfuncname) (struct script_state *st);
 	// for ENABLE_CASE_CHECK
 	unsigned int (*calc_hash_ci) (const char *p);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -6434,8 +6434,8 @@ typedef int (*HPMHOOK_pre_script_cleanfloor_sub) (struct block_list **bl, va_lis
 typedef int (*HPMHOOK_post_script_cleanfloor_sub) (int retVal___, struct block_list *bl, va_list ap);
 typedef int (*HPMHOOK_pre_script_run_func) (struct script_state **st);
 typedef int (*HPMHOOK_post_script_run_func) (int retVal___, struct script_state *st);
-typedef bool (*HPMHOOK_pre_script_sprintf) (struct script_state **st, int *start, struct StringBuf **out);
-typedef bool (*HPMHOOK_post_script_sprintf) (bool retVal___, struct script_state *st, int start, struct StringBuf *out);
+typedef bool (*HPMHOOK_pre_script_sprintf_helper) (struct script_state **st, int *start, struct StringBuf **out);
+typedef bool (*HPMHOOK_post_script_sprintf_helper) (bool retVal___, struct script_state *st, int start, struct StringBuf *out);
 typedef const char* (*HPMHOOK_pre_script_getfuncname) (struct script_state **st);
 typedef const char* (*HPMHOOK_post_script_getfuncname) (const char* retVal___, struct script_state *st);
 typedef unsigned int (*HPMHOOK_pre_script_calc_hash_ci) (const char **p);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -5054,8 +5054,8 @@ struct {
 	struct HPMHookPoint *HP_script_cleanfloor_sub_post;
 	struct HPMHookPoint *HP_script_run_func_pre;
 	struct HPMHookPoint *HP_script_run_func_post;
-	struct HPMHookPoint *HP_script_sprintf_pre;
-	struct HPMHookPoint *HP_script_sprintf_post;
+	struct HPMHookPoint *HP_script_sprintf_helper_pre;
+	struct HPMHookPoint *HP_script_sprintf_helper_post;
 	struct HPMHookPoint *HP_script_getfuncname_pre;
 	struct HPMHookPoint *HP_script_getfuncname_post;
 	struct HPMHookPoint *HP_script_calc_hash_ci_pre;
@@ -11335,8 +11335,8 @@ struct {
 	int HP_script_cleanfloor_sub_post;
 	int HP_script_run_func_pre;
 	int HP_script_run_func_post;
-	int HP_script_sprintf_pre;
-	int HP_script_sprintf_post;
+	int HP_script_sprintf_helper_pre;
+	int HP_script_sprintf_helper_post;
 	int HP_script_getfuncname_pre;
 	int HP_script_getfuncname_post;
 	int HP_script_calc_hash_ci_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -2589,7 +2589,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(script->buildin_mobuseskill_sub, HP_script_buildin_mobuseskill_sub) },
 	{ HP_POP(script->cleanfloor_sub, HP_script_cleanfloor_sub) },
 	{ HP_POP(script->run_func, HP_script_run_func) },
-	{ HP_POP(script->sprintf, HP_script_sprintf) },
+	{ HP_POP(script->sprintf_helper, HP_script_sprintf_helper) },
 	{ HP_POP(script->getfuncname, HP_script_getfuncname) },
 	{ HP_POP(script->calc_hash_ci, HP_script_calc_hash_ci) },
 	{ HP_POP(script->array_src, HP_script_array_src) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -67480,14 +67480,14 @@ int HP_script_run_func(struct script_state *st) {
 	}
 	return retVal___;
 }
-bool HP_script_sprintf(struct script_state *st, int start, struct StringBuf *out) {
+bool HP_script_sprintf_helper(struct script_state *st, int start, struct StringBuf *out) {
 	int hIndex = 0;
 	bool retVal___ = false;
-	if (HPMHooks.count.HP_script_sprintf_pre > 0) {
+	if (HPMHooks.count.HP_script_sprintf_helper_pre > 0) {
 		bool (*preHookFunc) (struct script_state **st, int *start, struct StringBuf **out);
 		*HPMforce_return = false;
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_script_sprintf_pre; hIndex++) {
-			preHookFunc = HPMHooks.list.HP_script_sprintf_pre[hIndex].func;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_script_sprintf_helper_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_script_sprintf_helper_pre[hIndex].func;
 			retVal___ = preHookFunc(&st, &start, &out);
 		}
 		if (*HPMforce_return) {
@@ -67496,12 +67496,12 @@ bool HP_script_sprintf(struct script_state *st, int start, struct StringBuf *out
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.script.sprintf(st, start, out);
+		retVal___ = HPMHooks.source.script.sprintf_helper(st, start, out);
 	}
-	if (HPMHooks.count.HP_script_sprintf_post > 0) {
+	if (HPMHooks.count.HP_script_sprintf_helper_post > 0) {
 		bool (*postHookFunc) (bool retVal___, struct script_state *st, int start, struct StringBuf *out);
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_script_sprintf_post; hIndex++) {
-			postHookFunc = HPMHooks.list.HP_script_sprintf_post[hIndex].func;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_script_sprintf_helper_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_script_sprintf_helper_post[hIndex].func;
 			retVal___ = postHookFunc(retVal___, st, start, out);
 		}
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`script->sprintf()` is renamed to `script->sprintf_helper()`, so that it won't break when the C library defines a `sprintf()` macro.

**Affected Branches:** 

- stable

**Issues addressed:**

- #2003 

### Known Issues and TODO List

N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
