### PR TITLE
Supress warning in skill_attack when MAGIC_REFLECTION_TYPE is 0.

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -2745,7 +2745,11 @@ static int skill_magic_reflect(struct block_list *src, struct block_list *bl, in
 static int skill_attack(int attack_type, struct block_list *src, struct block_list *dsrc, struct block_list *bl, uint16 skill_id, uint16 skill_lv, int64 tick, int flag)
 {
 	struct Damage dmg;
+#if MAGIC_REFLECTION_TYPE
 	struct status_data *sstatus, *tstatus;
+#else
+	struct status_data *tstatus;
+#endif
 	struct status_change *sc;
 	struct map_session_data *sd, *tsd;
 	int type;
@@ -2780,7 +2784,9 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 			)
 		return 0;
 
+#if MAGIC_REFLECTION_TYPE
 	sstatus = status->get_status_data(src);
+#endif
 	tstatus = status->get_status_data(bl);
 	sc = status->get_sc(bl);
 	if (sc && !sc->count) sc = NULL; //Don't need it.


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)
If MAGIC_REFLECTION_TYPE is set to 0 in src/config, a warning will appear in skill_attack. This suppresses it.

**Affected Branches:** 

[//]: # (Master? Slave?)
- [x] master
- [x] stable

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)
#1920 