### PR TITLE
remove specialeffect on first login from the novice academy script

### DIFF
--- a/npc/re/jobs/novice/academy.txt
+++ b/npc/re/jobs/novice/academy.txt
@@ -44,7 +44,6 @@
 iz_int,18,26,0	script	startpoint	HIDDEN_WARP_NPC,1,1,{
 OnTouch:
 	if (!izintspawn) {
-		specialeffect(EF_ANGEL3, AREA, playerattached()); // On official it is some kind of Poring Angel, but I can't find it
 		navigateto("int_land", NAV_NONE, 1); // individual map name not required
 		izintspawn = 1;
 	}


### PR DESCRIPTION
this effect is officialy given thought the achievements system on first login.

[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

remove the specialeffect as it's shown by the achievements system.

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
