### PR TITLE
Allow OnNPCKillEvent to run on monsters with event label

### DIFF
--- a/conf/map/script.conf
+++ b/conf/map/script.conf
@@ -59,6 +59,9 @@ script_configuration: {
 	// Defaults to INT_MAX.
 	//input_max_value: 2147483647
 	input_max_value: 10000000
+
+	// Allow OnNPCKillEvent to also run monster with event labels ?
+	kill_mob_event_type: false
 }
 
 import: "conf/import/script.conf"

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2684,18 +2684,26 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type) {
 				mercenary->kills(sd->md);
 		}
 
-		if( md->npc_event[0] && !md->state.npc_killmonster ) {
-			if( sd && battle_config.mob_npc_event_type ) {
-				pc->setparam(sd, SP_KILLERRID, sd->bl.id);
-				npc->event(sd,md->npc_event,0);
-			} else if( mvp_sd ) {
-				pc->setparam(mvp_sd, SP_KILLERRID, sd?sd->bl.id:0);
-				npc->event(mvp_sd,md->npc_event,0);
-			} else
-				npc->event_do(md->npc_event);
-		} else if( mvp_sd && !md->state.npc_killmonster ) {
-			pc->setparam(mvp_sd, SP_KILLEDRID, md->class_);
-			npc->script_event(mvp_sd, NPCE_KILLNPC); // PCKillNPC [Lance]
+		if (!md->state.npc_killmonster) {
+			if (md->npc_event[0]) {
+				if (sd && battle_config.mob_npc_event_type) {
+					pc->setparam(sd, SP_KILLEDRID, md->class_);
+					pc->setparam(sd, SP_KILLERRID, sd->bl.id);
+					npc->event(sd,md->npc_event,0);
+					if (script->config.kill_mob_event_type)
+						npc->script_event(mvp_sd, NPCE_KILLNPC);
+				} else if (mvp_sd) {
+					pc->setparam(mvp_sd, SP_KILLEDRID, md->class_);
+					pc->setparam(mvp_sd, SP_KILLERRID, sd?sd->bl.id:0);
+					npc->event(mvp_sd,md->npc_event,0);
+					if (script->config.kill_mob_event_type)
+						npc->script_event(mvp_sd, NPCE_KILLNPC);
+				} else
+					npc->event_do(md->npc_event);
+			} else if (mvp_sd) {
+				pc->setparam(mvp_sd, SP_KILLEDRID, md->class_);
+				npc->script_event(mvp_sd, NPCE_KILLNPC); // PCKillNPC [Lance]
+			}
 		}
 
 		md->status.hp = 1;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -4804,6 +4804,7 @@ bool script_config_read(const char *filename, bool imported)
 	libconfig->setting_lookup_int(setting, "check_gotocount", &script->config.check_gotocount);
 	libconfig->setting_lookup_int(setting, "input_min_value", &script->config.input_min_value);
 	libconfig->setting_lookup_int(setting, "input_max_value", &script->config.input_max_value);
+	libconfig->setting_lookup_bool_real(setting, "kill_mob_event_type", &script->config.kill_mob_event_type);
 
 	if (!HPM->parse_conf(&config, filename, HPCT_SCRIPT, imported))
 		retval = false;
@@ -25573,6 +25574,7 @@ void script_defaults(void)
 	script->config.check_gotocount = 2048;
 	script->config.input_min_value = 0;
 	script->config.input_max_value = INT_MAX;
+	script->config.kill_mob_event_type = false;
 	script->config.die_event_name = "OnPCDieEvent";
 	script->config.kill_pc_event_name = "OnPCKillEvent";
 	script->config.kill_mob_event_name = "OnNPCKillEvent";

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -482,6 +482,7 @@ struct Script_Config {
 	int check_gotocount;
 	int input_min_value;
 	int input_max_value;
+	bool kill_mob_event_type;
 
 	const char *die_event_name;
 	const char *kill_pc_event_name;


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### 2 Issues addressed
1. https://github.com/rathena/rathena/issues/1949
2. https://github.com/rathena/rathena/issues/1278
http://herc.ws/board/topic/15799-killedrid-variable-dont-work-with-script-command-monster/#comment-87230


### 2 Changes Proposed
1st. yes aleos has a point that OnNPCKillEvent shouldn't trigger with monster has event labels
however there are also cases that we want OnNPCKillEvent to trigger both of them together

let's say for example [my mission board script](https://rathena.org/board/topic/109667-mission-board-made-by-annieruru/?do=findComment&comment=344774) or [tr0n's quest board](https://github.com/rathena/rathena/blob/master/npc/custom/quests/questboard.txt)
members keep on complaining that when they setup a board nearby an instanced npc
the board doesn't trigger the kill for them, because those instanced npc already has event label attached

and the reason why I make this configurable so when members change the false into true
they should also change how their script going to work
... just like changing the `check_gotocount` means you don't have to use `*freeloop` as often

2nd. currently monster with event labels doesn't save the `killedrid` variable
suddenly remember this bug, and just add 2 lines in the process

### Affected Branches
* Master

### Known Issues and TODO List
none