### PR TITLE
GitLab-CI fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ stages:
   - primary
   - secondary
   - platforms
+  - clients
   - extras
 
 variables: &base_vars
@@ -61,6 +62,21 @@ re:clang-3.9:
     - ./tools/ci/travis.sh build CC=clang-3.9 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
+zero-2018:clang-3.9:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:stretch
+  services:
+    - mariadb:10.1
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-3.9 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-3.9 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
 pre_re:clang-4.0:
   <<: *branch_exceptions
   <<: *prerequisites
@@ -89,6 +105,21 @@ re:clang-4.0:
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-4.0 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+zero-2018:clang-4.0:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-4.0 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-4.0 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:clang-5.0:
@@ -121,6 +152,21 @@ re:clang-5.0:
     - ./tools/ci/travis.sh build CC=clang-5.0 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
+zero-2018:clang-5.0:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-5.0 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-5.0 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
 pre_re:clang-6.0:
   <<: *branch_exceptions
   <<: *prerequisites
@@ -149,6 +195,21 @@ re:clang-6.0:
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-6.0 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+zero-2018:clang-6.0:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-6.0 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-6.0 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:clang-7:
@@ -181,6 +242,21 @@ re:clang-7:
     - ./tools/ci/travis.sh build CC=clang-7 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
+zero-2018:clang-7:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-7 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-7 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
 pre_re:gcc-4.6:
   <<: *branch_exceptions
   <<: *prerequisites
@@ -209,6 +285,21 @@ re:gcc-4.6:
     SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.6 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+zero-2018:gcc-4.6:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:wheezy
+  services:
+    - mysql:5.5
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-4.6 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-4.6 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-4.7:
@@ -241,6 +332,21 @@ re:gcc-4.7:
     - ./tools/ci/travis.sh build CC=gcc-4.7 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
+zero-2018:gcc-4.7:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:wheezy
+  services:
+    - mysql:5.5
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-4.7 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-4.7 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
 pre_re:gcc-4.8:
   <<: *branch_exceptions
   <<: *prerequisites
@@ -269,6 +375,21 @@ re:gcc-4.8:
     SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.8 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+zero-2018:gcc-4.8:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:jessie
+  services:
+    - mysql:5.5
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-4.8 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-4.8 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-4.9:
@@ -301,6 +422,21 @@ re:gcc-4.9:
     - ./tools/ci/travis.sh build CC=gcc-4.9 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
+zero-2018:gcc-4.9:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:jessie
+  services:
+    - mysql:5.5
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-4.9 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-4.9 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
 pre_re:gcc-5:
   <<: *branch_exceptions
   <<: *prerequisites
@@ -329,6 +465,21 @@ re:gcc-5:
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-5 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+zero-2018:gcc-5:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-5 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-5 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-6:
@@ -361,6 +512,21 @@ re:gcc-6:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
+zero-2018:gcc-6:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:stretch
+  services:
+    - mariadb:10.1
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
 pre_re:gcc-7:
   <<: *branch_exceptions
   <<: *prerequisites
@@ -389,6 +555,21 @@ re:gcc-7:
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-7 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+zero-2018:gcc-7:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-7 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-7 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-8:
@@ -421,6 +602,21 @@ re:gcc-8:
     - ./tools/ci/travis.sh build CC=gcc-8 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
+zero-2018:gcc-8:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-8 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-8 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
 pre_re:gcc-6_i386:
   <<: *branch_exceptions
   <<: *prerequisites
@@ -449,6 +645,21 @@ re:gcc-6_i386:
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+zero-2018:gcc-6_i386:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: i386/debian:stable
+  services:
+    - mariadb:10.1
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-6_sanitize:
@@ -481,6 +692,21 @@ re:gcc-6_sanitize:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-manager --enable-sanitize=full
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
+zero-2018:gcc-6_sanitize:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: debian:stretch
+  services:
+    - mariadb:10.1
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-manager --enable-sanitize=full --enable-packetver-zero --enable-packetver=20180511
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
 pre_re:gcc-6_i386_sanitize:
   <<: *branch_exceptions
   <<: *prerequisites
