### PR TITLE
correct wrong respond message being used in stylist shop

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -20827,7 +20827,7 @@ void clif_parse_cz_req_style_change(int fd, struct map_session_data *sd)
 	if (p->BottomAccessory > 0)
 		clif->cz_req_style_change_sub(sd, LOOK_HEAD_BOTTOM, p->BottomAccessory, true);
 
-	clif->style_change_response(sd, true);
+	clif->style_change_response(sd, STYLIST_SHOP_SUCCESS);
 	return;
 }
 
@@ -20850,7 +20850,7 @@ void clif_cz_req_style_change_sub(struct map_session_data *sd, int type, int16 i
 	}
 }
 
-void clif_style_change_response(struct map_session_data *sd, int8 flag)
+void clif_style_change_response(struct map_session_data *sd, enum stylist_shop flag)
 {
 #if PACKETVER >= 20151104
 	struct PACKET_ZC_STYLE_CHANGE_RES p;

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -616,6 +616,14 @@ struct stylist_data_entry {
 VECTOR_DECL(struct stylist_data_entry) stylist_data[MAX_STYLIST_TYPE];
 
 /**
+* Stylist Shop Responds
+**/
+enum stylist_shop {
+	STYLIST_SHOP_SUCCESS,
+	STYLIST_SHOP_FAILURE
+};
+
+/**
  * Clif.c Interface
  **/
 struct clif_interface {
@@ -1458,7 +1466,7 @@ struct clif_interface {
 	void (*stylist_send_rodexitem) (struct map_session_data *sd, int16 itemid);
 	void (*pReqStyleChange) (int fd, struct map_session_data *sd);
 	void (*cz_req_style_change_sub) (struct map_session_data *sd, int type, int16 idx, bool isitem);
-	void (*style_change_response) (struct map_session_data *sd, int8 flag);
+	void (*style_change_response) (struct map_session_data *sd, enum stylist_shop flag);
 };
 
 #ifdef HERCULES_CORE


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.


fixes #2065

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
