### PR TITLE
Deprecate *petstat and add CONSTANTS to *getpetinfo

### DIFF
--- a/db/constants.conf
+++ b/db/constants.conf
@@ -1483,12 +1483,27 @@ constants_db: {
 	e_panic:       79
 	e_whisp:       80
 
-	comment__: "petstat"
-	PET_CLASS:    1
-	PET_NAME:     2
-	PET_LEVEL:    3
-	PET_HUNGRY:   4
-	PET_INTIMATE: 5
+	comment__: "petstat - deprecated, use *getpetinfo"
+	PET_CLASS: {
+		Value: 1
+		Deprecated: true
+	}
+	PET_NAME: {
+		Value: 2
+		Deprecated: true
+	}
+	PET_LEVEL: {
+		Value: 3
+		Deprecated: true
+	}
+	PET_HUNGRY: {
+		Value: 4
+		Deprecated: true
+	}
+	PET_INTIMATE: {
+		Value: 5
+		Deprecated: true
+	}
 
 	comment__: "getmonsterinfo"
 	MOB_NAME:     0

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3833,21 +3833,25 @@ how many skills a character has.
 
 *getpetinfo(<type>)
 
-This function will return pet information for the pet the invoking
-character currently has active. Valid types are:
+This command will return the currently active pet information of the invoking character.
+These fields are associate in 'db/(pre-)re/pet_db.conf'. Valid types are:
 
- 0 - Unique pet ID number as stored by the char server and distinguishing
-     it from all other pets the characters actually have. This value is
-     currently useless, at most you can use it to tell pets apart reliably.
- 1 - Pet class number as per 'db/pet_db.txt' - will tell you what kind of
-     a pet it is.
- 2 - Pet name. Will return "null" if there's no pet.
- 3 - Pet friendly level (intimacy score). 1000 is full loyalty.
- 4 - Pet hungry level. 100 is completely full.
- 5 - Pet rename flag. 0 means this pet has not been named yet.
-
-If the invoking player doesn't own a pet, this command will return
-"null" for type 2, and return 0 for other types.
+	PETINFO_ID            - Pet Database ID, stored in `pet` table to distinguish from other pets.
+	PETINFO_CLASS         - Pet class ID. (Id field)
+	PETINFO_NAME          - Pet Name, return "null" if there's no active pet.
+	PETINFO_INTIMACY      - Pet Intimacy level. 1000 is full loyalty.
+	PETINFO_HUNGRY        - Pet hungry level. 100 is completely full.
+	PETINFO_RENAME        - Pet rename flag. 0 means this pet has not been named yet.
+	PETINFO_GID           - Pet Game ID
+	PETINFO_EGGITEM       - Pet EggItem
+	PETINFO_FOODITEM      - Pet FoodItem
+	PETINFO_ACCESSORYITEM - Pet AccessoryItem
+	PETINFO_ACCESSORYFLAG - return 1 if the pet currently equipping accessory, return 0 otherwise.
+	PETINFO_EVO_EGGID     - Pet Evolve EggID
+	PETINFO_AUTOFEED      - Pet AutoFeed flag.
+	
+If the invoking player doesn't own a pet, this command will
+return "null" for type PETINFO_NAME, and return 0 for other types.
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3853,6 +3853,10 @@ If the invoking player doesn't own a pet, this command will return
 
 *petstat(<flag>)
 
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+    @ /!\ This command is deprecated @
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
 Returns current pet status, all are integers except name.
 Returns 0 or "" if the player doesn't have pets.
 
@@ -3865,6 +3869,9 @@ PET_INTIMATE
 
 Example:
 	.@i = petstat(PET_CLASS);
+
+This command is deprecated and it should not be used in new scripts, as it is
+likely to be removed at a later time. Please use 'getpetinfo' instead.
 
 ---------------------------------------
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -15573,36 +15573,74 @@ static BUILDIN(recovery)
 	return true;
 }
 
