### PR TITLE
deprecate buildin_prompt, bake it into buildin_select

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -1600,21 +1600,24 @@ perfectly equivalent.
 ---------------------------------------
 
 *select("<option>"{, "<option>", ...})
-*prompt("<option>"{, "<option>", ...})
 
 This function is a handy replacement for 'menu' that doesn't use a complex
-label structure. It will return the number of menu option picked,
-starting with 1. Like 'menu', it will also set the variable @menu to
-contain the option the user picked.
+label structure. It will return the number of the menu option picked,
+starting with 1. If the player presses cancel, the script is terminated.
 
-    if (select("Yes:No") == 1)
+    if (select("Yes", "No") == 1)
         mes("You said yes, I know.");
 
 And like 'menu', the selected option is consistent with grouped options
 and empty options.
 
-'prompt' works almost the same as select, except that when a character
-clicks the Cancel button, this function will return 255 instead.
+---------------------------------------
+
+*prompt("<option>"{, "<option>", ...})
+
+This function behaves exactly like select(), but when a player presses cancel
+it returns 255 and the script is not terminated. You almost always want to use
+select() rather than prompt().
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -714,6 +714,8 @@ MAX_BANK_ZENY		- Maximum Zeny in the bank
 MAX_BG_MEMBERS		- Maximum BattleGround members
 MAX_CHAT_USERS		- Maximum Chat users
 MAX_REFINE			- Maximum Refine level
+MAX_MENU_OPTIONS    - Maximum NPC menu options
+MAX_MENU_LENGTH     - Maximum NPC menu string length
 
 Send targets and status options are also hard-coded and can be found
 in 'doc/constants.md'.
@@ -1616,8 +1618,8 @@ and empty options.
 *prompt("<option>"{, "<option>", ...})
 
 This function behaves exactly like select(), but when a player presses cancel
-it returns 255 and the script is not terminated. You almost always want to use
-select() rather than prompt().
+it returns MAX_MENU_OPTIONS and the script is not terminated. You almost always
+want to use select() rather than prompt().
 
 ---------------------------------------
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -12342,7 +12342,7 @@ static void clif_parse_NpcSelectMenu(int fd, struct map_session_data *sd)
 	int npc_id = RFIFOL(fd,2);
 	uint8 select = RFIFOB(fd,6);
 
