### PR TITLE
Allow *input script command to support negative input

### DIFF
--- a/conf/map/script.conf
+++ b/conf/map/script.conf
@@ -52,7 +52,7 @@ script_configuration: {
 	// Default value of the 'min' argument of the script command 'input'.
 	// When the 'min' argument isn't provided, this value is used instead.
 	// Defaults to 0.
-	//input_min_value: 0
+	input_min_value: 0
 
 	// Default value of the 'max' argument of the script command 'input'.
 	// When the 'max' argument isn't provided, this value is used instead.

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -12587,10 +12587,19 @@ static void clif_parse_NpcAmountInput(int fd, struct map_session_data *sd)
 	int npcid = RFIFOL(fd,2);
 	int amount = RFIFOL(fd,6);
 
-	if (amount >= 0)
+	if (amount < sd->npc_amount_min) {
+		sd->npc_amount = sd->npc_amount_min;
+		sd->npc_input_capped_range = -1;
+	}
+	else if (amount > sd->npc_amount_max) {
+		sd->npc_amount = sd->npc_amount_max;
+		sd->npc_input_capped_range = 1;
+	}
+	else {
 		sd->npc_amount = amount;
-	else
-		sd->npc_amount = 0;
+		sd->npc_input_capped_range = 0;
+	}
+
 	npc->scriptcont(sd, npcid, false);
 }
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -273,6 +273,9 @@ struct map_session_data {
 	int npc_item_flag; //Marks the npc_id with which you can change equipments during interactions with said npc (see script command enable_itemuse)
 	int npc_menu; // internal variable, used in npc menu handling
 	int npc_amount;
+	int npc_amount_min;
+	int npc_amount_max;
+	int npc_input_capped_range;
 	struct script_state *st;
 	char npc_str[CHATBOX_SIZE]; // for passing npc input box text to script engine
 	int npc_timer_id; //For player attached npc timers. [Skotlex]

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -6947,54 +6947,52 @@ static BUILDIN(jobname)
 	return true;
 }
 
-/// Get input from the player.
-/// For numeric inputs the value is capped to the range [min,max]. Returns 1 if
-/// the value was higher than 'max', -1 if lower than 'min' and 0 otherwise.
-/// For string inputs it returns 1 if the string was longer than 'max', -1 is
-/// shorter than 'min' and 0 otherwise.
-///
-/// input(<var>{,<min>{,<max>}}) -> <int>
+/*
+ * Get input from the player.
+ * For numeric inputs the value is capped to the range [min,max]. Returns 1 if
+ * the value was higher than 'max', -1 if lower than 'min' and 0 otherwise.
+ * For string inputs it returns 1 if the string was longer than 'max', -1 is
+ * shorter than 'min' and 0 otherwise.
+ *
+ * input(<var>{,<min>{,<max>}}) -> <int>
+ */
 static BUILDIN(input)
 {
-	struct script_data* data;
-	int64 uid;
-	const char* name;
-	int min;
-	int max;
 	struct map_session_data *sd = script->rid2sd(st);
 	if (sd == NULL)
 		return true;
 
-	data = script_getdata(st,2);
-	if( !data_isreference(data) ) {
+	struct script_data *data = script_getdata(st, 2);
+	if (!data_isreference(data)) {
 		ShowError("script:input: not a variable\n");
 		script->reportdata(data);
 		st->state = END;
 		return false;
 	}
-	uid = reference_getuid(data);
-	name = reference_getname(data);
-	min = (script_hasdata(st,3) ? script_getnum(st,3) : script->config.input_min_value);
-	max = (script_hasdata(st,4) ? script_getnum(st,4) : script->config.input_max_value);
+
+	int64 uid  = reference_getuid(data);
+	const char *name = reference_getname(data);
+	int min = (script_hasdata(st, 3) ? script_getnum(st, 3) : script->config.input_min_value);
+	int max = (script_hasdata(st, 4) ? script_getnum(st, 4) : script->config.input_max_value);
 
 #ifdef SECURE_NPCTIMEOUT
 	sd->npc_idle_type = NPCT_WAIT;
 #endif
 
-	if( !sd->state.menu_or_input ) {
+	if (!sd->state.menu_or_input) {
 		// first invocation, display npc input box
 		sd->state.menu_or_input = 1;
 		st->state = RERUNLINE;
-		if( is_string_variable(name) )
-			clif->scriptinputstr(sd,st->oid);
+		if (is_string_variable(name))
+			clif->scriptinputstr(sd, st->oid);
 		else
-			clif->scriptinput(sd,st->oid);
+			clif->scriptinput(sd, st->oid);
 	} else {
 		// take received text/value and store it in the designated variable
 		sd->state.menu_or_input = 0;
 		if (is_string_variable(name)) {
 			int len = (int)strlen(sd->npc_str);
-			script->set_reg(st, sd, uid, name, sd->npc_str, script_getref(st,2));
+			script->set_reg(st, sd, uid, name, sd->npc_str, script_getref(st, 2));
 			script_pushint(st, (len > max ? 1 : len < min ? -1 : 0));
 		} else {
 			int amount = sd->npc_amount;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -6983,10 +6983,13 @@ static BUILDIN(input)
 		// first invocation, display npc input box
 		sd->state.menu_or_input = 1;
 		st->state = RERUNLINE;
-		if (is_string_variable(name))
+		if (is_string_variable(name)) {
 			clif->scriptinputstr(sd, st->oid);
-		else
+		} else {
+			sd->npc_amount_min = min;
+			sd->npc_amount_max = max;
 			clif->scriptinput(sd, st->oid);
+		}
 	} else {
 		// take received text/value and store it in the designated variable
 		sd->state.menu_or_input = 0;
@@ -6997,7 +7000,7 @@ static BUILDIN(input)
 		} else {
 			int amount = sd->npc_amount;
 			script->set_reg(st, sd, uid, name, (const void *)h64BPTRSIZE(cap_value(amount,min,max)), script_getref(st,2));
-			script_pushint(st, (amount > max ? 1 : amount < min ? -1 : 0));
+			script_pushint(st, sd->npc_input_capped_range);
 		}
 		st->state = RUN;
 	}


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
```
prontera,155,185,5	script	kljhdsfskjh	1_F_MARIA,{
	.@b = input(.@a, -1000,100);
	dispbottom .@a +" "+ .@b;
	end;
}
```
input -100, always gets 0

### Changes Proposed
blame clif.c, now allow negative input

### Affected Branches
* Master

### Known Issues and TODO List
rathena also allow it, why hercules don't ?