### PR TITLE
Comment out "MYPLUGINS ="

### DIFF
--- a/src/plugins/Makefile.in
+++ b/src/plugins/Makefile.in
@@ -33,7 +33,7 @@
 #                                                                    #
 # Note: DO NOT include the .c extension!!!                           #
 
-MYPLUGINS = 
+MYPLUGINS := $(MYPLUGINS)
 
 #                                                                    #
 #########  DO NOT EDIT ANYTHING BELOW THIS LINE!!!  ##################


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
There are 3 different ways to populate a variable in a Makefile (https://stackoverflow.com/a/28891382)

1.  You manipulate the file directly and set the variable before it gets used
2.  You pass it to make like so: make MYPLUGINS="test" all
3.  You set an env variable via export like so: export MYPLUGINS="test"

The problem is precedence. If you just set the MYPLUGINS in your environment via export it won't get used because the empty string declaration in the Makefile.in gets prefered.

This change will add upon the configurability of hercules.

**Affected Branches:**
stable

[master]: # (Master? Slave?)
master

**Issues addressed:**
lack of configurability options for used plugins

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
