### PR TITLE
Stops tsd client crashing if party inviter is disguised.

### DIFF
--- a/conf/messages.conf
+++ b/conf/messages.conf
@@ -298,7 +298,8 @@
 287: You cannot change party leaders in this map.
 //Missing stuff for @killer related commands.
 288: You are no longer killable.
-//289-290 FREE
+289: You cannot invite players while disguised.
+//290 FREE
 291: Weather effects will disappear after teleporting or refreshing.
 292: Killer state reset.
 //Item Bind System

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -12536,6 +12536,12 @@ static void clif_parse_PartyInvite(int fd, struct map_session_data *sd)
 		return;
 	}
 
+	// If inviter is disguised, crashes target's client
+	if (sd->disguise != -1) {
+		clif->messagecolor_self(sd->fd, COLOR_RED, msg_sd(sd, 289)); // You cannot invite players while disguised.
+		return;
+	}
+
 	t_sd = map->id2sd(RFIFOL(fd,2));
 
 	if(t_sd && t_sd->state.noask) {// @noask [LuzZza]
@@ -12557,6 +12563,12 @@ static void clif_parse_PartyInvite2(int fd, struct map_session_data *sd)
 	if(map->list[sd->bl.m].flag.partylock) {
 		// Party locked.
 		clif->message(fd, msg_fd(fd,227)); // Party modification is disabled in this map.
+		return;
+	}
+
+	// If inviter is disguised, crashes target's client
+	if (sd->disguise != -1) {
+		clif->messagecolor_self(sd->fd, COLOR_RED, msg_sd(sd, 289)); // You cannot invite players while disguised.
 		return;
 	}
 


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Stops disguised party invites if disguised. If the party inviter is disguised, they can crash anyone's client just by inviting them to their party (not sure if it will crash on partylock or if player already has party).

Confirmed to crash the target's client in 20160113.

[//]: # (Describe at length, the changes that this pull request makes.)

**Affected Branches:** 

[//]: # (Master? Slave?)
- [x] master
- [x] stable

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)

### Known Issues and TODO List

- [ ] Test in other clients to see if it is a packetver related thing.

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
