### PR TITLE
Storage item list packet size fix and minor clif.c fixes

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -2977,28 +2977,22 @@ static void clif_storageItems(struct map_session_data *sd, enum inventory_type t
 	nullpo_retv(sd);
 	nullpo_retv(items);
 
-	int i = 0;
-	struct item_data *id;
+	for (int i = 0, normal_count = 0, equip_count = 0; i < items_length; ++i) {
+		struct item_data *itd;
 
-	do {
-		int normal = 0, equip = 0, k = 0;
+		if (items[i].nameid == 0)
+			continue;
 
-		for( ; i < items_length && k < 500; i++, k++ ) {
+		itd = itemdb->search(items[i].nameid);
 
-			if( items[i].nameid <= 0 )
-				continue;
+		if (!itemdb->isstackable2(itd))
+			clif->item_equip(i + 1, &storelist_equip.list[equip_count++], &items[i], itd, itd->equip);
+		else
+			clif->item_normal(i + 1, &storelist_normal.list[normal_count++], &items[i], itd);
 
-			id = itemdb->search(items[i].nameid);
-
-			if( !itemdb->isstackable2(id) ) //Non-stackable (Equippable)
-				clif->item_equip(i+1,&storelist_equip.list[equip++],&items[i],id,id->equip);
-			else //Stackable (Normal)
-				clif->item_normal(i+1,&storelist_normal.list[normal++],&items[i],id);
-		}
-
-		if( normal ) {
-			storelist_normal.PacketType   = storageListNormalType;
-			storelist_normal.PacketLength =  ( sizeof( storelist_normal ) - sizeof( storelist_normal.list ) ) + (sizeof(struct NORMALITEM_INFO) * normal);
+		if (normal_count > 0 && (normal_count == MAX_STORAGE_ITEM_PACKET_NORMAL || i + 1 == items_length)) {
+			storelist_normal.PacketType = storageListNormalType;
+			storelist_normal.PacketLength = (sizeof(storelist_normal) - sizeof(storelist_normal.list)) + (sizeof(struct NORMALITEM_INFO) * normal_count);
 
 #if PACKETVER_RE_NUM >= 20180912 || PACKETVER_ZERO_NUM >= 20180919 || PACKETVER_MAIN_NUM >= 20181002
 			storelist_normal.invType = type;
@@ -3008,11 +3002,12 @@ static void clif_storageItems(struct map_session_data *sd, enum inventory_type t
 #endif
 
 			clif->send(&storelist_normal, storelist_normal.PacketLength, &sd->bl, SELF);
+			normal_count = 0;
 		}
 
-		if( equip ) {
-			storelist_equip.PacketType   = storageListEquipType;
-			storelist_equip.PacketLength = ( sizeof( storelist_equip ) - sizeof( storelist_equip.list ) ) + (sizeof(struct EQUIPITEM_INFO) * equip);
+		if (equip_count > 0 && (equip_count == MAX_STORAGE_ITEM_PACKET_EQUIP || i + 1 == items_length)) {
+			storelist_equip.PacketType = storageListEquipType;
+			storelist_equip.PacketLength = (sizeof(storelist_equip) - sizeof(storelist_equip.list)) + (sizeof(struct EQUIPITEM_INFO) * equip_count);
 
 #if PACKETVER_RE_NUM >= 20180912 || PACKETVER_ZERO_NUM >= 20180919 || PACKETVER_MAIN_NUM >= 20181002
 			storelist_equip.invType = type;
@@ -3022,10 +3017,9 @@ static void clif_storageItems(struct map_session_data *sd, enum inventory_type t
 #endif
 
 			clif->send(&storelist_equip, storelist_equip.PacketLength, &sd->bl, SELF);
+			equip_count = 0;
 		}
-
-	} while ( i < items_length );
-
+	}
 }
 
 static void clif_cartList(struct map_session_data *sd)

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -2978,12 +2978,10 @@ static void clif_storageItems(struct map_session_data *sd, enum inventory_type t
 	nullpo_retv(items);
 
 	for (int i = 0, normal_count = 0, equip_count = 0; i < items_length; ++i) {
-		struct item_data *itd;
-
 		if (items[i].nameid == 0)
 			continue;
 
-		itd = itemdb->search(items[i].nameid);
+		struct item_data *itd = itemdb->search(items[i].nameid);
 
 		if (!itemdb->isstackable2(itd))
 			clif->item_equip(i + 1, &storelist_equip.list[equip_count++], &items[i], itd, itd->equip);
@@ -7125,7 +7123,7 @@ static void clif_party_job_and_level(struct map_session_data *sd)
 	WBUFW(buf, 6) = sd->status.class;
 	WBUFW(buf, 8) = sd->status.base_level;
 
-	clif_send(buf, packet_len(0xabd), &sd->bl, PARTY);
+	clif->send(buf, packet_len(0xabd), &sd->bl, PARTY);
 #endif
 }
 
@@ -21630,7 +21628,7 @@ static void clif_hat_effect_single(struct block_list *bl, uint16 effectId, bool 
 	WBUFB(buf,8) = enable;
 	WBUFL(buf,9) = effectId;
 
-	clif_send(buf, 13, bl, AREA);
+	clif->send(buf, 13, bl, AREA);
 #endif
 }
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -431,19 +431,19 @@ static int clif_send_actual(int fd, void *buf, int len)
  *------------------------------------------*/
 static bool clif_send(const void *buf, int len, struct block_list *bl, enum send_target type)
 {
+	if (type != ALL_CLIENT)
+		nullpo_retr(false, bl);
+	nullpo_retr(false, buf);
+	Assert_retr(false, len > 0);
+
 	int i;
-	struct map_session_data *sd, *tsd;
+	struct map_session_data *sd = BL_CAST(BL_PC, bl), *tsd;
 	struct party_data *p = NULL;
 	struct guild *g = NULL;
 	struct battleground_data *bgd = NULL;
 	int x0 = 0, x1 = 0, y0 = 0, y1 = 0, fd;
 	struct s_mapiterator* iter;
 	int area_size;
-
-	if( type != ALL_CLIENT )
-		nullpo_ret(bl);
-
-	sd = BL_CAST(BL_PC, bl);
 
 	if (sd != NULL && pc_isinvisible(sd)) {
 		if (type == AREA || type == BG || type == BG_AREA)

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -78,6 +78,11 @@ enum rodex_get_items;
 #define COLOR_YELLOW  0xffff00U
 #define COLOR_DEFAULT COLOR_GREEN
 
+#define MAX_STORAGE_ITEM_PACKET_NORMAL ((INT16_MAX - (sizeof(struct ZC_STORE_ITEMLIST_NORMAL) - (sizeof(struct NORMALITEM_INFO) * MAX_ITEMLIST))) / sizeof(struct NORMALITEM_INFO))
+#define MAX_STORAGE_ITEM_PACKET_EQUIP  ((INT16_MAX - (sizeof(struct ZC_STORE_ITEMLIST_EQUIP) - (sizeof(struct EQUIPITEM_INFO) * MAX_ITEMLIST))) / sizeof(struct EQUIPITEM_INFO))
+STATIC_ASSERT(MAX_STORAGE_ITEM_PACKET_NORMAL > 0, "Max items per storage item packet for normal items is less than 1, it's most likely to be a bug and shall not be ignored.");
+STATIC_ASSERT(MAX_STORAGE_ITEM_PACKET_EQUIP > 0, "Max items per storage item packet for equip items is less than 1, it's most likely to be a bug and shall not be ignored.");
+
 /**
  * Enumerations
  **/


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
1. Fixed a packet size underflow in storage list sending which started with client supporting int32 for item id and added static assert to detect this problem if ever happened again.
2. Fixed direct calls to clif_send in clif.c
3. Add missing nullpo and assert to clif_send

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
