### PR TITLE
Standardize to "all" in script commands

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6502,7 +6502,7 @@ This command will kill all monsters that were spawned with monster() or
 areamonster() and have a specified event label attached to them. Commonly
 used to get rid of remaining quest monsters once the quest is complete.
 
-If the label is given as "All", all monsters which have their respawn
+If the label is given as "all", all monsters which have their respawn
 times set to -1 (like all the monsters summoned with 'monster' or
 'areamonster' script command, and all monsters summoned with GM commands,
 but no other ones - that is, all non-permanent monsters) on the specified

--- a/npc/custom/events/mushroom_event.txt
+++ b/npc/custom/events/mushroom_event.txt
@@ -41,7 +41,7 @@ OnMinute10:	// Start time (every hour)
 	set .status,1;
 	set .Spawn,rand(1,10);	// How many Mushrooms should spawn?
 	set .Map$,.maps$[rand(getarraysize(.maps$))];
-	killmonster .Map$,"All";
+	killmonster(.Map$, "all");
 	monster .Map$,0,0,"Please don't kill me!",1084,.Spawn,strnpcinfo(NPC_NAME)+"::OnMobKilled";
 	announce "Find the Mushroom : Total of "+.Spawn+" Mushrooms have been spawned in "+.Map$+"!",0;
 	sleep 2500;

--- a/npc/re/instances/ghost_palace.txt
+++ b/npc/re/instances/ghost_palace.txt
@@ -601,7 +601,7 @@ OnInstanceInit:
 OnStart:
 	stopnpctimer instance_npcname("#gp3control");
 	disablenpc(instance_npcname("#gp3control"));
-	killmonster(instance_mapname("1@spa"), "All");
+	killmonster(instance_mapname("1@spa"), "all");
 	disablenpc(instance_npcname("#gp3warp"));
 	enablenpc(instance_npcname("Lurid Royal Guard#gp5"));
 	enablenpc(instance_npcname("Tiara Princess#gp5"));

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11043,10 +11043,16 @@ static BUILDIN(killmonster)
 	int16 m,allflag=0;
 	mapname=script_getstr(st,2);
 	event=script_getstr(st,3);
-	if(strcmp(event,"All")==0)
+
+	if (strcmpi(event, "all") == 0) {
+		if (strcmp(event, "all") != 0) {
+			ShowWarning("buildin_killmonster: \"%s\" deprecated! Please use \"all\" instead.\n", event);
+			script->reportsrc(st);
+		}
 		allflag = 1;
-	else
+	} else {
 		script->check_event(st, event);
+	}
 
 	if( (m=map->mapname2mapid(mapname))<0 )
 		return true;


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
I don't want to memorize another special capital letter case
"All" and "all" is already enough for us -> #784

nobody was bother with the "All" and "all" because eathena/rathena is not case-sensitive script engine
during hercules early days, script engine became case-sensitive, and [Emistry has asked to change it](https://github.com/HerculesWS/Hercules/issues/784)
Haru said this isn't an issue -> because it mentioned in script-commands
and we are being force to memorize `*killmonster` -> "All", `*mobcount` -> "all"
```
prontera,155,185,5	script	kjhdsfks	1_F_MARIA,{
	monster "this",-1,-1, "--ja--", PORING, 1;
	sleep 1000;
	if ( mobcount( strnpcinfo(NPC_MAP), "all" ) )
		killmonster strnpcinfo(NPC_MAP), "All";
	end;
}
```

### Changes Proposed
Standardize to "all" in script commands

### Affected Branches
* Master

### Known Issues and TODO List
hard to tell small or big is better
"this", "--en--", "--ja--", ...
"Leader", "SavePoint", "SavePointAll", "Leader" ...