### PR TITLE
always set the type to C_NAME when adding variables through script->add_str 

### DIFF
--- a/npc/dev/test.txt
+++ b/npc/dev/test.txt
@@ -762,7 +762,7 @@ function	script	HerculesSelfTestHelper	{
 	callsub(OnCheck, "Getdatatype (numeric variable)",     getdatatype(.@x), DATATYPE_INT | DATATYPE_VAR);
 	callsub(OnCheck, "Getdatatype (string variable)",      getdatatype(.@x$), DATATYPE_STR | DATATYPE_VAR);
 	callsub(OnCheck, "Getdatatype (label)",                getdatatype(OnTestGetdatatype), DATATYPE_LABEL);
-	//callsub(OnCheck, "Getdatatype (constant)",             getdatatype(DATATYPE_CONST), DATATYPE_CONST); // FIXME
+	callsub(OnCheck, "Getdatatype (constant)",             getdatatype(DATATYPE_CONST), DATATYPE_INT | DATATYPE_CONST);
 	callsub(OnCheck, "Getdatatype (returned integer)",     getdatatype(callsub(OnTestReturnValue, 5)), DATATYPE_INT);
 	callsub(OnCheck, "Getdatatype (returned string)",      getdatatype(callsub(OnTestReturnValue, "foo")), DATATYPE_STR | DATATYPE_CONST);
 	callsub(OnCheck, "Getdatatype (getarg default value)", callsub(OnTestGetdatatypeDefault), DATATYPE_INT);

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -8680,19 +8680,19 @@ ACMD(set)
 		const char *str = NULL;
 		switch (reg[0]) {
 			case '@':
-				str = pc->readregstr(sd, script->add_str(reg));
+				str = pc->readregstr(sd, script->add_variable(reg));
 				break;
 			case '$':
-				str = mapreg->readregstr(script->add_str(reg));
+				str = mapreg->readregstr(script->add_variable(reg));
 				break;
 			case '#':
 				if (reg[1] == '#')
-					str = pc_readaccountreg2str(sd, script->add_str(reg));// global
+					str = pc_readaccountreg2str(sd, script->add_variable(reg));// global
 				else
-					str = pc_readaccountregstr(sd, script->add_str(reg));// local
+					str = pc_readaccountregstr(sd, script->add_variable(reg));// local
 				break;
 			default:
-				str = pc_readglobalreg_str(sd, script->add_str(reg));
+				str = pc_readglobalreg_str(sd, script->add_variable(reg));
 				break;
 		}
 		if (str == NULL || str[0] == '\0') {
@@ -8708,19 +8708,19 @@ ACMD(set)
 		data->type = C_INT;
 		switch( reg[0] ) {
 			case '@':
-				data->u.num = pc->readreg(sd, script->add_str(reg));
+				data->u.num = pc->readreg(sd, script->add_variable(reg));
 				break;
 			case '$':
-				data->u.num = mapreg->readreg(script->add_str(reg));
+				data->u.num = mapreg->readreg(script->add_variable(reg));
 				break;
 			case '#':
 				if( reg[1] == '#' )
-					data->u.num = pc_readaccountreg2(sd, script->add_str(reg));// global
+					data->u.num = pc_readaccountreg2(sd, script->add_variable(reg));// global
 				else
-					data->u.num = pc_readaccountreg(sd, script->add_str(reg));// local
+					data->u.num = pc_readaccountreg(sd, script->add_variable(reg));// local
 				break;
 			default:
-				data->u.num = pc_readglobalreg(sd, script->add_str(reg));
+				data->u.num = pc_readglobalreg(sd, script->add_variable(reg));
 				break;
 		}
 	}

--- a/src/map/battleground.c
+++ b/src/map/battleground.c
@@ -615,7 +615,7 @@ static void bg_match_over(struct bg_arena *arena, bool canceled)
 		if (canceled)
 			clif->messagecolor_self(sd->fd, COLOR_RED, "BG Match Canceled: not enough players");
 		else
-			pc_setglobalreg(sd, script->add_str(arena->delay_var), (unsigned int)time(NULL));
+			pc_setglobalreg(sd, script->add_variable(arena->delay_var), (unsigned int)time(NULL));
 	}
 
 	arena->begin_timer = INVALID_TIMER;
@@ -654,8 +654,8 @@ static void bg_begin(struct bg_arena *arena)
 			bg->afk_timer_id = timer->add(timer->gettick()+10000,bg->afk_timer,0,0);
 
 		/* TODO: make this a arena-independent var? or just .@? */
