### PR TITLE
Added missing parameter to init_unit_layout_unknown

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -19427,7 +19427,7 @@ static void skill_init_unit_layout(void)
 				}
 				break;
 			default:
-				skill->init_unit_layout_unknown(i);
+				skill->init_unit_layout_unknown(i, pos);
 				break;
 		}
 		if (!skill->dbs->unit_layout[pos].count)
@@ -19528,7 +19528,7 @@ static void skill_init_unit_layout(void)
 
 }
 
-static void skill_init_unit_layout_unknown(int skill_idx)
+static void skill_init_unit_layout_unknown(int skill_idx, int pos)
 {
 	Assert_retv(skill_idx >= 0 && skill_idx < MAX_SKILL_DB);
 	ShowError("unknown unit layout at skill %d\n", skill->dbs->db[skill_idx].nameid);

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -2093,7 +2093,7 @@ struct skill_interface {
 	int (*unit_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*unit_timer_sub) (union DBKey key, struct DBData *data, va_list ap);
 	void (*init_unit_layout) (void);
-	void (*init_unit_layout_unknown) (int skill_idx);
+	void (*init_unit_layout_unknown) (int skill_idx, int pos);
 	void (*validate_hittype) (struct config_setting_t *conf, struct s_skill_db *sk);
 	void (*validate_skilltype) (struct config_setting_t *conf, struct s_skill_db *sk);
 	void (*validate_attacktype) (struct config_setting_t *conf, struct s_skill_db *sk);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -7064,8 +7064,8 @@ typedef int (*HPMHOOK_pre_skill_unit_timer_sub) (union DBKey *key, struct DBData
 typedef int (*HPMHOOK_post_skill_unit_timer_sub) (int retVal___, union DBKey key, struct DBData *data, va_list ap);
 typedef void (*HPMHOOK_pre_skill_init_unit_layout) (void);
 typedef void (*HPMHOOK_post_skill_init_unit_layout) (void);
-typedef void (*HPMHOOK_pre_skill_init_unit_layout_unknown) (int *skill_idx);
-typedef void (*HPMHOOK_post_skill_init_unit_layout_unknown) (int skill_idx);
+typedef void (*HPMHOOK_pre_skill_init_unit_layout_unknown) (int *skill_idx, int *pos);
+typedef void (*HPMHOOK_post_skill_init_unit_layout_unknown) (int skill_idx, int pos);
 typedef void (*HPMHOOK_pre_skill_validate_hittype) (struct config_setting_t **conf, struct s_skill_db **sk);
 typedef void (*HPMHOOK_post_skill_validate_hittype) (struct config_setting_t *conf, struct s_skill_db *sk);
 typedef void (*HPMHOOK_pre_skill_validate_skilltype) (struct config_setting_t **conf, struct s_skill_db **sk);

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -75059,14 +75059,14 @@ void HP_skill_init_unit_layout(void) {
 	}
 	return;
 }
-void HP_skill_init_unit_layout_unknown(int skill_idx) {
+void HP_skill_init_unit_layout_unknown(int skill_idx, int pos) {
 	int hIndex = 0;
 	if (HPMHooks.count.HP_skill_init_unit_layout_unknown_pre > 0) {
-		void (*preHookFunc) (int *skill_idx);
+		void (*preHookFunc) (int *skill_idx, int *pos);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_skill_init_unit_layout_unknown_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_skill_init_unit_layout_unknown_pre[hIndex].func;
-			preHookFunc(&skill_idx);
+			preHookFunc(&skill_idx, &pos);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -75074,13 +75074,13 @@ void HP_skill_init_unit_layout_unknown(int skill_idx) {
 		}
 	}
 	{
-		HPMHooks.source.skill.init_unit_layout_unknown(skill_idx);
+		HPMHooks.source.skill.init_unit_layout_unknown(skill_idx, pos);
 	}
 	if (HPMHooks.count.HP_skill_init_unit_layout_unknown_post > 0) {
-		void (*postHookFunc) (int skill_idx);
+		void (*postHookFunc) (int skill_idx, int pos);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_skill_init_unit_layout_unknown_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_skill_init_unit_layout_unknown_post[hIndex].func;
-			postHookFunc(skill_idx);
+			postHookFunc(skill_idx, pos);
 		}
 	}
 	return;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)

skill_init_unit_layout_unknown is missing 'pos' parameter.

It is called with this:
```
                          default:
				skill->init_unit_layout_unknown(i);
				break;
```


If we see the loop, we need the `pos` variable to adjust the skill->dbs->unit_layout data:
```
case PF_FOGWALL: {
					static const int dx[] = {
						-2,-1, 0, 1, 2,-2,-1, 0, 1, 2,-2,-1, 0, 1, 2};
					static const int dy[] = {
						-1,-1,-1,-1,-1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
					skill->dbs->unit_layout[pos].count = 15;
					memcpy(skill->dbs->unit_layout[pos].dx,dx,sizeof(dx));
					memcpy(skill->dbs->unit_layout[pos].dy,dy,sizeof(dy));
				}
				break;
```


Changes Done:
Add pos as parameter to skill_init_unit_layout_unknown


**Affected Branches:** 

[//]: # (Master? Slave?)

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
