### PR TITLE
Fix pincodes after commit 2a05dbfc2f62c6bbac7983dcec120502914567f1.

### DIFF
--- a/src/char/pincode.c
+++ b/src/char/pincode.c
@@ -82,6 +82,7 @@ void pincode_check(int fd, struct char_session_data* sd)
 		return;
 
 	safestrncpy(pin, RFIFOP(fd, 6), sizeof(pin));
+	pincode->decrypt(sd->pincode_seed, pin);
 
 	if (pincode->check_blacklist && pincode->isBlacklisted(pin)) {
 		pincode->loginstate(fd, sd, PINCODE_LOGIN_RESTRICT_PW);

--- a/src/char/pincode.c
+++ b/src/char/pincode.c
@@ -206,7 +206,7 @@ void pincode_makestate(int fd, struct char_session_data *sd, enum pincode_make_r
 	WFIFOHEAD(fd, 8);
 	WFIFOW(fd, 0) = 0x8bb;
 	WFIFOW(fd, 2) = state;
-	WFIFOW(fd, 4) = 0;
+	WFIFOL(fd, 4) = sd->pincode_seed;
 	WFIFOSET(fd, 8);
 }
 
@@ -224,7 +224,7 @@ void pincode_editstate(int fd, struct char_session_data *sd, enum pincode_edit_r
 	WFIFOHEAD(fd, 8);
 	WFIFOW(fd, 0) = 0x8bf;
 	WFIFOW(fd, 2) = state;
-	WFIFOW(fd, 4) = sd->pincode_seed = rnd() % 0xFFFF;
+	WFIFOL(fd, 4) = sd->pincode_seed = rnd() % 0xFFFF;
 	WFIFOSET(fd, 8);
 }
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add missing pincode decryption.
Fix pincode packets field size to avoid send garbage to client.
Add missing seed in packet 0x8bb.
