### PR TITLE
Fix allychat leaveguild

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -8992,9 +8992,7 @@ static void atcommand_channel_help(int fd, const char *command, bool can_create)
 	clif->message(fd, msg_fd(fd,1428));// - binds global chat to <channel name>, making anything you type in global be sent to the channel
 	safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1429),command);// -- %s unbind
 	clif->message(fd, atcmd_output);
-	clif->message(fd, msg_fd(fd,1430));// - unbinds your global chat from its attached channel (if binded)
-	safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1429),command);// -- %s unbind
-	clif->message(fd, atcmd_output);
+	clif->message(fd, msg_fd(fd,1430));// - unbinds your global chat from its attached channel (if bound)
 	if( can_create ) {
 		safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1456),command);// -- %s ban <channel name> <character name>
 		clif->message(fd, atcmd_output);

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -9019,7 +9019,6 @@ ACMD(channel)
 {
 	struct channel_data *chan;
 	char subcmd[HCS_NAME_LENGTH], sub1[HCS_NAME_LENGTH], sub2[HCS_NAME_LENGTH], sub3[HCS_NAME_LENGTH];
-	unsigned char k = 0;
 	sub1[0] = sub2[0] = sub3[0] = '\0';
 
 	if (!*message || sscanf(message, "%19s %19s %19s %19s", subcmd, sub1, sub2, sub3) < 1) {
@@ -9056,7 +9055,7 @@ ACMD(channel)
 	} else if (strcmpi(subcmd,"list") == 0) {
 		// sub1 = list type; sub2 = unused; sub3 = unused
 		if (sub1[0] != '\0' && strcmpi(sub1,"colors") == 0) {
-			for (k = 0; k < channel->config->colors_count; k++) {
+			for (int k = 0; k < channel->config->colors_count; k++) {
 				safesnprintf(atcmd_output, sizeof(atcmd_output), "[ %s list colors ] : %s", command, channel->config->colors_name[k]);
 
 				clif->messagecolor_self(fd, channel->config->colors[k], atcmd_output);
@@ -9085,6 +9084,7 @@ ACMD(channel)
 		}
 	} else if (strcmpi(subcmd,"setcolor") == 0) {
 		// sub1 = channel name; sub2 = color; sub3 = unused
+		int k;
 		if (sub1[0] != '#') {
 			clif->message(fd, msg_fd(fd,1405));// Channel name must start with a '#'
 			return false;
@@ -9102,10 +9102,7 @@ ACMD(channel)
 			return false;
 		}
 
-		for (k = 0; k < channel->config->colors_count; k++) {
-			if (strcmpi(sub2, channel->config->colors_name[k]) == 0)
-				break;
-		}
+		ARR_FIND(0, channel->config->colors_count, k, strcmpi(sub2, channel->config->colors_name[k]) == 0);
 		if (k == channel->config->colors_count) {
 			safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1411), sub2);// Unknown color '%s'
 			clif->message(fd, atcmd_output);
@@ -9116,51 +9113,47 @@ ACMD(channel)
 		clif->message(fd, atcmd_output);
 	} else if (strcmpi(subcmd,"leave") == 0) {
 		// sub1 = channel name; sub2 = unused; sub3 = unused
+		int k;
 		if (sub1[0] != '#') {
 			clif->message(fd, msg_fd(fd,1405));// Channel name must start with a '#'
 			return false;
 		}
-		for (k = 0; k < sd->channel_count; k++) {
-			if (strcmpi(sub1+1,sd->channels[k]->name) == 0)
-				break;
-		}
-		if (k == sd->channel_count) {
+		ARR_FIND(0, VECTOR_LENGTH(sd->channels), k, strcmpi(sub1 + 1, VECTOR_INDEX(sd->channels, k)->name) == 0);
+		if (k == VECTOR_LENGTH(sd->channels)) {
 			safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1425),sub1);// You're not part of the '%s' channel
 			clif->message(fd, atcmd_output);
 			return false;
 		}
-		if (sd->channels[k]->type == HCS_TYPE_ALLY) {
+		if (VECTOR_INDEX(sd->channels, k)->type == HCS_TYPE_ALLY) {
 			do {
-				for (k = 0; k < sd->channel_count; k++) {
-					if (sd->channels[k]->type == HCS_TYPE_ALLY) {
-						channel->leave(sd->channels[k],sd);
+				for (k = 0; k < VECTOR_LENGTH(sd->channels); k++) {
+					if (VECTOR_INDEX(sd->channels, k)->type == HCS_TYPE_ALLY) {
+						channel->leave(VECTOR_INDEX(sd->channels, k), sd);
 						break;
 					}
 				}
-			} while (k != sd->channel_count);
+			} while (k != VECTOR_LENGTH(sd->channels)); // FIXME
 		} else {
-			channel->leave(sd->channels[k],sd);
+			channel->leave(VECTOR_INDEX(sd->channels, k), sd);
 		}
 		safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1426),sub1); // You've left the '%s' channel
 		clif->message(fd, atcmd_output);
 	} else if (strcmpi(subcmd,"bindto") == 0) {
 		// sub1 = channel name; sub2 = unused; sub3 = unused
+		int k;
 		if (sub1[0] != '#') {
 			clif->message(fd, msg_fd(fd,1405));// Channel name must start with a '#'
 			return false;
 		}
 
-		for (k = 0; k < sd->channel_count; k++) {
-			if (strcmpi(sub1+1,sd->channels[k]->name) == 0)
-				break;
-		}
-		if (k == sd->channel_count) {
+		ARR_FIND(0, VECTOR_LENGTH(sd->channels), k, strcmpi(sub1 + 1, VECTOR_INDEX(sd->channels, k)->name) == 0);
+		if (k == VECTOR_LENGTH(sd->channels)) {
 			safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1425),sub1);// You're not part of the '%s' channel
 			clif->message(fd, atcmd_output);
 			return false;
 		}
 
-		sd->gcbind = sd->channels[k];
+		sd->gcbind = VECTOR_INDEX(sd->channels, k);
 		safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,1431),sub1); // Your global chat is now bound to the '%s' channel
 		clif->message(fd, atcmd_output);
 	} else if (strcmpi(subcmd,"unbind") == 0) {
@@ -9332,6 +9325,7 @@ ACMD(channel)
 		dbi_destroy(iter);
 	} else if (strcmpi(subcmd,"setopt") == 0) {
 		// sub1 = channel name; sub2 = option name; sub3 = value
+		int k;
 		const char* opt_str[3] = {
 			"None",
 			"JoinAnnounce",

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -9125,14 +9125,12 @@ ACMD(channel)
 			return false;
 		}
 		if (VECTOR_INDEX(sd->channels, k)->type == HCS_TYPE_ALLY) {
-			do {
-				for (k = 0; k < VECTOR_LENGTH(sd->channels); k++) {
-					if (VECTOR_INDEX(sd->channels, k)->type == HCS_TYPE_ALLY) {
-						channel->leave(VECTOR_INDEX(sd->channels, k), sd);
-						break;
-					}
+			for (k = VECTOR_LENGTH(sd->channels) - 1; k >= 0; k--) {
+				// Loop downward to avoid issues when channel->leave() compacts the array
+				if (VECTOR_INDEX(sd->channels, k)->type == HCS_TYPE_ALLY) {
+					channel->leave(VECTOR_INDEX(sd->channels, k), sd);
 				}
-			} while (k != VECTOR_LENGTH(sd->channels)); // FIXME
+			}
 		} else {
 			channel->leave(VECTOR_INDEX(sd->channels, k), sd);
 		}

--- a/src/map/channel.c
+++ b/src/map/channel.c
@@ -565,7 +565,8 @@ static void channel_guild_leave_alliance(const struct guild *g_source, const str
 static void channel_quit_guild(struct map_session_data *sd)
 {
 	nullpo_retv(sd);
-	for (int i = 0; i < VECTOR_LENGTH(sd->channels); i++) { // FIXME
+	for (int i = VECTOR_LENGTH(sd->channels) - 1; i >= 0; i--) {
+		// Loop downward to avoid issues when channel->leave() compacts the array
 		struct channel_data *chan = VECTOR_INDEX(sd->channels, i);
 
 		if (chan->type != HCS_TYPE_ALLY)

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11083,8 +11083,8 @@ static void clif_parse_WisMessage(int fd, struct map_session_data *sd)
 
 		if (chan) {
 			int k;
-			ARR_FIND(0, sd->channel_count, k, sd->channels[k] == chan);
-			if (k < sd->channel_count || channel->join(chan, sd, "", true) == HCS_STATUS_OK) {
+			ARR_FIND(0, VECTOR_LENGTH(sd->channels), k, VECTOR_INDEX(sd->channels, k) == chan);
+			if (k < VECTOR_LENGTH(sd->channels) || channel->join(chan, sd, "", true) == HCS_STATUS_OK) {
 				channel->send(chan,sd,message);
 			} else {
 				clif->message(fd, msg_fd(fd,1402)); //You're not in that channel, type '@join <#channel_name>'

--- a/src/map/guild.c
+++ b/src/map/guild.c
@@ -828,6 +828,11 @@ static int guild_member_added(int guild_id, int account_id, int char_id, int fla
 	//Next line commented because it do nothing, look at guild_recv_info [LuzZza]
 	//clif->charnameupdate(sd); //Update display name [Skotlex]
 
+	// Makes the character join their respective guild's channel for #ally chat
+	if (channel->config->ally && channel->config->ally_autojoin) {
+		channel->join(g->channel, sd, "", true);
+	}
+
 	return 0;
 }
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1330,6 +1330,7 @@ static bool pc_authok(struct map_session_data *sd, int login_id2, time_t expirat
 	sd->bg_queue.client_has_bg_data = 0;
 	sd->bg_queue.type = 0;
 
+	VECTOR_INIT(sd->channels);
 	VECTOR_INIT(sd->script_queues);
 	VECTOR_INIT(sd->achievement); // Achievements [Smokexyz/Hercules]
 	VECTOR_INIT(sd->storage.item); // initialize storage item vector.

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -5839,8 +5839,11 @@ static int pc_setpos(struct map_session_data *sd, unsigned short map_index, int 
 			vending->close(sd);
 		}
 
-		if (map->list[sd->bl.m].channel) {
-			channel->leave(map->list[sd->bl.m].channel,sd);
+		if (sd->mapindex != 0) {
+			// Only if the character is already on a map
+			if (map->list[sd->bl.m].channel) {
+				channel->leave(map->list[sd->bl.m].channel,sd);
+			}
 		}
 	}
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -557,8 +557,7 @@ END_ZEROED_BLOCK;
 	int shadowform_id;
 
 	/* [Ind/Hercules] */
-	struct channel_data **channels;
-	unsigned char channel_count;
+	VECTOR_DECL(struct channel_data *) channels;
 	struct channel_data *gcbind;
 	unsigned char fontcolor;
 	int fontcolor_tid;

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -2764,6 +2764,7 @@ static int unit_free(struct block_list *bl, clr_type clrtype)
 				aFree(sd->instance);
 				sd->instance = NULL;
 			}
+			VECTOR_CLEAR(sd->channels);
 			VECTOR_CLEAR(sd->script_queues);
 			VECTOR_CLEAR(sd->achievement); // Achievement [Smokexyz/Hercules]
 			VECTOR_CLEAR(sd->storage.item);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR includes the fix for an issue that caused characters leaving a guild to stay into some of the allied guilds' `#ally` sub-channels, and be able to receive messages they shouldn't be entitled to.

Other related fixes/improvements are included. In detail:

- The `sd->channels` array has been changed into a VECTOR, to remove some awkward array compaction code related to the main issue.
- `#ally` is now left correctly when leaving the channel or guild. The code that loops through the channels to find the `#ally` ones is now safer against vector compaction.
- When joining a guild, if the `ally_channel_autojoin` setting is enabled, the channel is now joined immediately, without requiring a relog.
- A duplicate line was removed from the help message for `@channel`, likely caused by an excess of copy-paste in the original code.
- An issue in `pc_setpos()` has been corrected, attempting to leave the `#map` channel for an invalid map, when called during the login process (when there is no current map).

This PR was co-authored with @MathyM 

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