@@ -509,6 +735,21 @@ re:gcc-6_i386_sanitize:
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-manager --enable-sanitize=full
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+zero-2018:gcc-6_i386_sanitize:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: clients
+  image: i386/debian:stable
+  services:
+    - mariadb:10.1
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-manager --enable-sanitize=full --enable-packetver-zero --enable-packetver=20180511
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-6_cov:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ re:clang-3.9:
 pre_re:clang-4.0:
   <<: *branch_exceptions
   <<: *prerequisites
-  stage: primary
+  stage: secondary
   image: debian:unstable
   services:
     - mariadb:10
@@ -79,7 +79,7 @@ pre_re:clang-4.0:
 re:clang-4.0:
   <<: *branch_exceptions
   <<: *prerequisites
-  stage: primary
+  stage: secondary
   image: debian:unstable
   services:
     - mariadb:10
@@ -89,6 +89,96 @@ re:clang-4.0:
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-4.0 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+pre_re:clang-5.0:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: secondary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-5.0 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-5.0 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+re:clang-5.0:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: secondary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-5.0 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-5.0 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+pre_re:clang-6.0:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: primary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-6.0 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-6.0 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+re:clang-6.0:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: primary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-6.0 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-6.0 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+pre_re:clang-7:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: secondary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-7 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-7 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+re:clang-7:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: secondary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: clang-7 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=clang-7 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-4.6:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -244,7 +244,7 @@ re:gcc-4.7:
 pre_re:gcc-4.8:
   <<: *branch_exceptions
   <<: *prerequisites
-  stage: primary
+  stage: secondary
   image: debian:jessie
   services:
     - mysql:5.5
@@ -259,7 +259,7 @@ pre_re:gcc-4.8:
 re:gcc-4.8:
   <<: *branch_exceptions
   <<: *prerequisites
-  stage: primary
+  stage: secondary
   image: debian:jessie
   services:
     - mysql:5.5
@@ -359,6 +359,66 @@ re:gcc-6:
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+pre_re:gcc-7:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: secondary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-7 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-7 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+re:gcc-7:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: secondary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-7 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-7 --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+pre_re:gcc-8:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: secondary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-8 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-8 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+re:gcc-8:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: secondary
+  image: debian:unstable
+  services:
+    - mariadb:10
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc-8 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build CC=gcc-8 --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-6_i386:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,10 +19,8 @@ variables: &base_vars
     - uname -a
     - ./tools/ci/retry.sh apt-get update
     - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
     - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mysql:latest
 
 .branch_exceptions: &branch_exceptions
   only:
@@ -38,276 +36,345 @@ pre_re:clang-3.9:
   <<: *prerequisites
   stage: primary
   image: debian:stretch
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: clang-3.9 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-3.9 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:clang-3.9:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
   image: debian:stretch
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: clang-3.9 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-3.9 --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:clang-4.0:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
   image: debian:unstable
+  services:
+    - mariadb:10
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: clang-4.0 mysql-client libmysqlclient-dev
+    INSTALL_PACKAGES: clang-4.0 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-4.0 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:clang-4.0:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
   image: debian:unstable
+  services:
+    - mariadb:10
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: clang-4.0 mysql-client libmysqlclient-dev
+    INSTALL_PACKAGES: clang-4.0 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-4.0 --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-4.6:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
   image: debian:wheezy
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-4.6 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:gcc-4.6:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
   image: debian:wheezy
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-4.6 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.6 --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-4.7:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
   image: debian:wheezy
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-4.7 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.7 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:gcc-4.7:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
   image: debian:wheezy
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-4.7 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.7 --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-4.8:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
   image: debian:jessie
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-4.8 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.8 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:gcc-4.8:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
   image: debian:jessie
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-4.8 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.8 --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-4.9:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
   image: debian:jessie
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-4.9 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.9 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:gcc-4.9:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
   image: debian:jessie
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-4.9 mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build CC=gcc-4.9 --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-5:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
   image: debian:unstable
+  services:
+    - mariadb:10
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: gcc-5 mysql-client libmysqlclient-dev
+    INSTALL_PACKAGES: gcc-5 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-5 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:gcc-5:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
   image: debian:unstable
