### PR TITLE
Adds configuration for Magic Rod behavior (official/eAthena).

### DIFF
--- a/conf/map/battle/skill.conf
+++ b/conf/map/battle/skill.conf
@@ -330,3 +330,8 @@ bowling_bash_area: 0
 // punch a hole into SG it will for example create a "suck in" effect.
 // If you disable this setting, the knockback direction will be completely random (eAthena style).
 stormgust_knockback: true
+
+// Magic Rod's animation behavior (Note 1)
+// 0 : (official) Magic Rod's animation occurs every time it is used.
+// 1 : Magic Rod's animation would not occur unless a spell was absorbed. (old behavior)
+magicrod_type: 0

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7413,6 +7413,7 @@ static const struct battle_data {
 	{ "min_item_buy_price",                 &battle_config.min_item_buy_price,              1,      0,      INT_MAX,        },
 	{ "min_item_sell_price",                &battle_config.min_item_sell_price,             0,      0,      INT_MAX,        },
 	{ "display_fake_hp_when_dead",          &battle_config.display_fake_hp_when_dead,       1,      0,      1,              },
+	{ "magicrod_type",                      &battle_config.magicrod_type,                   0,      0,      1,              },
 };
 
 static bool battle_set_value_sub(int index, int value)

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -576,6 +576,8 @@ struct Battle_Config {
 	int min_item_sell_price;
 
 	int display_fake_hp_when_dead;
+
+	int magicrod_type;
 };
 
 /* criteria for battle_config.idletime_critera */

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -2892,14 +2892,16 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 			}
 		#endif /* MAGIC_REFLECTION_TYPE */
 		}
-		if(sc && sc->data[SC_MAGICROD] && src == dsrc) {
-			int sp = skill->get_sp(skill_id,skill_lv);
+		if (sc && sc->data[SC_MAGICROD] && src == dsrc) {
+			int sp = skill->get_sp(skill_id, skill_lv);
 			dmg.damage = dmg.damage2 = 0;
 			dmg.dmg_lv = ATK_MISS; //This will prevent skill additional effect from taking effect. [Skotlex]
 			sp = sp * sc->data[SC_MAGICROD]->val2 / 100;
-			if(skill_id == WZ_WATERBALL && skill_lv > 1)
-				sp = sp/((skill_lv|1)*(skill_lv|1)); //Estimate SP cost of a single water-ball
+			if (skill_id == WZ_WATERBALL && skill_lv > 1)
+				sp = sp / ((skill_lv | 1) * (skill_lv | 1)); //Estimate SP cost of a single water-ball
 			status->heal(bl, 0, sp, STATUS_HEAL_SHOWEFFECT);
+			if (battle->bc->magicrod_type == 1)
+				clif->skill_nodamage(bl, bl, SA_MAGICROD, sc->data[SC_MAGICROD]->val1, 1); // Animation used here in eAthena [Wolfie]
 		}
 	}
 
@@ -7881,8 +7883,9 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 			}
 			break;
 		case SA_MAGICROD:
-			clif->skill_nodamage(src,src,SA_MAGICROD,skill_lv,1);
-			sc_start(src,bl,type,100,skill_lv,skill->get_time(skill_id,skill_lv));
+			if (battle->bc->magicrod_type == 0)
+				clif->skill_nodamage(src, src, SA_MAGICROD, skill_lv, 1); // Animation used here in official [Wolfie]
+			sc_start(src, bl, type, 100, skill_lv, skill->get_time(skill_id, skill_lv));
 			break;
 		case SA_AUTOSPELL:
 			clif->skill_nodamage(src,bl,skill_id,skill_lv,1);


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)
Adds a battleconf option for Magic Rod behavior, allowing a choice between official and old eAthena.
- Official: Every time you use the Magic Rod skill, the animation will occur.
- eAthena: The animation for Magic Rod will only occur when you absorb a spell.

**Affected Branches:** 

[//]: # (Master? Slave?)
Master.

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)
None.

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
