### PR TITLE
Fixed monsters not disappearing from some clients upon death

### DIFF
--- a/conf/map/battle/client.conf
+++ b/conf/map/battle/client.conf
@@ -72,6 +72,13 @@ area_size: 14
 // Chat area size (how many squares away from a player can they chat)
 chat_area_size: 9
 
+// Area which monster death packets should be sent to.
+// This should be set to the farthest distance a player can reach in 250ms
+// after a monster dies.
+// Setting it to (area_size + 18) (18 being the range of Monk's Snap skill)
+// should be a great value
+dead_area_size: 32
+
 // Maximum walk path (how many cells a player can walk going to cursor)
 // default: 17(official)
 max_walk_path: 17

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7205,6 +7205,7 @@ static const struct battle_data {
 	{ "vcast_stat_scale",                   &battle_config.vcast_stat_scale,                530,    1,      INT_MAX,        },
 	{ "area_size",                          &battle_config.area_size,                       14,     0,      INT_MAX,        },
 	{ "chat_area_size",                     &battle_config.chat_area_size,                  9,      0,      INT_MAX,        },
+	{ "dead_area_size",                     &battle_config.dead_area_size,                  32,     0,      INT_MAX,        },
 	{ "zeny_from_mobs",                     &battle_config.zeny_from_mobs,                  0,      0,      1,              },
 	{ "mobs_level_up",                      &battle_config.mobs_level_up,                   0,      0,      1,              },
 	{ "mobs_level_up_exp_rate",             &battle_config.mobs_level_up_exp_rate,          1,      1,      INT_MAX,        },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -366,6 +366,7 @@ struct Battle_Config {
 	int castrate_dex_scale; // added by [MouseJstr]
 	int area_size; // added by [MouseJstr]
 	int chat_area_size; // added by [gumi]
+	int dead_area_size; // Monster die area [KirieZ]
 
 	int max_def, over_def_bonus; //added by [Skotlex]
 

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -89,6 +89,7 @@ typedef enum send_target {
 	AREA_WOC,           // area, without chatrooms
 	AREA_WOSC,          // area, without own chatrooms
 	AREA_CHAT_WOC,      // hearable area, without chatrooms
+	AREA_DEAD,          // area, for clear unit (monster death)
 	CHAT,               // current chatroom
 	CHAT_WOS,           // current chatroom, without self
 	PARTY,

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -48,6 +48,7 @@ enum E_MAPSERVER_ST {
 #define MAX_NPC_PER_MAP 512
 #define AREA_SIZE (battle->bc->area_size)
 #define CHAT_AREA_SIZE (battle->bc->chat_area_size)
+#define DEAD_AREA_SIZE (battle->bc->dead_area_size)
 #define DAMAGELOG_SIZE 30
 #define LOOTITEM_SIZE 10
 #define MAX_MOBSKILL 50


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)

This fixes an issue where a dead monster stay on the user map until he somehow reloads the map (e.g. through refresh/login out/warp). This happens when the user goes out of the area range of the monster in a couple miliseconds between monster dead and the actual packet that removes the monster.

This PR adds a new area that is big enough to allow `clearunit` to reach those clients.

**Affected Branches:** 

[//]: # (Master? Slave?)
master

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)
I think there isn't a github issue

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
