### PR TITLE
Fix SC_INCATKRATE not working on monsters and Divest Weapon

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -4985,9 +4985,6 @@ unsigned short status_calc_batk(struct block_list *bl, struct status_change *sc,
 #ifndef RENEWAL
 	if(sc->data[SC_LKCONCENTRATION])
 		batk += batk * sc->data[SC_LKCONCENTRATION]->val2/100;
-#else
-	if ( sc->data[SC_NOEQUIPWEAPON] && bl->type != BL_PC )
-		batk -= batk * sc->data[SC_NOEQUIPWEAPON]->val2 / 100;
 #endif
 	if(sc->data[SC_SKE])
 		batk += batk * 3;
@@ -5090,7 +5087,7 @@ unsigned short status_calc_watk(struct block_list *bl, struct status_change *sc,
 	if(sc->data[SC_LKCONCENTRATION])
 		watk += watk * sc->data[SC_LKCONCENTRATION]->val2/100;
 #endif
-	if(sc->data[SC_INCATKRATE] && bl->type != BL_MOB)
+	if(sc->data[SC_INCATKRATE])
 		watk += watk * sc->data[SC_INCATKRATE]->val1/100;
 	if(sc->data[SC_PROVOKE])
 		watk += watk * sc->data[SC_PROVOKE]->val3/100;
@@ -5100,10 +5097,8 @@ unsigned short status_calc_watk(struct block_list *bl, struct status_change *sc,
 		watk += watk * sc->data[SC_HLIF_FLEET]->val3/100;
 	if(sc->data[SC_CURSE])
 		watk -= watk * 25/100;
-#ifndef RENEWAL
 	if(sc->data[SC_NOEQUIPWEAPON] && bl->type != BL_PC)
 		watk -= watk * sc->data[SC_NOEQUIPWEAPON]->val2/100;
-#endif
 	if(sc->data[SC__ENERVATION])
 		watk -= watk * sc->data[SC__ENERVATION]->val2 / 100;
 	if(sc->data[SC_RUSH_WINDMILL])


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
The commit this PR reverts has broken SC_INCATKRATE and thus made skills like NPC_POWERUP for Monsters like Doppelganger or Atroce useless as it doesn't increase their ATK by 200% anymore as it is supposed to. (This has been tested by @Asheraf and looked at in decompiled Aegis Code by Rytech)
Additionally reverting this commit will also make Divest Weapon's ATK Reduction of 25% on Monsters work again as it is supposed to in Renewal. (It's already working in pre-Renewal)

**Affected Branches:** Master
**Issues addressed:** none(?)

### Known Issues and TODO List
none

### Attached codeblock from Aegis
```
if ( SKID == 349 )
{
        CNPC::SetATKPercentInfo(v6, 0x15Du, 5000 * v4[4], 200);
        v93 = 0;
        v92 = 0;
        v91 = 0;
        v90 = 0;
        v63 = 5000 * v4[4];
        v89 = 1;
        *&v88[8] = v63;
        *&v88[4] = 98;
        goto LABEL_182;
}
```

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
