### PR TITLE
* Add *mobattached and *killmonstergid script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -266,8 +266,8 @@ direction across Y. Walking into that area will trigger the NPC. If no
 'OnTouch:' special label is present in the NPC code, the execution will
 start from the beginning of the script, otherwise, it will start from the
 'OnTouch:' label. Monsters can also trigger the NPC, though the label
-'OnTouchNPC:' is used in this case. If player left area npc will called
-if present label 'OnUnTouch'.
+'OnTouchNPC:' is used in this case, and using mobattached() will return
+monster GID. If player left the area will trigger the label 'OnUnTouch'.
 
 The code part is the script code that will execute whenever the NPC is
 triggered. It may contain commands and function calls, descriptions of
@@ -6505,6 +6505,14 @@ other number for this parameter won't be recognized.
 
 ---------------------------------------
 
+*killmonstergid(<GID>);
+
+This command will kill the specific monster GID. The difference between
+this command and 'unitkill', is this command does not trigger monster's
+event label.
+
+---------------------------------------
+
 *strmobinfo(<type>, <monster id>)
 
 This function will return information about a monster record in the
@@ -6590,6 +6598,17 @@ will run as if by donpcevent().
 
 // Will summon a poring to fight for the character.
 	summon("--ja--", PORING);
+
+---------------------------------------
+
+*mobattached()
+
+This command will return RID of the monster running from 'OnTouchNPC:' label.
+
+
+//	Kill any monster entering npc's trigger area
+OnTouchNPC:
+	killmonstergid mobattached();
 
 ---------------------------------------
 

--- a/npc/quests/quests_rachel.txt
+++ b/npc/quests/quests_rachel.txt
@@ -3210,7 +3210,7 @@ OnTouch:
 
 OnTouchNPC:
 	emotion e_an;
-	//emotion e_gg,1; //Emote on monster - unsupported
+	unitemote mobattached(), e_gg;
 	end;
 
 OnMyMobDead:

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11095,6 +11095,21 @@ static BUILDIN(killmonsterall)
 	return true;
 }
 
+static BUILDIN(killmonstergid)
+{
+	int mobgid = script_getnum(st, 2);
+	struct mob_data *md = map->id2md(mobgid);
+
+	if (md == NULL) {
+		ShowWarning("buildin_killmonstergid: Error in finding monster GID '%d' or the target is not a monster.\n", mobgid);
+		return false;
+	}
+
+	md->state.npc_killmonster = 1;
+	status_kill(&md->bl);
+	return true;
+}
+
 /*==========================================
  * Creates a clone of a player.
  * clone map, x, y, event, char_id, master_id, mode, flag, duration
@@ -11726,6 +11741,18 @@ static BUILDIN(playerattached)
 		script_pushint(st,0);
 	else
 		script_pushint(st,st->rid);
+	return true;
+}
+
+/*==========================================
+ * Used by OnTouchNPC: label to return monster GID
+ *------------------------------------------*/
+static BUILDIN(mobattached)
+{
+	if (st->rid == 0 || map->id2md(st->rid) == NULL)
+		script_pushint(st, 0);
+	else
+		script_pushint(st, st->rid);
 	return true;
 }
 
@@ -25338,6 +25365,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(areamonster,"siiiisii???"),
 		BUILDIN_DEF(killmonster,"ss?"),
 		BUILDIN_DEF(killmonsterall,"s?"),
+		BUILDIN_DEF(killmonstergid, "i"),
 		BUILDIN_DEF(clone,"siisi????"),
 		BUILDIN_DEF(doevent,"s"),
 		BUILDIN_DEF(donpcevent,"s"),
@@ -25354,6 +25382,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(attachnpctimer,"?"), // attached the player id to the npc timer [Celest]
 		BUILDIN_DEF(detachnpctimer,"?"), // detached the player id from the npc timer [Celest]
 		BUILDIN_DEF(playerattached,""), // returns id of the current attached player. [Skotlex]
+		BUILDIN_DEF(mobattached, ""),
 		BUILDIN_DEF(announce,"si?????"),
 		BUILDIN_DEF(mapannounce,"ssi?????"),
 		BUILDIN_DEF(areaannounce,"siiiisi?????"),


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
Actually I was writing this for my custom scripts,
but when I do a search `OnTouchNPC` in npc folder, suddenly found this is actually official

rAthena already having `*getattachedrid` like for ages already
https://github.com/rathena/rathena/blob/master/doc/script_commands.txt#L922-L925

### Changes Proposed
Add `*mobattached` and `*killmonstergid` script command

### Tested with
```c
prontera,155,185,5	script	qwer	1_F_MARIA,{
	getmapxy .@map$, .@x, .@y, UNITTYPE_NPC;
	.@mobid = monster( .@map$, .@x, .@y, "--ja--", PORING, 1, strnpcinfo(0)+"::Onaaa" );
	unitwalk .@mobid, 160,185;
	end;
Onaaa:
	npctalk "run";
	end;
}
prontera,160,185,5	script	asdf	1_F_MARIA,0,0,{
	end;
OnTouchNPC:
//	unitkill mobattached();
	killmonstergid mobattached();
//	unitemote mobattached(), e_gg;
	end;
}
```

### Affected Branches
* Master

### Known Issues and TODO List
I accidentally push this branch into main hercules repo, need to remove it