### PR TITLE
Fix wrong validation for quests in setquestinfo

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9414,7 +9414,7 @@ supported types: values
 	QINFO_SEX: sex
 	QINFO_BASE_LEVEL: min, max
 	QINFO_JOB_LEVEL: min, max
-	QINFO_ITEM: item_id, amount // append to the items list on each use
+	QINFO_ITEM: item_id, min amount, max amount // append to the items list on each use
 	QINFO_HOMUN_LEVEL: min
 	QINFO_HOMUN_TYPE: homunculus_type (0 - regular, 1 - evolved, 2 - S)
 	QINFO_QUEST: quest_id, state // append to the quests list on each use

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -789,6 +789,12 @@ struct questinfo_qreq {
 	int state;
 };
 
+struct questinfo_itemreq {
+	int nameid;
+	int min;
+	int max;
+};
+
 struct questinfo {
 	struct npc_data *nd;
 	unsigned short icon;
@@ -805,7 +811,7 @@ struct questinfo {
 		int min;
 		int max;
 	} job_level;
-	VECTOR_DECL(struct item) items;
+	VECTOR_DECL(struct questinfo_itemreq) items;
 	struct s_homunculus homunculus;
 	int homunculus_type;
 	VECTOR_DECL(struct questinfo_qreq) quest_requirement;

--- a/src/map/quest.c
+++ b/src/map/quest.c
@@ -887,7 +887,14 @@ static bool quest_questinfo_validate_quests(struct map_session_data *sd, struct 
 	
 	for (i = 0; i < VECTOR_LENGTH(qi->quest_requirement); i++) {
 		struct questinfo_qreq *quest_requirement = &VECTOR_INDEX(qi->quest_requirement, i);
-		if (quest->check(sd, quest_requirement->id, HAVEQUEST) != quest_requirement->state)
+		int quest_progress = quest->check(sd, quest_requirement->id, HAVEQUEST);
+		if (quest_progress == -1)
+			quest_progress = 0;
+		else if (quest_progress == 0 || quest_progress == 1)
+			quest_progress = 1;
+		else
+			quest_progress = 2;
+		if (quest_progress != quest_requirement->state)
 			return false;
 	}
 

--- a/src/map/quest.c
+++ b/src/map/quest.c
@@ -805,18 +805,17 @@ static bool quest_questinfo_validate_joblevel(struct map_session_data *sd, struc
  */
 static bool quest_questinfo_validate_items(struct map_session_data *sd, struct questinfo *qi)
 {
-	int i, idx;
-
 	nullpo_retr(false, sd);
 	nullpo_retr(false, qi);
-	
 
-	for (i = 0; i < VECTOR_LENGTH(qi->items); i++) {
-		struct item *item = &VECTOR_INDEX(qi->items, i);
-		idx = pc->search_inventory(sd, item->nameid);
-		if (idx == INDEX_NOT_FOUND)
-			return false;
-		if (sd->status.inventory[idx].amount < item->amount)
+	for (int i = 0; i < VECTOR_LENGTH(qi->items); i++) {
+		struct questinfo_itemreq *item = &VECTOR_INDEX(qi->items, i);
+		int count = 0;
+		for (int j = 0; j < MAX_INVENTORY; j++) {
+			if (sd->status.inventory[j].nameid == item->nameid)
+				count += sd->status.inventory[j].amount;
+		}
+		if (count < item->min || count > item->max)
 			return false;
 	}
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -21114,17 +21114,26 @@ static BUILDIN(setquestinfo)
 	}
 	case QINFO_ITEM:
 	{
-		struct item item = { 0 };
+		struct questinfo_itemreq item = { 0 };
 
 		item.nameid = script_getnum(st, 3);
-		item.amount = script_getnum(st, 4);
+		item.min = script_hasdata(st, 4) ? script_getnum(st, 4) : 0;
+		item.max = script_hasdata(st, 5) ? script_getnum(st, 5) : 0;
 
 		if (itemdb->exists(item.nameid) == NULL) {
 			ShowWarning("buildin_setquestinfo: non existing item (%d) have been given.\n", item.nameid);
 			return false;
 		}
-		if (item.amount <= 0 || item.amount > MAX_AMOUNT) {
-			ShowWarning("buildin_setquestinfo: given amount (%d) must be bigger than 0 and smaller than %d.\n", item.amount, MAX_AMOUNT + 1);
+		if (item.min > item.max) {
+			ShowWarning("buildin_setquestinfo: minimal amount (%d) is bigger than the maximal amount (%d).\n", item.min, item.max);
+			return false;
+		}
+		if (item.min < 0 || item.min > MAX_AMOUNT) {
+			ShowWarning("buildin_setquestinfo: given amount (%d) must be bigger than or equal to 0 and smaller than %d.\n", item.min, MAX_AMOUNT + 1);
+			return false;
+		}
+		if (item.max < 0 || item.max > MAX_AMOUNT) {
+			ShowWarning("buildin_setquestinfo: given amount (%d) must be bigger than or equal to 0 and smaller than %d.\n", item.max, MAX_AMOUNT + 1);
 			return false;
 		}
 		if (VECTOR_LENGTH(qi->items) == 0)
@@ -25447,7 +25456,7 @@ static void script_parse_builtin(void)
 
 		//Quest Log System [Inkfish]
 		BUILDIN_DEF(questinfo, "i?"),
-		BUILDIN_DEF(setquestinfo, "i??"),
+		BUILDIN_DEF(setquestinfo, "i???"),
 		BUILDIN_DEF(setquest, "i?"),
 		BUILDIN_DEF(erasequest, "i?"),
 		BUILDIN_DEF(completequest, "i?"),


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

fix wrong check that was used to validate quest type in questinfo, thanks to the report on http://herc.ws/board/topic/16319-questinfo-setquestinfo

