### PR TITLE
Fix atcommand_interface variable members being represented as functions

### DIFF
--- a/src/map/atcommand.h
+++ b/src/map/atcommand.h
@@ -92,8 +92,8 @@ struct atcmd_binding_data {
  * Interface
  **/
 struct atcommand_interface {
-	char (*atcmd_output)[CHAT_SIZE_MAX];
-	char (*atcmd_player_name)[NAME_LENGTH];
+	char atcmd_output[CHAT_SIZE_MAX];
+	char atcmd_player_name[NAME_LENGTH];
 	unsigned char at_symbol;
 	unsigned char char_symbol;
 	/* atcommand binding */


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix atcommand_interface::atcmd_ouput and atcommand_interface::atcmd_player_name variables being defined like functions, caused HPMHooks generator to fail to parse those lines.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
