### PR TITLE
Added configuration to fullprotect skill

### DIFF
--- a/conf/map/battle/skill.conf
+++ b/conf/map/battle/skill.conf
@@ -330,3 +330,10 @@ bowling_bash_area: 0
 // punch a hole into SG it will for example create a "suck in" effect.
 // If you disable this setting, the knockback direction will be completely random (eAthena style).
 stormgust_knockback: true
+
+// Config for full protect skill creator.
+// 0: Default, only for equipped itens.
+// 1: Apply full protected even item not equipped.
+//    Remove all debuffs from stripped status.
+// 2: Apply this config even for alchemist skills. (Protect Armor, Protect Weapon, Protect Helm, Protect Shield)
+creator_fullprotect: 0

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7413,6 +7413,7 @@ static const struct battle_data {
 	{ "min_item_buy_price",                 &battle_config.min_item_buy_price,              1,      0,      INT_MAX,        },
 	{ "min_item_sell_price",                &battle_config.min_item_sell_price,             0,      0,      INT_MAX,        },
 	{ "display_fake_hp_when_dead",          &battle_config.display_fake_hp_when_dead,       1,      0,      1,              },
+	{ "creator_fullprotect",                &battle_config.creator_fullprotect,             0,      0,      2,              },
 };
 
 static bool battle_set_value_sub(int index, int value)

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -576,6 +576,8 @@ struct Battle_Config {
 	int min_item_sell_price;
 
 	int display_fake_hp_when_dead;
+
+    int creator_fullprotect;
 };
 
 /* criteria for battle_config.idletime_critera */

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -7678,10 +7678,10 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 		{
 			unsigned int equip[] = { EQP_WEAPON, EQP_SHIELD, EQP_ARMOR, EQP_HEAD_TOP };
 			int index;
-			if ( sd && (bl->type != BL_PC || (dstsd && pc->checkequip(dstsd, equip[skill_id - AM_CP_WEAPON]) < 0) ||
+			if ( sd && (bl->type != BL_PC || (battle_config.creator_fullprotect != 2 && (dstsd && pc->checkequip(dstsd, equip[skill_id - AM_CP_WEAPON]) < 0) ||
 				(dstsd && equip[skill_id - AM_CP_WEAPON] == EQP_SHIELD && pc->checkequip(dstsd, EQP_SHIELD) > 0
 				&& (index = dstsd->equip_index[EQI_HAND_L]) >= 0 && dstsd->inventory_data[index]
-				&& dstsd->inventory_data[index]->type != IT_ARMOR)) ) {
+				&& dstsd->inventory_data[index]->type != IT_ARMOR))) ) {
 				clif->skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0, 0);
 				map->freeblock_unlock(); // Don't consume item requirements
 				return 0;
@@ -8380,15 +8380,17 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 		{
 			unsigned int equip[] = { EQP_WEAPON, EQP_SHIELD, EQP_ARMOR, EQP_HEAD_TOP };
 			int i, s = 0, skilltime = skill->get_time(skill_id, skill_lv);
-			for ( i = 0; i < 4; i++ ) {
-				if ( bl->type != BL_PC || (dstsd && pc->checkequip(dstsd, equip[i]) < 0) )
-					continue;
-				if ( dstsd && equip[i] == EQP_SHIELD ) {
-					short index = dstsd->equip_index[EQI_HAND_L];
-					if ( index >= 0 && dstsd->inventory_data[index] && dstsd->inventory_data[index]->type != IT_ARMOR )
-						continue;
-				}
-				sc_start(src, bl, (sc_type)(SC_PROTECTWEAPON + i), 100, skill_lv, skilltime);
+			for (i = 0; i < 4; i++) {
+                if (!battle_config.creator_fullprotect) {
+                    if (bl->type != BL_PC || (dstsd && pc->checkequip(dstsd, equip[i]) < 0))
+                        continue;
+                    if ( dstsd && equip[i] == EQP_SHIELD ) {
+                        short index = dstsd->equip_index[EQI_HAND_L];
+                        if ( index >= 0 && dstsd->inventory_data[index] && dstsd->inventory_data[index]->type != IT_ARMOR )
+                            continue;
+                    }
+                }
+ 				sc_start(src, bl, (sc_type)(SC_PROTECTWEAPON + i), 100, skill_lv, skilltime);
 				s++;
 			}
 			if ( sd && !s ) {

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7755,6 +7755,22 @@ static int status_change_start(struct block_list *src, struct block_list *bl, en
 			}
 			if (tick == 1) return 1; //Minimal duration: Only strip without causing the SC
 			break;
+        case SC_PROTECTWEAPON:
+            if(battle_config.creator_fullprotect)
+                status_change_end(bl, SC_NOEQUIPWEAPON, INVALID_TIMER);
+            break;
+        case SC_PROTECTHELM:
+            if(battle_config.creator_fullprotect)
+                status_change_end(bl, SC_NOEQUIPHELM, INVALID_TIMER);
+            break;
+        case SC_PROTECTARMOR:
+            if(battle_config.creator_fullprotect)
+                status_change_end(bl, SC_NOEQUIPARMOR, INVALID_TIMER);
+            break;
+        case SC_PROTECTSHIELD:
+            if(battle_config.creator_fullprotect)
+                status_change_end(bl, SC_NOEQUIPSHIELD, INVALID_TIMER);
+            break;
 		case SC_MER_FLEE:
 		case SC_MER_ATK:
 		case SC_MER_HP:


### PR DESCRIPTION
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Today, the equip protect status (SC_PROTECTWEAPON, SC_PROTECTHELM, SC_PROTECTARMOR, and SC_PROTECTSHIELD) only apply if there's equip on a respective slot.

Old days, the protect status, apply without the test. So, protect shield work with no shield equip. This PR creates a config that allows going back old days =]

**Issues addressed:**
There is no issues


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
