### PR TITLE
Fix the name of monsters summoned through SA_SUMMONMONSTER

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -2056,7 +2056,7 @@ ACMD(monster)
 		number = 1;
 
 	if (!name[0])
-		strcpy(name, "--ja--");
+		strcpy(name, DEFAULT_MOB_JNAME);
 
 	// If value of atcommand_spawn_quantity_limit directive is greater than or equal to 1 and quantity of monsters is greater than value of the directive
 	if (battle_config.atc_spawn_quantity_limit && number > battle_config.atc_spawn_quantity_limit)
@@ -6128,9 +6128,10 @@ ACMD(mobsearch)
 		clif->message(fd, atcmd_output);
 		return false;
 	}
-	if (mob_id == atoi(mob_name))
-		strcpy(mob_name,mob->db(mob_id)->jname); // --ja--
-		//strcpy(mob_name,mob_db(mob_id)->name); // --en--
+	if (mob_id == atoi(mob_name)) {
+		strcpy(mob_name,mob->db(mob_id)->jname); // DEFAULT_MOB_JNAME
+		//strcpy(mob_name,mob_db(mob_id)->name); // DEFAULT_MOB_NAME
+	}
 
 	snprintf(atcmd_output, sizeof atcmd_output, msg_fd(fd,1220), mob_name, mapindex_id2name(sd->mapindex)); // Mob Search... %s %s
 	clif->message(fd, atcmd_output);
@@ -6373,7 +6374,7 @@ ACMD(summon)
 		return false;
 	}
 
-	md = mob->once_spawn_sub(&sd->bl, sd->bl.m, -1, -1, "--ja--", mob_id, "", SZ_SMALL, AI_NONE);
+	md = mob->once_spawn_sub(&sd->bl, sd->bl.m, -1, -1, DEFAULT_MOB_JNAME, mob_id, "", SZ_SMALL, AI_NONE);
 
 	if(!md)
 		return false;
@@ -6814,9 +6815,10 @@ ACMD(showmobs)
 		return false;
 	}
 
-	if(mob_id == atoi(mob_name))
-		strcpy(mob_name,mob->db(mob_id)->jname);    // --ja--
-	//strcpy(mob_name,mob_db(mob_id)->name);    // --en--
+	if (mob_id == atoi(mob_name)) {
+		strcpy(mob_name,mob->db(mob_id)->jname); // DEFAULT_MOB_JNAME
+		//strcpy(mob_name,mob_db(mob_id)->name); // DEFAULT_MOB_NAME
+	}
 
 	snprintf(atcmd_output, sizeof atcmd_output, msg_fd(fd,1252), // Mob Search... %s %s
 			 mob_name, mapindex_id2name(sd->mapindex));

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -316,9 +316,9 @@ int mob_parse_dataset(struct spawn_data *data)
 			memmove(data->eventname, data->eventname+1, len-1);
 	}
 
-	if(strcmp(data->name,"--en--")==0)
+	if (strcmp(data->name, DEFAULT_MOB_NAME) == 0)
 		safestrncpy(data->name, mob->db(data->class_)->name, sizeof(data->name));
-	else if(strcmp(data->name,"--ja--")==0)
+	else if (strcmp(data->name, DEFAULT_MOB_JNAME) == 0)
 		safestrncpy(data->name, mob->db(data->class_)->jname, sizeof(data->name));
 
 	return 1;
@@ -498,13 +498,12 @@ struct mob_data *mob_once_spawn_sub(struct block_list *bl, int16 m, int16 x, int
 	data.state.size = size;
 	data.state.ai = ai;
 
-	if (mobname)
+	if (mobname != NULL)
 		safestrncpy(data.name, mobname, sizeof(data.name));
+	else if (battle_config.override_mob_names == 1)
+		strcpy(data.name, DEFAULT_MOB_NAME);
 	else
-		if (battle_config.override_mob_names == 1)
-			strcpy(data.name, "--en--");
-		else
-			strcpy(data.name, "--ja--");
+		strcpy(data.name, DEFAULT_MOB_JNAME);
 
 	if (event)
 		safestrncpy(data.eventname, event, sizeof(data.eventname));
@@ -3034,10 +3033,10 @@ int mob_summonslave(struct mob_data *md2,int *value,int amount,uint16 skill_id)
 		}
 
 		//These two need to be loaded from the db for each slave.
-		if(battle_config.override_mob_names==1)
-			strcpy(data.name,"--en--");
+		if (battle_config.override_mob_names == 1)
+			strcpy(data.name, DEFAULT_MOB_NAME);
 		else