-/*==========================================
- * Get your pet info: getpetinfo(n)
- * n -> 0:pet_id 1:pet_class 2:pet_name
- * 3:friendly 4:hungry, 5: rename flag.
- *------------------------------------------*/
+/* 
+ * Get your current pet information
+ */
 static BUILDIN(getpetinfo)
 {
 	struct map_session_data *sd = script->rid2sd(st);
-	struct pet_data *pd;
-	int type=script_getnum(st,2);
+	if (sd == NULL)
+		return true;
 
-	if (sd == NULL || sd->pd == NULL) {
-		if (type == 2)
-			script_pushconststr(st,"null");
+	struct pet_data *pd = sd->pd;
+	int type = script_getnum(st, 2);
+	if (pd == NULL) {
+		if (type == PETINFO_NAME)
+			script_pushconststr(st, "null");
 		else
-			script_pushint(st,0);
+			script_pushint(st, 0);
 		return true;
 	}
-	pd = sd->pd;
+
 	switch(type) {
-		case 0: script_pushint(st,pd->pet.pet_id); break;
-		case 1: script_pushint(st,pd->pet.class_); break;
-		case 2: script_pushstrcopy(st,pd->pet.name); break;
-		case 3: script_pushint(st,pd->pet.intimate); break;
-		case 4: script_pushint(st,pd->pet.hungry); break;
-		case 5: script_pushint(st,pd->pet.rename_flag); break;
-		default:
-			script_pushint(st,0);
-			break;
+	case PETINFO_ID:
+		script_pushint(st, pd->pet.pet_id);
+		break;
+	case PETINFO_CLASS:
+		script_pushint(st, pd->pet.class_);
+		break;
+	case PETINFO_NAME:
+		script_pushstrcopy(st, pd->pet.name);
+		break;
+	case PETINFO_INTIMACY:
+		script_pushint(st, pd->pet.intimate);
+		break;
+	case PETINFO_HUNGRY:
+		script_pushint(st, pd->pet.hungry);
+		break;
+	case PETINFO_RENAME:
+		script_pushint(st, pd->pet.rename_flag);
+		break;
+	case PETINFO_GID:
+		script_pushint(st, pd->bl.id);
+		break;
+	case PETINFO_EGGITEM:
+		script_pushint(st, pd->pet.egg_id);
+		break;
+	case PETINFO_FOODITEM:
+		script_pushint(st, pd->petDB->FoodID);
+		break;
+	case PETINFO_ACCESSORYITEM:
+		script_pushint(st, pd->petDB->AcceID);
+		break;
+	case PETINFO_ACCESSORYFLAG:
+		script_pushint(st, (pd->pet.equip != 0)? 1:0);
+		break;
+	case PETINFO_EVO_EGGID: 
+		if (VECTOR_DATA(pd->petDB->evolve_data) != NULL)
+			script_pushint(st, VECTOR_DATA(pd->petDB->evolve_data)->petEggId);
+		else
+			script_pushint(st, 0);
+		break;
+	case PETINFO_AUTOFEED:
+		script_pushint(st, pd->pet.autofeed);
+		break;
+	default:
+		ShowWarning("buildin_getpetinfo: Invalid type %d.\n", type);
+		script_pushint(st, 0);
+		return false;
 	}
+
 	return true;
 }
 
@@ -26181,6 +26219,21 @@ static void script_hardcoded_constants(void)
 	script->set_constant("MERCINFO_LIFETIME", MERCINFO_LIFETIME, false, false);
 	script->set_constant("MERCINFO_LEVEL", MERCINFO_LEVEL, false, false);
 	script->set_constant("MERCINFO_GID", MERCINFO_GID, false, false);
+
+	script->constdb_comment("getpetinfo options");
+	script->set_constant("PETINFO_ID", PETINFO_ID, false, false);
+	script->set_constant("PETINFO_CLASS", PETINFO_CLASS, false, false);
+	script->set_constant("PETINFO_NAME", PETINFO_NAME, false, false);
+	script->set_constant("PETINFO_INTIMACY", PETINFO_INTIMACY, false, false);
+	script->set_constant("PETINFO_HUNGRY", PETINFO_HUNGRY, false, false);
+	script->set_constant("PETINFO_RENAME", PETINFO_RENAME, false, false);
+	script->set_constant("PETINFO_GID", PETINFO_GID, false, false);
+	script->set_constant("PETINFO_EGGITEM", PETINFO_EGGITEM, false, false);
+	script->set_constant("PETINFO_FOODITEM", PETINFO_FOODITEM, false, false);
+	script->set_constant("PETINFO_ACCESSORYITEM", PETINFO_ACCESSORYITEM, false, false);
+	script->set_constant("PETINFO_ACCESSORYFLAG", PETINFO_ACCESSORYFLAG, false, false);
+	script->set_constant("PETINFO_EVO_EGGID", PETINFO_EVO_EGGID, false, false);
+	script->set_constant("PETINFO_AUTOFEED", PETINFO_AUTOFEED, false, false);
 
 	script->constdb_comment("monster skill states");
 	script->set_constant("MSS_ANY", MSS_ANY, false, false);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -25598,7 +25598,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(getd,"s"),
 		BUILDIN_DEF(setd,"sv"),
 		// <--- [zBuffer] List of dynamic var commands
-		BUILDIN_DEF(petstat,"i"),
+		BUILDIN_DEF_DEPRECATED(petstat, "i"), // Deprecated 2019-03-11
 		BUILDIN_DEF(callshop,"s?"), // [Skotlex]
 		BUILDIN_DEF(npcshopitem,"sii*"), // [Lance]
 		BUILDIN_DEF(npcshopadditem,"sii*"),

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -478,6 +478,27 @@ enum script_mercinfo_types {
 };
 
 /**
+ * Pet Info types.
+ */
+enum script_petinfo_types {
+	PETINFO_ID = 0,
+	PETINFO_CLASS,
+	PETINFO_NAME,
+	PETINFO_INTIMACY,
+	PETINFO_HUNGRY,
+	PETINFO_RENAME,
+	PETINFO_GID,
+	PETINFO_EGGITEM,
+	PETINFO_FOODITEM,
+	PETINFO_ACCESSORYITEM,
+	PETINFO_ACCESSORYFLAG,
+	PETINFO_EVO_EGGID,
+	PETINFO_AUTOFEED,
+
+	PETINFO_MAX
+};
+
+/**
  * Player blocking actions related flags.
  */
 enum pcblock_action_flag {


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
Copy Paste from rAthena !!!
although they don't support pet evolution yet, though ...

### Changes Proposed
1. Deprecate *petstat script command 
2. Add constants to *getpetinfo, and add some new fields

### Tested with
```c
prontera,155,185,5	script	kjdshfs	1_F_MARIA,{
	for ( .@i = 0; .@i <= 12; ++.@i )
		mes (.@i)+". "+getpetinfo(.@i)+"";
	close;
}
```

### Affected Branches
* Master

### Known Issues and TODO List
I have to go back on the forum .... 
there is still `*gethominfo` and `*geteleminfo` need to do ...