### PR TITLE
bake sprintf into debugmes

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -7663,15 +7663,19 @@ solution rather than sending the map and the monster_id.
 //=====================================
 ---------------------------------------
 
-*debugmes("<message>")
+*debugmes("<format string>"{, <param>{, ...}})
 
-This command will send the message to the server console (map-server
-window). It will not be displayed anywhere else.
-//
+This command will print a message in the server console (map-server window),
+after applying the same format-string replacements as sprintf(). It will not be
+displayed anywhere else. Returns true on success.
+
+Example:
+
 	// Displays "NAME has clicked me!" in the map-server window.
-	debugmes(strcharinfo(PC_NAME)+" has clicked me!");
+	debugmes("%s has clicked me!", strcharinfo(PC_NAME));
 
-	debugmes("\033[38D\033[K ==Message== \n"); // enable colour code.
+	debugmes("\033[0;32mHello World"); // supports ANSI escape sequences
+
 ---------------------------------------
 
 *logmes("<message>"{, <log type>})

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -12349,9 +12349,18 @@ static BUILDIN(getstatus)
  *------------------------------------------*/
 static BUILDIN(debugmes)
 {
-	const char *str;
-	str=script_getstr(st,2);
-	ShowDebug("script debug : %d %d : %s\n",st->rid,st->oid,str);
+	struct StringBuf buf;
+	StrBuf->Init(&buf);
+
+	if (!script->sprintf_helper(st, 2, &buf)) {
+		StrBuf->Destroy(&buf);
+		script_pushint(st, 0);
+		return false;
+	}
+
+	ShowDebug("script debug : %d %d : %s\n", st->rid, st->oid, StrBuf->Value(&buf));
+	StrBuf->Destroy(&buf);
+	script_pushint(st, 1);
 	return true;
 }
 
@@ -24872,7 +24881,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(sc_end,"i?"),
 		BUILDIN_DEF(getstatus, "i?"),
 		BUILDIN_DEF(getscrate,"ii?"),
-		BUILDIN_DEF(debugmes,"v"),
+		BUILDIN_DEF(debugmes,"v*"),
 		BUILDIN_DEF2(catchpet,"pet","i"),
 		BUILDIN_DEF2(birthpet,"bpet",""),
 		BUILDIN_DEF(resetlvl,"i"),


### PR DESCRIPTION
I frequently find myself doing things like `debugmes(sprintf("foo=%d, bar=%d", .@foo, .@bar));` so I thought "why not simplify this?".

```c
debugmes("Hello %s!", "World"); // => Hello World!
```
