### PR TITLE
Add missing documentation for disable battleground respawn

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9616,6 +9616,11 @@ is run when they relog.
 <On Death Event> refers to an NPC label that attaches to the character and
 is run when they die. Can be "" for empty.
 
+If "-" is supplied for <mapname>, this will remove the 1 second automatic
+respawn on the battleground map. This allows for better manipulation of
+<On Death Event>. The player will have to be warped to desired location
+at the end of <On Death Event>.
+
 Unlike the prior command, the latter will attach a GROUP in a waiting room
 to the battleground, and sets the array $@arenamembers[0] where 0 holds
 the IDs of the first group, and 1 holds the IDs of the second.
@@ -9747,6 +9752,8 @@ mapflag%TAB%<map_name>%TAB%battleground%TAB%2
 
 This command will create a new BG Team.
 When player dies, they will be respawned map_name,X,Y as mentioned.
+If "-" is supplied for the map name, this will remove the 1 second automatic
+respawn on the battleground map.
 
 Command will return -1 if BG Creation is failed,
 else it will return the BG ID(Also known as TeamID).

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -23687,7 +23687,7 @@ static BUILDIN(bg_create_team)
 	if( strcmp(map_name,"-") != 0 ) {
 		map_index = script->mapindexname2id(st,map_name);
 		if( map_index == 0 ) { // Invalid Map
-			script_pushint(st,0);
+			script_pushint(st, -1);
 			return true;
 		}
 	}


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
Add missing **documentation** for disable battleground respawn

### Tested with
... erm ...
https://github.com/AnnieRuru/customs/blob/master/scripts/bg_pvp_point_queue.txt
just change 
```
	.red = bg_create_team( "guild_vs3", 13,50 );
	.blue = bg_create_team( "guild_vs3", 86,50 );
```
into
```
	.red = bg_create_team( "-", 13,50 );
	.blue = bg_create_team( "-", 86,50 );
```

### Affected Branches
* Master

### Known Issues and TODO List
well, pressing the [Return to last Save Point] from the client side will forcefully leave the battleground team though