### PR TITLE
Remove flag RTLD_DEEPBIND from dlopen.

### DIFF
--- a/src/common/HPM.h
+++ b/src/common/HPM.h
@@ -42,11 +42,7 @@
 	#define DLL                   HINSTANCE
 #else // ! WIN32
 	#include <dlfcn.h>
-	#ifdef RTLD_DEEPBIND // Certain linux distributions require this, but it's not available everywhere
-		#define plugin_open(x) dlopen((x),RTLD_NOW|RTLD_DEEPBIND)
-	#else // ! RTLD_DEEPBIND
-		#define plugin_open(x) dlopen((x),RTLD_NOW)
-	#endif // RTLD_DEEPBIND
+	#define plugin_open(x)         dlopen((x), RTLD_NOW)
 	#define plugin_import(x,y,z)   (z)dlsym((x),(y))
 	#define plugin_close(x)        dlclose(x)
 	#define plugin_geterror(buf)   ((void)buf, dlerror())


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Remove flag RTLD_DEEPBIND from dlopen.
This flag unneeded now, and it may prevent using asan in gcc-8.
