### PR TITLE
WIP: make some script buildins require constants instead of numbers

### DIFF
--- a/conf/map/script.conf
+++ b/conf/map/script.conf
@@ -59,6 +59,11 @@ script_configuration: {
 	// Defaults to INT_MAX.
 	//input_max_value: 2147483647
 	input_max_value: 10000000
+
+	// Throw a warning when passing an integer to a command that expects
+	// a constant. This should be set to true on all new Hercules installations,
+	// but is set to false by default if not present for backward compatibility.
+	require_constants: true
 }
 
 import: "conf/import/script.conf"

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2401,11 +2401,11 @@ using only numbers reduces script readability
 This function will return the various parts of the name of the calling NPC.
 Whatever it returns is determined by type.
 
-(0) NPC_NAME	    - The NPC's display name (visible#hidden)
-(1) NPC_NAME_VISIBLE - The visible part of the NPC's display name
-(2) NPC_NAME_HIDDEN  - The hidden part of the NPC's display name
-(3) NPC_NAME_UNIQUE  - The NPC's unique name (::name)
-(4) NPC_MAP		    - The name of the map the NPC is in.
+NPC_NAME           - The NPC's display name (visible#hidden)
+NPC_NAME_VISIBLE   - The visible part of the NPC's display name
+NPC_NAME_HIDDEN    - The hidden part of the NPC's display name
+NPC_NAME_UNIQUE    - The NPC's unique name (::name)
+NPC_MAP            - The name of the map the NPC is in.
 
 If <GID> is passed, it will return the value of the specified NPC instead of
 the attached NPC. If the NPC is not found, it will return <default value>,

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2377,11 +2377,12 @@ deleted.
 
 This function will return either the name, party name or guild name for
 the invoking character. Whatever it returns is determined by type.
-(0) PC_NAME		- Character's name.
-(1) PC_PARTY	- The name of the party they're in if any.
-(2) PC_GUILD	- The name of the guild they're in if any.
-(3) PC_MAP		- The name of the map the character is in.
-(4) PC_CLAN   - The name of the clan they're in if any.
+
+PC_NAME     - Character's name.
+PC_PARTY    - The name of the party they're in if any.
+PC_GUILD    - The name of the guild they're in if any.
+PC_MAP      - The name of the map the character is in.
+PC_CLAN     - The name of the clan they're in if any.
 
 If <GID> is passed, it will return the value of the specified player instead
 the attached player. If the player is not found, it will return
@@ -6195,7 +6196,7 @@ Examples:
     @ /!\ This command is deprecated @
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
-Prevents the player from moving when the option != 0, and 0 enables the 
+Prevents the player from moving when the option != 0, and 0 enables the
 player to move again. The player has to be the account ID of a character,
 and will run for the attached player if zero is supplied.
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3443,16 +3443,16 @@ Valid types are :
 This function returns specified information about the current system time.
 
 Valid types:
-	1 - GETTIME_SECOND     - Seconds (of a minute)
-	2 - GETTIME_MINUTE     - Minutes (of an hour)
-	3 - GETTIME_HOUR       - Hour (of a day)
-	4 - GETTIME_WEEKDAY    - Week day (0 for Sunday, 6 is Saturday)
-	                       - Additional: SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY
-	5 - GETTIME_DAYOFMONTH - Day of the month.
-	6 - GETTIME_MONTH      - Number of the month.
-	                       - Additional: JANUARY, FEBRUARY, MARCH, APRIL, MAY, JUNE, JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER
-	7 - GETTIME_YEAR       - Year
-	8 - GETTIME_DAYOFYEAR  - Day of the year.
+	GETTIME_SECOND     - Seconds (of a minute)
+	GETTIME_MINUTE     - Minutes (of an hour)
+	GETTIME_HOUR       - Hour (of a day)
+	GETTIME_WEEKDAY    - Week day (0 for Sunday, 6 is Saturday)
+	                   - Additional: SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY
+	GETTIME_DAYOFMONTH - Day of the month.
+	GETTIME_MONTH      - Number of the month.
+	                   - Additional: JANUARY, FEBRUARY, MARCH, APRIL, MAY, JUNE, JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER
+	GETTIME_YEAR       - Year
+	GETTIME_DAYOFYEAR  - Day of the year.
 
 It will only return numbers based on types.
 Example :

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6812,13 +6812,13 @@ Returns informations on timers that were created by addtimer().
 
 valid <type> for gettimer() are:
 
-(0) TIMER_COUNT
+TIMER_COUNT
 	Will return the total number of timers for the specified or
 	attached player. Can be filtered by <event>.
-(1) TIMER_TICK_NEXT
+TIMER_TICK_NEXT
 	Will return the number of ticks until the next timer runs
 	for the specified or attached player. Can be filtered by <event>.
-(2) TIMER_TICK_LAST
+TIMER_TICK_LAST
 	Will return the number of ticks until the last timer runs
 	for the specified or attached player. Can be filtered by <event>.
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24460,8 +24460,8 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(checkmount,""),
 		BUILDIN_DEF(checkwug,""),
 		BUILDIN_DEF(savepoint,"sii"),
-		BUILDIN_DEF(gettimetick,"i"),
-		BUILDIN_DEF(gettime,"i"),
+		BUILDIN_DEF(gettimetick,"i"), // FIXME: add constants for this
+		BUILDIN_DEF(gettime,"c"),
 		BUILDIN_DEF(gettimestr,"si"),
 		BUILDIN_DEF(openstorage,""),
 		BUILDIN_DEF(guildopenstorage,""),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24479,7 +24479,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(addtimer,"is?"),
 		BUILDIN_DEF(deltimer,"s?"),
 		BUILDIN_DEF(addtimercount,"si?"),
