### PR TITLE
Fixes an assertion error when sc_end is called for SC_BERSERK

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -12335,7 +12335,9 @@ static BUILDIN(sc_end)
 		}
 
 		//This should help status_change_end force disabling the SC in case it has no limit.
-		sce->val1 = sce->val2 = sce->val3 = sce->val4 = 0;
+		if (type != SC_BERSERK)
+			sce->val1 = 0; // SC_BERSERK requires skill_lv that's stored in sce->val1 when being removed [KirieZ]
+		sce->val2 = sce->val3 = sce->val4 = 0;
 		status_change_end(bl, (sc_type)type, INVALID_TIMER);
 	}
 	else


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This fixes the assertion error reported in #1388.

When sc_end is called it sets all sc `val*` fields to 0 before calling `status_change_end`. This works fine most of the time, but for `SC_BERSERK` the value on `val1` is used as an skill level to run an `sc_start` when berserk ends. So by setting `val1` to `0` it caused an assertion error.

On this pull request I added a check to not set `val1` to `0` when running sc_end for SC_BERSERK. I chose to do it on the script command instead of around the `sc_start` call because I believe this way it'll be easier to debug in case a bug happens in the future that makes this `sc_start` get invoked with 0 for other reasons (that could be a bug).

[//]: # (Describe at length, the changes that this pull request makes.)

**Affected Branches:** 

master

**Issues addressed:**

Fixes #1388

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