-		mapreg->setreg(script->add_str("$@bg_queue_id"),arena->queue_id);
-		mapreg->setregstr(script->add_str("$@bg_delay_var$"),bg->gdelay_var);
+		mapreg->setreg(script->add_variable("$@bg_queue_id"),arena->queue_id);
+		mapreg->setregstr(script->add_variable("$@bg_delay_var$"),bg->gdelay_var);
 
 		count = 0;
 		for (i = 0; i < VECTOR_LENGTH(queue->entries); i++) {
@@ -664,20 +664,20 @@ static void bg_begin(struct bg_arena *arena)
 			if (sd == NULL || sd->bg_queue.ready != 1)
 				continue;
 
-			mapreg->setreg(reference_uid(script->add_str("$@bg_member"), count), sd->status.account_id);
-			mapreg->setreg(reference_uid(script->add_str("$@bg_member_group"), count),
+			mapreg->setreg(reference_uid(script->add_variable("$@bg_member"), count), sd->status.account_id);
+			mapreg->setreg(reference_uid(script->add_variable("$@bg_member_group"), count),
 			               sd->bg_queue.type == BGQT_GUILD ? sd->status.guild_id :
 			               sd->bg_queue.type == BGQT_PARTY ? sd->status.party_id :
 			               0
 			               );
-			mapreg->setreg(reference_uid(script->add_str("$@bg_member_type"), count),
+			mapreg->setreg(reference_uid(script->add_variable("$@bg_member_type"), count),
 			               sd->bg_queue.type == BGQT_GUILD ? 1 :
 			               sd->bg_queue.type == BGQT_PARTY ? 2 :
 			               0
 			               );
 			count++;
 		}
-		mapreg->setreg(script->add_str("$@bg_member_size"),count);
+		mapreg->setreg(script->add_variable("$@bg_member_size"),count);
 
 		npc->event_do(arena->npc_event);
 	}
@@ -857,7 +857,7 @@ static enum BATTLEGROUNDS_QUEUE_ACK bg_canqueue(struct map_session_data *sd, str
 
 	tsec = (unsigned int)time(NULL);
 
-	if ( ( tick = pc_readglobalreg(sd, script->add_str(bg->gdelay_var)) ) && tsec < tick ) {
+	if ( ( tick = pc_readglobalreg(sd, script->add_variable(bg->gdelay_var)) ) && tsec < tick ) {
 		char response[100];
 		if( (tick-tsec) > 60 )
 			sprintf(response, "You are a deserter! Wait %u minute(s) before you can apply again", (tick - tsec) / 60);
@@ -867,7 +867,7 @@ static enum BATTLEGROUNDS_QUEUE_ACK bg_canqueue(struct map_session_data *sd, str
 		return BGQA_FAIL_DESERTER;
 	}
 
-	if ( ( tick = pc_readglobalreg(sd, script->add_str(arena->delay_var)) ) && tsec < tick ) {
+	if ( ( tick = pc_readglobalreg(sd, script->add_variable(arena->delay_var)) ) && tsec < tick ) {
 		char response[100];
 		if( (tick-tsec) > 60 )
 			sprintf(response, "You can't reapply to this arena so fast. Apply to the different arena or wait %u minute(s)", (tick - tsec) / 60);

--- a/src/map/channel.c
+++ b/src/map/channel.c
@@ -290,7 +290,7 @@ static void channel_send(struct channel_data *chan, struct map_session_data *sd,
 
 		for (i = 0; i < MAX_EVENTQUEUE; i++) {
 			if (chan->handlers[i][0] != '\0') {
-				pc->setregstr(sd, script->add_str("@channelmes$"), msg);
+				pc->setregstr(sd, script->add_variable("@channelmes$"), msg);
 				npc->event(sd, chan->handlers[i], 0);
 			}
 		}

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -15195,7 +15195,7 @@ static void clif_parse_FeelSaveOk(int fd, struct map_session_data *sd)
 
 	sd->feel_map[i].index = map_id2index(sd->bl.m);
 	sd->feel_map[i].m = sd->bl.m;
-	pc_setglobalreg(sd,script->add_str(pc->sg_info[i].feel_var),sd->feel_map[i].index);
+	pc_setglobalreg(sd,script->add_variable(pc->sg_info[i].feel_var),sd->feel_map[i].index);
 
 #if 0 // Are these really needed? Shouldn't they show up automatically from the feel save packet?
 	clif_misceffect2(&sd->bl, 0x1b0);
@@ -16758,7 +16758,7 @@ static void clif_quest_update_objective(struct map_session_data *sd, struct ques
 
 	qi = quest->db(qd->quest_id);
 	Assert_retv(qi->objectives_count < MAX_QUEST_OBJECTIVES);
-	
+
 	len = sizeof(struct packet_quest_update_header)
 	            + MAX_QUEST_OBJECTIVES * sizeof(struct packet_quest_update_hunt); // >= than the actual length
 
@@ -16771,7 +16771,7 @@ static void clif_quest_update_objective(struct map_session_data *sd, struct ques
 
 	for (i = 0; i < qi->objectives_count; i++) {
 		real_len += sizeof(packet->objectives[i]);
-		
+
 		packet->objectives[i].questID = qd->quest_id;
 #if PACKETVER >= 20150513
 		packet->objectives[i].huntIdent = (qd->quest_id * 1000) + i;
@@ -16801,7 +16801,7 @@ static void clif_quest_notify_objective(struct map_session_data *sd, struct ques
 
 	qi = quest->db(qd->quest_id);
 	Assert_retv(qi->objectives_count < MAX_QUEST_OBJECTIVES);
-	
+
 	len = sizeof(struct packet_quest_hunt_info)
 	            + MAX_QUEST_OBJECTIVES * sizeof(struct packet_quest_hunt_info_sub); // >= than the actual length
 
@@ -16813,7 +16813,7 @@ static void clif_quest_notify_objective(struct map_session_data *sd, struct ques
 
 	for (i = 0; i < qi->objectives_count; i++) {
 		real_len += sizeof(packet->info[i]);
-		
+
 		packet->info[i].questID = qd->quest_id;
 		packet->info[i].mob_id = qi->objectives[i].mob;
 		packet->info[i].maxCount = qi->objectives[i].count;
@@ -18742,12 +18742,12 @@ static void clif_parse_CashShopBuy(int fd, struct map_session_data *sd)
 				struct item item_tmp;
 				int k, get_count;
 				int ret = 0;
-				
+
 				get_count = qty;
 
 				if (!itemdb->isstackable2(data))
 					get_count = 1;
-				
+
 				ret = pc->paycash(sd, clif->cs.data[tab][j]->price * qty, kafra_pay);// [Ryuuzaki] //changed Kafrapoints calculation. [Normynator]
 				if (ret < 0) {
 					ShowError("clif_parse_CashShopBuy: The return from pc->paycash was negative which is not allowed.\n");
@@ -19548,9 +19548,9 @@ static void clif_parse_RouletteOpen(int fd, struct map_session_data *sd)
 	p.Step = sd->roulette.stage - 1;
 	p.Idx = (char)sd->roulette.prizeIdx;
 	p.AdditionItemID = -1; /** TODO **/
-	p.BronzePoint = pc_readglobalreg(sd, script->add_str("TmpRouletteBronze"));
-	p.GoldPoint = pc_readglobalreg(sd, script->add_str("TmpRouletteGold"));
-	p.SilverPoint = pc_readglobalreg(sd, script->add_str("TmpRouletteSilver"));
+	p.BronzePoint = pc_readglobalreg(sd, script->add_variable("TmpRouletteBronze"));
+	p.GoldPoint = pc_readglobalreg(sd, script->add_variable("TmpRouletteGold"));
+	p.SilverPoint = pc_readglobalreg(sd, script->add_variable("TmpRouletteSilver"));
 
 	clif->send(&p,sizeof(p), &sd->bl, SELF);
 #endif
@@ -19617,21 +19617,21 @@ static void clif_parse_RouletteGenerate(int fd, struct map_session_data *sd)
 		stage = sd->roulette.stage = 0;
 
 	if( stage == 0 ) {
-		if( pc_readglobalreg(sd, script->add_str("TmpRouletteBronze")) <= 0 &&
-		    pc_readglobalreg(sd, script->add_str("TmpRouletteSilver")) < 10 &&
-		    pc_readglobalreg(sd, script->add_str("TmpRouletteGold")) < 10 )
+		if( pc_readglobalreg(sd, script->add_variable("TmpRouletteBronze")) <= 0 &&
+		    pc_readglobalreg(sd, script->add_variable("TmpRouletteSilver")) < 10 &&
+		    pc_readglobalreg(sd, script->add_variable("TmpRouletteGold")) < 10 )
 			result = GENERATE_ROULETTE_NO_ENOUGH_POINT;
 	}
 
 	if( result == GENERATE_ROULETTE_SUCCESS ) {
 		if( stage == 0 ) {
-			if( pc_readglobalreg(sd, script->add_str("TmpRouletteBronze")) > 0 ) {
-				pc_setglobalreg(sd, script->add_str("TmpRouletteBronze"), pc_readglobalreg(sd, script->add_str("TmpRouletteBronze")) - 1);
-			} else if( pc_readglobalreg(sd, script->add_str("TmpRouletteSilver")) > 9 ) {
-				pc_setglobalreg(sd, script->add_str("TmpRouletteSilver"), pc_readglobalreg(sd, script->add_str("TmpRouletteSilver")) - 10);
+			if( pc_readglobalreg(sd, script->add_variable("TmpRouletteBronze")) > 0 ) {
+				pc_setglobalreg(sd, script->add_variable("TmpRouletteBronze"), pc_readglobalreg(sd, script->add_variable("TmpRouletteBronze")) - 1);
+			} else if( pc_readglobalreg(sd, script->add_variable("TmpRouletteSilver")) > 9 ) {
+				pc_setglobalreg(sd, script->add_variable("TmpRouletteSilver"), pc_readglobalreg(sd, script->add_variable("TmpRouletteSilver")) - 10);
 				stage = sd->roulette.stage = 2;
-			} else if( pc_readglobalreg(sd, script->add_str("TmpRouletteGold")) > 9 ) {
-				pc_setglobalreg(sd, script->add_str("TmpRouletteGold"), pc_readglobalreg(sd, script->add_str("TmpRouletteGold")) - 10);
+			} else if( pc_readglobalreg(sd, script->add_variable("TmpRouletteGold")) > 9 ) {
+				pc_setglobalreg(sd, script->add_variable("TmpRouletteGold"), pc_readglobalreg(sd, script->add_variable("TmpRouletteGold")) - 10);
 				stage = sd->roulette.stage = 4;
 			}
 		}
@@ -19813,9 +19813,9 @@ static void clif_roulette_generate_ack(struct map_session_data *sd, unsigned cha
 	p.Step = stage;
 	p.Idx = prizeIdx;
 	p.AdditionItemID = bonusItemID;
-	p.RemainBronze = pc_readglobalreg(sd, script->add_str("TmpRouletteBronze"));
-	p.RemainGold = pc_readglobalreg(sd, script->add_str("TmpRouletteGold"));
-	p.RemainSilver = pc_readglobalreg(sd, script->add_str("TmpRouletteSilver"));
+	p.RemainBronze = pc_readglobalreg(sd, script->add_variable("TmpRouletteBronze"));
+	p.RemainGold = pc_readglobalreg(sd, script->add_variable("TmpRouletteGold"));
+	p.RemainSilver = pc_readglobalreg(sd, script->add_variable("TmpRouletteSilver"));
 
 	clif->send(&p,sizeof(p), &sd->bl, SELF);
 #endif
@@ -20738,7 +20738,7 @@ static void clif_rodex_send_mails_all(int fd, struct map_session_data *sd, int64
 	nullpo_retv(sd);
 
 	mailsSize = VECTOR_LENGTH(sd->rodex.messages);
-	
+
 	if (mail_id > 0)
 		ARR_FIND(0, VECTOR_LENGTH(sd->rodex.messages), j, (VECTOR_INDEX(sd->rodex.messages, j)).id == mail_id);
 
@@ -21360,8 +21360,8 @@ static void clif_parse_private_airship_request(int fd, struct map_session_data *
 
 	safestrncpy(evname, "private_airship::OnAirShipRequest", EVENT_NAME_LENGTH);
 	if ((ev = strdb_get(npc->ev_db, evname))) {
-		pc->setregstr(sd, script->add_str("@mapname$"), p->mapName);
-		pc->setreg(sd, script->add_str("@itemid"), p->ItemID);
+		pc->setregstr(sd, script->add_variable("@mapname$"), p->mapName);
+		pc->setreg(sd, script->add_variable("@itemid"), p->ItemID);
 		script->run_npc(ev->nd->u.scr.script, ev->pos, sd->bl.id, ev->nd->bl.id);
 	} else {
 		ShowError("clif_parse_private_airship_request: event '%s' not found, operation failed.\n", evname);

--- a/src/map/duel.c
+++ b/src/map/duel.c
@@ -47,7 +47,7 @@ static void duel_savetime(struct map_session_data *sd)
 	time(&clock);
 	t = localtime(&clock);
 
-	pc_setglobalreg(sd, script->add_str("PC_LAST_DUEL_TIME"), t->tm_mday*24*60 + t->tm_hour*60 + t->tm_min);
+	pc_setglobalreg(sd, script->add_variable("PC_LAST_DUEL_TIME"), t->tm_mday*24*60 + t->tm_hour*60 + t->tm_min);
 }
 
 static int duel_checktime(struct map_session_data *sd)
@@ -59,7 +59,7 @@ static int duel_checktime(struct map_session_data *sd)
 	time(&clock);
 	t = localtime(&clock);
 
-	diff = t->tm_mday*24*60 + t->tm_hour*60 + t->tm_min - pc_readglobalreg(sd, script->add_str("PC_LAST_DUEL_TIME") );
+	diff = t->tm_mday*24*60 + t->tm_hour*60 + t->tm_min - pc_readglobalreg(sd, script->add_variable("PC_LAST_DUEL_TIME") );
 
 	return !(diff >= 0 && diff < battle_config.duel_time_interval);
 }

--- a/src/map/intif.c
+++ b/src/map/intif.c
@@ -1324,7 +1324,7 @@ static void intif_parse_Registers(int fd)
 				safestrncpy(sval, RFIFOP(fd, cursor + 1), min((int)sizeof(sval), len));
 				cursor += len + 1;
 
-				script->set_reg(NULL,sd,reference_uid(script->add_str(key), index), key, sval, NULL);
+				script->set_reg(NULL,sd,reference_uid(script->add_variable(key), index), key, sval, NULL);
 			}
 		/**
 		 * Vessel!
@@ -1346,7 +1346,7 @@ static void intif_parse_Registers(int fd)
 				ival = RFIFOL(fd, cursor);
 				cursor += 4;
 
-				script->set_reg(NULL,sd,reference_uid(script->add_str(key), index), key, (const void *)h64BPTRSIZE(ival), NULL);
+				script->set_reg(NULL,sd,reference_uid(script->add_variable(key), index), key, (const void *)h64BPTRSIZE(ival), NULL);
 			}
 		}
 		script->parser_current_file = NULL;/* reset */

--- a/src/map/mapreg_sql.c
+++ b/src/map/mapreg_sql.c
@@ -221,7 +221,7 @@ static void script_load_mapreg(void)
 	SQL->StmtBindColumn(stmt, 2, SQLDT_STRING, &value,   sizeof value,   NULL,    NULL);
 
 	while ( SQL_SUCCESS == SQL->StmtNextRow(stmt) ) {
-		int s = script->add_str(varname);
+		int s = script->add_variable(varname);
 		int i = index;
 
 

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2702,11 +2702,11 @@ static int mob_dead(struct mob_data *md, struct block_list *src, int type)
 				if (++sd->mission_count >= 100 && (temp = mob->get_random_id(0, 0xE, sd->status.base_level)) != 0) {
 					pc->addfame(sd, RANKTYPE_TAEKWON, 1);
 					sd->mission_mobid = temp;
-					pc_setglobalreg(sd,script->add_str("TK_MISSION_ID"), temp);
+					pc_setglobalreg(sd,script->add_variable("TK_MISSION_ID"), temp);
 					sd->mission_count = 0;
 					clif->mission_info(sd, temp, 0);
 				}
-				pc_setglobalreg(sd,script->add_str("TK_MISSION_COUNT"), sd->mission_count);
+				pc_setglobalreg(sd,script->add_variable("TK_MISSION_COUNT"), sd->mission_count);
 			}
 
 			if( sd->status.party_id )

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -1762,8 +1762,8 @@ static bool npc_trader_pay(struct npc_data *nd, struct map_session_data *sd, int
 
 	snprintf(evname, EVENT_NAME_LENGTH, "%s::OnPayFunds",nd->exname);
 	if ( (ev = strdb_get(npc->ev_db, evname)) ) {
-		pc->setreg(sd,script->add_str("@price"),price);
-		pc->setreg(sd,script->add_str("@points"),points);
+		pc->setreg(sd,script->add_variable("@price"),price);
+		pc->setreg(sd,script->add_variable("@points"),points);
 		script->run_npc(ev->nd->u.scr.script, ev->pos, sd->bl.id, ev->nd->bl.id);
 	} else
 		ShowError("npc_trader_pay: '%s' event '%s' not found, operation failed\n",nd->exname,evname);

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1459,7 +1459,7 @@ static int pc_set_hate_mob(struct map_session_data *sd, int pos, struct block_li
 			return 0; //Wrong size
 	}
 	sd->hate_mob[pos] = class_;
-	pc_setglobalreg(sd,script->add_str(pc->sg_info[pos].hate_var),class_+1);
+	pc_setglobalreg(sd,script->add_variable(pc->sg_info[pos].hate_var),class_+1);
 	clif->hate_info(sd, pos, class_, 1);
 	return 1;
 }
@@ -1473,27 +1473,28 @@ static int pc_reg_received(struct map_session_data *sd)
 
 	nullpo_ret(sd);
 	sd->vars_ok = true;
-	sd->change_level_2nd = pc_readglobalreg(sd,script->add_str("jobchange_level"));
-	sd->change_level_3rd = pc_readglobalreg(sd,script->add_str("jobchange_level_3rd"));
-	sd->die_counter = pc_readglobalreg(sd,script->add_str("PC_DIE_COUNTER"));
+
+	sd->change_level_2nd = pc_readglobalreg(sd,script->add_variable("jobchange_level"));
+	sd->change_level_3rd = pc_readglobalreg(sd,script->add_variable("jobchange_level_3rd"));
+	sd->die_counter = pc_readglobalreg(sd,script->add_variable("PC_DIE_COUNTER"));
 
 	// Cash shop
-	sd->cashPoints = pc_readaccountreg(sd,script->add_str("#CASHPOINTS"));
-	sd->kafraPoints = pc_readaccountreg(sd,script->add_str("#KAFRAPOINTS"));
+	sd->cashPoints = pc_readaccountreg(sd,script->add_variable("#CASHPOINTS"));
+	sd->kafraPoints = pc_readaccountreg(sd,script->add_variable("#KAFRAPOINTS"));
 
 	// Cooking Exp
-	sd->cook_mastery = pc_readglobalreg(sd,script->add_str("COOK_MASTERY"));
+	sd->cook_mastery = pc_readglobalreg(sd,script->add_variable("COOK_MASTERY"));
 
 	if ((sd->job & MAPID_BASEMASK) == MAPID_TAEKWON) {
 		// Better check for class rather than skill to prevent "skill resets" from unsetting this
-		sd->mission_mobid = pc_readglobalreg(sd,script->add_str("TK_MISSION_ID"));
-		sd->mission_count = pc_readglobalreg(sd,script->add_str("TK_MISSION_COUNT"));
+		sd->mission_mobid = pc_readglobalreg(sd,script->add_variable("TK_MISSION_ID"));
+		sd->mission_count = pc_readglobalreg(sd,script->add_variable("TK_MISSION_COUNT"));
 	}
 
 	//SG map and mob read [Komurka]
 	for (i = 0; i < MAX_PC_FEELHATE; i++) {
 		//for now - someone need to make reading from txt/sql
-		int j = pc_readglobalreg(sd,script->add_str(pc->sg_info[i].feel_var));
+		int j = pc_readglobalreg(sd,script->add_variable(pc->sg_info[i].feel_var));
 		if (j != 0) {
 			sd->feel_map[i].index = j;
 			sd->feel_map[i].m = map->mapindex2mapid(j);
@@ -1501,24 +1502,24 @@ static int pc_reg_received(struct map_session_data *sd)
 			sd->feel_map[i].index = 0;
 			sd->feel_map[i].m = -1;
 		}
-		sd->hate_mob[i] = pc_readglobalreg(sd,script->add_str(pc->sg_info[i].hate_var))-1;
+		sd->hate_mob[i] = pc_readglobalreg(sd,script->add_variable(pc->sg_info[i].hate_var))-1;
 	}
 
 	if ((i = pc->checkskill(sd,RG_PLAGIARISM)) > 0) {
-		sd->cloneskill_id = pc_readglobalreg(sd,script->add_str("CLONE_SKILL"));
+		sd->cloneskill_id = pc_readglobalreg(sd,script->add_variable("CLONE_SKILL"));
 		if (sd->cloneskill_id > 0 && (idx = skill->get_index(sd->cloneskill_id)) > 0) {
 			sd->status.skill[idx].id = sd->cloneskill_id;
-			sd->status.skill[idx].lv = pc_readglobalreg(sd,script->add_str("CLONE_SKILL_LV"));
+			sd->status.skill[idx].lv = pc_readglobalreg(sd,script->add_variable("CLONE_SKILL_LV"));
 			if (sd->status.skill[idx].lv > i)
 				sd->status.skill[idx].lv = i;
 			sd->status.skill[idx].flag = SKILL_FLAG_PLAGIARIZED;
 		}
 	}
 	if ((i = pc->checkskill(sd,SC_REPRODUCE)) > 0) {
-		sd->reproduceskill_id = pc_readglobalreg(sd,script->add_str("REPRODUCE_SKILL"));
+		sd->reproduceskill_id = pc_readglobalreg(sd,script->add_variable("REPRODUCE_SKILL"));
 		if( sd->reproduceskill_id > 0 && (idx = skill->get_index(sd->reproduceskill_id)) > 0) {
 			sd->status.skill[idx].id = sd->reproduceskill_id;
-			sd->status.skill[idx].lv = pc_readglobalreg(sd,script->add_str("REPRODUCE_SKILL_LV"));
+			sd->status.skill[idx].lv = pc_readglobalreg(sd,script->add_variable("REPRODUCE_SKILL_LV"));
 			if( i < sd->status.skill[idx].lv)
 				sd->status.skill[idx].lv = i;
 			sd->status.skill[idx].flag = SKILL_FLAG_PLAGIARIZED;
@@ -1964,7 +1965,7 @@ static int pc_calc_skilltree_normalize_job(struct map_session_data *sd)
 
 			}
 
-			pc_setglobalreg(sd, script->add_str("jobchange_level"), sd->change_level_2nd);
+			pc_setglobalreg(sd, script->add_variable("jobchange_level"), sd->change_level_2nd);
 		}
 
 		if (skill_point < novice_skills + (sd->change_level_2nd - 1)) {
@@ -1977,7 +1978,7 @@ static int pc_calc_skilltree_normalize_job(struct map_session_data *sd)
 						- (sd->status.job_level - 1)
 						- (sd->change_level_2nd - 1)
 						- novice_skills;
-					pc_setglobalreg(sd, script->add_str("jobchange_level_3rd"), sd->change_level_3rd);
+					pc_setglobalreg(sd, script->add_variable("jobchange_level_3rd"), sd->change_level_3rd);
 			}
 
 			if (skill_point < novice_skills + (sd->change_level_2nd - 1) + (sd->change_level_3rd - 1)) {
@@ -4523,7 +4524,7 @@ static int pc_payzeny(struct map_session_data *sd, int zeny, enum e_log_pick_typ
  *
  * @param price     Price of the item.
  * @param points    Provided kafra points.
- * 	
+ *
  * @return points	Leftover kafra points.
  */
 //Changed Kafrapoints calculation. [Normynator]
@@ -4555,15 +4556,15 @@ static int pc_paycash(struct map_session_data *sd, int price, int points)
 		return -1;
 	}
 
-	pc_setaccountreg(sd, script->add_str("#CASHPOINTS"), sd->cashPoints - cash);
-	pc_setaccountreg(sd, script->add_str("#KAFRAPOINTS"), sd->kafraPoints - mempoints);
+	pc_setaccountreg(sd, script->add_variable("#CASHPOINTS"), sd->cashPoints - cash);
+	pc_setaccountreg(sd, script->add_variable("#KAFRAPOINTS"), sd->kafraPoints - mempoints);
 
 	if (battle_config.cashshop_show_points) {
 		char output[128];
 		sprintf(output, msg_sd(sd,504), points, cash, sd->kafraPoints, sd->cashPoints);
 		clif_disp_onlyself(sd, output);
 	}
-	
+
 	return points;
 }
 
@@ -4582,7 +4583,7 @@ static int pc_getcash(struct map_session_data *sd, int cash, int points)
 			cash = MAX_ZENY-sd->cashPoints;
 		}
 
-		pc_setaccountreg(sd, script->add_str("#CASHPOINTS"), sd->cashPoints+cash);
+		pc_setaccountreg(sd, script->add_variable("#CASHPOINTS"), sd->cashPoints+cash);
 
 		if( battle_config.cashshop_show_points )
 		{
@@ -4605,7 +4606,7 @@ static int pc_getcash(struct map_session_data *sd, int cash, int points)
 			points = MAX_ZENY-sd->kafraPoints;
 		}
 
-		pc_setaccountreg(sd, script->add_str("#KAFRAPOINTS"), sd->kafraPoints+points);
+		pc_setaccountreg(sd, script->add_variable("#KAFRAPOINTS"), sd->kafraPoints+points);
 
 		if( battle_config.cashshop_show_points )
 		{
@@ -5789,7 +5790,7 @@ static int pc_setpos(struct map_session_data *sd, unsigned short map_index, int 
 		for (i = 0; i < VECTOR_LENGTH(sd->script_queues); i++) {
 			struct script_queue *queue = script->queue(VECTOR_INDEX(sd->script_queues, i));
 			if (queue && queue->event_mapchange[0] != '\0') {
-				pc->setregstr(sd, script->add_str("@Queue_Destination_Map$"), map->list[m].name);
+				pc->setregstr(sd, script->add_variable("@Queue_Destination_Map$"), map->list[m].name);
 				npc->event(sd, queue->event_mapchange, 0);
 			}
 		}
@@ -7220,7 +7221,7 @@ static uint64 pc_thisjobexp(const struct map_session_data *sd)
 	const struct class_exp_group *exp_group = NULL;
 
 	nullpo_ret(sd);
-	
+
 	if (sd->status.job_level > pc->maxjoblv(sd) || sd->status.job_level <= 1)
 		return 0;
 
@@ -7696,7 +7697,7 @@ static int pc_resetstate(struct map_session_data *sd)
 	if( sd->mission_mobid ) { //bugreport:2200
 		sd->mission_mobid = 0;
 		sd->mission_count = 0;
-		pc_setglobalreg(sd,script->add_str("TK_MISSION_ID"), 0);
+		pc_setglobalreg(sd,script->add_variable("TK_MISSION_ID"), 0);
 	}
 
 	status_calc_pc(sd,SCO_NONE);
@@ -7856,7 +7857,7 @@ static int pc_resetfeel(struct map_session_data *sd)
 	{
 		sd->feel_map[i].m = -1;
 		sd->feel_map[i].index = 0;
-		pc_setglobalreg(sd,script->add_str(pc->sg_info[i].feel_var),0);
+		pc_setglobalreg(sd,script->add_variable(pc->sg_info[i].feel_var),0);
 	}
 
 	return 0;
@@ -7869,7 +7870,7 @@ static int pc_resethate(struct map_session_data *sd)
 
 	for (i = 0; i < MAX_PC_FEELHATE; i++) {
 		sd->hate_mob[i] = -1;
-		pc_setglobalreg(sd,script->add_str(pc->sg_info[i].hate_var),0);
+		pc_setglobalreg(sd,script->add_variable(pc->sg_info[i].hate_var),0);
 	}
 	return 0;
 }
@@ -8059,7 +8060,7 @@ static int pc_dead(struct map_session_data *sd, struct block_list *src)
 	if (sd->npc_id && sd->st && sd->st->state != RUN)
 		npc->event_dequeue(sd);
 
-	pc_setglobalreg(sd,script->add_str("PC_DIE_COUNTER"),sd->die_counter+1);
+	pc_setglobalreg(sd,script->add_variable("PC_DIE_COUNTER"),sd->die_counter+1);
 	pc->setparam(sd, SP_KILLERRID, src?src->id:0);
 
 	if( sd->bg_id ) {/* TODO: purge when bgqueue is deemed ok */
@@ -8920,11 +8921,11 @@ static int pc_jobchange(struct map_session_data *sd, int class, int upper)
 	if ((job & JOBL_2) != 0 && (sd->job & JOBL_2) == 0 && (job & MAPID_UPPERMASK) != MAPID_SUPER_NOVICE) {
 		// changing from 1st to 2nd job
 		sd->change_level_2nd = sd->status.job_level;
-		pc_setglobalreg(sd, script->add_str("jobchange_level"), sd->change_level_2nd);
+		pc_setglobalreg(sd, script->add_variable("jobchange_level"), sd->change_level_2nd);
 	} else if((job & JOBL_THIRD) != 0 && (sd->job & JOBL_THIRD) == 0) {
 		// changing from 2nd to 3rd job
 		sd->change_level_3rd = sd->status.job_level;
-		pc_setglobalreg(sd, script->add_str("jobchange_level_3rd"), sd->change_level_3rd);
+		pc_setglobalreg(sd, script->add_variable("jobchange_level_3rd"), sd->change_level_3rd);
 	}
 
 	if(sd->cloneskill_id) {
@@ -8936,8 +8937,8 @@ static int pc_jobchange(struct map_session_data *sd, int class, int upper)
 			clif->deleteskill(sd,sd->cloneskill_id);
 		}
 		sd->cloneskill_id = 0;
-		pc_setglobalreg(sd, script->add_str("CLONE_SKILL"), 0);
-		pc_setglobalreg(sd, script->add_str("CLONE_SKILL_LV"), 0);
+		pc_setglobalreg(sd, script->add_variable("CLONE_SKILL"), 0);
+		pc_setglobalreg(sd, script->add_variable("CLONE_SKILL_LV"), 0);
 	}
 
 	if(sd->reproduceskill_id) {
@@ -8949,8 +8950,8 @@ static int pc_jobchange(struct map_session_data *sd, int class, int upper)
 			clif->deleteskill(sd,sd->reproduceskill_id);
 		}
 		sd->reproduceskill_id = 0;
-		pc_setglobalreg(sd, script->add_str("REPRODUCE_SKILL"),0);
-		pc_setglobalreg(sd, script->add_str("REPRODUCE_SKILL_LV"),0);
+		pc_setglobalreg(sd, script->add_variable("REPRODUCE_SKILL"),0);
+		pc_setglobalreg(sd, script->add_variable("REPRODUCE_SKILL_LV"),0);
 	}
 
 	if ((job & MAPID_UPPERMASK) != (sd->job & MAPID_UPPERMASK)) { //Things to remove when changing class tree.

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -17800,7 +17800,7 @@ static BUILDIN(getd)
 
 	id = script->search_str(varname);
 
-	if (id < 0 || script->str_data[id].type == C_NOP) {
+	if (id < 0) {
 		id = script->add_str(varname);
 		script->str_data[id].type = C_NAME;
 	} else if (script->str_data[id].type != C_NAME) {

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -143,7 +143,6 @@ struct item_data;
 /// Returns if this a reference to a param
 #define reference_toparam(data) ( script->str_data[reference_getid(data)].type == C_PARAM )
 /// Returns if this a reference to a variable
-//##TODO confirm it's C_NAME [FlavioJS]
 #define reference_tovariable(data) ( script->str_data[reference_getid(data)].type == C_NAME )
 /// Returns the unique id of the reference (id and index)
 #define reference_getuid(data) ( (data)->u.num )

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -829,6 +829,7 @@ struct script_interface {
 	void (*setarray_pc) (struct map_session_data* sd, const char* varname, uint32 idx, void* value, int* refcache);
 	bool (*config_read) (const char *filename, bool imported);
 	int (*add_str) (const char* p);
+	int (*add_variable) (const char *varname);
 	const char* (*get_str) (int id);
 	int (*search_str) (const char* p);
 	void (*setd_sub) (struct script_state *st, struct map_session_data *sd, const char *varname, int elem, const void *value, struct reg_db *ref);

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3212,8 +3212,8 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 				}
 
 				tsd->reproduceskill_id = copy_skill;
-				pc_setglobalreg(tsd, script->add_str("REPRODUCE_SKILL"), copy_skill);
-				pc_setglobalreg(tsd, script->add_str("REPRODUCE_SKILL_LV"), lv);
+				pc_setglobalreg(tsd, script->add_variable("REPRODUCE_SKILL"), copy_skill);
+				pc_setglobalreg(tsd, script->add_variable("REPRODUCE_SKILL_LV"), lv);
 
 				tsd->status.skill[cidx].id = copy_skill;
 				tsd->status.skill[cidx].lv = lv;
@@ -3236,8 +3236,8 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 					lv = plagiarismlvl;
 
 				tsd->cloneskill_id = copy_skill;
-				pc_setglobalreg(tsd, script->add_str("CLONE_SKILL"), copy_skill);
-				pc_setglobalreg(tsd, script->add_str("CLONE_SKILL_LV"), lv);
+				pc_setglobalreg(tsd, script->add_variable("CLONE_SKILL"), copy_skill);
+				pc_setglobalreg(tsd, script->add_variable("CLONE_SKILL_LV"), lv);
 
 				tsd->status.skill[cidx].id = copy_skill;
 				tsd->status.skill[cidx].lv = lv;
@@ -6752,7 +6752,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 				}
 				sd->mission_mobid = id;
 				sd->mission_count = 0;
-				pc_setglobalreg(sd,script->add_str("TK_MISSION_ID"), id);
+				pc_setglobalreg(sd,script->add_variable("TK_MISSION_ID"), id);
 				clif->mission_info(sd, id, 0);
 				clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
 			}
@@ -8531,7 +8531,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 			if (skill_id == SL_SUPERNOVICE && dstsd && dstsd->die_counter && !(rnd()%100)) {
 				//Erase death count 1% of the casts
 				dstsd->die_counter = 0;
-				pc_setglobalreg(dstsd,script->add_str("PC_DIE_COUNTER"), 0);
+				pc_setglobalreg(dstsd,script->add_variable("PC_DIE_COUNTER"), 0);
 				clif->specialeffect(bl, 0x152, AREA);
 				//SC_SOULLINK invokes status_calc_pc for us.
 			}
@@ -18480,7 +18480,7 @@ static int skill_produce_mix(struct map_session_data *sd, uint16 skill_id, int n
 					{ //Cooking items.
 						clif->specialeffect(&sd->bl, 608, AREA);
 						if( sd->cook_mastery < 1999 )
-							pc_setglobalreg(sd, script->add_str("COOK_MASTERY"),sd->cook_mastery + ( 1 << ( (skill->dbs->produce_db[idx].itemlv - 11) / 2 ) ) * 5);
+							pc_setglobalreg(sd, script->add_variable("COOK_MASTERY"),sd->cook_mastery + ( 1 << ( (skill->dbs->produce_db[idx].itemlv - 11) / 2 ) ) * 5);
 					}
 					break;
 			}
@@ -18591,7 +18591,7 @@ static int skill_produce_mix(struct map_session_data *sd, uint16 skill_id, int n
 				{ //Cooking items.
 					clif->specialeffect(&sd->bl, 609, AREA);
 					if( sd->cook_mastery > 0 )
-						pc_setglobalreg(sd, script->add_str("COOK_MASTERY"), sd->cook_mastery - ( 1 << ((skill->dbs->produce_db[idx].itemlv - 11) / 2) ) - ( ( ( 1 << ((skill->dbs->produce_db[idx].itemlv - 11) / 2) ) >> 1 ) * 3 ));
+						pc_setglobalreg(sd, script->add_variable("COOK_MASTERY"), sd->cook_mastery - ( 1 << ((skill->dbs->produce_db[idx].itemlv - 11) / 2) ) - ( ( ( 1 << ((skill->dbs->produce_db[idx].itemlv - 11) / 2) ) >> 1 ) * 3 ));
 				}
 		}
 	}

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -6608,6 +6608,8 @@ typedef bool (*HPMHOOK_pre_script_config_read) (const char **filename, bool *imp
 typedef bool (*HPMHOOK_post_script_config_read) (bool retVal___, const char *filename, bool imported);
 typedef int (*HPMHOOK_pre_script_add_str) (const char **p);
 typedef int (*HPMHOOK_post_script_add_str) (int retVal___, const char *p);
+typedef int (*HPMHOOK_pre_script_add_variable) (const char **varname);
+typedef int (*HPMHOOK_post_script_add_variable) (int retVal___, const char *varname);
 typedef const char* (*HPMHOOK_pre_script_get_str) (int *id);
 typedef const char* (*HPMHOOK_post_script_get_str) (const char* retVal___, int id);
 typedef int (*HPMHOOK_pre_script_search_str) (const char **p);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -5130,6 +5130,8 @@ struct {
 	struct HPMHookPoint *HP_script_config_read_post;
 	struct HPMHookPoint *HP_script_add_str_pre;
 	struct HPMHookPoint *HP_script_add_str_post;
+	struct HPMHookPoint *HP_script_add_variable_pre;
+	struct HPMHookPoint *HP_script_add_variable_post;
 	struct HPMHookPoint *HP_script_get_str_pre;
 	struct HPMHookPoint *HP_script_get_str_post;
 	struct HPMHookPoint *HP_script_search_str_pre;
@@ -11681,6 +11683,8 @@ struct {
 	int HP_script_config_read_post;
 	int HP_script_add_str_pre;
 	int HP_script_add_str_post;
+	int HP_script_add_variable_pre;
+	int HP_script_add_variable_post;
 	int HP_script_get_str_pre;
 	int HP_script_get_str_post;
 	int HP_script_search_str_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -2628,6 +2628,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(script->setarray_pc, HP_script_setarray_pc) },
 	{ HP_POP(script->config_read, HP_script_config_read) },
 	{ HP_POP(script->add_str, HP_script_add_str) },
+	{ HP_POP(script->add_variable, HP_script_add_variable) },
 	{ HP_POP(script->get_str, HP_script_get_str) },
 	{ HP_POP(script->search_str, HP_script_search_str) },
 	{ HP_POP(script->setd_sub, HP_script_setd_sub) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -68339,6 +68339,33 @@ int HP_script_add_str(const char *p) {
 	}
 	return retVal___;
 }
+int HP_script_add_variable(const char *varname) {
+	int hIndex = 0;
+	int retVal___ = 0;
+	if (HPMHooks.count.HP_script_add_variable_pre > 0) {
+		int (*preHookFunc) (const char **varname);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_script_add_variable_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_script_add_variable_pre[hIndex].func;
+			retVal___ = preHookFunc(&varname);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.script.add_variable(varname);
+	}
+	if (HPMHooks.count.HP_script_add_variable_post > 0) {
+		int (*postHookFunc) (int retVal___, const char *varname);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_script_add_variable_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_script_add_variable_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, varname);
+		}
+	}
+	return retVal___;
+}
 const char* HP_script_get_str(int id) {
 	int hIndex = 0;
 	const char* retVal___ = NULL;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
A lot of places add variables to `script->str_data` without setting their type afterwards, so these variables end up with the type `C_NOP`, which was made evident by #2163. This PR adds `script->add_variable()` which works like `script->add_str()` but also sets the type to `C_NAME`

<br>

### Issues addressed
closes #2163 
closes #1801 

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
