### PR TITLE
Fix CentOS builds in gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -901,13 +901,12 @@ pre_re:centos-previous:
     - echo "Building $CI_BUILD_NAME"
     - uname -a
     - yum -y update
-    - yum install -y make mysql-devel pcre-devel git zlib-devel mysql
-    - yum install -y centos-release-scl
-    - yum install -y yum install devtoolset-3-toolchain
+    - yum install -y make mysql-devel pcre-devel git zlib-devel mysql centos-release-scl
+    - yum install -y devtoolset-6-toolchain
     - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
     - ./tools/ci/travis.sh getplugins || true
   script:
-    - scl enable devtoolset-3 './tools/ci/travis.sh build CFLAGS="-Wno-cast-qual" --enable-debug --enable-Werror --enable-buildbot --disable-renewal'
+    - 'source /opt/rh/devtoolset-6/enable && ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal'
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 re:centos-previous:
@@ -923,13 +922,12 @@ re:centos-previous:
     - echo "Building $CI_BUILD_NAME"
     - uname -a
     - yum -y update
-    - yum install -y make mysql-devel pcre-devel git zlib-devel mysql
-    - yum install -y centos-release-scl
-    - yum install -y yum install devtoolset-3-toolchain
+    - yum install -y make mysql-devel pcre-devel git zlib-devel mysql centos-release-scl
+    - yum install -y devtoolset-6-toolchain
     - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
     - ./tools/ci/travis.sh getplugins || true
   script:
-    - scl enable devtoolset-3  './tools/ci/travis.sh build CFLAGS="-Wno-cast-qual" --enable-debug --enable-Werror --enable-buildbot'
+    - 'source /opt/rh/devtoolset-6/enable && ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot'
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
 
 pre_re:centos-current:


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The devtoolset-3 package is no longer available in the scl repositories (it's been EOL since october 2016, as stated on the [package information page](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-3/) and was eventually removed). This PR replaces it with [devtoolset-6](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-6/).

A typo (accidental repetition) in one of the package installation lines is also fixed.

This is the only remaining change before the GitLab CI builds can turn green again.

**Affected Branches:** 

- master

**Issues addressed:**

N/A

### Known Issues and TODO List

None. A fully green build based on this commit can be seen at https://gitlab.com/HerculesWS/Hercules/pipelines/28699649

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
