### PR TITLE
Add MOB_CLONE_START & MOB_CLONE_END to server defined constants

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -718,6 +718,8 @@ MAX_CHAT_USERS		- Maximum Chat users
 MAX_REFINE			- Maximum Refine level
 MAX_MENU_OPTIONS    - Maximum NPC menu options
 MAX_MENU_LENGTH     - Maximum NPC menu string length
+MOB_CLONE_START     - Clone ID start from this range
+MOB_CLONE_END       - Clone ID end with this range
 
 Send targets and status options are also hard-coded and can be found
 in 'doc/constants.md'.

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -25845,6 +25845,8 @@ static void script_hardcoded_constants(void)
 	script->set_constant("MAX_REFINE",MAX_REFINE,false, false);
 	script->set_constant("MAX_MENU_OPTIONS", MAX_MENU_OPTIONS, false, false);
 	script->set_constant("MAX_MENU_LENGTH", MAX_MENU_LENGTH, false, false);
+	script->set_constant("MOB_CLONE_START", MOB_CLONE_START, false, false);
+	script->set_constant("MOB_CLONE_END", MOB_CLONE_END, false, false);
 
 	script->constdb_comment("status options");
 	script->set_constant("Option_Nothing",OPTION_NOTHING,false, false);


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
http://herc.ws/board/topic/16588-1-how-to-make-it-not-list-clone-monster-or-slaveclone/#comment-90623
that script is flawed, obviously I could do `if ( .@mobid >= 4001 && .@mobid < 5000 )`
but if somehow gravity introduce more monsters ID, this range will subject to change,
which break my custom script

### Changes Proposed
Add `MOB_CLONE_START` & `MOB_CLONE_END` to server defined constants

### Tested with
```c
prontera,155,185,5	script	sdkfjhsdkf	1_F_MARIA,{
	.@mobgid = monster( "this", -1,-1, "--ja--", PORING, 1 );
	.@mobid = uid2mobid(.@mobgid);
	dispbottom "GID: "+ .@mobgid +" | mob ID: "+ .@mobid;
	if ( .@mobid >= MOB_CLONE_START && .@mobid < MOB_CLONE_END )
		dispbottom "this is a clone";
	getmapxy .@map$, .@x, .@y, UNITTYPE_PC;
	.@mobgid = clone( .@map$, .@x, .@y, "", getcharid(CHAR_ID_CHAR), getcharid(CHAR_ID_CHAR) );
	.@mobid = uid2mobid(.@mobgid);
	dispbottom "GID: "+ .@mobgid +" | mob ID: "+ .@mobid;
	dispbottom MOB_CLONE_START +""+ MOB_CLONE_END;
	if ( .@mobid >= MOB_CLONE_START && .@mobid < MOB_CLONE_END )
		dispbottom "this is a clone";
	end;
}
```
<details><summary>using a custom script command `*uid2mobid` because our `*setunitdata` is broken</summary>

```c
#include "common/hercules.h"
#include "map/mob.h"
#include "map/script.h"
#include "common/HPMDataCheck.h"

HPExport struct hplugin_info pinfo = {
	"uid2mobid",
	SERVER_TYPE_MAP,
	"0.1",
	HPM_VERSION,
};
BUILDIN(uid2mobid) {
	struct mob_data *md = map->id2md( script_getnum(st,2) );
	if ( !md ) {
		ShowWarning( "buildin_uid2mobid: Error in finding object GID or target GID is not a monster.\n" );
		return false;
	}
	script_pushint( st, md->class_ );
	return true;
}
HPExport void plugin_init(void) {
	addScriptCommand( "uid2mobid", "i", uid2mobid );
}
```
</details>

### Affected Branches
* Master

### Known Issues and TODO List
or maybe introduce a new source function `check_mob_clone` to check for clone ID ?