### PR TITLE
Fix the shutdown callback (2015 regression)

### DIFF
--- a/src/common/console.c
+++ b/src/common/console.c
@@ -133,7 +133,10 @@ int console_parse_key_pressed(void)
  **/
 CPCMD_C(exit, server)
 {
-	core->runflag = 0;
+	if (core->shutdown_callback != NULL)
+		core->shutdown_callback();
+	else
+		core->runflag = CORE_ST_STOP;
 }
 
 /**

--- a/src/common/core.c
+++ b/src/common/core.c
@@ -80,9 +80,6 @@
 // And don't complain to us if the XYZ plugin you installed wiped your hard disk, or worse.
 // Note: This feature is deprecated, and should not be used.
 
-/// Called when a terminate signal is received.
-void (*shutdown_callback)(void) = NULL;
-
 struct core_interface core_s;
 struct core_interface *core = &core_s;
 
@@ -128,8 +125,8 @@ static BOOL WINAPI console_handler(DWORD c_event)
 		case CTRL_CLOSE_EVENT:
 		case CTRL_LOGOFF_EVENT:
 		case CTRL_SHUTDOWN_EVENT:
-			if( shutdown_callback != NULL )
-				shutdown_callback();
+			if (core->shutdown_callback != NULL)
+				core->shutdown_callback();
 			else
 				core->runflag = CORE_ST_STOP;// auto-shutdown
 			break;
@@ -158,8 +155,8 @@ static void sig_proc(int sn)
 		case SIGTERM:
 			if (++is_called > 3)
 				exit(EXIT_SUCCESS);
-			if( shutdown_callback != NULL )
-				shutdown_callback();
+			if (core->shutdown_callback != NULL)
+				core->shutdown_callback();
 			else
 				core->runflag = CORE_ST_STOP;// auto-shutdown
 			break;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

When the `core` module was interfaced, the `shutdown_callback` was overlooked. Before this pull request, there exist two:

- `core->shutdown_callback`, which is assigned to, but never used
- `core->shutdown_callback`, which is never assigned to, but checked

This implies that the callback is defined but never called. The pull request fixes this, and removes the extra variable.

The `server:exit` console command is also updated to call the callback, so that proper cleanup is ensured.

**Affected Branches:** 

- master (since 22bd368e5d4d8d61a7189d03f52c3afd90c0729e)
- stable

**Issues addressed:**

- Unlisted regression, since 22bd368e5d4d8d61a7189d03f52c3afd90c0729e

### Known Issues and TODO List

N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
