### PR TITLE
Minor fixes to Asura Strike

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -5613,6 +5613,8 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 
 	// Use a do so that you can break out of it when the skill fails.
 	do {
+		bool is_asura = (ud->skill_id == MO_EXTREMITYFIST);
+
 		if(!target || target->prev==NULL) break;
 
 		if(src->m != target->m || status->isdead(src)) break;
@@ -5845,7 +5847,8 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 			ud->skill_lv = ud->skilltarget = 0;
 		}
 
-		if (src->id != target->id)
+		// Asura Strike caster doesn't look to their target in the end
+		if (src->id != target->id && !is_asura)
 			unit->setdir(src, map->calc_dir(src, target->x, target->y));
 
 		map->freeblock_unlock();

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -5882,7 +5882,8 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 				clif->slide(src,src->x,src->y);
 				clif->spiritball(src);
 			}
-			clif->skill_fail(sd, ud->skill_id, USESKILL_FAIL_LEVEL, 0, 0);
+			// "Skill Failed" message was already shown when checking that target is invalid
+			//clif->skill_fail(sd, ud->skill_id, USESKILL_FAIL_LEVEL, 0, 0);
 		}
 	}
 

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -5873,16 +5873,26 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 		if (target && target->m == src->m) {
 			//Move character to target anyway.
 			int dir, x, y;
+			int dist = 3; // number of cells that asura caster will walk
+
 			dir = map->calc_dir(src,target->x,target->y);
-			if( dir > 0 && dir < 4) x = -2;
-			else if( dir > 4 ) x = 2;
-			else x = 0;
-			if( dir > 2 && dir < 6 ) y = -2;
-			else if( dir == 7 || dir < 2 ) y = 2;
-			else y = 0;
-			if (unit->movepos(src, src->x+x, src->y+y, 1, 1)) {
+			if (dir > 0 && dir < 4)
+				x = -dist;
+			else if (dir > 4)
+				x = dist;
+			else
+				x = 0;
+			
+			if (dir > 2 && dir < 6)
+				y = -dist;
+			else if (dir == 7 || dir < 2)
+				y = dist;
+			else
+				y = 0;
+
+			if (unit->movepos(src, src->x + x, src->y + y, 1, 1) == 1) {
 				//Display movement + animation.
-				clif->slide(src,src->x,src->y);
+				clif->slide(src, src->x, src->y);
 				clif->spiritball(src);
 			}
 			// "Skill Failed" message was already shown when checking that target is invalid


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

These are small fixes to how Asura Strike skill behaves. This fixes:
* After using Asura Strike the caster doesn't end up looking to its target anymore
* When Asura Strike fails, it doesn't shows "Skill failed" twice in chat
* When Asura Strike fails, the caster will now walk 3 cells from where he originally was (instead of 2)

**Affected Branches:** 
master

**Issues addressed:**
Fixes #1239

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

Special thanks to @kyeme

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