+  services:
+    - mariadb:10
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: gcc-5 mysql-client libmysqlclient-dev
+    INSTALL_PACKAGES: gcc-5 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-5 --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-6:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
   image: debian:stretch
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:gcc-6:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
   image: debian:stretch
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-6_i386:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
-  image: vicamo/debian:sid-i386
+  image: i386/debian:stable
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: gcc-6 mysql-client libmysqlclient-dev
+    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:gcc-6_i386:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: primary
-  image: vicamo/debian:sid-i386
+  image: i386/debian:stable
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: gcc-6 mysql-client libmysqlclient-dev
+    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-6_sanitize:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
   image: debian:stretch
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal --disable-manager --enable-sanitize=full
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:gcc-6_sanitize:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
   image: debian:stretch
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-manager --enable-sanitize=full
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-6_i386_sanitize:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
-  image: vicamo/debian:sid-i386
+  image: i386/debian:stable
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: gcc-6 mysql-client libmysqlclient-dev
+    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal --disable-manager --enable-sanitize=full
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:gcc-6_i386_sanitize:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
-  image: vicamo/debian:sid-i386
+  image: i386/debian:stable
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: gcc-6 mysql-client libmysqlclient-dev
+    INSTALL_PACKAGES: gcc-6 mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-manager --enable-sanitize=full
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:gcc-6_cov:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
   image: debian:stretch
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-6 gcovr mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot --disable-renewal CFLAGS="-coverage" LDFLAGS="-coverage"
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
     - gcovr -r . --gcov-executable=gcov-6 -o gcov_pre.txt
     - gcovr -r . --gcov-executable=gcov-6 --html -o gcov_pre.html
     - cat gcov_pre.txt
@@ -321,12 +388,15 @@ re:gcc-6_cov:
   <<: *prerequisites
   stage: secondary
   image: debian:stretch
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc-6 gcovr mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=gcc-6 --enable-debug --enable-Werror --enable-buildbot CFLAGS="-coverage" LDFLAGS="-coverage"
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
     - gcovr -r . --gcov-executable=gcov-6 -o gcov_re.txt
     - gcovr -r . --gcov-executable=gcov-6 --html -o gcov_re.html
     - cat gcov_re.txt
@@ -342,77 +412,100 @@ pre_re:debian-oldstable:
   <<: *prerequisites
   stage: platforms
   image: debian:oldstable
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:debian-oldstable:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
   image: debian:oldstable
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:debian-stable:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
   image: debian:stable
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:debian-stable:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
   image: debian:stable
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:debian-testing:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
   image: debian:testing
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:debian-testing:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
   image: debian:testing
+  services:
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:centos-previous:
   <<: *branch_exceptions
   stage: platforms
   image: centos:6
+  services:
+    - mysql:5.5
+  variables:
+    <<: *base_vars
+    SQLHOST: mysql
   before_script:
     - echo "Building $CI_BUILD_NAME"
     - uname -a
@@ -420,20 +513,21 @@ pre_re:centos-previous:
     - yum install -y make mysql-devel pcre-devel git zlib-devel mysql
     - yum install -y centos-release-scl
     - yum install -y yum install devtoolset-3-toolchain
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
     - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mysql:latest
-  variables:
-    <<: *base_vars
   script:
     - scl enable devtoolset-3 './tools/ci/travis.sh build CFLAGS="-Wno-cast-qual" --enable-debug --enable-Werror --enable-buildbot --disable-renewal'
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:centos-previous:
   <<: *branch_exceptions
   stage: platforms
   image: centos:6
+  services:
+    - mysql:5.5
+  variables:
+    <<: *base_vars
+    SQLHOST: mysql
   before_script:
     - echo "Building $CI_BUILD_NAME"
     - uname -a
@@ -441,53 +535,51 @@ re:centos-previous:
     - yum install -y make mysql-devel pcre-devel git zlib-devel mysql
     - yum install -y centos-release-scl
     - yum install -y yum install devtoolset-3-toolchain
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
     - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mysql:latest
-  variables:
-    <<: *base_vars
   script:
     - scl enable devtoolset-3  './tools/ci/travis.sh build CFLAGS="-Wno-cast-qual" --enable-debug --enable-Werror --enable-buildbot'
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:centos-current:
   <<: *branch_exceptions
   stage: platforms
   image: centos:7
