### PR TITLE
Fix novending cause player gets stuck

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -14137,6 +14137,19 @@ int skill_check_condition_castbegin(struct map_session_data* sd, uint16 skill_id
 
 	// perform skill-specific checks (and actions)
 	switch( skill_id ) {
+		case MC_VENDING:
+		case ALL_BUYING_STORE:
+			if (map->list[sd->bl.m].flag.novending) {
+				clif->message(sd->fd, msg_sd(sd, 276)); // "You can't open a shop on this map"
+				clif->skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0);
+				return 0;
+			}
+			if (map->getcell(sd->bl.m, &sd->bl, sd->bl.x, sd->bl.y, CELL_CHKNOVENDING)) {
+				clif->message(sd->fd, msg_sd(sd, 204)); // "You can't open a shop on this cell."
+				clif->skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0);
+				return 0;
+			}
+			break;
 		case SO_SPELLFIST:
 			if(sd->skill_id_old != MG_FIREBOLT && sd->skill_id_old != MG_COLDBOLT && sd->skill_id_old != MG_LIGHTNINGBOLT){
 				clif->skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
https://github.com/HerculesWS/Hercules/issues/662

### Changes Proposed
Follow rathena method ->
https://github.com/rathena/rathena/blob/master/src/map/skill.cpp#L739-L750

Note: I've already tested npc->isnear, no need to do that check
https://github.com/AnnieRuru/customs/blob/master/screenshots/screenHercules018.jpg

### Affected Branches
* Master

### Known Issues and TODO List
maybe should remove related checks in clif.c and buyingstore.c ?
rathena also left those blueprints behind