### PR TITLE
Change short group to bool is_group in s_add_drop

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2546,7 +2546,7 @@ static int mob_dead(struct mob_data *md, struct block_list *src, int type)
 		if(sd) {
 			// process script-granted extra drop bonuses
 			int itemid = 0;
-			for (i = 0; i < ARRAYLENGTH(sd->add_drop) && (sd->add_drop[i].id || sd->add_drop[i].group); i++)
+			for (i = 0; i < ARRAYLENGTH(sd->add_drop) && (sd->add_drop[i].id != 0 || sd->add_drop[i].is_group); i++)
 			{
 				if ( sd->add_drop[i].race == -md->class_ ||
 					( sd->add_drop[i].race > 0 && (
@@ -2568,7 +2568,7 @@ static int mob_dead(struct mob_data *md, struct block_list *src, int type)
 
 					if (rnd()%10000 >= drop_rate)
 						continue;
-					itemid = (sd->add_drop[i].id > 0) ? sd->add_drop[i].id : itemdb->chain_item(sd->add_drop[i].group,&drop_rate);
+					itemid = (!sd->add_drop[i].is_group) ? sd->add_drop[i].id : itemdb->chain_item(sd->add_drop[i].id, &drop_rate);
 					if( itemid )
 						mob->item_drop(md, dlist, mob->setdropitem(itemid,1,NULL), 0, drop_rate, homkillonly);
 				}

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -151,8 +151,8 @@ struct s_addeffectonskill {
 	unsigned char target;
 };
 struct s_add_drop {
+	bool is_group;
 	int id;
-	short group;
 	int race, rate;
 };
 struct s_autobonus {
@@ -1124,7 +1124,7 @@ END_ZEROED_BLOCK; /* End */
 	int (*bonus_autospell_onskill) (struct s_autospell *spell, int max, short src_skill, short id, short lv, short rate, int card_id);
 	int (*bonus_addeff) (struct s_addeffect* effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration);
 	int (*bonus_addeff_onskill) (struct s_addeffectonskill* effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target);
-	int (*bonus_item_drop) (struct s_add_drop *drop, const short max, short id, short group, int race, int rate);
+	int (*bonus_item_drop) (struct s_add_drop *drop, const short max, int id, bool is_group, int race, int rate);
 	void (*calcexp) (struct map_session_data *sd, uint64 *base_exp, uint64 *job_exp, struct block_list *src);
 	int (*respawn_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*jobchange_killclone) (struct block_list *bl, va_list ap);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Current checks for empty entries assumed that if id and group is 0 that
it is empty, while in fact ITMCHAIN_ORE has group 0 as value,
for easier checks and more aesthetic code short group has been
replaced, id's are now always written into short id and bool
is_group decides if it's an item or a group.

**Issues addressed:** Gaia Sword not dropping anything at all.

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
