### PR TITLE
only update zeny achievements and logs for non-zero transactions

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -4506,14 +4506,15 @@ static int pc_payzeny(struct map_session_data *sd, int zeny, enum e_log_pick_typ
 	sd->status.zeny -= zeny;
 	clif->updatestatus(sd,SP_ZENY);
 
-	achievement->validate_zeny(sd, -zeny); // Achievements [Smokexyz/Hercules]
+	if (zeny > 0) {
+		achievement->validate_zeny(sd, -zeny); // Achievements [Smokexyz/Hercules]
+		logs->zeny(sd, type, tsd ? tsd : sd, -zeny);
 
-	if(!tsd) tsd = sd;
-	logs->zeny(sd, type, tsd, -zeny);
-	if( zeny > 0 && sd->state.showzeny ) {
-		char output[255];
-		sprintf(output, "Removed %dz.", zeny);
-		clif_disp_onlyself(sd, output);
+		if (sd->state.showzeny) {
+			char output[255];
+			sprintf(output, "Removed %dz.", zeny);
+			clif_disp_onlyself(sd, output);
+		}
 	}
 
 	return 0;
@@ -4644,14 +4645,15 @@ static int pc_getzeny(struct map_session_data *sd, int zeny, enum e_log_pick_typ
 	sd->status.zeny += zeny;
 	clif->updatestatus(sd,SP_ZENY);
 
-	achievement->validate_zeny(sd, zeny); // Achievements [Smokexyz/Hercules]
+	if (zeny > 0) {
+		achievement->validate_zeny(sd, zeny); // Achievements [Smokexyz/Hercules]
+		logs->zeny(sd, type, tsd ? tsd : sd, zeny);
 
-	if(!tsd) tsd = sd;
-	logs->zeny(sd, type, tsd, zeny);
-	if( zeny > 0 && sd->state.showzeny ) {
-		char output[255];
-		sprintf(output, "Gained %dz.", zeny);
-		clif_disp_onlyself(sd, output);
+		if (sd->state.showzeny) {
+			char output[255];
+			sprintf(output, "Gained %dz.", zeny);
+			clif_disp_onlyself(sd, output);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

When a player does a zeny transaction, `achievement_validate_zeny` is called to see if the transaction triggered the completion of an achievement objective, but this function expects `z < 0 || z > 0`, so we should either remove the non-zero assert or only call it when we have a non-zero zeny transaction.

This PR fixes http://herc.ws/board/topic/16336--


[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
