### PR TITLE
Add MD_NORANDOM_WALK, MD_NOCAST_SKILL & MD_CANATTACK_MOB monster mode flag

### DIFF
--- a/doc/mob_db_mode_list.txt
+++ b/doc/mob_db_mode_list.txt
@@ -11,23 +11,26 @@
 Bit Legend:
 -------------------------------------------------------------------------------
 
-MD_CANMOVE            | 0x00001 |      1
-MD_LOOTER             | 0x00002 |      2
-MD_AGGRESSIVE         | 0x00004 |      4
-MD_ASSIST             | 0x00008 |      8
-MD_CASTSENSOR_IDLE    | 0x00010 |     16
-MD_BOSS               | 0x00020 |     32
-MD_PLANT              | 0x00040 |     64
-MD_CANATTACK          | 0x00080 |    128
-MD_DETECTOR           | 0x00100 |    256
-MD_CASTSENSOR_CHASE   | 0x00200 |    512
-MD_CHANGECHASE        | 0x00400 |   1024
-MD_ANGRY              | 0x00800 |   2048
-MD_CHANGETARGET_MELEE | 0x01000 |   4096
-MD_CHANGETARGET_CHASE | 0x02000 |   8192
-MD_TARGETWEAK         | 0x04000 |  16384
-MD_NOKNOCKBACK        | 0x08000 |  32768
-MD_RANDOMTARGET       | 0x10000 |  65536 (not implemented)
+MD_CANMOVE            | 0x00001 |       1
+MD_LOOTER             | 0x00002 |       2
+MD_AGGRESSIVE         | 0x00004 |       4
+MD_ASSIST             | 0x00008 |       8
+MD_CASTSENSOR_IDLE    | 0x00010 |      16
+MD_BOSS               | 0x00020 |      32
+MD_PLANT              | 0x00040 |      64
+MD_CANATTACK          | 0x00080 |     128
+MD_DETECTOR           | 0x00100 |     256
+MD_CASTSENSOR_CHASE   | 0x00200 |     512
+MD_CHANGECHASE        | 0x00400 |    1024
+MD_ANGRY              | 0x00800 |    2048
+MD_CHANGETARGET_MELEE | 0x01000 |    4096
+MD_CHANGETARGET_CHASE | 0x02000 |    8192
+MD_TARGETWEAK         | 0x04000 |   16384
+MD_NOKNOCKBACK        | 0x08000 |   32768
+MD_RANDOMTARGET       | 0x10000 |   65536 (not implemented)
+MD_NORANDOM_WALK      | 0x20000 |  131072
+MD_NOCAST_SKILL       | 0x40000 |  262144
+MD_CANATTACK_MOB      | 0x80000 |  524288
 
 Explanation for modes:
 -------------------------------------------------------------------------------
@@ -79,6 +82,14 @@ NoKnockback: Monsters will be immune to Knockback's.
 
 Random Target: Picks a new random target in range on each attack / skill.
 	(not implemented)
+
+No Random Walk: Monsters will not randomly walk around during idle state.
+
+No Cast Skill: Monsters will be unable to cast skills.
+
+Can Attack Mob: Both monsters with this flag can attack each other. Best use
+	on battleground maps, as the monsters on same battleground team cannot
+	attack each other.
 
 Aegis Mob Types:
 -------------------------------------------------------------------------------

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -6735,7 +6735,9 @@ int battle_check_target( struct block_list *src, struct block_list *target,int f
 				&& md->guardian_data && (md->guardian_data->g || md->guardian_data->castle->guild_id) )
 				return 0; // Disable guardians/emperium owned by Guilds on non-woe times.
 
