### PR TITLE
Add *checkwall script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9140,6 +9140,7 @@ Example:
 
 *setwall("<map name>", <x>, <y>, <size>, <dir>, <shootable>, "<name>")
 *delwall("<name>")
+*checkwall("<name>")
 
 Creates an invisible wall, an array of setcell() starting from x,y and
 doing a line of the given size in the given direction. The difference with

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -3268,6 +3268,11 @@ static bool map_iwall_remove(const char *wall_name)
 	return true;
 }
 
+static bool map_iwall_exist(const char *wall_name)
+{
+	return strdb_exists(map->iwall_db, wall_name);
+}
+
 /**
  * @see DBCreateData
  */
@@ -6979,6 +6984,7 @@ void map_defaults(void)
 	map->iwall_set = map_iwall_set;
 	map->iwall_get = map_iwall_get;
 	map->iwall_remove = map_iwall_remove;
+	map->iwall_exist = map_iwall_exist;
 
 	map->addmobtolist = map_addmobtolist; // [Wizputer]
 	map->spawnmobs = map_spawnmobs; // [Wizputer]

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -1338,6 +1338,7 @@ END_ZEROED_BLOCK;
 	bool (*iwall_set) (int16 m, int16 x, int16 y, int size, int8 dir, bool shootable, const char* wall_name);
 	void (*iwall_get) (struct map_session_data *sd);
 	bool (*iwall_remove) (const char *wall_name);
+	bool (*iwall_exist) (const char *wall_name);
 
 	int (*addmobtolist) (unsigned short m, struct spawn_data *spawn); // [Wizputer]
 	void (*spawnmobs) (int16 m); // [Wizputer]

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -14185,6 +14185,14 @@ static BUILDIN(delwall)
 	return true;
 }
 
+static BUILDIN(checkwall)
+{
+	const char *wall_name = script_getstr(st, 2);
+
+	script_pushint(st, map->iwall_exist(wall_name));
+	return true;
+}
+
 /// Retrieves various information about the specified guardian.
 ///
 /// guardianinfo("<map_name>", <index>, <type>) -> <value>
@@ -25487,6 +25495,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(setcell,"siiiiii"),
 		BUILDIN_DEF(setwall,"siiiiis"),
 		BUILDIN_DEF(delwall,"s"),
+		BUILDIN_DEF(checkwall,"s"),
 		BUILDIN_DEF(searchitem,"rs"),
 		BUILDIN_DEF(mercenary_create,"ii"),
 		BUILDIN_DEF(mercenary_heal,"ii"),


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
blame https://github.com/HerculesWS/Hercules/pull/2017

when I made that pull request, my original intention was to help other scripters not repeat my mistakes
it was done that way because I thought *delwall script command is only meant for **event script**
when event commence = `*setwall`, and when start = `*delwall` ... simple as that

however after that pr merge, some members complaint their server throw error on them
originally, I was expecting to point their **EVENT script** mistakes
but they show up their script in this way (not original, but something like this) -->
<details>

```
-    script    sdfsdf    -1,{
OnInit:
    switch ( gettime(GETTIME_WEEKDAY) ) {
    case SUNDAY: goto OnSun0000;
    case MONDAY: goto OnMon0000;
    case TUESDAY: goto OnTue0000;
    case WEDNESDAY: goto OnWed0000;
    case THURSDAY: goto OnThu0000;
    case FRIDAY: goto OnFri0000;
    case SATURDAY: goto OnSat0000;
    }
OnMon0000:
OnWed0000:
OnFri0000:
    delwall "Weekday_wall2";
    delwall "Weekend_wall";
    setwall <map>,<x>,<y>,<size>,<dir>,0,"Weekday1_wall";
    end;
OnTue0000:
OnThu0000:
    delwall "Weekday_wall1";
    delwall "Weekend_wall";
    setwall <map>,<x>,<y>,<size>,<dir>,0,"Weekday1_wall2";
    end;
OnSat0000:
OnSun0000:
    delwall "Weekday_wall1";
    delwall "Weekday_wall2";
    setwall <map>,<x>,<y>,<size>,<dir>,0,"Weekend_wall";
    end;
}
```

</details>

they actually use the *setwall/*delwall for **Utility script** !!
and I have no idea how to actually solve it without making the script ugly

... and that's how rathena got `*checkwall` script command
https://github.com/rathena/rathena/pull/3393

**Moral of the story** : never underestimate the creativity of the community =/

### Changes Proposed
Add *checkwall script command

### Tested with
```
prontera,155,185,5	script	kjsdfhkshf	1_F_MARIA,{
	if ( checkwall("asdf") )
		delwall "asdf";
	end;
}
```

### Affected Branches
* Master

### Known Issues and TODO List
none

please don't follow [rathena's way of adding all delwall with checkwall in all their scripts](https://github.com/rathena/rathena/pull/3393/commits/a8651318829384d56d82e7c3682fbf65332aa13f)
like I said, 1 `*setwall`, 1 `*delwall`, it was meant to throw error for the cleanliness to the event scripts

well ... enablenpc/disablenpc ... also doesn't throw error when use multiple times
imagine if we actually throw error for the *disablenpc .... hahaha~ 