### PR TITLE
Fix *atcommand cannot be use when PCBLOCK_COMMANDS is true

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -10270,9 +10270,9 @@ static bool atcommand_exec(const int fd, struct map_session_data *sd, const char
 			clif->message(fd, msg_fd(fd,143));
 			return false;
 		}
+		if (sd->block_action.commands) // *pcblock script command
+			return false;
 	}
-	if (sd->block_action.commands) // *pcblock script command
-		return false;
 
 	if (*message == atcommand->char_symbol)
 		is_atcommand = false;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -15453,6 +15453,8 @@ static BUILDIN(atcommand)
 
 	if (!atcommand->exec(fd, sd, cmd, false)) {
 		ShowWarning("script: buildin_atcommand: failed to execute command '%s'\n", cmd);
+		if (dummy_sd != NULL)
+			aFree(dummy_sd);
 		return false;
 	}
 	if (dummy_sd) aFree(dummy_sd);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -15431,7 +15431,6 @@ static BUILDIN(atcommand)
 	struct map_session_data *sd, *dummy_sd = NULL;
 	int fd;
 	const char* cmd;
-	bool ret = true;
 
 	cmd = script_getstr(st,2);
 
@@ -15454,11 +15453,10 @@ static BUILDIN(atcommand)
 
 	if (!atcommand->exec(fd, sd, cmd, false)) {
 		ShowWarning("script: buildin_atcommand: failed to execute command '%s'\n", cmd);
-		script->reportsrc(st);
-		ret = false;
+		return false;
 	}
 	if (dummy_sd) aFree(dummy_sd);
-	return ret;
+	return true;
 }
 
 /**


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
```
prontera,155,185,5	script	jskdhfjshfd	1_F_MARIA,{
	setpcblock PCBLOCK_COMMANDS, true;
	atcommand "@kick "+ strcharinfo(0);
	end;
}
```
cause map-server.exe to show warning
```
[Warning] buildin_atcommand: failed to execute command '@kick AnnieRuru'
```

### Changes Proposed
`*atcommand` should bypass the restriction
I also failed to noticed the `player_invoked` variable in the function
> * @param player_invoked true if the command was invoked by a player, false if invoked by the server (bypassing any restrictions)


### Affected Branches
* Master

### Known Issues and TODO List
none, this is minor edit