### PR TITLE
deprecate the UNITTYPE_ constants, and the commands that use them

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3319,6 +3319,14 @@ enable (true) or disable (false) the effect on the player.
 
 *getmapxy("<variable for map name>", <variable for x>, <variable for y>, <type>{, "<search parameter>"})
 
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    @ /!\ This command is deprecated @
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+This command is deprecated and it should not be used in new scripts, as it is
+likely to be removed at a later time. Please use getunitdata instead,
+ie: getunitdata(<unit id>, UDT_MAPIDXY, .@location);
+
 This function will locate a character object, NPC object or pet's
 coordinates and place their coordinates into the variables specified when
 calling it. It will return 0 if the search was successful, and -1 if the
@@ -6610,6 +6618,10 @@ and will return the following values:
 
 *getunittype(<GID>)
 
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    @ /!\ This command is deprecated @
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
 Returns the type of object from the given Game ID. Returns -1 if the given GID
 does not exist. The return values are :-
 
@@ -6620,6 +6632,10 @@ does not exist. The return values are :-
 	UNITTYPE_HOM    4
 	UNITTYPE_MER    5
 	UNITTYPE_ELEM   6
+
+This command is deprecated and it should not be used in new scripts, as it is
+likely to be removed at a later time. Please use getunitdata instead,
+ie: getunitdata(<unit id>, UDT_TYPE)
 
 ---------------------------------------
 
@@ -10032,6 +10048,7 @@ an array variable may be passed to store the data in.
 
 Applicable Data types (available as constants) -
 	Data Types          Description (return type)
+	UDT_TYPE:           Unit type (see BL_ constants in getunits())
 	UDT_SIZE:           Unit Size (int)
 	UDT_LEVEL:          Level (int)
 	UDT_HP:             Current HP (int)
@@ -10040,7 +10057,7 @@ Applicable Data types (available as constants) -
 	UDT_MAXSP:          MAX SP (int)
 	UDT_MASTERAID:      Master Account ID (for Summons) (int)
 	UDT_MASTERCID:      Master Char ID (for Summons) (int)
-	UDT_MAPIDXY:        Warp a Unit to a map. (Val1 = (string) MapName, Val2 = (int) x, Val3 = (int) y)
+	UDT_MAPIDXY:        Unit location. (Val1 = (int) map id, Val2 = (int) x, Val3 = (int) y)
 	UDT_SPEED:          Unit Speed. (int)
 	UDT_MODE:           Mode (Mobs only) (int)
 	UDT_AI:             Unit AI Type (see doc/constants.md for Unit AI Types)

--- a/npc/battleground/bg_common.txt
+++ b/npc/battleground/bg_common.txt
@@ -260,7 +260,7 @@ bat_room,148,150,5	script	Teleporter#Battlefield	4_F_TELEPORTER,{
 		mes("[Maroll Battle Recruiter]");
 		mes("May the war god bless you.");
 		close2;
-		getmapxy(.@mapname$, .@x, .@y, UNITTYPE_NPC);
+		getunitlocation(getnpcid(0), .@mapname$, .@x, .@y);
 		if (.@mapname$ == "prontera")
 			bat_return = 1;
 		else if (.@mapname$ == "moc_ruins")