+  services:
+    - mariadb:5.5
   before_script:
     - echo "Building $CI_BUILD_NAME"
     - uname -a
     - yum -y update
-    - yum install -y gcc make mysql-devel pcre-devel git zlib-devel mysql
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mysql
+    - yum install -y gcc make mariadb-devel pcre-devel git zlib-devel mariadb
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
     - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mysql:latest
   variables:
     <<: *base_vars
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:centos-current:
   <<: *branch_exceptions
   stage: platforms
   image: centos:7
+  services:
+    - mariadb:5.5
   before_script:
     - echo "Building $CI_BUILD_NAME"
     - uname -a
     - yum -y update
-    - yum install -y gcc make mysql-devel pcre-devel git zlib-devel mysql
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mysql
+    - yum install -y gcc make mariadb-devel pcre-devel git zlib-devel mariadb
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
     - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mysql:latest
   variables:
     <<: *base_vars
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:ubuntu-xenial:
   <<: *branch_exceptions
@@ -495,13 +587,14 @@ pre_re:ubuntu-xenial:
   stage: platforms
   image: ubuntu:16.04
   services:
-    - mysql:latest
+    - mysql:5.7
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:ubuntu-xenial:
   <<: *branch_exceptions
@@ -509,13 +602,14 @@ re:ubuntu-xenial:
   stage: platforms
   image: ubuntu:16.04
   services:
-    - mysql:latest
+    - mysql:5.7
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 # SQL servers
 
@@ -524,204 +618,180 @@ pre_re:mysql-5.5:
   <<: *prerequisites
   stage: platforms
   image: debian:jessie
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client-5.5 libmysqlclient-dev
-  services:
-    - mysql:5.5
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:mysql-5.5:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
   image: debian:jessie
+  services:
+    - mysql:5.5
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client-5.5 libmysqlclient-dev
-  services:
-    - mysql:5.5
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:mysql-5.6:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
-  image: debian:jessie
+  image: debian:unstable
+  services:
+    - mysql:5.6
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
-  services:
-    - mysql:5.6
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:mysql-5.6:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
-  image: debian:jessie
+  image: debian:unstable
+  services:
+    - mysql:5.6
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
-  services:
-    - mysql:5.6
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:mysql-5.7:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
   image: debian:unstable
+  services:
+    - mysql:5.7
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client-5.7 libmysqlclient-dev
-  services:
-    - mysql:5.7
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:mysql-5.7:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
   image: debian:unstable
+  services:
+    - mysql:5.7
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mysql-client-5.7 libmysqlclient-dev
-  services:
-    - mysql:5.7
+    SQLHOST: mysql
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mysql
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:mariadb-10.0:
   <<: *branch_exceptions
+  <<: *prerequisites
   stage: platforms
-  image: debian:jessie
+  image: debian:stretch
+  services:
+    - mariadb:10.0
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mariadb-client-10.0 libmysqlclient-dev
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - ./tools/ci/retry.sh apt-get update
-    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mariadb
-    - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mariadb:10.0
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mariadb
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:mariadb-10.0:
   <<: *branch_exceptions
+  <<: *prerequisites
   stage: platforms
-  image: debian:jessie
+  image: debian:stretch
+  services:
+    - mariadb:10.0
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mariadb-client-10.0 libmysqlclient-dev
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - ./tools/ci/retry.sh apt-get update
-    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mariadb
-    - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mariadb:10.0
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mariadb
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:mariadb-latest:
   <<: *branch_exceptions
+  <<: *prerequisites
   stage: platforms
   image: debian:unstable
+  services:
+    - mariadb:latest
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mariadb-client-10.1 libmariadbclient-dev-compat
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - ./tools/ci/retry.sh apt-get update
-    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mariadb
-    - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mariadb:latest
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mariadb
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:mariadb-latest:
   <<: *branch_exceptions
+  <<: *prerequisites
   stage: platforms
   image: debian:unstable
+  services:
+    - mariadb:latest
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mariadb-client-10.1 libmariadbclient-dev-compat
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - ./tools/ci/retry.sh apt-get update
-    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok mariadb
-    - ./tools/ci/travis.sh getplugins || true
-  services:
-    - mariadb:latest
+    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok mariadb
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:percona:
   <<: *branch_exceptions