-	if( (select > sd->npc_menu && select != 0xff) || select == 0 ) {
+	if( (select > sd->npc_menu && select != MAX_MENU_OPTIONS) || select == 0 ) {
 #ifdef SECURE_NPCTIMEOUT
 		if( sd->npc_idle_timer != INVALID_TIMER ) {
 #endif

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -6099,11 +6099,11 @@ static BUILDIN(menu)
 		sd->state.menu_or_input = 1;
 
 		/* menus beyond this length crash the client (see bugreport:6402) */
-		if( StrBuf->Length(&buf) >= 2047 ) {
+		if( StrBuf->Length(&buf) >= MAX_MENU_LENGTH - 1 ) {
 			struct npc_data * nd = map->id2nd(st->oid);
 			char* menu;
-			CREATE(menu, char, 2048);
-			safestrncpy(menu, StrBuf->Value(&buf), 2047);
+			CREATE(menu, char, MAX_MENU_LENGTH);
+			safestrncpy(menu, StrBuf->Value(&buf), MAX_MENU_LENGTH - 1);
 			ShowWarning("NPC Menu too long! (source:%s / length:%d)\n",nd?nd->name:"Unknown",StrBuf->Length(&buf));
 			clif->scriptmenu(sd, st->oid, menu);
 			aFree(menu);
@@ -6112,13 +6112,13 @@ static BUILDIN(menu)
 
 		StrBuf->Destroy(&buf);
 
-		if( sd->npc_menu >= 0xff )
+		if( sd->npc_menu >= MAX_MENU_OPTIONS )
 		{// client supports only up to 254 entries; 0 is not used and 255 is reserved for cancel; excess entries are displayed but cause 'uint8' overflow
-			ShowWarning("buildin_menu: Too many options specified (current=%d, max=254).\n", sd->npc_menu);
+			ShowWarning("buildin_menu: Too many options specified (current=%d, max=%d).\n", sd->npc_menu, MAX_MENU_OPTIONS - 1);
 			script->reportsrc(st);
 		}
 	}
-	else if( sd->npc_menu == 0xff )
+	else if( sd->npc_menu == MAX_MENU_OPTIONS )
 	{// Cancel was pressed
 		sd->state.menu_or_input = 0;
 		st->state = END;
@@ -6200,11 +6200,11 @@ static BUILDIN(select)
 		sd->state.menu_or_input = 1;
 
 		/* menus beyond this length crash the client (see bugreport:6402) */
-		if( StrBuf->Length(&buf) >= 2047 ) {
+		if( StrBuf->Length(&buf) >= MAX_MENU_LENGTH - 1 ) {
 			struct npc_data * nd = map->id2nd(st->oid);
 			char* menu;
-			CREATE(menu, char, 2048);
-			safestrncpy(menu, StrBuf->Value(&buf), 2047);
+			CREATE(menu, char, MAX_MENU_LENGTH);
+			safestrncpy(menu, StrBuf->Value(&buf), MAX_MENU_LENGTH - 1);
 			ShowWarning("NPC Menu too long! (source:%s / length:%d)\n",nd?nd->name:"Unknown",StrBuf->Length(&buf));
 			clif->scriptmenu(sd, st->oid, menu);
 			aFree(menu);
@@ -6212,16 +6212,16 @@ static BUILDIN(select)
 			clif->scriptmenu(sd, st->oid, StrBuf->Value(&buf));
 		StrBuf->Destroy(&buf);
 
-		if( sd->npc_menu >= 0xff ) {
-			ShowWarning("buildin_select: Too many options specified (current=%d, max=254).\n", sd->npc_menu);
+		if( sd->npc_menu >= MAX_MENU_OPTIONS ) {
+			ShowWarning("buildin_select: Too many options specified (current=%d, max=%d).\n", sd->npc_menu, MAX_MENU_OPTIONS - 1);
 			script->reportsrc(st);
 		}
-	} else if(sd->npc_menu == 0xff) { // Cancel was pressed
+	} else if(sd->npc_menu == MAX_MENU_OPTIONS) { // Cancel was pressed
 		sd->state.menu_or_input = 0;
 
 		if (strncmp(get_buildin_name(st), "prompt", 6) == 0) {
-			pc->setreg(sd, script->add_variable("@menu"), 0xff);
-			script_pushint(st, 0xff);
+			pc->setreg(sd, script->add_variable("@menu"), MAX_MENU_OPTIONS);
+			script_pushint(st, MAX_MENU_OPTIONS); // XXX: we should really be pushing -1 instead
 			st->state = RUN;
 		} else {
 			st->state = END;
@@ -25514,6 +25514,8 @@ static void script_hardcoded_constants(void)
 	script->set_constant("MAX_BG_MEMBERS",MAX_BG_MEMBERS,false, false);
 	script->set_constant("MAX_CHAT_USERS",MAX_CHAT_USERS,false, false);
 	script->set_constant("MAX_REFINE",MAX_REFINE,false, false);
+	script->set_constant("MAX_MENU_OPTIONS", MAX_MENU_OPTIONS, false, false);
+	script->set_constant("MAX_MENU_LENGTH", MAX_MENU_LENGTH, false, false);
 
 	script->constdb_comment("status options");
 	script->set_constant("Option_Nothing",OPTION_NOTHING,false, false);

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -64,6 +64,9 @@ struct item_data;
 
 #define SCRIPT_EQUIP_TABLE_SIZE 20
 
+#define MAX_MENU_OPTIONS 0xFF
+#define MAX_MENU_LENGTH 0x800
+
 //#define SCRIPT_DEBUG_DISP
 //#define SCRIPT_DEBUG_DISASM
 //#define SCRIPT_DEBUG_HASH

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -177,6 +177,8 @@ struct item_data;
 
 #define BUILDIN(x) bool buildin_ ## x (struct script_state* st)
 
+#define get_buildin_name(st) ( script->get_str((int)(script_getdata((st), 0)->u.num)) )
+
 #define script_fetch(st, n, t) do { \
 	if( script_hasdata((st),(n)) ) \
 		(t)=script_getnum((st),(n)); \


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

* Deprecates `prompt()`
    * It has the same behaviour as `select()`, except that it does not terminate the script on cancel
    * no Hercules scripts make use of it

<br>
<sub>El Deprecador strikes again 🧛</sub>

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
