### PR TITLE
fix map_zone_remove not actually removing flags

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -3707,7 +3707,7 @@ static void map_zonedb_reload(void)
 {
 	// first, reset maps to their initial zones:
 	for (int i = 0; i < map->count; i++) {
-		map->zone_remove(i);
+		map->zone_remove_all(i);
 
 		if (battle_config.pk_mode) {
 			map->list[i].flag.pvp = 1;
@@ -4680,6 +4680,27 @@ static void map_zone_remove(int m)
 		}
 
 		npc->parse_mapflag(map->list[m].name,empty,flag,params,empty,empty,empty, NULL);
+		aFree(map->list[m].zone_mf[k]);
+		map->list[m].zone_mf[k] = NULL;
+	}
+
+	aFree(map->list[m].zone_mf);
+	map->list[m].zone_mf = NULL;
+	map->list[m].zone_mf_count = 0;
+}
+// this one removes every flag, even if they were previously turned on before
+// the current zone was applied
+static void map_zone_remove_all(int m)
+{
+	Assert_retv(m >= 0 && m < map->count);
+
+	for (unsigned short k = 0; k < map->list[m].zone_mf_count; k++) {
+		char flag[MAP_ZONE_MAPFLAG_LENGTH];
+
+		memcpy(flag, map->list[m].zone_mf[k], MAP_ZONE_MAPFLAG_LENGTH);
+		strtok(flag, "\t");
+
+		npc->parse_mapflag(map->list[m].name, "", flag, "off", "", "", "", NULL);
 		aFree(map->list[m].zone_mf[k]);
 		map->list[m].zone_mf[k] = NULL;
 	}
@@ -6840,6 +6861,7 @@ void map_defaults(void)
 	/* funcs */
 	map->zone_init = map_zone_init;
 	map->zone_remove = map_zone_remove;
+	map->zone_remove_all = map_zone_remove_all;
 	map->zone_apply = map_zone_apply;
 	map->zone_change = map_zone_change;
 	map->zone_change2 = map_zone_change2;

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -1220,6 +1220,7 @@ END_ZEROED_BLOCK;
 	/* funcs */
 	void (*zone_init) (void);
 	void (*zone_remove) (int m);
+	void (*zone_remove_all) (int m);
 	void (*zone_apply) (int m, struct map_zone_data *zone, const char* start, const char* buffer, const char* filepath);
 	void (*zone_change) (int m, struct map_zone_data *zone, const char* start, const char* buffer, const char* filepath);
 	void (*zone_change2) (int m, struct map_zone_data *zone);

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -4971,6 +4971,7 @@ static int npc_reload(void)
 	npc->npc_mob = npc->npc_cache_mob = npc->npc_delay_mob = 0;
 
 	// reset mapflags
+	map->zone_reload();
 	map->flags_init();
 
 	// Reprocess npc files and reload constants
@@ -4980,7 +4981,6 @@ static int npc_reload(void)
 
 	instance->reload();
 
-	map->zone_reload();
 	map->zone_init();
 
 	npc->motd = npc->name2id("HerculesMOTD"); /* [Ind/Hercules] */

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -4458,6 +4458,8 @@ typedef void (*HPMHOOK_pre_map_zone_init) (void);
 typedef void (*HPMHOOK_post_map_zone_init) (void);
 typedef void (*HPMHOOK_pre_map_zone_remove) (int *m);
 typedef void (*HPMHOOK_post_map_zone_remove) (int m);
+typedef void (*HPMHOOK_pre_map_zone_remove_all) (int *m);
+typedef void (*HPMHOOK_post_map_zone_remove_all) (int m);
 typedef void (*HPMHOOK_pre_map_zone_apply) (int *m, struct map_zone_data **zone, const char **start, const char **buffer, const char **filepath);
 typedef void (*HPMHOOK_post_map_zone_apply) (int m, struct map_zone_data *zone, const char *start, const char *buffer, const char *filepath);
 typedef void (*HPMHOOK_pre_map_zone_change) (int *m, struct map_zone_data **zone, const char **start, const char **buffer, const char **filepath);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -3388,6 +3388,8 @@ struct {
 	struct HPMHookPoint *HP_map_zone_init_post;
 	struct HPMHookPoint *HP_map_zone_remove_pre;
 	struct HPMHookPoint *HP_map_zone_remove_post;
+	struct HPMHookPoint *HP_map_zone_remove_all_pre;
+	struct HPMHookPoint *HP_map_zone_remove_all_post;
 	struct HPMHookPoint *HP_map_zone_apply_pre;
 	struct HPMHookPoint *HP_map_zone_apply_post;
 	struct HPMHookPoint *HP_map_zone_change_pre;
@@ -9991,6 +9993,8 @@ struct {
 	int HP_map_zone_init_post;
 	int HP_map_zone_remove_pre;
 	int HP_map_zone_remove_post;
+	int HP_map_zone_remove_all_pre;
+	int HP_map_zone_remove_all_post;
 	int HP_map_zone_apply_pre;
 	int HP_map_zone_apply_post;
 	int HP_map_zone_change_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -1737,6 +1737,7 @@ struct HookingPointData HookingPoints[] = {
 /* map_interface */
 	{ HP_POP(map->zone_init, HP_map_zone_init) },
 	{ HP_POP(map->zone_remove, HP_map_zone_remove) },
+	{ HP_POP(map->zone_remove_all, HP_map_zone_remove_all) },
 	{ HP_POP(map->zone_apply, HP_map_zone_apply) },
 	{ HP_POP(map->zone_change, HP_map_zone_change) },
 	{ HP_POP(map->zone_change2, HP_map_zone_change2) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -44624,6 +44624,32 @@ void HP_map_zone_remove(int m) {
 	}
 	return;
 }
+void HP_map_zone_remove_all(int m) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_map_zone_remove_all_pre > 0) {
+		void (*preHookFunc) (int *m);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_map_zone_remove_all_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_map_zone_remove_all_pre[hIndex].func;
+			preHookFunc(&m);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.map.zone_remove_all(m);
+	}
+	if (HPMHooks.count.HP_map_zone_remove_all_post > 0) {
+		void (*postHookFunc) (int m);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_map_zone_remove_all_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_map_zone_remove_all_post[hIndex].func;
+			postHookFunc(m);
+		}
+	}
+	return;
+}
 void HP_map_zone_apply(int m, struct map_zone_data *zone, const char *start, const char *buffer, const char *filepath) {
 	int hIndex = 0;
 	if (HPMHooks.count.HP_map_zone_apply_pre > 0) {


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
`map_zone_remove` is supposed to remove all mapflags from a map that were added by a zone, but instead just re-applies them (wtf?). this PR makes it actually disable them by passing the `off` argument

This should fix #2242 

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