--- a/npc/custom/quests/hunting_missions.txt
+++ b/npc/custom/quests/hunting_missions.txt
@@ -270,14 +270,14 @@ OnNPCKillEvent:
 		}
 	} else if (.Party) {
 		set .@mob, killedrid;
-		getmapxy(.@map1$, .@x1, .@y1, UNITTYPE_PC);
+		getunitlocation(playerattached(), .@map1$, .@x1, .@y1);
 		getpartymember getcharid(CHAR_ID_PARTY),1;
 		getpartymember getcharid(CHAR_ID_PARTY),2;
 		for(set .@i,0; .@i<$@partymembercount; set .@i,.@i+1) {
 			if (isloggedin($@partymemberaid[.@i], $@partymembercid[.@i])) {
 				attachrid $@partymemberaid[.@i];
 				if (#Mission_Count && Mission0 && Hp > 0) {
-					getmapxy(.@map2$, .@x2, .@y2, UNITTYPE_PC);
+					getunitlocation(playerattached(), .@map2$, .@x2, .@y2);
 					if ((.@map1$ == .@map2$ || .Party == 1) && (distance(.@x1,.@y1,.@x2,.@y2) <= 30 || .Party < 3)) {
 						for(set .@j,0; .@j<.Quests; set .@j,.@j+1) {
 							if (strmobinfo(1,.@mob) == strmobinfo(1,getd("Mission"+.@j))) {

--- a/npc/events/halloween_2009.txt
+++ b/npc/events/halloween_2009.txt
@@ -261,7 +261,7 @@ prontera,220,72,5	duplicate(09Treats)	Trick or Treater#iRO8	4_M_KID1,2,2
 				mes "[Halloween Wizard]";
 				mes "Which town do you want to play a trick on?";
 				next;
-				getmapxy(.@mapname$, .@mapx, .@mapy, UNITTYPE_PC, strcharinfo(PC_NAME));
+				getunitlocation(playerattached(), .@map$, .@x, .@y);
 				if (.@mapname$ == "prontera") {
 					switch(select("Geffen", "Payon", "Alberta", "Aldebaran")) {
 						case 1:

--- a/npc/other/CashShop_Functions.txt
+++ b/npc/other/CashShop_Functions.txt
@@ -58,7 +58,7 @@ function	script	F_CashStore	{
 function	script	F_CashPartyCall	{
 	warp "Random", 0, 0;
 	if (getpartyleader(getcharid(CHAR_ID_PARTY), 2) == getcharid(CHAR_ID_CHAR)) {
-		getmapxy(.@map$, .@x, .@y, UNITTYPE_PC);
+		getunitlocation(playerattached(), .@map$, .@x, .@y);
 		do {
 			.@x2 = .@x + rand(-2, 2);
 			.@y2 = .@y + rand(-2, 2);

--- a/npc/other/Global_Functions.txt
+++ b/npc/other/Global_Functions.txt
@@ -407,7 +407,7 @@ function	script	Time2Str	{
 //== Function F_ShuffleNumbers =============================
 // Generate a set of numbers in random order that the numbers are not repeated
 //    callfunc "F_ShuffleNumbers",<start num>,<last num>,<output array>{,<count>};
-// Examples: 
+// Examples:
 //    callfunc("F_ShuffleNumbers", 0, 5, .@output)      // possible output 4,1,3,2,0,5
 //    callfunc("F_ShuffleNumbers", -5, 1, .@output)     // possible output -3,-5,-4,-2,-1,1,0
 //    callfunc("F_ShuffleNumbers", 0, 100, .@output, 5) // possible output 9,55,27,84,33
@@ -437,4 +437,14 @@ function	script	F_ShuffleNumbers	{
 //    mes callfunc("F_MesColor", C_BLUE) +"This message is now in BLUE";
 function	script	F_MesColor	{
 	return sprintf("^%06X", min(getarg(0), 0xFFFFFF));
+}
+
+// getunitlocation(<unit id>, <map variable>, <x variable>, <y variable>)
+//     syntax sugar for getunitdata
+function	script	getunitlocation	{
+	getunitdata(getarg(0), UDT_MAPIDXY, .@__loc[0]);
+	set(getarg(1), getmapinfo(MAPINFO_NAME, .@__loc[0]));
+	swap(.@__loc[1], getarg(2));
+	swap(.@__loc[2], getarg(3));
+	return true;
 }

--- a/npc/other/gm_npcs.txt
+++ b/npc/other/gm_npcs.txt
@@ -41,7 +41,7 @@ function	script	F_GM_NPC	{
 	// To set a minimum GM level to access the NPCs, edit the line below.
 	if (getgmlevel() < 99) {/* TODO: perhaps better to just add a group permission? [Ind] */
 		// Log the event.
-		getmapxy(.@map$, .@x, .@y, UNITTYPE_NPC);
+		getunitlocation(getnpcid(0), .@map$, .@x, .@y);
 		logmes strcharinfo(PC_NAME)+" attempted to access GM NPC "+strnpcinfo(NPC_NAME)+" ("+.@map$+","+.@x+","+.@y+").";
 		end;
 	}

--- a/npc/other/monster_race.txt
+++ b/npc/other/monster_race.txt
@@ -241,7 +241,7 @@ OnInit:
 OnEnable:
 	emotion e_gasp;
 	enablenpc strnpcinfo(NPC_NAME);
-	getmapxy(.@m$, .@x, .@y, UNITTYPE_NPC);
+	getunitlocation(getnpcid(0), .@m$, .@x, .@y);
 	setarray .@mob[1], R_PORING,R_LUNATIC,R_SAVAGE_BABE,R_DESERT_WOLF_B,R_DEVIRUCHI,R_BAPHOMET_;
 	monster "p_track01",58,.@y,"The "+ F_Ord() +" Racer", .@mob[F_Num()],1,strnpcinfo(NPC_NAME)+"::OnMyMobDead";
 	end;
@@ -1750,7 +1750,7 @@ p_track02,76,38,1	script	Exit Guide#double	4_M_NFMAN,{
 OnEnable:
 	enablenpc strnpcinfo(NPC_NAME);
 	setarray .@mob[1], R_PORING,R_LUNATIC,R_SAVAGE_BABE,R_DESERT_WOLF_B,R_DEVIRUCHI,R_BAPHOMET_;
-	getmapxy(.@m$, .@x, .@y, UNITTYPE_NPC);
+	getunitlocation(getnpcid(0), .@m$, .@x, .@y);
 	.@num = MN();
 	monster "p_track02",58,.@y,"Monster "+.@num,.@mob[.@num],1,strnpcinfo(NPC_NAME)+"::OnMyMobDead";
 	end;

--- a/npc/other/poring_war.txt
+++ b/npc/other/poring_war.txt
@@ -318,7 +318,7 @@ poring_w01,96,97,3	script	Sweet Devi#wop	4_DEVIRUCHI,{
 	}
 
 OnPCLogoutEvent:
-	getmapxy(.@map$, .@x, .@y, UNITTYPE_PC);
+	getunitlocation(playerattached(), .@map$, .@x, .@y);
 	if (.@map$ == "poring_w02") {
 		if (WoP_SaveMap$ != "") {
 			savepoint WoP_SaveMap$,WoP_SaveMap_X,WoP_SaveMap_Y;
@@ -332,7 +332,7 @@ OnPCLogoutEvent:
 	end;
 
 OnPCDieEvent:
-	getmapxy(.@map$, .@x, .@y, UNITTYPE_PC);
+	getunitlocation(playerattached(), .@map$, .@x, .@y);
 	if (.@map$ == "poring_w02" && wop_team) {
 		if (getsavepoint(0) != "poring_w02" && WoP_SaveMap$ == "") {
 			WoP_SaveMap$ = getsavepoint(0);
@@ -349,7 +349,7 @@ OnPCDieEvent:
 	end;
 
 OnPCKillEvent:
-	getmapxy(.@map$, .@x, .@y, UNITTYPE_PC);
+	getunitlocation(playerattached(), .@map$, .@x, .@y);
 	if (.@map$ == "poring_w02" && wop_team) {
 		getnameditem War_Badge,rid2name(killedrid);
 	}

--- a/npc/quests/guildrelay.txt
+++ b/npc/quests/guildrelay.txt
@@ -1240,7 +1240,7 @@
 
 -	script	RelayDummy2::GuildRelay2	4_M_SAGE_A,{
 	.@name$ = strnpcinfo(NPC_NAME_VISIBLE);
-	getmapxy(.@m$, .@x, .@x, UNITTYPE_NPC);
+	getunitlocation(getnpcid(0), .@m$, .@x, .@x);
 	.@GID = getcastledata(.@m$,1);
 	if (checkweight(Knife,1) == 0) {
 		mes "^3355FFWait a minute! You're";
@@ -1749,7 +1749,7 @@
 
 -	script	RelayDummy3::GuildRelay3	4_M_SAGE_A,{
 	.@name$ = strnpcinfo(NPC_NAME_VISIBLE);
-	getmapxy(.@m$, .@x, .@x, UNITTYPE_NPC);
+	getunitlocation(getnpcid(0), .@m$, .@x, .@x);
 	.@GID = getcastledata(.@m$,1);
 	if (checkweight(Knife,1) == 0) {
 		mes "^3355FFWait a minute! You're";
@@ -2433,7 +2433,7 @@
 
 -	script	GuildDummy4::GuildRelay4	4_M_SAGE_A,{
 	.@name$ = strnpcinfo(NPC_NAME_VISIBLE);
-	getmapxy(.@m$, .@x, .@x, UNITTYPE_NPC);
+	getunitlocation(getnpcid(0), .@m$, .@x, .@x);
 	.@GID = getcastledata(.@m$,1);
 	if (checkweight(Knife,1) == 0) {
 		mes "^3355FFWait a minute! You're";

--- a/npc/quests/partyrelay.txt
+++ b/npc/quests/partyrelay.txt
@@ -2492,7 +2492,7 @@ payon,168,314,3	script	Lospii#payon::RelayLospii	4_M_KID1,{
 		close;
 	}
 	.@relaytime = gettime(GETTIME_HOUR);
-	getmapxy(.@m$, .@x, .@y, UNITTYPE_NPC, strnpcinfo(NPC_NAME_UNIQUE));
+	getunitlocation(getnpcid(0), .@map$, .@x, .@y);
 	.@juwi = getareausers(.@m$,.@x-8,.@y-8,.@x+8,.@y+8);
 	if (party_relay == 32) {
 		mes "[Lospii]";

--- a/npc/re/instances/MalangdoCulvert.txt
+++ b/npc/re/instances/MalangdoCulvert.txt
@@ -781,7 +781,7 @@ OnEnable:
 	areamonster(.@map$, .@c[0], .@c[1], .@c[2], .@c[3], _("Ancient Kukre"), MD_KUKRE, rand(1, 3), .@label$);
 	areamonster(.@map$, .@c[0], .@c[1], .@c[2], .@c[3], _("Abysmal Cornutus"), MD_CORNUTUS, rand(1, 3), .@label$);
 	specialeffect(EF_MAPPILLAR2, ALL_SAMEMAP); //currently broken
-	getmapxy(.@map$, .@x, .@y, UNITTYPE_NPC);
+	getunitlocation(getnpcid(0), .@map$, .@x, .@y);
 	getpartymember('party_id, 2);
 	copyarray(.@partymemberaid[0], $@partymemberaid[0], $@partymembercount);
 	for(.@i = 0; .@i<$@partymembercount; ++.@i) {

--- a/npc/re/instances/OldGlastHeim.txt
+++ b/npc/re/instances/OldGlastHeim.txt
@@ -1015,7 +1015,7 @@ OnTouch:
 		.@mobs = 6;
 	else
 		.@mobs = 7;
-	getmapxy(.@map$, .@x, .@y, UNITTYPE_NPC);
+	getunitlocation(getnpcid(0), .@map$, .@x, .@y);
 	specialeffect(EF_VENOMDUST);
 	monster(.@map$, .@x, .@y, _("Maggot"), MG_ARCLOUSE, .@mobs, instance_npcname(strnpcinfo(NPC_NAME))+"::OnMyMobDead");
 	disablenpc(instance_npcname(strnpcinfo(NPC_NAME)));
@@ -2039,7 +2039,7 @@ OnTimer80000:
 		mes("Now, let me remove your memory. If you see me again, that will be brand new.");
 		specialeffect(EF_FREEZE, AREA, playerattached());
 		close2();
-		getmapxy(.@map$, .@x, .@y, UNITTYPE_PC);
+		getunitlocation(playerattached(), .@map$, .@x, .@y);
 		warp(.@map$, .@x, .@y);
 		end;
 	} else {

--- a/npc/re/jobs/3-1/guillotine_cross.txt
+++ b/npc/re/jobs/3-1/guillotine_cross.txt
@@ -3470,7 +3470,7 @@ OnTouch:
 OnTimer:
 	//FIXME: This is a workaround for...
 	//var pccount_tt = GetNeighborPcNumber 2
-	getmapxy(.@map$, .@x, .@y, UNITTYPE_NPC);
+	getunitlocation(getnpcid(0), .@map$, .@x, .@y);
 	setarray .@x[1],.@x-2,.@x+2;
 	setarray .@y[1],.@y-2,.@y+2;
 	sleep 1000;

--- a/npc/re/jobs/3-1/ranger.txt
+++ b/npc/re/jobs/3-1/ranger.txt
@@ -1589,7 +1589,7 @@ OnInit:
 OnEnable:
 	enablenpc strnpcinfo(NPC_NAME);
 	initnpctimer;
-	getmapxy(.@map$, .@x, .@y, UNITTYPE_NPC);
+	getunitlocation(getnpcid(0), .@map$, .@x, .@y);
 	monster "job3_rang02",.@x,.@y,"Egg Bomb",1047,1,strnpcinfo(NPC_NAME)+"::OnMyMobDead";
 	switch(atoi(strnpcinfo(NPC_NAME_HIDDEN))%3) {
 		case 0: .@str$ = "Hey, I am going to explode. What are you going to do?"; break;

--- a/npc/re/quests/quests_malangdo.txt
+++ b/npc/re/quests/quests_malangdo.txt
@@ -4196,7 +4196,7 @@ malangdo,133,134,0	script	Strange Pile of Sand#7	4_SOIL,{
 				setquest .@quest;
 				if (!rand(3)) {
 					emotion e_omg;
-					getmapxy(.@map$, .@x, .@y, UNITTYPE_NPC);
+					getunitlocation(getnpcid(0), .@map$, .@x, .@y);
 					monster .@map$,.@x,.@y,"Quick Dark Shadow",2209,1;
 				} else
 					getitem Cat_Hard_Biscuit,1;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19718,6 +19718,11 @@ static BUILDIN(getunitdata)
 
 	type = script_getnum(st, 3);
 
+	if (type == UDT_TYPE) {
+		script_pushint(st, bl->type);
+		return true;
+	}
+
 	/* Type check */
 	if (type < UDT_TYPE || type >= UDT_MAX) {
 		ShowError("buildin_getunitdata: Invalid unit data type %d provided.\n", type);
@@ -19756,7 +19761,6 @@ static BUILDIN(getunitdata)
 
 		switch (type)
 		{
-		case UDT_TYPE:        script_pushint(st, BL_MOB); break;
 		case UDT_SIZE:        script_pushint(st, md->status.size); break;
 		case UDT_LEVEL:       script_pushint(st, md->level); break;
 		case UDT_HP:          script_pushint(st, md->status.hp); break;
@@ -19822,7 +19826,6 @@ static BUILDIN(getunitdata)
 
 		switch (type)
 		{
-		case UDT_TYPE:        script_pushint(st, BL_HOM); break;
 		case UDT_SIZE:        script_pushint(st, hd->base_status.size); break;
 		case UDT_LEVEL:       script_pushint(st, hd->homunculus.level); break;
 		case UDT_HP:          script_pushint(st, hd->base_status.hp); break;
@@ -19879,7 +19882,6 @@ static BUILDIN(getunitdata)
 
 		switch (type)
 		{
-		case UDT_TYPE:        script_pushint(st, BL_PET); break;
 		case UDT_SIZE:        script_pushint(st, pd->status.size); break;
 		case UDT_LEVEL:       script_pushint(st, pd->pet.level); break;
 		case UDT_HP:          script_pushint(st, pd->status.hp); break;
@@ -19936,7 +19938,6 @@ static BUILDIN(getunitdata)
 
 		switch (type)
 		{
-		case UDT_TYPE:        script_pushint(st, BL_MER); break;
 		case UDT_SIZE:        script_pushint(st, mc->base_status.size); break;
 		case UDT_HP:          script_pushint(st, mc->base_status.hp); break;
 		case UDT_MAXHP:       script_pushint(st, mc->base_status.max_hp); break;
@@ -19992,7 +19993,6 @@ static BUILDIN(getunitdata)
 
 		switch (type)
 		{
-		case UDT_TYPE:        script_pushint(st, BL_ELEM); break;
 		case UDT_SIZE:        script_pushint(st, ed->base_status.size); break;
 		case UDT_HP:          script_pushint(st, ed->base_status.hp); break;
 		case UDT_MAXHP:       script_pushint(st, ed->base_status.max_hp); break;
@@ -20046,7 +20046,6 @@ static BUILDIN(getunitdata)
 
 		switch (type)
 		{
-		case UDT_TYPE:        script_pushint(st, BL_NPC); break;
 		case UDT_SIZE:        script_pushint(st, nd->status.size); break;
 		case UDT_HP:          script_pushint(st, nd->status.hp); break;
 		case UDT_MAXHP:       script_pushint(st, nd->status.max_hp); break;
@@ -25204,7 +25203,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(getnpcdir,"?"), // [4144]
 		BUILDIN_DEF(setnpcdir,"*"), // [4144]
 		BUILDIN_DEF(getnpcclass,"?"), // [4144]
-		BUILDIN_DEF(getmapxy,"rrri?"), //by Lorky [Lupus]
+		BUILDIN_DEF_DEPRECATED(getmapxy,"rrri?"), //by Lorky [Lupus]
 		BUILDIN_DEF(checkoption1,"i?"),
 		BUILDIN_DEF(checkoption2,"i?"),
 		BUILDIN_DEF(guildgetexp,"i"),
@@ -25311,7 +25310,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(checkpcblock, ""),
 		// <--- [zBuffer] List of player cont commands
 		// [zBuffer] List of mob control commands --->
-		BUILDIN_DEF(getunittype,"i"),
+		BUILDIN_DEF_DEPRECATED(getunittype,"i"),
 		/* Unit Data */
 		BUILDIN_DEF(setunitdata,"iiv??"),
 		BUILDIN_DEF(getunitdata,"ii?"),


### PR DESCRIPTION
If we make `getmapxy()` accept `BL_` constants then we can't make it backwards-compatible with `UNITTYPE_` constants, because if an integer is given instead of a constant there's no way to know if the value is intended to be one of `UNITTYPE_` or `BL_`, so it's better to just deprecate the whole command altogether, since it's already integrated into `getunitdata()`. Also `getmapxy()` has some weird behaviour, such as finding the location of a pet by the name of its owner (WTF?) and is quite messy in general.

closes #1677 

<br> <br> <br>

- - -

<sub>BTW this is meko, I changed by username</sub>