### PR TITLE
Fix *needed_status_point not support <char_id>

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6074,7 +6074,7 @@ Amount can be negative. See statusup().
 
 ---------------------------------------
 
-*needed_status_point(<type>, <val>, {<char_id>});
+*needed_status_point(<type>, <val>);
 
 Returns the number of stat points needed to change the specified stat <type> by <val>.
 If <val> is negative, returns the number of stat points that would be needed to

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9720,7 +9720,7 @@ static BUILDIN(statusup2)
 
 /*==========================================
 * Returns the number of stat points needed to change the specified stat by val.
-* needed_status_point(<type>,<val>{,<char id>}); [secretdataz]
+* needed_status_point(<type>,<val>); [secretdataz]
 *------------------------------------------*/
 static BUILDIN(needed_status_point)
 {
@@ -25296,7 +25296,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(downrefitem,"i?"),
 		BUILDIN_DEF(statusup,"i"),
 		BUILDIN_DEF(statusup2,"ii"),
-		BUILDIN_DEF(needed_status_point,"ii?"),
+		BUILDIN_DEF(needed_status_point, "ii"),
 		BUILDIN_DEF(bonus,"iv"),
 		BUILDIN_DEF2(bonus,"bonus2","ivi"),
 		BUILDIN_DEF2(bonus,"bonus3","ivii"),


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
thanks to @Emistry showing me this link https://github.com/HerculesWS/Hercules/pull/2246
we actually don't support `<char_id>` field, unlike rathena counterpart

### Changes Proposed
Fix *needed_status_point not support `<char_id>` field

### Affected Branches
* Master

### Known Issues and TODO List
