### PR TITLE
break the loop in buildin_getunits when the max is reached

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -635,6 +635,18 @@ static int map_foreachinmap(int (*func)(struct block_list*, va_list), int16 m, i
 	return returnCount;
 }
 
+static int map_forcountinmap(int (*func)(struct block_list*, va_list), int16 m, int count, int type, ...)
+{
+	int returnCount;
+	va_list ap;
+
+	va_start(ap, type);
+	returnCount = map->vforcountinarea(func, m, 0, 0, map->list[m].bxs, map->list[m].bys, count, type, ap);
+	va_end(ap);
+
+	return returnCount;
+}
+
 /**
  * Applies func to every block_list object of bl_type type on all maps
  * of instance instance_id.
@@ -6873,6 +6885,7 @@ void map_defaults(void)
 	map->foreachinpath = map_foreachinpath;
 	map->vforeachinmap = map_vforeachinmap;
 	map->foreachinmap = map_foreachinmap;
+	map->forcountinmap = map_forcountinmap;
 	map->vforeachininstance = map_vforeachininstance;
 	map->foreachininstance = map_foreachininstance;
 

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -1285,6 +1285,7 @@ END_ZEROED_BLOCK;
 	int (*foreachinpath) (int (*func)(struct block_list*,va_list), int16 m, int16 x0, int16 y0, int16 x1, int16 y1, int16 range, int length, int type, ...);
 	int (*vforeachinmap) (int (*func)(struct block_list*,va_list), int16 m, int type, va_list args);
 	int (*foreachinmap) (int (*func)(struct block_list*,va_list), int16 m, int type, ...);
+	int (*forcountinmap) (int (*func)(struct block_list*,va_list), int16 m, int count, int type, ...);
 	int (*vforeachininstance)(int (*func)(struct block_list*,va_list), int16 instance_id, int type, va_list ap);
 	int (*foreachininstance)(int (*func)(struct block_list*,va_list), int16 instance_id, int type,...);
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11382,7 +11382,7 @@ static int buildin_getunits_sub(struct block_list *bl, va_list ap)
 		(const void *)h64BPTRSIZE(bl->id), ref);
 
 	(*count)++;
-	return 0;
+	return 1;
 }
 
 static int buildin_getunits_sub_pc(struct map_session_data *sd, va_list ap)
@@ -11454,18 +11454,10 @@ static BUILDIN(getunits)
 			int16 x2 = script_getnum(st, 8);
 			int16 y2 = script_getnum(st, 9);
 
-			// FIXME: map_foreachinarea does NOT stop iterating when the callback
-			//        function returns -1. we still limit the array size, but
-			//        this doesn't break the loop. We need a foreach function
-			//        that behaves like map_foreachiddb, but for areas
-			map->foreachinarea(buildin_getunits_sub, m, x1, y1, x2, y2, type,
+			map->forcountinarea(buildin_getunits_sub, m, x1, y1, x2, y2, limit, type,
 				st, sd, id, start, &count, limit, name, ref, type);
 		} else {
-			// FIXME: map_foreachinmap does NOT stop iterating when the callback
-			//        function returns -1. we still limit the array size, but
-			//        this doesn't break the loop. We need a foreach function
-			//        that behaves like map_foreachiddb, but for maps
-			map->foreachinmap(buildin_getunits_sub, m, type,
+			map->forcountinmap(buildin_getunits_sub, m, limit, type,
 				st, sd, id, start, &count, limit, name, ref, type);
 		}
 	} else {


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Makes `getunits()` stop iterating when the max number of units is reached. Currently it just stops filling the array but keeps on iterating, so this PR fixes this.

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