-			strcpy(data.name,"--ja--");
+			strcpy(data.name, DEFAULT_MOB_JNAME);
 
 		if (!mob->parse_dataset(&data))
 			continue;
@@ -3649,7 +3648,7 @@ int mob_clone_spawn(struct map_session_data *sd, int16 m, int16 x, int16 y, cons
 	sd->fd = fd;
 
 	//Finally, spawn it.
-	md = mob->once_spawn_sub(&sd->bl, m, x, y, "--en--", class_, event, SZ_SMALL, AI_NONE);
+	md = mob->once_spawn_sub(&sd->bl, m, x, y, DEFAULT_MOB_NAME, class_, event, SZ_SMALL, AI_NONE);
 	if (!md) return 0; //Failed?
 
 	md->special_state.clone = 1;

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -60,6 +60,9 @@ struct hplugin_data_store;
 
 #define MAX_MOB_CHAT 250 //Max Skill's messages
 
+#define DEFAULT_MOB_NAME "--en--"
+#define DEFAULT_MOB_JNAME "--ja--"
+
 // On official servers, monsters will only seek targets that are closer to walk to than their
 // search range. The search range is affected depending on if the monster is walking or not.
 // On some maps there can be a quite long path for just walking two cells in a direction and

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -3956,10 +3956,10 @@ const char *npc_parse_mob(const char *w1, const char *w2, const char *w3, const 
 	}
 
 	//Use db names instead of the spawn file ones.
-	if(battle_config.override_mob_names==1)
-		strcpy(mobspawn.name,"--en--");
-	else if (battle_config.override_mob_names==2)
-		strcpy(mobspawn.name,"--ja--");
+	if (battle_config.override_mob_names == 1)
+		strcpy(mobspawn.name, DEFAULT_MOB_NAME);
+	else if (battle_config.override_mob_names == 2)
+		strcpy(mobspawn.name, DEFAULT_MOB_JNAME);
 	else
 		safestrncpy(mobspawn.name, mobname, sizeof(mobspawn.name));
 

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -6304,7 +6304,8 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 			break;
 		case SA_SUMMONMONSTER:
 			clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
-			if (sd) mob->once_spawn(sd, src->m, src->x, src->y," --ja--", -1, 1, "", SZ_SMALL, AI_NONE);
+			if (sd != NULL)
+				mob->once_spawn(sd, src->m, src->x, src->y, "--ja--", -1, 1, "", SZ_SMALL, AI_NONE);
 			break;
 		case SA_LEVELUP:
 			clif->skill_nodamage(src,bl,skill_id,skill_lv,1);

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -6305,7 +6305,7 @@ int skill_castend_nodamage_id(struct block_list *src, struct block_list *bl, uin
 		case SA_SUMMONMONSTER:
 			clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
 			if (sd != NULL)
-				mob->once_spawn(sd, src->m, src->x, src->y, "--ja--", -1, 1, "", SZ_SMALL, AI_NONE);
+				mob->once_spawn(sd, src->m, src->x, src->y, DEFAULT_MOB_JNAME, -1, 1, "", SZ_SMALL, AI_NONE);
 			break;
 		case SA_LEVELUP:
 			clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
@@ -11430,7 +11430,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 					clif->skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				} else {
 					int mob_id = skill_lv < 2 ? MOBID_BLACK_MUSHROOM + rnd()%2 : MOBID_RED_PLANT + rnd()%6;
-					struct mob_data *md = mob->once_spawn_sub(src, src->m, x, y, "--ja--", mob_id, "", SZ_SMALL, AI_NONE);
+					struct mob_data *md = mob->once_spawn_sub(src, src->m, x, y, DEFAULT_MOB_JNAME, mob_id, "", SZ_SMALL, AI_NONE);
 					int i;
 					if (md == NULL)
 						break;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR fixes an extra space inside a `" --ja--"` string (since d9d3adf3fd4795bf2483ec8549ddc30e01629db of 2012) that causes the automatic mob name replacement to fail, for all monsters summoned by the sage skill SA_SUMMONMONSTER (i.e. through Hocus Pocus).

To make it harder for a similar issue to occur again, it also replaces the use of literal `"--ja--"` and `"--en--"` with the newly introduced `DEFAULT_MOB_JNAME` and `DEFAULT_MOB_NAME` constants, respectively.

**Affected Branches:** 

- stable

**Issues addressed:**

N/A

### Known Issues and TODO List

N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
