### PR TITLE
Prevent a null pointer failure when TK_JUMPKICK is used by a non-player

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -6503,16 +6503,14 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 
 		case TK_JUMPKICK:
 			/* Check if the target is an enemy; if not, skill should fail so the character doesn't unit->movepos (exploitable) */
-			if( battle->check_target(src, bl, BCT_ENEMY) > 0 )
-			{
-				if( unit->movepos(src, bl->x, bl->y, 1, 1) )
-				{
-					skill->attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag);
-					clif->slide(src,bl->x,bl->y);
+			if (battle->check_target(src, bl, BCT_ENEMY) > 0) {
+				if (unit->movepos(src, bl->x, bl->y, 1, 1)) {
+					skill->attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag);
+					clif->slide(src, bl->x, bl->y);
 				}
+			} else if (sd != NULL) {
+				clif->skill_fail(sd, skill_id, USESKILL_FAIL, 0);
 			}
-			else
-				clif->skill_fail(sd,skill_id,USESKILL_FAIL,0);
 			break;
 
 		case AL_INCAGI:


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The `sd` pointer is checked before calling the clif function, as suggested in #1875.

**Affected Branches:** 

- stable

**Issues addressed:**

- Fixes #1875

### Known Issues and TODO List

N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
