### PR TITLE
Fix an issue that causes skill cooldowns to get stuck indefinitely

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1405,16 +1405,6 @@ static bool pc_authok(struct map_session_data *sd, int login_id2, time_t expirat
 		clif->changemap(sd,sd->bl.m,sd->bl.x,sd->bl.y);
 	}
 
-	/**
-	 * Check if player have any cool downs on
-	 **/
-	skill->cooldown_load(sd);
-
-	/**
-	 * Check if player have any item cooldowns on
-	 **/
-	pc->itemcd_do(sd,true);
-
 #ifdef GP_BOUND_ITEMS
 	if( sd->status.party_id == 0 )
 		pc->bound_clear(sd,IBT_PARTY);
@@ -1553,6 +1543,10 @@ static int pc_reg_received(struct map_session_data *sd)
 	map->delnickdb(sd->status.char_id, sd->status.name);
 	if (!chrif->auth_finished(sd))
 		ShowError("pc_reg_received: Failed to properly remove player %d:%d from logging db!\n", sd->status.account_id, sd->status.char_id);
+
+	// Restore any cooldowns
+	skill->cooldown_load(sd);
+	pc->itemcd_do(sd, true);
 
 	pc->load_combo(sd);
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

A cooldown timer could expire before the associated character's data gets added to the ID/PC DB, causing skill_blockpc_end() to be unable to find and clear the cooldown data.

The normal order of operations is:

- (1) `pc_authok()` is executed upon login
  - `skill_cooldown_load()` is called, and all the character's cooldows are restored, with the relative timers.
  - `intif_request_registry()` is called, and continues asynchronously.
- (2a) `pc_reg_received()` is called asynchronously
  - `map_addiddb()` is called, adding the `sd` to the `pc_db`.
- (2b) Cooldowns eventually expire, calling the timer function `skill_blockpc_end()`
  - the `sd` is fetched through `map_id2sd()`, and its `sd->blockskill[]` data is cleared

But this leaves a race condition open, since (2a) and (2b) can be arbitrarily swapped, depending on the char server processing time and the remaining duration of the restored cooldowns, producing the following order of operations:

- (1) `pc_authok()` is executed upon login
  - `skill_cooldown_load()` is called, and all the character's cooldows are restored, with the relative timers.
  - `intif_request_registry()` is called, and continues asynchronously.
- (2b) Cooldowns eventually expire, calling the timer function `skill_blockpc_end()`
  - /!\ CRITICAL /!\ the `sd` lookup through `map_id2sd()` fails, since the `pc_db` hasn't been populated yet. The `sd->blockskill[]` data is **not** cleared
  - **The cooldown is not cleared, and the associated skill is no longer usable by the character**
- (2a) `pc_reg_received()` is called asynchronously
  - `map_addiddb()` is called, adding the `sd` to the `pc_db`.

Additionally, starting with 57ba23012d78b8bae37953d65831e932d1365283, it's possible that a cooldown gets restored with a remaining time of zero (the timer gets safely created with an expiration of `gettick() + 1` in that case), making the race condition very easy to reproduce.

This pull request moves the cooldown loading function to a safer place, in `pc_reg_received()`, after
the character data is initialized and the `pc_db` is populated, closing the race condition:

- (1) `pc_authok()` is executed upon login
  - `intif_request_registry()` is called, and continues asynchronously.
- (2) `pc_reg_received()` is called asynchronously
  - `map_addiddb()` is called, adding the `sd` to the `pc_db`.
  - `skill_cooldown_load()` is called, and all the character's cooldows are restored, with the relative timers.
- (3) Cooldowns eventually expire, calling the timer function `skill_blockpc_end()`
  - the `sd` is fetched through `map_id2sd()`, and its `sd->blockskill[]` data is cleared

**Affected Branches:** 

- stable

**Issues addressed:**

- Issue #1535 

This has haunting us since at least 2014, but possibly earlier (see an example at http://herc.ws/board/tracker/issue-8402-serious-problem-with-skill-that-cant-be-cast-or-used/ and the related commit 0957abd4d19b82b8dc8d7db2743008fa3daff3fa that added debug measures). I've experienced this personally in rare cases, but haven't been able to arbitrarily reproduce it until recently (thanks to 57ba23012d78b8bae37953d65831e932d1365283 that made it obvious and easily reproducible)

### Known Issues and TODO List

N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
