### PR TITLE
Adds BUILDIN(delitemidx), which deletes an item at the given index.

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5317,6 +5317,34 @@ Check getitem2() to understand its expanded parameters.
 
 ---------------------------------------
 
+*delitemidx(<index>{, <amount>{, <account id>}})
+
+This command will remove an item at the given inventory index. Unlike the
+'delitem()' counterpart, this doesn't check invalid Item ID, making it useful to remove
+invalid item IDs in player's inventory.
+
+If <amount> is not specified, this will remove all of the items at the specified index.
+Note that items with the 'ForceSerial' flag, not yet merged through 'mergeitem()', will only
+be removed at the given index.
+
+The only way to get the inventory index is by using 'getinventorylist()'. After deleting
+an item at the given index, that index can remain empty until the player relogs, so you
+should recall 'getinventorylist()' again. If you try to delete an item at an invalid index, the
+script will terminate with an error.
+
+This command is also useful to remove rental/bound items because 'delitem()'
+does not discriminate at choosing which item to remove.
+
+Example:
+
+	// This will remove all invalid Item ID in player's inventory
+	getinventorylist();
+	for (.@i = 0; .@i < @inventorylist_count; ++.@i)
+		if (getiteminfo(@inventorylist_id[.@i], ITEMINFO_TYPE) == -1)
+			delitemidx(@inventorylist_idx[.@i]);
+
+---------------------------------------
+
 *countitem(<item id>)
 *countitem("<item name>")
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -8616,6 +8616,48 @@ static BUILDIN(delitem2)
 	return false;
 }
 
+/**
+ * Deletes item at given index.
+ * delitem(<index>{, <amount{, <account id>}});
+ */
+static BUILDIN(delitemidx)
+{
+	struct map_session_data *sd;
+
+	if (script_hasdata(st, 4)) {
+		if ((sd = script->id2sd(st, script_getnum(st, 4))) == NULL) {
+			st->state = END;
+			return true;
+		}
+	} else {
+		if ((sd = script->rid2sd(st)) == NULL)
+			return true;
+	}
+
+	int i = script_getnum(st, 2);
+	if (i < 0 || i >= sd->status.inventorySize) {
+		ShowError("buildin_delitemidx: Index (%d) should be from 0-%d.\n", i, sd->status.inventorySize - 1);
+		st->state = END;
+		return false;
+	}
+
+	if (itemdb->exists(sd->status.inventory[i].nameid) == NULL)
+		ShowWarning("buildin_delitemidx: Deleting invalid Item ID (%d).\n", sd->status.inventory[i].nameid);
+
+	int amount = 0;
+	if (script_hasdata(st, 3)) {
+		if ((amount = script_getnum(st, 3)) > sd->status.inventory[i].amount)
+			amount = sd->status.inventory[i].amount;
+	} else {
+		amount = sd->status.inventory[i].amount;
+	}
+
+	if (amount > 0)
+		script->buildin_delitem_delete(sd, i, &amount, true);
+
+	return true;
+}
+
 /*==========================================
  * Enables/Disables use of items while in an NPC [Skotlex]
  *------------------------------------------*/
@@ -25252,6 +25294,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(makeitem2,"viiiiiiii????"),
 		BUILDIN_DEF(delitem,"vi?"),
 		BUILDIN_DEF(delitem2,"viiiiiiii?"),
+		BUILDIN_DEF(delitemidx, "i??"),
 		BUILDIN_DEF2(enableitemuse,"enable_items",""),
 		BUILDIN_DEF2(disableitemuse,"disable_items",""),
 		BUILDIN_DEF(cutin,"si"),


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Adds new script command delitemidx().
`delitem(<index>{, <account id>})`

An important command which will allow scripters to delete an item at a specific index. Why is this important? Now we can check an item for cards, if it's a rental and other useful information `getinventorylist()` provides us.

**Issues addressed:** <!-- Write here the issue number, if any. -->

Currently if you have a quest which has an item requirement which can also be a Rental on your server, it will just eat up that rental item with no regard. This can be problematic if that rental item is a recolour, effectively allowing you to make the item with a rental.

**Hypothetical example:**
- Recolouring Beret (Black, Blue, Red, Yellow) quest requires Beret and 10,000z.
- You can rent a Beret for 1z.
- If you give it a rental Beret, you can still complete the quest. Now you can get basically unlimited recoloured Berets as it only costs 1z to rent.

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
