### PR TITLE
getunitdata should return -1 instead of 0. Phase 2

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -10159,7 +10159,7 @@ Applicable Data types (available as constants) -
 	UDT_LIFETIME:       LifeTime (int) - for summons.
 	UDT_MERC_KILLCOUNT: Kill count for mercenaries (int).
 
-returns 0 if value could not be retrieved.
+returns -1 if value could not be retrieved.
 
 ---------------------------------------
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19767,7 +19767,7 @@ static BUILDIN(getunitdata)
 
 	if (bl == NULL) {
 		ShowWarning("buildin_getunitdata: Error in finding object with given GID %d!\n", script_getnum(st, 2));
-		script_pushint(st, 0);
+		script_pushint(st, -1);
 		return false;
 	}
 
@@ -19776,7 +19776,7 @@ static BUILDIN(getunitdata)
 	/* Type check */
 	if (type < UDT_TYPE || type >= UDT_MAX) {
 		ShowError("buildin_getunitdata: Invalid unit data type %d provided.\n", type);
-		script_pushint(st, 0);
+		script_pushint(st, -1);
 		return false;
 	}
 
@@ -19784,7 +19784,7 @@ static BUILDIN(getunitdata)
 	if (type == UDT_MAPIDXY) {
 		if (data == NULL || !data_isreference(data)) {
 			ShowWarning("buildin_getunitdata: Error in argument 3. Please provide a reference variable to store values in.\n");
-			script_pushint(st, 0);
+			script_pushint(st, -1);
 			return false;
 		}
 
@@ -19794,7 +19794,7 @@ static BUILDIN(getunitdata)
 			sd = script->rid2sd(st);
 			if (sd == NULL) {
 				ShowWarning("buildin_getunitdata: Player not attached! Cannot use player variable %s.\n",name);
-				script_pushint(st, 0);
+				script_pushint(st, -1);
 				return true;// no player attached
 			}
 		}
@@ -19864,7 +19864,7 @@ static BUILDIN(getunitdata)
 		case UDT_DMOTION:     script_pushint(st, md->status.dmotion); break;
 		default:
 			ShowWarning("buildin_getunitdata: Invalid data type '%s' for Mob unit.\n", udtype);
-			script_pushint(st, 0);
+			script_pushint(st, -1);
 			return false;
 		}
 	}
@@ -19921,7 +19921,7 @@ static BUILDIN(getunitdata)
 		case UDT_INTIMACY:    script_pushint(st, hd->homunculus.intimacy); break;
 		default:
 			ShowWarning("buildin_getunitdata: Invalid data type '%s' for Homunculus unit.\n", udtype);
-			script_pushint(st, 0);
+			script_pushint(st, -1);
 			return false;
 		}
 	}
@@ -19978,7 +19978,7 @@ static BUILDIN(getunitdata)
 		case UDT_INTIMACY:    script_pushint(st, pd->pet.intimate); break;
 		default:
 			ShowWarning("buildin_getunitdata: Invalid data type '%s' for Pet unit.\n", udtype);
-			script_pushint(st, 0);
+			script_pushint(st, -1);
 			return false;
 		}
 	}
@@ -20034,7 +20034,7 @@ static BUILDIN(getunitdata)
 		case UDT_LIFETIME:    script_pushint(st, mc->mercenary.life_time); break;
 		default:
 			ShowWarning("buildin_getunitdata: Invalid data type '%s' for Mercenary unit.\n", udtype);
-			script_pushint(st, 0);
+			script_pushint(st, -1);
 			return false;
 		}
 	}
@@ -20088,7 +20088,7 @@ static BUILDIN(getunitdata)
 		case UDT_MASTERCID:   script_pushint(st, ed->elemental.char_id); break;
 		default:
 			ShowWarning("buildin_getunitdata: Invalid data type '%s' for Elemental unit.\n", udtype);
-			script_pushint(st, 0);
+			script_pushint(st, -1);
 			return false;
 		}
 	}
@@ -20153,14 +20153,14 @@ static BUILDIN(getunitdata)
 		case UDT_BODY2:       script_pushint(st, nd->vd.body_style); break;
 		default:
 			ShowWarning("buildin_getunitdata: Invalid data type '%s' for NPC unit.\n", udtype);
-			script_pushint(st, 0);
+			script_pushint(st, -1);
 			return false;
 		}
 	}
 		break;
 	default:
 		ShowError("buildin_getunitdata: Unknown object!\n");
-		script_pushint(st, 0);
+		script_pushint(st, -1);
 		return false;
 	} // end of bl->type switch
 


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
There are some constants return 0,
example `UDT_SEX` can have `SEX_FEMALE`, which is 0
`UDT_SIZE` -> `Size_Small` == 0
`UDT_LOOKDIR` -> `DIR_NORTH` == 0
etc etc

### Changes Proposed
Change return value from 0 into -1 when `*getunitdata` return error 

### Affected Branches
* Master

### Known Issues and TODO List
more to come .....
https://github.com/HerculesWS/Hercules/compare/stable...AnnieRuru:34-setunitdata

by the way, this will break existing custom scripts that made check on 0 already ...