### PR TITLE
Fix @bodystyle crash client

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -12335,7 +12335,8 @@ static bool pc_has_second_costume(struct map_session_data *sd)
 {
 	nullpo_retr(false, sd);
 
-	if ((sd->job & JOBL_THIRD) != 0)
+//	FIXME: JOB_SUPER_NOVICE_E(4190) is not supposed to be 3rd Job. (Issue#2383)
+	if ((sd->job & JOBL_THIRD) != 0 && (sd->job & MAPID_BASEMASK) != MAPID_NOVICE)
 		return true;
 	return false;
 }

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -9008,6 +9008,13 @@ static int pc_jobchange(struct map_session_data *sd, int class, int upper)
 	if (sd->disguise != -1)
 		pc->disguise(sd, -1);
 
+	// Fix atcommand @jobchange when the player changing from 3rd job having alternate body style into non-3rd job, crashing the client
+	if (pc->has_second_costume(sd) == false) {
+		sd->status.body = 0;
+		sd->vd.body_style = 0;
+		clif->changelook(&sd->bl, LOOK_BODY2, sd->vd.body_style);
+	}
+
 	status->set_viewdata(&sd->bl, class);
 	clif->changelook(&sd->bl, LOOK_BASE, sd->vd.class); // move sprite update to prevent client crashes with incompatible equipment [Valaris]
 	if(sd->vd.cloth_color)


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### 2 Issues addressed
1. https://github.com/HerculesWS/Hercules/issues/2383#issuecomment-467607801
2. if the player on 3rd job, having alternate bodystyle, and `@jobchange` into novice for example,will crash the client.
This is extremely annoying when we testing stuffs

### Changes Proposed
1. Apply temporary fix so Job_Super_Novice_E no longer crash client 
2. Fix atcommand @jobchange when the player changing from 3rd job into non-3rd job, crashing client

### Affected Branches
* Master

### Known Issues and TODO List
