### PR TITLE
Fix Venom Splasher consuming its gemstome requirement twice

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -4649,6 +4649,11 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 				// recursive invocation of skill->castend_damage_id() with flag|1
 				map->foreachinrange(skill->area_sub, bl, skill->get_splash(skill_id, skill_lv), skill->splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill->castend_damage_id);
 
+				if (skill_id == AS_SPLASHER) {
+					// Prevent double item consumption when the target explodes (item requirements have already been processed in skill_castend_nodamage_id)
+					flag |= 1;
+				}
+
 				if (sd && skill_id == SU_LUNATICCARROTBEAT) {
 					short item_idx = pc->search_inventory(sd, ITEMID_CARROT);
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The Venom Splasher skill is handled in a special way, causing its item requirement to be processed twice:

- The skill is cast and processed through `skill_castend_nodamage_id()`.
  - Item requirements are processed the first time here, and the gemstone is consumed normally
  - Damage is not applied right away, but `SC_SPLASHER` is started on the target.
- When the `SC_SPLASHER` status ends, `skill_castend_damage_id()` is called.
  - Item requirements are processed again, consuming the gemstone a second time (note that this is not a strict requirement, and the gemstone is only consumed if present in the inventory at this time, since it's a collateral effect, and the double consumption wasn't taken into account when calculating the skill requirements! i.e. it's a bug, and not an intentional consumption)
  - `skill_castend_damage_id()` is called again on the surrounding targets (only one level of recursion, guaranteed by the `(flag & 1)` value set in the recursive call).


This pull request adds the bit `1` to the `flag` during the non-recursive step of `skill_castend_damage_id()`, since that's what currently controls the requirement consumption. This mimics existing code in the same function (see `case 0` near the end of the function, where this method is used to prevent ammunition double consumption for non-skill attacks)

**Affected Branches:** 

- stable

**Issues addressed:**

- #1837

### Known Issues and TODO List

N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
