### PR TITLE
Fix pre-increment / pre-decrement operator error

### DIFF
--- a/npc/dev/test.txt
+++ b/npc/dev/test.txt
@@ -150,6 +150,20 @@ function	script	HerculesSelfTestHelper	{
 	callsub(OnCheck, "Prefix decrement --", .@y);
 	callsub(OnCheck, "Prefix decrement --", .@x);
 
+	// Increment and decrement operators after a condition
+	.@x = 0;
+	if (1) .@x++;
+	callsub(OnCheck, "Suffix increment ++ after (condition)", .@x);
+	.@x = 2;
+	if (1) .@x--;
+	callsub(OnCheck, "Suffix decrement -- after (condition)", .@x);
+	.@x = 0;
+	if (1) ++.@x;
+	callsub(OnCheck, "Prefix increment ++ after (condition)", .@x);
+	.@x = 2;
+	if (1) --.@x;
+	callsub(OnCheck, "Prefix decrement -- after (condition)", .@x);
+
 	// Order of [] and --/++
 	.@a[1] = 0;
 	.@a[1]++; // .@a[1] = .@a[1] + 1;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -1428,8 +1428,8 @@ const char* script_parse_subexpr(const char* p,int limit)
 	p=script->skip_space(p);
 	while((
 	   (op=C_OP3,    opl=0, len=1,*p=='?')              // ?:
-	|| (op=C_ADD,    opl=9, len=1,*p=='+')              // +
-	|| (op=C_SUB,    opl=9, len=1,*p=='-')              // -
+	|| (op=C_ADD,    opl=9, len=1,*p=='+' && p[1]!='+') // +
+	|| (op=C_SUB,    opl=9, len=1,*p=='-' && p[1]!='-') // -
 	|| (op=C_POW,    opl=11,len=2,*p=='*' && p[1]=='*') // **
 	|| (op=C_MUL,    opl=10,len=1,*p=='*')              // *
 	|| (op=C_DIV,    opl=10,len=1,*p=='/')              // /


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
https://github.com/HerculesWS/Hercules/issues/912
https://github.com/HerculesWS/Hercules/issues/1553
https://github.com/HerculesWS/Hercules/issues/1710
yes all were duplicates
https://github.com/HerculesWS/Hercules/issues/705
only the main one

### Changes Proposed
Fix `if (1) ++.@i;` no longer throw error
which is parse as C_ADD_PRE and C_SUB_PRE ... I guess ?

actually ... rathena already fixed this ... this is something I just compare with theirs ...

### Tested with
```
prontera,150,182,5	script	kshdfkfs	1_F_MARIA,{
	for ( .@i = 0; .@i < 5; ++.@i )
		dispbottom .@i +"";
	.@i = 0;
	if (1) ++.@i;
	dispbottom .@i +"";
	if (1) .@i++;
	dispbottom .@i +"";
//	dispbottom ++.@i +""; // still throw error, but its bad practice anyway since should enclose it with bracket
	dispbottom ""+ ++.@i;
	dispbottom .@i++ +""; // shouldn't increase
	end;
}
```
### Affected Branches
* Master

### Known Issues and TODO List
the 2nd thing that Haru said in the valid bug report is not included
but everyone knows its a bad syntax anyway ....