### PR TITLE
fix setting char/account variables of another player 

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -3316,119 +3316,28 @@ static void set_reg_npcscope_str(struct script_state *st, struct reg_db *n, int6
 
 static void set_reg_pc_ref_str(struct script_state *st, struct reg_db *n, int64 num, const char *name, const char *str)
 {
-	struct script_reg_str *p = NULL;
-	unsigned int index = script_getvaridx(num);
+	struct DBIterator *iter = db_iterator(map->pc_db);
 
-	nullpo_retv(n);
-
-	if ((p = i64db_get(n->vars, num)) != NULL) {
-		if (str[0]) {
-			if (p->value) {
-				aFree(p->value);
-			} else if (index) {
-				script->array_update(n, num, false);
-			}
-			p->value = aStrdup(str);
-		} else {
-			p->value = NULL;
-			if (index) {
-				script->array_update(n, num, true);
-			}
-		}
-
-		if (!pc->reg_load) {
-			p->flag.update = 1;
-		}
-	} else if (str[0]) {
-		struct DBData prev;
-		if (index) {
-			script->array_update(n, num, false);
-		}
-
-		p = ers_alloc(pc->str_reg_ers, struct script_reg_str);
-		p->value = aStrdup(str);
-
-		if (!pc->reg_load) {
-			p->flag.update = 1;
-		}
-		p->flag.type = 1;
-
-		if(n->vars->put(n->vars, DB->i642key(num), DB->ptr2data(p), &prev)) {
-			p = DB->data2ptr(&prev);
-			if (p->value) {
-				aFree(p->value);
-			}
-			ers_free(pc->str_reg_ers, p);
+	for (struct map_session_data *sd = dbi_first(iter); dbi_exists(iter); sd = dbi_next(iter)) {
+		if (sd != NULL && n == &sd->regs) {
+			pc->setregistry_str(sd, num, str);
+			break;
 		}
 	}
-
-	if (!pc->reg_load && p != NULL) {
-		struct DBIterator *iter = db_iterator(map->pc_db);
-
-		for (struct map_session_data *sd = dbi_first(iter); dbi_exists(iter); sd = dbi_next(iter)) {
-			if (sd != NULL && n == &sd->regs) {
-				sd->vars_dirty = true; // tell char server to update our vars!
-				break;
-			}
-		}
-		dbi_destroy(iter);
-	}
+	dbi_destroy(iter);
 }
 
 static void set_reg_pc_ref_num(struct script_state *st, struct reg_db *n, int64 num, const char *name, int val)
 {
-	struct script_reg_num *p = NULL;
-	unsigned int index = script_getvaridx(num);
+	struct DBIterator *iter = db_iterator(map->pc_db);
 
-	nullpo_retv(n);
-
-	if ((p = i64db_get(n->vars, num)) != NULL) {
-		if (val) {
-			if (!p->value && index) {
-				script->array_update(n, num, false);
-			}
-			p->value = val;
-		} else {
-			p->value = 0;
-			if (index) {
-				script->array_update(n, num, true);
-			}
-		}
-
-		if (!pc->reg_load) {
-			p->flag.update = 1;
-		}
-	} else if (val) {
-		struct DBData prev;
-		if (index) {
-			script->array_update(n, num, false);
-		}
-
-		p = ers_alloc(pc->num_reg_ers, struct script_reg_num);
-		p->value = val;
-
-		if (!pc->reg_load) {
-			p->flag.update = 1;
-		}
-		p->flag.type = 0;
-
-		if(n->vars->put(n->vars, DB->i642key(num), DB->ptr2data(p), &prev)) {
-			p = DB->data2ptr(&prev);
-			ers_free(pc->num_reg_ers, p);
+	for (struct map_session_data *sd = dbi_first(iter); dbi_exists(iter); sd = dbi_next(iter)) {
+		if (sd != NULL && n == &sd->regs) {
+			pc->setregistry(sd, num, val);
+			break;
 		}
 	}
-
-	if (!pc->reg_load && p != NULL) {
-		struct DBIterator *iter = db_iterator(map->pc_db);
-
-		for (struct map_session_data *sd = dbi_first(iter); dbi_exists(iter); sd = dbi_next(iter)) {
-			if (sd != NULL && n == &sd->regs) {
-				sd->vars_dirty = true; // tell char server to update our vars!
-				break;
-			}
-		}
-		dbi_destroy(iter);
-	}
+	dbi_destroy(iter);
 }
 
 static void set_reg_npcscope_num(struct script_state *st, struct reg_db *n, int64 num, const char *name, int val)

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -3361,6 +3361,18 @@ static void set_reg_pc_ref_str(struct script_state *st, struct reg_db *n, int64 
 			ers_free(pc->str_reg_ers, p);
 		}
 	}
+
+	if (!pc->reg_load && p != NULL) {
+		struct DBIterator *iter = db_iterator(map->pc_db);
+
+		for (struct map_session_data *sd = dbi_first(iter); dbi_exists(iter); sd = dbi_next(iter)) {
+			if (sd != NULL && n == &sd->regs) {
+				sd->vars_dirty = true; // tell char server to update our vars!
+				break;
+			}
+		}
+		dbi_destroy(iter);
+	}
 }
 
 static void set_reg_pc_ref_num(struct script_state *st, struct reg_db *n, int64 num, const char *name, int val)
@@ -3398,12 +3410,24 @@ static void set_reg_pc_ref_num(struct script_state *st, struct reg_db *n, int64 
 		if (!pc->reg_load) {
 			p->flag.update = 1;
 		}
-		p->flag.type = 1;
+		p->flag.type = 0;
 
 		if(n->vars->put(n->vars, DB->i642key(num), DB->ptr2data(p), &prev)) {
 			p = DB->data2ptr(&prev);
 			ers_free(pc->num_reg_ers, p);
 		}
+	}
+
+	if (!pc->reg_load && p != NULL) {
+		struct DBIterator *iter = db_iterator(map->pc_db);
+
+		for (struct map_session_data *sd = dbi_first(iter); dbi_exists(iter); sd = dbi_next(iter)) {
+			if (sd != NULL && n == &sd->regs) {
+				sd->vars_dirty = true; // tell char server to update our vars!
+				break;
+			}
+		}
+		dbi_destroy(iter);
 	}
 }
 
@@ -20698,7 +20722,7 @@ static BUILDIN(getvariableofpc)
 	}
 
 	if (!sd->regs.vars)
-		sd->regs.vars = i64db_alloc(DB_OPT_RELEASE_DATA);
+		sd->regs.vars = i64db_alloc(DB_OPT_BASE);
 
 	script->push_val(st->stack, C_NAME, reference_getuid(data), &sd->regs);
 	return true;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
`building_getvariableofpc` __never__ actually worked when using it to set char-scope or account-scope variables

This PR fixes the following bugs:
- `set_reg_pc_ref_num` was incorrectly setting the type to `1`, which made `script_reg_destroy` behave unexpectedly
- `set_reg_pc_ref_num` was not setting the `vars_dirty` flag _at all_, which made map server not send the updated vars to char server
  - ⚠ **possible exploit**: if a script sets an account variable on another char, the player can just logout and the variable will not be updated
- `building_getvariableofpc` was not using the right option for `i64db_alloc`
- `set_reg_pc_ref_num` was unable to set "special" variables, such as `#KAFRAPOINTS`

<br><br>

closes #2212 

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
