### PR TITLE
Change channel delay message to time left instead of generic message.

### DIFF
--- a/conf/messages.conf
+++ b/conf/messages.conf
@@ -1499,7 +1499,7 @@
 1452: option '%s' is now enabled for channel '%s' with %d seconds
 1453: option '%s' is now disabled for channel '%s'
 1454: option '%s' is not enabled on channel '%s'
-1455: You're talking too fast!
+1455: You cannot send a message to this channel for another %d seconds.
 1456: -- %s ban <channel name> <character name>
 1457: - bans <character name> from <channel name> channel
 1458: -- %s banlist <channel name>

--- a/src/map/channel.c
+++ b/src/map/channel.c
@@ -276,7 +276,9 @@ static void channel_send(struct channel_data *chan, struct map_session_data *sd,
 	if (sd && chan->msg_delay != 0
 	 && DIFF_TICK(sd->hchsysch_tick + chan->msg_delay*1000, timer->gettick()) > 0
 	 && !pc_has_permission(sd, PC_PERM_HCHSYS_ADMIN)) {
-		clif->messagecolor_self(sd->fd, COLOR_RED, msg_sd(sd,1455));
+		char output[CHAT_SIZE_MAX];
+		sprintf(output, msg_sd(sd, 1455), DIFF_TICK(sd->hchsysch_tick + chan->msg_delay * 1000, timer->gettick()) / 1000); // "You cannot send a message to this channel for another %d seconds."
+		clif->messagecolor_self(sd->fd, COLOR_RED, output);
 		return;
 	} else if (sd) {
 		int i;


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[//]: # (Describe at length, the changes that this pull request makes.)
Old
`You're talking too fast!`

New
`You cannot send a message to this channel for another %d seconds.`

This is not a bug so it will be subjective as to whether it is necessary. I feel it would be a nice change for our custom channels system to include the delay before a player can message a specific channel again.

**Affected Branches:** 

[//]: # (Master? Slave?)
- [x] master
- [x] stable

**Issues addressed:**

[//]: # (Issue Tracker Number if any.)

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
