### PR TITLE
Fixed a condition in RoDEX attachment

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -15876,7 +15876,7 @@ static void clif_parse_Mail_getattach(int fd, struct map_session_data *sd)
 	if( sd->mail.inbox.msg[i].zeny < 1 && (sd->mail.inbox.msg[i].item.nameid < 1 || sd->mail.inbox.msg[i].item.amount < 1) )
 		return;
 
-	if( sd->mail.inbox.msg[i].zeny + sd->status.zeny > MAX_ZENY ) {
+	if( sd->mail.inbox.msg[i].zeny > MAX_ZENY - sd->status.zeny ) {
 		clif->mail_getattachment(fd, 1);
 		return;
 	}


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)

The condition `if( sd->mail.inbox.msg[i].zeny + sd->status.zeny > MAX_ZENY ) {` would overflow and turn into negative value, resulting in the code never executing even if it exceed MAX_ZENY

**Affected Branches:** 

[//]: # (Master? Slave?)

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
