### PR TITLE
standardize script commands to small letters

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -10444,7 +10444,7 @@ Works for 20170830 RE and main and for any zero clients
 
 ---------------------------------------
 
-*expandInventoryAck(<result>{, <itemId>})
+*expandinventoryack(<result>{, <itemId>})
 
 Send initial inventory expansion result.
 Normally this function should be called from script label
@@ -10462,7 +10462,7 @@ Works for 20181212 zero clients
 
 ---------------------------------------
 
-*expandInventoryResult(<result>)
+*expandinventoryresult(<result>)
 
 Send final inventory expansion result.
 Normally this function should be called from script label
@@ -10479,7 +10479,7 @@ Works for 20181212 zero clients
 
 ---------------------------------------
 
-*expandInventory(<value>)
+*expandinventory(<value>)
 
 Adjust player inventory to given value.
 Maximum inventory size is MAX_INVENTORY.
@@ -10490,7 +10490,7 @@ Current max inventory size can be read by function getInventorySize().
 
 ---------------------------------------
 
-*getInventorySize()
+*getinventorysize()
 
 Return current player max inventory size.
 This value always smaller or equal to MAX_INVENTORY.

--- a/npc/other/inventory_expansion.txt
+++ b/npc/other/inventory_expansion.txt
@@ -33,28 +33,28 @@
 
 OnInvExpandRequest:
 	if (countitem(Inventory_Extension_Coupon) < 1) {
-		expandInventoryAck(EXPAND_INV_MISSING_ITEM);
+		expandinventoryack(EXPAND_INV_MISSING_ITEM);
 		end;
 	}
-	if (getInventorySize() + INVENTORY_INCREASE_STEP > MAX_INVENTORY) {
-		expandInventoryAck(EXPAND_INV_MAX_SIZE);
+	if (getinventorysize() + INVENTORY_INCREASE_STEP > MAX_INVENTORY) {
+		expandinventoryack(EXPAND_INV_MAX_SIZE);
 		end;
 	}
-	expandInventoryAck(EXPAND_INV_ASK_CONFIRMATION, Inventory_Extension_Coupon);
+	expandinventoryack(EXPAND_INV_ASK_CONFIRMATION, Inventory_Extension_Coupon);
 	end;
 
 OnInvExpandConfirmed:
 	if (countitem(Inventory_Extension_Coupon) < 1) {
-		expandInventoryResult(EXPAND_INV_RESULT_MISSING_ITEM);
+		expandinventoryresult(EXPAND_INV_RESULT_MISSING_ITEM);
 		end;
 	}
-	if (getInventorySize() + INVENTORY_INCREASE_STEP > MAX_INVENTORY) {
-		expandInventoryResult(EXPAND_INV_RESULT_MAX_SIZE);
+	if (getinventorysize() + INVENTORY_INCREASE_STEP > MAX_INVENTORY) {
+		expandinventoryresult(EXPAND_INV_RESULT_MAX_SIZE);
 		end;
 	}
 	delitem(Inventory_Extension_Coupon, 1);
-	if (expandInventory(INVENTORY_INCREASE_STEP) == true) {
-		expandInventoryResult(EXPAND_INV_RESULT_SUCCESS);
+	if (expandinventory(INVENTORY_INCREASE_STEP) == true) {
+		expandinventoryresult(EXPAND_INV_RESULT_SUCCESS);
 	}
 	end;
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -25325,7 +25325,7 @@ static BUILDIN(enchantitem)
 }
 
 // send ack to inventory expand request
-static BUILDIN(expandInventoryAck)
+static BUILDIN(expandinventoryack)
 {
 	struct map_session_data *sd = script_rid2sd(st);
 	if (sd == NULL)
@@ -25339,7 +25339,7 @@ static BUILDIN(expandInventoryAck)
 }
 
 // send final ack to inventory expand request
-static BUILDIN(expandInventoryResult)
+static BUILDIN(expandinventoryresult)
 {
 	struct map_session_data *sd = script_rid2sd(st);
 	if (sd == NULL)
@@ -25349,7 +25349,7 @@ static BUILDIN(expandInventoryResult)
 }
 
 // adjust player inventory size to given value positive or negative
-static BUILDIN(expandInventory)
+static BUILDIN(expandinventory)
 {
 	struct map_session_data *sd = script_rid2sd(st);
 	if (sd == NULL)
@@ -25359,7 +25359,7 @@ static BUILDIN(expandInventory)
 }
 
 // return current player inventory size
-static BUILDIN(getInventorySize)
+static BUILDIN(getinventorysize)
 {
 	struct map_session_data *sd = script_rid2sd(st);
 	if (sd == NULL)
@@ -26147,10 +26147,10 @@ static void script_parse_builtin(void)
 
 		BUILDIN_DEF(itempreview, "i"),
 		BUILDIN_DEF(enchantitem, "iii"),
-		BUILDIN_DEF(expandInventoryAck, "i?"),
-		BUILDIN_DEF(expandInventoryResult, "i"),
-		BUILDIN_DEF(expandInventory, "i"),
-		BUILDIN_DEF(getInventorySize, ""),
+		BUILDIN_DEF(expandinventoryack, "i?"),
+		BUILDIN_DEF(expandinventoryresult, "i"),
+		BUILDIN_DEF(expandinventory, "i"),
+		BUILDIN_DEF(getinventorysize, ""),
 
 		BUILDIN_DEF(closeroulette, ""),
 		BUILDIN_DEF(openrefineryui, ""),


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
http://herc.ws/board/topic/16526-some-upcoming-hercules-features/?do=findComment&comment=90516

### Changes Proposed
All script commands should be in small letters

### Affected Branches
* Master

### Known Issues and TODO List
I don't want to memorize another special capital letter case
"All" and "all" is already enough for us -> https://github.com/HerculesWS/Hercules/issues/784
--> standardize into "all" for script commands -> https://github.com/HerculesWS/Hercules/pull/2380

~so if Haru say again this isn't an issue, feel free to close this PR~
for standardization, script commands has to be small letters