### PR TITLE
Fix SCRIPT_MAX_ARRAYSIZE

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -4884,7 +4884,7 @@ void script_cleararray_pc(struct map_session_data* sd, const char* varname, void
 void script_setarray_pc(struct map_session_data* sd, const char* varname, uint32 idx, void* value, int* refcache) {
 	int key;
 
-	if( idx >= SCRIPT_MAX_ARRAYSIZE ) {
+	if (idx > SCRIPT_MAX_ARRAYSIZE) {
 		ShowError("script_setarray_pc: Variable '%s' has invalid index '%u' (char_id=%d).\n", varname, idx, sd->status.char_id);
 		return;
 	}
@@ -7484,7 +7484,7 @@ BUILDIN(getelementofarray)
 	id = reference_getid(data);
 
 	i = script_getnum(st, 3);
-	if (i < 0 || i >= SCRIPT_MAX_ARRAYSIZE) {
+	if (i < 0 || i > SCRIPT_MAX_ARRAYSIZE) {
 		ShowWarning("script:getelementofarray: index out of range (%"PRId64")\n", i);
 		script->reportdata(data);
 		script_pushnil(st);

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -50,7 +50,7 @@ struct item_data;
 #define NUM_WHISPER_VAR 10
 
 /// Maximum amount of elements in script arrays
-#define SCRIPT_MAX_ARRAYSIZE (UINT_MAX - 1)
+#define SCRIPT_MAX_ARRAYSIZE (INT_MAX - 1)
 
 #define SCRIPT_BLOCK_SIZE 512
 


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed

## Issue no.1
SCRIPT_MAX_ARRAYSIZE is UINT_MAX -1 ...
so let's try it out
```
prontera,161,185,5	script	test	1_F_MARIA,{
	.@test[2147483648] = 1;
	end;
}
```
oops ~ already got an error
```
[Warning]: script error in file 'npc/zzz.txt' line 2 column 9
    parse_simpleexpr: overflow detected, capping value to INT_MAX
     1: {
*    2:         .@test[2147483648] = 1;
        ~~~~~~~~~~~~~~~^
     3:         end;
     4: }
```
and no need to say that it cannot be a negative value
```
[Warning]: script:getelementofarray: index out of range (-1)
[Debug]: Data: variable name='.@test' index=0
[Debug]: Source (NPC): test9 at prontera (161,185)
```
this means ... the element in array can only hold between 0~2147483647

## Issue No. 2
let's try another thing
```
prontera,161,185,5	script	test9	1_F_MARIA,{
	.@test[0x7FFFFFFF] = 1;
	dispbottom getarraysize(.@test) +"";
	end;
}
```
return ... WHAT ?? `2147483648` ?? shouldn't this throw error ?
```
prontera,161,185,5	script	test9	1_F_MARIA,{
	.@test[0x7FFFFFFF] = 1;
	dispbottom ( getarraysize(.@test) +0 )+"";
	end;
}
```
now this is better, OVERFLOW !! return `-2147483648`

in other words, the maximum array limit should be INT_MAX -1,
because when needed to display in `*getarraysize`, it shouldn't hit the INT limit

### Changes Proposed
Fix `SCRIPT_MAX_ARRAYSIZE`

### Affected Branches
* Master

### Known Issues and TODO List
```
prontera,161,185,5	script	test9	1_F_MARIA,{
	.@test[0x7FFFFFFF] = 1;
	dispbottom ( getarraysize(.@test) +100 )+"";
	end;
}
```
try this out !