### PR TITLE
Add optional parameter for *gettimestr

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3536,9 +3536,9 @@ Examples :
 This function will return a string containing time data as specified by
 the format string.
 
-This uses the C function 'strfmtime', which obeys special format
+This uses the C function 'strftime', which obeys special format
 characters. For a full description see, for example, the description of
-'strfmtime' at http://www.delorie.com/gnu/docs/glibc/libc_437.html
+'strftime' at http://www.delorie.com/gnu/docs/glibc/libc_437.html
 All the format characters given in there should properly work.
 Max length is the maximum length of a time string to generate.
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3531,7 +3531,7 @@ Examples :
 
 ---------------------------------------
 
-*gettimestr(<format string>, <max length>)
+*gettimestr(<format string>, <max length>{, <timestamp>})
 
 This function will return a string containing time data as specified by
 the format string.
@@ -3545,6 +3545,7 @@ Max length is the maximum length of a time string to generate.
 The example given in Hercules sample scripts works like this:
 
 	mes(gettimestr("%Y-%m/%d %H:%M:%S", 21));
+	mes(gettimestr("%Y-%m/%d %H:%M:%S", 21, getcalendartime(0, 0)));
 
 This will print a full date and time like 'YYYY-MM/DD HH:MM:SS'.
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10612,10 +10612,22 @@ static BUILDIN(gettimestr)
 	char *tmpstr;
 	const char *fmtstr;
 	int maxlen;
-	time_t now = time(NULL);
+	time_t now;
 
 	fmtstr=script_getstr(st,2);
 	maxlen=script_getnum(st,3);
+
+	if (script_hasdata(st, 4)) {
+		int timestamp = script_getnum(st, 4);
+		if (timestamp < 0) {
+			ShowWarning("buildin_gettimestr: UNIX timestamp must be in positive value.\n");
+			return false;
+		}
+
+		now = (time_t)timestamp;
+	} else {
+		now = time(NULL);
+	}
 
 	tmpstr=(char *)aMalloc((maxlen+1)*sizeof(char));
 	strftime(tmpstr,maxlen,fmtstr,localtime(&now));
@@ -25378,7 +25390,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(savepoint,"sii"),
 		BUILDIN_DEF(gettimetick,"i"),
 		BUILDIN_DEF(gettime,"i"),
-		BUILDIN_DEF(gettimestr,"si"),
+		BUILDIN_DEF(gettimestr, "si?"),
 		BUILDIN_DEF(openstorage,""),
 		BUILDIN_DEF(guildopenstorage,""),
 		BUILDIN_DEF(itemskill,"vi?"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10604,9 +10604,9 @@ static BUILDIN(gettime)
 	return true;
 }
 
-/*==========================================
+/*
  * GetTimeStr("TimeFMT", Length);
- *------------------------------------------*/
+ */
 static BUILDIN(gettimestr)
 {
 	char *tmpstr;
@@ -10614,8 +10614,8 @@ static BUILDIN(gettimestr)
 	int maxlen;
 	time_t now;
 
-	fmtstr=script_getstr(st,2);
-	maxlen=script_getnum(st,3);
+	fmtstr = script_getstr(st, 2);
+	maxlen = script_getnum(st, 3);
 
 	if (script_hasdata(st, 4)) {
 		int timestamp = script_getnum(st, 4);
@@ -10629,11 +10629,11 @@ static BUILDIN(gettimestr)
 		now = time(NULL);
 	}
 
-	tmpstr=(char *)aMalloc((maxlen+1)*sizeof(char));
-	strftime(tmpstr,maxlen,fmtstr,localtime(&now));
-	tmpstr[maxlen]='\0';
+	tmpstr = (char *)aMalloc((maxlen +1)*sizeof(char));
+	strftime(tmpstr, maxlen, fmtstr, localtime(&now));
+	tmpstr[maxlen] = '\0';
 
-	script_pushstr(st,tmpstr);
+	script_pushstr(st, tmpstr);
 	return true;
 }
 


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
we have `*getcalendartime` script command, but why our `*gettimestr` isn't update for it?

### Changes Proposed
Add optional parameter for `*gettimestr`

### Tested with
```
prontera,155,185,5	script	sdkfjhsdkf	1_F_MARIA,{
	mes(gettimestr("%Y-%m/%d %H:%M:%S", 21));
	mes(gettimestr("%Y-%m/%d %H:%M:%S", 21, getcalendartime(0,0)));
	close;
}
```
which is stated in the documentation

### Affected Branches
* Master

### Known Issues and TODO List
none
in fact this is mostly a copy-paste from rathena repo