### PR TITLE
Retarget 10.0.15063.0 into 10.0.17763.0 for Visual Studio 2017

### DIFF
--- a/vcproj-15/char-server.vcxproj
+++ b/vcproj-15/char-server.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{D356871D-58E1-450B-967A-E4E9646175AF}</ProjectGuid>
     <RootNamespace>char-server</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/vcproj-15/login-server.vcxproj
+++ b/vcproj-15/login-server.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{D356871D-58E1-450B-967A-E5E9646175AF}</ProjectGuid>
     <RootNamespace>login-server</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/vcproj-15/map-server.vcxproj
+++ b/vcproj-15/map-server.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{D356871D-58E1-450B-967A-E6E9646175AF}</ProjectGuid>
     <RootNamespace>map-server</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/vcproj-15/plugin-HPMHooking_char.vcxproj
+++ b/vcproj-15/plugin-HPMHooking_char.vcxproj
@@ -15,7 +15,7 @@
     <RootNamespace>plugin-HPMHooking_char</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>plugin-HPMHooking_char</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/vcproj-15/plugin-HPMHooking_login.vcxproj
+++ b/vcproj-15/plugin-HPMHooking_login.vcxproj
@@ -15,7 +15,7 @@
     <RootNamespace>plugin-HPMHooking_login</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>plugin-HPMHooking_login</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/vcproj-15/plugin-HPMHooking_map.vcxproj
+++ b/vcproj-15/plugin-HPMHooking_map.vcxproj
@@ -15,7 +15,7 @@
     <RootNamespace>plugin-HPMHooking_map</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>plugin-HPMHooking_map</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/vcproj-15/plugin-sample.vcxproj
+++ b/vcproj-15/plugin-sample.vcxproj
@@ -15,7 +15,7 @@
     <RootNamespace>plugin-sample</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>plugin-sample</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
http://herc.ws/board/topic/16521-how-to-setup-offline-server-for-personal-development-use/?do=findComment&comment=90471
Thanks to utofaery !!

Currently Visual Studio 2017 default their Windows Platform Version at 10.0.17763.0
but Hercules uses 10.0.15063.0 ...
means we have to download additional 1.43GB just to compile Hercules

### Changes Proposed
So change the Windows Platform Version into 10.0.17763.0,
so we don't have to download unnecessary stuff ... 

### Affected Branches
* Master

### Known Issues and TODO List
not really sure if this break anything ?
let's see what Travis says ... ALL GREEN ... probably means ok to do so