### PR TITLE
Fixes delayed-consume items not being consumed after using Abracadabra

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -5323,6 +5323,10 @@ static int pc_useitem(struct map_session_data *sd, int n)
 	if(sd->catch_target_class != -1) //Abort pet catching.
 		sd->catch_target_class = -1;
 
+	// Removes abracadabra/randomize spell flag for delayed consume items or item doesn't get consumed
+	if (sd->inventory_data[n]->flag.delay_consume)
+		sd->state.abra_flag = 0;
+
 	amount = sd->status.inventory[n].amount;
 	//Check if the item is to be consumed immediately [Skotlex]
 	if (sd->inventory_data[n]->flag.delay_consume || sd->inventory_data[n]->flag.keepafteruse)


### PR DESCRIPTION
[//]: # (**********************************)
[//]: # (** Fill in the following fields **)
[//]: # (**********************************)

[//]: # (Note: Lines beginning with syntax such as this one, are comments and will not be visible in your report!)

### Pull Request Prelude

[//]: # (Thank you for working on improving Hercules!)

[//]: # (Please complete these steps and check the following boxes by putting an `x` inside the brackets _before_ filing your Pull Request.)

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes an issue when you cast abracadabra and a target skill is chosen and instead of using the skill you cancel and use a DELAYCONSUME item, as the abra_flag is not unset in this case, the item doesn't get consumed. My change clears abra_flag when you're using a delayed consume item.

**Affected Branches:** 

master

**Issues addressed:**

Fixes #1169 

### Known Issues and TODO List

[//]: # (Insert checklist here)
[//]: # (Syntax: - [ ] Checkbox)

[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it.)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
