### PR TITLE
Add PCBLOCK_NPCCLICK to the *setpcblock script commands

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6322,11 +6322,16 @@ The <type> listed are a bit mask of the following:
 	PCBLOCK_IMMUNE
 	PCBLOCK_SITSTAND
 	PCBLOCK_COMMANDS
+	PCBLOCK_NPCCLICK
+	PCBLOCK_EMOTION
 
 Examples:
 
 // Make the current attached player invulnerable, same as @monsterignore
 	setpcblock(PCBLOCK_IMMUNE, true);
+
+// Prevents the current char from using npc, shops or warp portals
+	setpcblock(PCBLOCK_NPCCLICK, true);
 
 // Prevents the current char from attacking or using skills
 	setpcblock(PCBLOCK_ATTACK|PCBLOCK_SKILL, true);

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10988,6 +10988,11 @@ static void clif_parse_Emotion(int fd, struct map_session_data *sd)
 
 		pc->update_idle_time(sd, BCIDLE_EMOTION);
 
+		if (sd->block_action.emotion) {
+			clif->skill_fail(sd, 1, USESKILL_FAIL_LEVEL, 1, 0);
+			return;
+		}
+
 		if(battle_config.client_reshuffle_dice && emoticon>=E_DICE1 && emoticon<=E_DICE6) {// re-roll dice
 			emoticon = rnd()%6+E_DICE1;
 		}

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -978,6 +978,9 @@ static int npc_touch_areanpc(struct map_session_data *sd, int16 m, int16 x, int1
 		return 1;
 #endif // 0
 
+	if (sd->block_action.npcclick)
+		return 1;
+
 	for(i=0;i<map->list[m].npc_num;i++) {
 		if (map->list[m].npc[i]->option&OPTION_INVISIBLE) {
 			f=0; // a npc was found, but it is disabled; don't print warning
@@ -1058,6 +1061,9 @@ static int npc_untouch_areanpc(struct map_session_data *sd, int16 m, int16 x, in
 	struct npc_data *nd = NULL;
 	nullpo_retr(1, sd);
 	Assert_retr(1, m >= 0 && m < map->count);
+
+	if (sd->block_action.npcclick)
+		return 1;
 
 	if (!sd->areanpc_id)
 		return 0;
@@ -1283,6 +1289,9 @@ static void run_tomb(struct map_session_data *sd, struct npc_data *nd)
 static int npc_click(struct map_session_data *sd, struct npc_data *nd)
 {
 	nullpo_retr(1, sd);
+
+	if (sd->block_action.npcclick)
+		return 1;
 
 	// This usually happens when the player clicked on a NPC that has the view id
 	// of a mob, to activate this kind of npc it's needed to be in a 2,2 range

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -629,6 +629,8 @@ END_ZEROED_BLOCK;
 		unsigned immune   : 1;
 		unsigned sitstand : 1;
 		unsigned commands : 1;
+		unsigned npcclick : 1;
+		unsigned emotion  : 1;
 	} block_action;
 
 	/* Achievement System */

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18518,6 +18518,12 @@ static BUILDIN(setpcblock)
 	if ((type & PCBLOCK_COMMANDS) != 0)
 		sd->block_action.commands = state;
 
+	if ((type & PCBLOCK_NPCCLICK) != 0)
+		sd->block_action.npcclick = state;
+
+	if ((type & PCBLOCK_EMOTION) != 0)
+		sd->block_action.emotion = state;
+
 	return true;
 }
 
@@ -18554,6 +18560,12 @@ static BUILDIN(checkpcblock)
 
 	if (sd->block_action.commands != 0)
 		retval |= PCBLOCK_COMMANDS;
+
+	if (sd->block_action.npcclick != 0)
+		retval |= PCBLOCK_NPCCLICK;
+
+	if (sd->block_action.emotion != 0)
+		retval |= PCBLOCK_EMOTION;
 
 	script_pushint(st, retval);
 	return true;
@@ -26180,6 +26192,8 @@ static void script_hardcoded_constants(void)
 	script->set_constant("PCBLOCK_IMMUNE",   PCBLOCK_IMMUNE,   false, false);
 	script->set_constant("PCBLOCK_SITSTAND", PCBLOCK_SITSTAND, false, false);
 	script->set_constant("PCBLOCK_COMMANDS", PCBLOCK_COMMANDS, false, false);
+	script->set_constant("PCBLOCK_NPCCLICK", PCBLOCK_NPCCLICK, false, false);
+	script->set_constant("PCBLOCK_EMOTION",  PCBLOCK_EMOTION,  false, false);
 
 	script->constdb_comment("private airship responds");
 	script->set_constant("P_AIRSHIP_NONE", P_AIRSHIP_NONE, false, false);

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -464,16 +464,18 @@ enum script_iteminfo_types {
  * Player blocking actions related flags.
  */
 enum pcblock_action_flag {
-	PCBLOCK_NONE     = 0x00,
-	PCBLOCK_MOVE     = 0x01,
-	PCBLOCK_ATTACK   = 0x02,
-	PCBLOCK_SKILL    = 0x04,
-	PCBLOCK_USEITEM  = 0x08,
-	PCBLOCK_CHAT     = 0x10,
-	PCBLOCK_IMMUNE   = 0x20,
-	PCBLOCK_SITSTAND = 0x40,
-	PCBLOCK_COMMANDS = 0x80,
-	PCBLOCK_ALL      = 0xFF,
+	PCBLOCK_NONE     = 0x000,
+	PCBLOCK_MOVE     = 0x001,
+	PCBLOCK_ATTACK   = 0x002,
+	PCBLOCK_SKILL    = 0x004,
+	PCBLOCK_USEITEM  = 0x008,
+	PCBLOCK_CHAT     = 0x010,
+	PCBLOCK_IMMUNE   = 0x020,
+	PCBLOCK_SITSTAND = 0x040,
+	PCBLOCK_COMMANDS = 0x080,
+	PCBLOCK_NPCCLICK = 0x100,
+	PCBLOCK_EMOTION  = 0x200,
+	PCBLOCK_ALL      = 0x3FF,
 };
 
 /**


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
https://github.com/rathena/rathena/pull/3209
err ... in the documentation she mentions `clicking npc`
I was like ... **OOPS~ !!**
reminds me when vending or chatroom, you can't click on the npc

### Changes Proposed
Add PCBLOCK_NPCCLICK to the *setpcblock script commands

### Tested with
```
prontera,155,185,5	script	kjhdfksjf	1_F_MARIA,{
OnTalk:
	mes "test pcblock";
	next;
	for ( .@i = 0; .@i < .menusize; ++.@i )
		.@menu$ += F_MesColor( ( checkpcblock() & 1 << .@i )? C_GREEN : C_RED ) + .pcblock$[.@i] +":";
	.@s = select( .@menu$ ) -1;
	setpcblock 1 << .@s, !( checkpcblock() & 1 << .@s );
	close;
OnInit:
	setarray .pcblock$, "PCBLOCK_MOVE", "PCBLOCK_ATTACK", "PCBLOCK_SKILL", "PCBLOCK_USEITEM",
		"PCBLOCK_CHAT", "PCBLOCK_IMMUNE", "PCBLOCK_SITSTAND", "PCBLOCK_COMMANDS", "PCBLOCK_NPCCLICK";
	.menusize = getarraysize( .pcblock$ );
	bindatcmd "test", strnpcinfo(NPC_NAME) +"::OnTalk";
	end;
}
prontera,155,179,5	warp	asdf	2,2,prontera,156,191
```

### Affected Branches
* Master

### Known Issues and TODO List
@Asheraf said we allow to have `<account ID>` as optional parameter ...
well, as you can see this script command doesn''t have because 3 years ago Haru said no ...
but if Haru has a change of heart now, I could add it back again :rofl: 