### PR TITLE
Fix UDT_LEVEL when show_mob_info level display is on

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18926,6 +18926,8 @@ static BUILDIN(setunitdata)
 			break;
 		case UDT_LEVEL:
 			md->level = val;
+			if (battle_config.show_mob_info & 4)
+				clif->charnameack(0, &md->bl);
 			break;
 		case UDT_HP:
 			status->set_hp(bl, (unsigned int) val, STATUS_HEAL_DEFAULT);


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
http://herc.ws/board/topic/16641-q-about-setunitdata/

### Changes Proposed
Fix UDT_LEVEL when show_mob_info level display is on

### Tested With
no.1 there is a battle_config.mobs_level_up,
when player is killed by a monster, it run clif->charnameack
https://github.com/HerculesWS/Hercules/blob/a0820df92f781bfc721bb7797f6f840880f1de08/src/map/pc.c#L8129-L8143

no.2
```c
prontera,155,185,5	script	askdaksd	1_F_MARIA,{
	.@mobgid = monster( "this", -1,-1, "--ja--", PORING, 1 );
	setunitdata .@mobgid, UDT_MAXHP, 1000000;
	setunitdata .@mobgid, UDT_HP, 1000000;
	setunitdata .@mobgid, UDT_LEVEL, 99;
	end;
}
```

### Affected Branches
* Master

### Known Issues and TODO List
yes I know there are a lot more,
but I am thinking its very much better to split into separate pull request now