+  <<: *prerequisites
   stage: platforms
-  image: debian:jessie
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - ./tools/ci/retry.sh apt-get update
-    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok percona
-    - ./tools/ci/travis.sh getplugins || true
+  image: debian:stretch
   services:
     - percona:latest
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
+    SQLHOST: percona
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok percona
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:percona:
   <<: *branch_exceptions
+  <<: *prerequisites
   stage: platforms
-  image: debian:jessie
-  variables:
-    <<: *base_vars
-    INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - ./tools/ci/retry.sh apt-get update
-    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok percona
-    - ./tools/ci/travis.sh getplugins || true
+  image: debian:stretch
   services:
     - percona:latest
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
+    SQLHOST: percona
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok percona
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 # Documentation
 pages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -761,6 +761,36 @@ re:ubuntu-xenial:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
+pre_re:ubuntu-bionic:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: platforms
+  image: ubuntu:18.04
+  services:
+    - mysql:5.7
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
+    SQLHOST: mysql
+  script:
+    - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+re:ubuntu-bionic:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: platforms
+  image: ubuntu:18.04
+  services:
+    - mysql:5.7
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc mysql-client libmysqlclient-dev
+    SQLHOST: mysql
+  script:
+    - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
 # SQL servers
 
 pre_re:mysql-5.5:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -887,7 +887,7 @@ pre_re:mariadb-10.0:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
-  image: debian:stretch
+  image: debian:jessie
   services:
     - mariadb:10.0
   variables:
@@ -902,12 +902,42 @@ re:mariadb-10.0:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: platforms
-  image: debian:stretch
+  image: debian:jessie
   services:
     - mariadb:10.0
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: gcc mariadb-client-10.0 libmysqlclient-dev
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+pre_re:mariadb-10.1:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: platforms
+  image: debian:stable
+  services:
+    - mariadb:10.1
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc mariadb-client-10.1 libmariadbclient-dev-compat
+    SQLHOST: mariadb
+  script:
+    - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+re:mariadb-10.1:
+  <<: *branch_exceptions
+  <<: *prerequisites
+  stage: platforms
+  image: debian:stable
+  services:
+    - mariadb:10.1
+  variables:
+    <<: *base_vars
+    INSTALL_PACKAGES: gcc mariadb-client-10.1 libmariadbclient-dev-compat
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
@@ -922,7 +952,7 @@ pre_re:mariadb-latest:
     - mariadb:latest
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: gcc mariadb-client-10.1 libmariadbclient-dev-compat
+    INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
@@ -937,7 +967,7 @@ re:mariadb-latest:
     - mariadb:latest
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: gcc mariadb-client-10.1 libmariadbclient-dev-compat
+    INSTALL_PACKAGES: gcc mariadb-client libmariadbclient-dev-compat
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR updates the GitLab CI configuration for compatibility with various changes in the target linux distributions that were causing build failures, and adds new versions of the compilers and systems to the tests.

- Each job now specifies the correct version of the SQL server image to use (to match the client and libraries shipped with the linux distribution it's running), in order to avoid test failures.
- The following clang jobs were changed:
  - clang-4.0 moved from the primary to the secondary stage
  - clang-5.0 added (secondary stage)
  - clang-6.0 added (primary stage)
  - clang-7 added (secondary stage)
- The following gcc jobs were changed:
  - Removed gcc-4.6
  - Removed gcc-4.7
  - Moved gcc-4.8 from the primary to the secondary stage
  - Added gcc-7 (secondary stage)
  - Added gcc-8 (secondary stage)
- The following Ubuntu jobs were changed:
  - Added Bionic Beaver (18.04)
- The following MariaDB jobs were changed:
  - Added MariaDB 10.1
- The removed gcc-4.6 and gcc-4.7 jobs were the last ones using debian:wheezy, so this also effectively removes any Wheezy leftovers (Wheezy is EOL)

An example of a successful test result after merging this PR is available at https://gitlab.com/HerculesWS/Hercules/pipelines/24827778

**Affected Branches:** 

- stable

**Issues addressed:**

None

### Known Issues and TODO List

None

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
