### PR TITLE
Fix sealed bapho problem

### DIFF
--- a/npc/instances/SealedShrine.txt
+++ b/npc/instances/SealedShrine.txt
@@ -1108,13 +1108,15 @@ OnInstanceInit:
 		next();
 		mes("The bottom of the Main Altar trembles furiously.");
 		next();
-		specialeffect(EF_METEORSTORM);
-		specialeffect(EF_METEORSTORM);
-		mesf("[%s]", strcharinfo(PC_NAME));
-		mes("Watch out! Something... Something is coming.");
-		'ins_baphomet = 6;
-		donpcevent(instance_npcname("ins_2f_hero_broad")+"::OnEnable");
-		disablenpc(instance_npcname("The Main Altar#ss"));
+		if ('ins_baphomet == 5 && getpartyleader(.@party_id, 2) == getcharid(CHAR_ID_CHAR)) {
+			specialeffect(EF_METEORSTORM);
+			specialeffect(EF_METEORSTORM);
+			mesf("[%s]", strcharinfo(PC_NAME));
+			mes("Watch out! Something... Something is coming.");
+			'ins_baphomet = 6;
+			donpcevent(instance_npcname("ins_2f_hero_broad")+"::OnEnable");
+			disablenpc(instance_npcname("The Main Altar#ss"));
+		}
 		close();
 	} else {
 		mes("An evil power, too terrible to describe, lies under the great altar radiating a violet color.");

--- a/npc/instances/SealedShrine.txt
+++ b/npc/instances/SealedShrine.txt
@@ -1108,7 +1108,7 @@ OnInstanceInit:
 		next();
 		mes("The bottom of the Main Altar trembles furiously.");
 		next();
-		if ('ins_baphomet == 5 && getpartyleader(.@party_id, 2) == getcharid(CHAR_ID_CHAR)) {
+		if ('ins_baphomet == 5) {
 			specialeffect(EF_METEORSTORM);
 			specialeffect(EF_METEORSTORM);
 			mesf("[%s]", strcharinfo(PC_NAME));


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
There is a situation where you can invoke more than one sealed Baphomet.

To reproduce:

1. Go to the second floor of catacombs and before you summon, as party leader, stop on the dialog "The bottom of the Main Altar trembles furiously.".
2. Change party leader to another member, so, he can talk with the seal in the middle too. He stops on the same dialog "The bottom of the Main Altar trembles furiously."
3. Keep doing it until all party is on the same dialog. All of them proceeds the dialog to invoke the sealed Baphomet, and we'll have a lot of sealed Baphomet unsealed.

So, this PR is to don't allow players to abuse the instance using this way.
I've just added instance status check and if the character is truly the party leader.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Related to instances #1582, not directly reported.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
