### PR TITLE
fix PACKET_ZC_PROPERTY_HOMUN size for old clients

### DIFF
--- a/src/map/packets_struct.h
+++ b/src/map/packets_struct.h
@@ -2274,8 +2274,13 @@ struct PACKET_ZC_PROPERTY_HOMUN {
 	uint16 mdef;
 	uint16 flee;
 	uint16 amotion;
+#if PACKETVER < 20150513
+	uint16 hp;
+	uint16 maxHp;
+#else
 	uint32 hp;
 	uint32 maxHp;
+#endif
 	uint16 sp;
 	uint16 maxSp;
 	uint32 exp;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

this fixes the size of hp fields in PACKET_ZC_PROPERTY_HOMUN  for clients older than 20150513
this bug was introduced in eb54c762a3e9ca00fab5ff94a082861e1b70c0e0

reported at http://herc.ws/board/topic/16349-homunculus-bug-new-update-bug/