-			if (md->special_state.ai == AI_NONE) {
+			if (status_get_mode(s_bl) & MD_CANATTACK_MOB && t_bl->type == BL_MOB && status_get_mode(t_bl) & MD_CANATTACK_MOB)
+				state |= BCT_ENEMY;
+			else if (md->special_state.ai == AI_NONE) {
 				//Normal mobs
 				const struct mob_data *target_md = BL_CCAST(BL_MOB, target);
 				if ((target_md != NULL && t_bl->type == BL_PC && target_md->special_state.ai != AI_ZANZOU && target_md->special_state.ai != AI_ATTACK)

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -1414,6 +1414,7 @@ int mob_randomwalk(struct mob_data *md, int64 tick) {
 	nullpo_ret(md);
 
 	if(DIFF_TICK(md->next_walktime,tick)>0 ||
+	   status_get_mode(&md->bl) & MD_NORANDOM_WALK ||
 	   !unit->can_move(&md->bl) ||
 	   !(status_get_mode(&md->bl)&MD_CANMOVE))
 		return 0;
@@ -3208,7 +3209,7 @@ int mobskill_use(struct mob_data *md, int64 tick, int event) {
 	nullpo_ret(md);
 	nullpo_ret(ms = md->db->skill);
 
-	if (!battle_config.mob_skill_rate || md->ud.skilltimer != INVALID_TIMER || !md->db->maxskill)
+	if (!battle_config.mob_skill_rate || md->ud.skilltimer != INVALID_TIMER || !md->db->maxskill || status_get_mode(&md->bl) & MD_NOCAST_SKILL)
 		return 0;
 
 	if (event == -1 && DIFF_TICK(md->ud.canact_tick, tick) > 0)

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -25094,6 +25094,29 @@ void script_hardcoded_constants(void)
 	script->set_constant("MST_AROUND4", MST_AROUND4, false, false);
 	script->set_constant("MST_AROUND", MST_AROUND , false, false);
 
+	script->constdb_comment("monster mode database");
+	script->set_constant("MD_NONE", MD_NONE, false, false);
+	script->set_constant("MD_CANMOVE", MD_CANMOVE, false, false);
+	script->set_constant("MD_LOOTER", MD_LOOTER, false, false);
+	script->set_constant("MD_AGGRESSIVE", MD_AGGRESSIVE, false, false);
+	script->set_constant("MD_ASSIST", MD_ASSIST, false, false);
+	script->set_constant("MD_CASTSENSOR_IDLE", MD_CASTSENSOR_IDLE, false, false);
+	script->set_constant("MD_BOSS", MD_BOSS, false, false);
+	script->set_constant("MD_PLANT", MD_PLANT, false, false);
+	script->set_constant("MD_CANATTACK", MD_CANATTACK, false, false);
+	script->set_constant("MD_DETECTOR", MD_DETECTOR, false, false);
+	script->set_constant("MD_CASTSENSOR_CHASE", MD_CASTSENSOR_CHASE, false, false);
+	script->set_constant("MD_CHANGECHASE", MD_CHANGECHASE, false, false);
+	script->set_constant("MD_ANGRY", MD_ANGRY, false, false);
+	script->set_constant("MD_CHANGETARGET_MELEE", MD_CHANGETARGET_MELEE, false, false);
+	script->set_constant("MD_CHANGETARGET_CHASE", MD_CHANGETARGET_CHASE, false, false);
+	script->set_constant("MD_TARGETWEAK", MD_TARGETWEAK, false, false);
+	script->set_constant("MD_NOKNOCKBACK", MD_NOKNOCKBACK, false, false);
+//	script->set_constant("MD_RANDOMTARGET", MD_RANDOMTARGET, false, false);
+	script->set_constant("MD_NORANDOM_WALK", MD_NORANDOM_WALK, false, false);
+	script->set_constant("MD_NOCAST_SKILL", MD_NOCAST_SKILL, false, false);
+	script->set_constant("MD_CANATTACK_MOB", MD_CANATTACK_MOB, false, false);
+
 	script->constdb_comment("Renewal");
 #ifdef RENEWAL
 	script->set_constant("RENEWAL", 1, false, false);

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -1922,6 +1922,9 @@ enum e_mode
 	MD_TARGETWEAK         = 0x00004000,
 	MD_NOKNOCKBACK        = 0x00008000,
 	//MD_RANDOMTARGET     = 0x00010000, // Not implemented
+	MD_NORANDOM_WALK      = 0x00020000,
+	MD_NOCAST_SKILL       = 0x00040000,
+	MD_CANATTACK_MOB      = 0x00080000,
 	// Note: This should be kept within INT_MAX, since it's often cast to int.
 	MD_MASK               = 0x7FFFFFFF,
 };


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.
### Issues addressed
This is part of unit controller script commands -> https://github.com/HerculesWS/Hercules/issues/998
### Changes Proposed
Add **MD_NORANDOM_WALK**, **MD_NOCAST_SKILL** & **MD_CANATTACK_MOB** monster mode flag

### Affected Branches
* Master

### Tested with
```
prontera,155,185,5	script	jskdhfjshfd	1_F_MARIA,{
	if ( .monster_a || .monster_b ) end;
	.monster_a = monster( "this", -1,-1, "monster A", PORING,1, strnpcinfo(3)+"::Onaaa" );
	.monster_b = monster( "this", -1,-1, "monster B", PORING,1, strnpcinfo(3)+"::Onbbb" );
//	setunitdata .monster_a, UDT_MODE, getunitdata(.monster_a, UDT_MODE) | (MD_AGGRESSIVE|MD_CANATTACK|MD_CANATTACK_MOB);
//	setunitdata .monster_b, UDT_MODE, getunitdata(.monster_b, UDT_MODE) | (MD_CANATTACK|MD_CANATTACK_MOB);
//	setunitdata .monster_b, UDT_MODE, getunitdata(.monster_b, UDT_MODE) | (MD_CANATTACK);
//	setunitdata .monster_b, UDT_MODE, getunitdata(.monster_b, UDT_MODE) | (MD_NORANDOM_WALK);
//	setunitdata .monster_b, UDT_MODE, getunitdata(.monster_b, UDT_MODE) | (MD_NORANDOM_WALK);
	
	.monster_c = monster( "this", -1,-1, "monster C", G_KATRINN,1, strnpcinfo(3)+"::Onccc" );
	setunitdata .monster_c, UDT_MODE, getunitdata(.monster_c, UDT_MODE) | (MD_NOCAST_SKILL);
	end;
Onaaa:
	.monster_a = 0;
	end;
Onbbb:
	.monster_b = 0;
	end;
Onccc:
	.monster_c = 0;
	end;
}
```
```
prontera	mapflag	battleground
prontera,155,185,5	script	jskdhfjshfd	1_F_MARIA,{
	if ( getcharid(4) ) bg_leave;
	.@test = bg_create_team( .map$, .x, .y );
	bg_join_team .@test;
	dispbottom getcharid(4) +"";
	bg_monster 0, .map$, .x +1, .y, "--ja--", 1001, strnpcinfo(3) +"::Onaaa";
	.@a = bg_monster(0, .map$, .x +2, .y, "--ja--", 1001, strnpcinfo(3) +"::Onaaa");
	.@b = bg_monster(.@test, .map$, .x +3, .y, "--ja--", 1001, strnpcinfo(3) +"::Onaaa");
	.@c = bg_monster(.@test, .map$, .x +4, .y, "--ja--", 1001, strnpcinfo(3) +"::Onaaa");
	setunitdata .@a, UDT_MODE, getunitdata(.@a, UDT_MODE) | (MD_AGGRESSIVE|MD_CANATTACK|MD_CANATTACK_MOB);
	setunitdata .@b, UDT_MODE, getunitdata(.@b, UDT_MODE) | (MD_AGGRESSIVE|MD_CANATTACK|MD_CANATTACK_MOB);
	setunitdata .@c, UDT_MODE, getunitdata(.@c, UDT_MODE) | (MD_AGGRESSIVE|MD_CANATTACK|MD_CANATTACK_MOB);
	end;
Onaaa:
	end;
OnInit:
	getmapxy .map$, .x, .y, UNITTYPE_NPC;
	.x += 2;
	end;
}
```
### Known Issues and TODO List
is it true that bg_monster spawn inside battleground map, the monster will follow you around ?
both rathena and hercules has this behavior