### PR TITLE
Fix clang-4.0 builds in gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,9 +81,9 @@ pre_re:clang-4.0:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
-  image: debian:unstable
+  image: debian:stretch
   services:
-    - mariadb:10
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: clang-4.0 mariadb-client libmariadbclient-dev-compat
@@ -96,9 +96,9 @@ re:clang-4.0:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: secondary
-  image: debian:unstable
+  image: debian:stretch
   services:
-    - mariadb:10
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: clang-4.0 mariadb-client libmariadbclient-dev-compat
@@ -111,9 +111,9 @@ zero-2018:clang-4.0:
   <<: *branch_exceptions
   <<: *prerequisites
   stage: clients
-  image: debian:unstable
+  image: debian:stretch
   services:
-    - mariadb:10
+    - mariadb:10.1
   variables:
     <<: *base_vars
     INSTALL_PACKAGES: clang-4.0 mariadb-client libmariadbclient-dev-compat


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Debian removed the clang-4.0 package from unstable (as it won't be part of their next release), and our builds are failing.

This switches them to `debian:stretch`, where it's unlikely to get removed.

After this gets merged, the pipeline should be green again: https://gitlab.com/MishimaHaruna/Hercules/pipelines/36470066

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
