### PR TITLE
Fix the skill element for levels above the MAX_SKILL_LEVEL

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -189,10 +189,6 @@ int skill_get_ele(int skill_id, int skill_lv)
 	idx = skill->get_index(skill_id);
 	Assert_retr(ELE_NEUTRAL, idx != 0);
 	Assert_retr(ELE_NEUTRAL, skill_lv > 0);
-	if (skill_lv > MAX_SKILL_LEVEL) {
-		int val = skill->dbs->db[idx].element[skill_get_lvl_idx(skill_lv)];
-		return skill_adjust_over_level(val, skill_lv, skill->dbs->db[idx].max);
-	}
 	return skill->dbs->db[idx].element[skill_get_lvl_idx(skill_lv)];
 }
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

**Affected Branches:** 

- master
- stable

**Issues addressed:**

This fixes a regression introduced in 2b4bfa5d08931530d5c9b30af10dd58c1af14883
When over the max skill level, the skill element shouldn't be attempted to be extrapolated from the skill element table (arithmetic can't really be applied to elements), yielding an invalid element.

### Known Issues and TODO List

N/A