### PR TITLE
Don't overwrite mob.range with Inherit:true

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -4312,7 +4312,7 @@ int mob_read_db_sub(struct config_setting_t *mobt, int n, const char *source)
 
 	if (mob->lookup_const(mobt, "AttackRange", &i32) && i32 >= 0) {
 		md.status.rhw.range = i32;
-	} else {
+	} else if (!inherit) {
 		md.status.rhw.range = 1;
 	}
 


### PR DESCRIPTION
Using mob_db2 and Inherit: true shouldn't override the base mob's range if it's not included.

[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)

**Affected Branches:** 
all

[//]: # (Master? Slave?)

**Issues addressed:**
Using mob_db2 mode "Inherit: true" should not set the overridden mob's range to 1.

[//]: # (Issue Tracker Number if any.)

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