-		BUILDIN_DEF(gettimer,"i??"),
+		BUILDIN_DEF(gettimer,"c??"),
 		BUILDIN_DEF(getunits,"iri?????"),
 		BUILDIN_DEF(initnpctimer,"??"),
 		BUILDIN_DEF(stopnpctimer,"??"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -4319,6 +4319,9 @@ bool script_check_buildin_argtype(struct script_state* st, int func)
 			name = reference_getname(data);
 		}
 
+		if (type == 'c' && !script->config.require_constants)
+			type = 'i';
+
 		switch (type) {
 			case 'v':
 				if (!data_isstring(data) && !data_isint(data) && !data_isreference(data)) {
@@ -4340,6 +4343,14 @@ bool script_check_buildin_argtype(struct script_state* st, int func)
 				if (!data_isint(data) && !(data_isreference(data) && (reference_toparam(data) || reference_toconstant(data) || !is_string_variable(name)))) {
 					// int ( params and constants are always int )
 					ShowWarning("Unexpected type for argument %d. Expected number.\n", idx-1);
+					script->reportdata(data);
+					invalid++;
+				}
+				break;
+			case 'c':
+				if (!data_isreference(data) || !reference_toconstant(data)) {
+					// constant int
+					ShowWarning("Unexpected type for argument %d. Expected constant.\n", idx-1);
 					script->reportdata(data);
 					invalid++;
 				}
@@ -4804,6 +4815,7 @@ bool script_config_read(const char *filename, bool imported)
 	libconfig->setting_lookup_int(setting, "check_gotocount", &script->config.check_gotocount);
 	libconfig->setting_lookup_int(setting, "input_min_value", &script->config.input_min_value);
 	libconfig->setting_lookup_int(setting, "input_max_value", &script->config.input_max_value);
+	libconfig->setting_lookup_bool_real(setting, "require_constants", &script->config.require_constants);
 
 	if (!HPM->parse_conf(&config, filename, HPCT_SCRIPT, imported))
 		retval = false;
@@ -24196,12 +24208,13 @@ bool script_add_builtin(const struct script_function *buildin, bool override)
 		// 'v' - value (either string or int or reference)
 		// 's' - string
 		// 'i' - int
+		// 'c' - constant int
 		// 'r' - reference (of a variable)
 		// 'l' - label
 		// '?' - one optional parameter
 		// '*' - unknown number of optional parameters
 		char *p = buildin->arg;
-		while( *p == 'v' || *p == 's' || *p == 'i' || *p == 'r' || *p == 'l' ) ++p;
+		while( *p == 'v' || *p == 's' || *p == 'i' || *p == 'c' || *p == 'r' || *p == 'l' ) ++p;
 		while( *p == '?' ) ++p;
 		if( *p == '*' ) ++p;
 		if( *p != 0 ) {
@@ -25588,6 +25601,7 @@ void script_defaults(void)
 	script->config.ontouch_name = "OnTouch_";  //ontouch_name (runs on first visible char to enter area, picks another char if the first char leaves)
 	script->config.ontouch2_name = "OnTouch";  //ontouch2_name (run whenever a char walks into the OnTouch area)
 	script->config.onuntouch_name = "OnUnTouch";  //onuntouch_name (run whenever a char walks from the OnTouch area)
+	script->config.require_constants = false; // false by default, for backward compatibility
 
 	// for ENABLE_CASE_CHECK
 	script->calc_hash_ci = calc_hash_ci;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24480,7 +24480,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(deltimer,"s?"),
 		BUILDIN_DEF(addtimercount,"si?"),
 		BUILDIN_DEF(gettimer,"c??"),
-		BUILDIN_DEF(getunits,"iri?????"),
+		BUILDIN_DEF(getunits,"cri?????"),
 		BUILDIN_DEF(initnpctimer,"??"),
 		BUILDIN_DEF(stopnpctimer,"??"),
 		BUILDIN_DEF(startnpctimer,"??"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24412,7 +24412,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(getguildmaster,"i"),
 		BUILDIN_DEF(getguildmasterid,"i"),
 		BUILDIN_DEF(getguildmember,"i?"),
-		BUILDIN_DEF(strcharinfo,"i??"),
+		BUILDIN_DEF(strcharinfo,"c??"),
 		BUILDIN_DEF(strnpcinfo,"i??"),
 		BUILDIN_DEF(charid2rid,"i"),
 		BUILDIN_DEF(getequipid,"i"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24413,7 +24413,7 @@ void script_parse_builtin(void) {
 		BUILDIN_DEF(getguildmasterid,"i"),
 		BUILDIN_DEF(getguildmember,"i?"),
 		BUILDIN_DEF(strcharinfo,"c??"),
-		BUILDIN_DEF(strnpcinfo,"i??"),
+		BUILDIN_DEF(strnpcinfo,"c??"),
 		BUILDIN_DEF(charid2rid,"i"),
 		BUILDIN_DEF(getequipid,"i"),
 		BUILDIN_DEF(getequipname,"i"),

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -478,6 +478,7 @@ enum pcblock_action_flag {
 struct Script_Config {
 	bool warn_func_mismatch_argtypes;
 	bool warn_func_mismatch_paramnum;
+	bool require_constants;
 	int check_cmdcount;
 	int check_gotocount;
 	int input_min_value;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
throws a warning when trying to do things like `strcharinfo(0)`

### Known Issues and TODO List
for now I only made a handful of commands require constants, because I still need to add enums for commands that don't have one yet

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
