### PR TITLE
Party skill behavior battleconf for party skills vs enemy party members

### DIFF
--- a/conf/map/battle/skill.conf
+++ b/conf/map/battle/skill.conf
@@ -324,3 +324,8 @@ bowling_bash_area: 0
 // punch a hole into SG it will for example create a "suck in" effect.
 // If you disable this setting, the knockback direction will be completely random (eAthena style).
 stormgust_knockback: true
+
+// Party Skill Behavior
+// 0: (official) On gvg_noparty and pvp_noparty mapflags, party-based buffs such as Devotion can be used on all party members.
+// 1: (eAthena) On gvg_noparty and pvp_noparty mapflags, party-based buffs such as Devotion cannot be used on enemy party members.
+party_skill_behavior: 0

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -6839,9 +6839,11 @@ static int battle_check_target(struct block_list *src, struct block_list *target
 				if (map_flag_gvg(m) && map->list[m].flag.gvg_noparty) {
 					if (s_guild != 0 && t_guild != 0 && (s_guild == t_guild || guild->isallied(s_guild, t_guild)))
 						state |= BCT_PARTY;
-					else
+					else if (battle->bc->party_skill_behavior == 0)
 						state |= flag & BCT_ENEMY ? BCT_ENEMY : BCT_PARTY;
-				} else if (!(map->list[m].flag.pvp && map->list[m].flag.pvp_noparty)
+					else
+						state |= BCT_ENEMY;
+				} else if (!(map->list[m].flag.pvp && map->list[m].flag.pvp_noparty && battle->bc->party_skill_behavior == 0)
 					&& (!map->list[m].flag.battleground || sbg_id == tbg_id)) {
 					state |= BCT_PARTY;
 				} else if (!map->list[m].flag.cvc || s_clan == t_clan) {
@@ -7371,6 +7373,7 @@ static const struct battle_data {
 	{ "storage_use_item",                   &battle_config.storage_use_item,                0,      0,      1,              },
 	{ "features/enable_attendance_system",  &battle_config.feature_enable_attendance_system,1,      0,      1,              },
 	{ "features/feature_attendance_endtime",&battle_config.feature_attendance_endtime,      1,      0,      99999999,       },
+	{ "party_skill_behavior",               &battle_config.party_skill_behavior,            0,      0,      1,              },
 };
 
 static bool battle_set_value_sub(int index, int value)

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -570,6 +570,8 @@ struct Battle_Config {
 
 	int feature_enable_attendance_system;
 	int feature_attendance_endtime;
+
+	int party_skill_behavior; // Skill behavior on gvg_noparty/pvp_noparty maps [Wolfie]
 };
 
 /* criteria for battle_config.idletime_critera */


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)
Addresses #2223 and #1649 by adding a battleconf option for the old behavior.
```
// Party Skill Behavior
// 0: (official) On gvg_noparty and pvp_noparty mapflags, party-based buffs such as Devotion can be used on all party members.
// 1: (eAthena) On gvg_noparty and pvp_noparty mapflags, party-based buffs such as Devotion cannot be used on enemy party members.
party_skill_behavior: 0
```

**Affected Branches:** 

[//]: # (Master? Slave?)
- [x] master
- [x] stable

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)
#2223 

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
