### PR TITLE
fix getd not setting the type to C_NAME for new variables

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -17784,14 +17784,26 @@ static BUILDIN(getd)
 	char varname[100];
 	const char *buffer;
 	int elem;
+	int id;
 
 	buffer = script_getstr(st, 2);
 
 	if (sscanf(buffer, "%99[^[][%d]", varname, &elem) < 2)
 		elem = 0;
 
+	id = script->search_str(varname);
+
+	if (id < 0) {
+		id = script->add_str(varname);
+		script->str_data[id].type = C_NAME;
+	} else if (script->str_data[id].type != C_NAME) {
+		ShowError("script:getd: `%s` is already used by something that is not a variable.\n", varname);
+		st->state = END;
+		return false;
+	}
+
 	// Push the 'pointer' so it's more flexible [Lance]
-	script->push_val(st->stack, C_NAME, reference_uid(script->add_str(varname), elem),NULL);
+	script->push_val(st->stack, C_NAME, reference_uid(id, elem),NULL);
 
 	return true;
 }


### PR DESCRIPTION
consider the following:
```c
.@var = 1;
set(getd(".@var"), 2);
```
here everything works fine, because on the first line `.@var` is defined, so the script engine gives it type `C_NAME`, but if the first line is omitted,  `.@var` will not be defined and `getd` will give it type `C_NIL` (default type from `add_str`)

this creates issues when the script engine checks the type of the reference:
```c
set(getd(".@var"), 2);
getdatatype(getd(".@var"));
```
```
script:getdatatype: Unknown reference type!
Data: reference name='.@var' type=C_NAME
Please report this!!! - script->str_data.type=C_NIL
```

The solution is simple: always give type `C_NAME` when using `getd`.
`setd` is not affected by this bug.
