### PR TITLE
Deprecate *getunitname script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -10165,9 +10165,16 @@ returns -1 if value could not be retrieved.
 
 *getunitname(<GID>)
 
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    @ /!\ This command is deprecated @
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
 Retrieve the name of a unit.
 
 returns "Unknown" if the value could not be retrieved.
+
+This command is deprecated and it should not be used in new scripts, as it is
+likely to be removed at a later time. Please use rid2name instead.
 
 ---------------------------------------
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18449,6 +18449,7 @@ static BUILDIN(rid2name)
 			case BL_PET: script_pushstrcopy(st, BL_UCCAST(BL_PET, bl)->pet.name); break;
 			case BL_HOM: script_pushstrcopy(st, BL_UCCAST(BL_HOM, bl)->homunculus.name); break;
 			case BL_MER: script_pushstrcopy(st, BL_UCCAST(BL_MER, bl)->db->name); break;
+			case BL_ELEM: script_pushstrcopy(st, BL_UCCAST(BL_ELEM, bl)->db->name); break;
 			default:
 				ShowError("buildin_rid2name: BL type unknown.\n");
 				script_pushconststr(st,"");
@@ -25581,7 +25582,7 @@ static void script_parse_builtin(void)
 		/* Unit Data */
 		BUILDIN_DEF(setunitdata,"iiv??"),
 		BUILDIN_DEF(getunitdata,"ii?"),
-		BUILDIN_DEF(getunitname,"i"),
+		BUILDIN_DEF_DEPRECATED(getunitname,"i"), // Deprecated 2019-02-28
 		BUILDIN_DEF(setunitname,"is"),
 		BUILDIN_DEF(unitwalk,"ii?"),
 		BUILDIN_DEF(unitkill,"i"),


### PR DESCRIPTION
After I give it some thought, I think better split the `*getunitname` deprecation out from https://github.com/HerculesWS/Hercules/pull/2391

-----------------------------------

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
we have 2 script command do the same thing, `*rid2name` and `*getunitname`

### Changes Proposed
deprecate `*getunitname` because rid2name has been exist since eathena times
also minor fix rid2name to support elementals

### Affected Branches
* Master

### Known Issues and TODO List
we have to decide which one to deprecate,
better don't have 2 script commands do exact same thing again, like this https://github.com/HerculesWS/Hercules/pull/2089