### PR TITLE
Fix a bug that causes disguise event to run indefinitely

### DIFF
--- a/npc/custom/events/disguise.txt
+++ b/npc/custom/events/disguise.txt
@@ -8,6 +8,7 @@
 //= Note: This script requires PCRE to run properly.
 //= 5.0 Last update by GmOcean.
 //= 5.1 Cleaned and standardized, mostly. [Euphy]
+//= 5.2 Fix a bug that causes this event run indefinitely [AnnieRuru]
 //============================================================
 
 prontera,160,155,4	script	Disguise Event	4_M_NFDEADMAN,{
@@ -183,6 +184,15 @@ OnTimer30000:
 	deletepset 1;
 	stopnpctimer;
 	setnpctimer 0;
+	++.RoundCount;
+	if (.RoundCount >= .Rounds) {
+		setnpcdisplay "Disguise Event", 4_M_NFDEADMAN;
+		.RoundCount = 0;
+		.Change = 0;
+		.EventON = 0;
+		npctalk "Thank you all for playing. That was the last round of the Disguise Event. Come play again later.";
+		end;
+	}
 	initnpctimer;
 	end;
 OnTimer60000:


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
https://rathena.org/board/topic/117852-i-got-error-when-applying-custom-commands/?do=findComment&comment=356295
Fix a bug in custom disguise event script that causes the event to run indefinitely
the .RoundCount only increase when having players answer correctly
if nobody playing this event, or players give up before .Rounds(10) rounds, it will continue run forever

### Changes Proposed
add the exact same line from answer correctly, into wrong answer label

### Affected Branches
* Master

### Known Issues and TODO List