### PR TITLE
Add *msgtxt script command to read from conf/message.conf

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2825,6 +2825,13 @@ If the character is sitting, it will return true, otherwise (standing) it will r
 In case no player is specified, the function will return the state of the attached player.
 
 ---------------------------------------
+
+*msgtxt(<number>)
+
+This function return the string defined from 'conf/message.conf'.
+return "??" if not found.
+
+---------------------------------------
 //=====================================
 2.1 - Item-Related Commands
 //=====================================

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24920,6 +24920,19 @@ static BUILDIN(msgtable2)
 	return true;
 }
 
+static BUILDIN(msgtxt)
+{
+	int num = script_getnum(st, 2);
+	
+	if (num < 0 || num >= MAX_MSG) {
+		ShowWarning("buildin_msgtxt: Invalid range %d. Min: %d Max: %d\n", num, 0, MAX_MSG);
+		return false;
+	}
+
+	script_pushstrcopy(st, msg_txt(num));
+	return true;
+}
+
 // show/hide camera info
 static BUILDIN(camerainfo)
 {
@@ -25634,6 +25647,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(showdigit,"i?"),
 		BUILDIN_DEF(msgtable, "i?"),
 		BUILDIN_DEF(msgtable2, "iv?"),
+		BUILDIN_DEF(msgtxt, "i"),
 		// WoE SE
 		BUILDIN_DEF(agitstart2,""),
 		BUILDIN_DEF(agitend2,""),


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Add `*msgtxt` script command to read a line from `conf/message.conf`

### Tested with
```c
prontera,155,185,5	script	sdkfjhsdkf	1_F_MARIA,{
	input .@a, 0, 1000;
	#CASHPOINTS += .@a;
	mesf(msgtxt(505), .@a, #CASHPOINTS); // Gained 100 cash points. Total 100 points.
	dispbottom sprintf( msgtxt(505), .@a, #CASHPOINTS ), C_SPRINGGREEN;
	msgtxt(5000);
	close;
}
```

### Affected Branches
* Master

### Additional context
we have HULD, which allows to members to ~machine~ translate their npc files
this should probably reduce the work load to translate part of the npc stuffs

### Known Issues and TODO List
