### PR TITLE
Add F_MesItemInfo function to show item name with description link

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -1228,7 +1228,7 @@ you have to set it back to black unless you want all the rest of the text be in
 that color:
 
     mes("This is ^FF0000 red ^000000 and this is ^00FF00 green, ^000000 so.");
-    mes(callfunc("F_MesColor", C_BLUE) +"This message is now in BLUE");
+    mesf("%sThis message is now in BLUE.", F_MesColor(C_BLUE));
 
 Notice that the text coloring is handled purely by the client. If you use
 non-English characters, the color codes might get screwed if they stick to
@@ -1251,6 +1251,14 @@ This will allow you to visit 'Google' with the in-game browser using default dim
     mes("You can <URL>Bing!<INFO>http://www.bing.com/,800,600</INFO></URL> anything");
 
 Clicking 'Bing!' will open the in-game browser using the specified dimensions. (800x600)
+
+If you're using client from 2013-01-30 onwards, you can also use <ITEMLINK> to show
+the item's description. Gravity changed this into <ITEM> since 2015-07-29 onwards.
+
+    mes("Bring me an <ITEM>Apple<INFO>512</INFO></ITEM>.");
+    mesf("Bring me an %s.", F_MesItemInfo(Apple));
+
+This will show the item name and a clickable link for the item description.
 
 ---------------------------------------
 

--- a/npc/other/Global_Functions.txt
+++ b/npc/other/Global_Functions.txt
@@ -434,7 +434,7 @@ function	script	F_ShuffleNumbers	{
 //== Function F_MesColor ===================================
 // Function to colorize npc dialog without having to memorize the color code
 // Examples:
-//    mes callfunc("F_MesColor", C_BLUE) +"This message is now in BLUE";
+//    mesf("%sThis message is now in BLUE.", F_MesColor(C_BLUE));
 function	script	F_MesColor	{
 	return sprintf("^%06X", min(getarg(0), 0xFFFFFF));
 }
@@ -474,4 +474,25 @@ function	script	F_GetTradeRestriction	{
 	if (.@trade & ITR_NOAUCTION) {
 		.@trade$ += "NoAuction|";
 	}
+}
+
+//== Function F_MesItemInfo ===================================
+// Show the item name and a clickable link for the item description
+// Only works with mes and mesf, does not work in menu/select
+function	script	F_MesItemInfo	{
+	.@item = getarg(0);
+	.@itemname$ = getitemname(.@item);
+	if (.@itemname$ != "null") {
+		.@itemslot = getitemslots(.@item);
+		if (.@itemslot)
+			.@itemname$ = sprintf("%s [%d]", .@itemname$, .@itemslot);
+	}
+	else
+		.@itemname$ = "Unknown Item";
+	if (PACKETVER >= 20150729)
+		return sprintf("<ITEM>%s<INFO>%d</INFO></ITEM>", .@itemname$, .@item);
+	else if (PACKETVER >= 20130130)
+		return sprintf("<ITEMLINK>%s<INFO>%d</INFO></ITEMLINK>", .@itemname$, .@item);
+	else
+		return .@itemname$;
 }

--- a/npc/re/instances/OldGlastHeim.txt
+++ b/npc/re/instances/OldGlastHeim.txt
@@ -2744,7 +2744,7 @@ glast_01,188,273,5	script	White Knight#1a	4_WHITEKNIGHT,{
 		close();
 	}
 	mes("I exchange you a White Knight Card for ^0000FF3000 Coagulated Spell^000000 or ^FF000070 Contaminated Magic^000000.");
-	mes("<ITEMLINK>White Knight Card<INFO>4608</INFO></ITEMLINK>");
+	mes(F_MesItemInfo(White_Knightage_Card));
 	next();
 	setarray(.@item[0], Coagulated_Spell, Corrupted_Charm);
 	setarray(.@cost[0], 3000, 70);
@@ -2777,7 +2777,7 @@ glast_01,192,273,3	script	Khalitzburg Knight#1a	4_F_KHALITZBURG,{
 		close();
 	}
 	mes("I exchange you a Khalitzburg Knight Card for ^0000FF5000 Coagulated Spell^000000 or ^FF0000100 Contaminated Magic^000000.");
-	mes("<ITEMLINK>Khalitzburg Knight Card<INFO>4609</INFO></ITEMLINK>");
+	mes(F_MesItemInfo(Khali_Knightage_Card));
 	next();
 	setarray(.@item[0], Coagulated_Spell, Corrupted_Charm);
 	setarray(.@cost[0], 5000, 100);


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
too many members doesn't even know this exist
simply because it is not documented

### Changes Proposed
Add `F_MesItemInfo` function to show item name with description link

### Affected Branches
* Master

### Tested with
```
prontera,155,180,0	script	Test Instance	1_F_MARIA,{
	mes("You can <URL>Google<INFO>http://www.google.com/</INFO></URL> anything");
	.@id = Apple;
	mes(F_MesColor(C_BLUE) +"This message is now in BLUE");
	mes F_MesColor(C_BLACK);
    mesf("%sThis message is now in BLUE.", F_MesColor(C_BLUE));
	mes F_MesColor(C_BLACK);
	mes F_MesItemInfo(.@id);
	mesf "Testing %s", F_MesItemInfo(.@id);
	mes("Bring me an <ITEM>Apple<INFO>512</INFO></ITEM>.");
	mes("Bring me an "+ F_MesItemInfo(Apple) +".");
    mesf("Bring me an %s.", F_MesItemInfo(Apple));
	select getitemname(.@id), F_MesItemInfo(.@id);
	close;
}
```

### Known Issues and TODO List
although unrelated, but my hexed client doesn't show the `www.google.com` properly