### PR TITLE
fix a wrong iterator used for mob skill db parsing

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -4879,7 +4879,7 @@ bool mob_skill_db_libconfig_sub(struct config_setting_t *it, int n)
 
 bool mob_skill_db_libconfig_sub_skill(struct config_setting_t *it, int n, int mob_id)
 {
-	int i, j;
+	int i, j, idx = 0;
 	int i32;
 	int skill_id = 0;
 	int skill_idx = 0;
@@ -4910,8 +4910,8 @@ bool mob_skill_db_libconfig_sub_skill(struct config_setting_t *it, int n, int mo
 		memset(&gms, 0, sizeof (struct mob_skill));
 		ms = &gms;
 	} else {
-		ARR_FIND(0, MAX_MOBSKILL, i, (ms = &mob->db_data[mob_id]->skill[i])->skill_id == 0);
-		if (i == MAX_MOBSKILL) {
+		ARR_FIND(0, MAX_MOBSKILL, idx, (ms = &mob->db_data[mob_id]->skill[idx])->skill_id == 0);
+		if (idx == MAX_MOBSKILL) {
 			ShowError("mob_skill_db_libconfig_sub_skill: Too many skills for monster %d\n", mob_id);
 			return false;
 		}
@@ -5043,7 +5043,7 @@ bool mob_skill_db_libconfig_sub_skill(struct config_setting_t *it, int n, int mo
 			mob->db_data[i]->maxskill = j + 1;
 		}
 	} else { //Skill set on a single mob.
-		mob->db_data[mob_id]->maxskill = i + 1;
+		mob->db_data[mob_id]->maxskill = idx + 1;
 	}
 
 	return true;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
a followup to be90f6c69b6ac54ee83878f603cb9bf733d29d04

this is fixes an issue where max monster skills got limited to 5
now skill index is saved in it own variable to save it for later use and avoid confusion with others

Thanks to @trojal  for noticing this.

[//]: # (Issue Tracker Number if any.)

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
