### PR TITLE
Added countnameditem script command.

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5340,6 +5340,30 @@ Check getitem2() to understand the arguments of the function.
 
 ---------------------------------------
 
+*countnameditem(<item id>, "<character name>")
+*countnameditem(<item id>, <character ID>)
+*countnameditem("<item name>", "<character name>")
+*countnameditem("<item name>", <character ID>)
+
+This function will return the number of signed items for the specified item ID
+that the invoking character has in their inventory.
+
+	mes("[Item Checker]");
+	if (countnameditem(Apple) > 0) {
+		mes("You have an apple with your name on it!");
+	} else {
+		mes("You do not have an apple with your name on it.");
+	}
+	next();
+	mes("[Item Checker]");
+	mesf("You have %d apples with John's name on it!", countnameditem(Apple, "John"));
+	close();
+
+Like getnameditem(), this function will also accept an 'english name' from the
+database as an argument.
+
+---------------------------------------
+
 *groupranditem(<item id>)
 
 Returns the item_id of a random item picked from the item container specified. There

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -7714,6 +7714,65 @@ static BUILDIN(countitem2)
 }
 
 /*==========================================
+ * countnameditem(item ID, { <Char Name / ID> })
+ * returns number of named items.
+ *------------------------------------------*/
+static BUILDIN(countnameditem)
+{
+	int count = 0;
+	struct item_data* id = NULL;
+	struct map_session_data *sd;
+
+	if (script_hasdata(st, 3)) {
+		if (script_isstringtype(st, 3)) {
+			// Character name was given
+			sd = script->nick2sd(st, script_getstr(st, 3));
+		} else {
+			// Character ID was given
+			sd = script->charid2sd(st, script_getnum(st, 3));
+		}
+	} else {
+		// Use RID by default if no name was provided
+		sd = script->rid2sd(st);
+	}
+
+	// Player not attached
+	if (sd == NULL) {
+		return true;
+	}
+
+	if (script_isstringtype(st, 2)) {
+		// Get item from DB via item name
+		id = itemdb->search_name(script_getstr(st, 2));
+	} else {
+		// Get item from DB via item ID
+		id = itemdb->exists(script_getnum(st, 2));
+	}
+
+	if (id == NULL) {
+		ShowError("buildin_countnameditem: Invalid item '%s'.\n", script_getstr(st, 2));  // returns string, regardless of what it was
+		script_pushint(st, 0);
+		return false;
+	}
+
+	for (int i = 0; i < MAX_INVENTORY; i++) {
+		if (sd->status.inventory[i].nameid > 0 &&
+			sd->inventory_data[i] != NULL &&
+			sd->status.inventory[i].amount > 0 &&
+			sd->status.inventory[i].nameid == id->nameid &&
+			sd->status.inventory[i].card[0] == CARD0_CREATE &&
+			sd->status.inventory[i].card[2] == sd->status.char_id &&
+			sd->status.inventory[i].card[3] == sd->status.char_id >> 16)
+		{
+			count += sd->status.inventory[i].amount;
+		}
+	}
+
+	script_pushint(st, count);
+	return true;
+}
+
+/*==========================================
  * Check if item with this amount can fit in inventory
  * Checking : weight, stack amount >32k, slots amount >(MAX_INVENTORY)
  * Return
@@ -25038,6 +25097,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(rand,"i?"),
 		BUILDIN_DEF(countitem,"v"),
 		BUILDIN_DEF(countitem2,"viiiiiii"),
+		BUILDIN_DEF(countnameditem,"v?"),
 		BUILDIN_DEF(checkweight,"vi*"),
 		BUILDIN_DEF(checkweight2,"rr"),
 		BUILDIN_DEF(readparam,"i?"),


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Adds a script command to return the number of signed items a character has in their inventory.

Currently you have to do the following for this same functionality:

```
.@slot3 = getcharid(0) & 65535;
.@slot4 = getcharid(0) >> 16;
countitem2(<item ID>, 1, 0, 0, 254, 0, .@slot3, .@slot4)
```
This pull request changes that so you can simply do this:
```
countnameditem(<item ID>, {<character id/name>});
```

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
