### PR TITLE
Add *setfavoriteitemidx & *autofavoriteitem script commands - alter item favorite state

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3192,6 +3192,30 @@ runs of getcartinventorylist().
 
 ---------------------------------------
 
+*setfavoriteitemidx(<idx>, <flag>)
+
+This function will set an item in inventory as favorite or not.
+If its favorite item, it will be moved to favorite tab, else move out from favorite tab.
+Note: Cant change favorite flag of an equipped item.
+
+Valid Parameters: 
+	<idx>    - inventory index, refer *getinventorylist()
+	<flag>   - true/false (true = favorite item, false = otherwise)
+
+---------------------------------------
+
+*autofavoriteitem(<item_id>, <flag>)
+
+This function will auto set an item as favorite when <item_id> is obtained. 
+If its favorite item, it will be auto moved to favorite tab, else move out from favorite tab.
+This setting affect not only attached player, but also everyone player globally.
+
+Valid Parameters: 
+	<item_id> - item ID
+	<flag>    - true/false (true = favorite item, false = otherwise)
+
+---------------------------------------
+
 *cardscnt()
 
 This function will return the number of cards inserted into the weapon

--- a/src/map/itemdb.h
+++ b/src/map/itemdb.h
@@ -521,7 +521,8 @@ struct item_data {
 		unsigned no_refine : 1; // [celest]
 		unsigned delay_consume : 1;     ///< Signifies items that are not consumed immediately upon double-click [Skotlex]
 		unsigned trade_restriction : 9; ///< Item trade restrictions mask (@see enum ItemTradeRestrictions)
-		unsigned autoequip: 1;
+		unsigned autoequip : 1;
+		unsigned auto_favorite : 1;
 		unsigned buyingstore : 1;
 		unsigned bindonequip : 1;
 		unsigned keepafteruse : 1;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -4778,6 +4778,13 @@ static int pc_additem(struct map_session_data *sd, const struct item *item_data,
 
 	sd->weight += w;
 	clif->updatestatus(sd,SP_WEIGHT);
+
+	// auto-favorite
+	if (data->flag.auto_favorite > 0) {
+		sd->status.inventory[i].favorite = 1;
+		clif->favorite_item(sd, i);
+	}
+
 	//Auto-equip
 	if(data->flag.autoequip)
 		pc->equipitem(sd, i, data->equip);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24681,6 +24681,49 @@ static BUILDIN(consolemes)
 	return true;
 }
 
+static BUILDIN(setfavoriteitemidx)
+{
+	struct map_session_data *sd = script_rid2sd(st);
+	int idx = script_getnum(st, 2);
+	int value = script_getnum(st, 3);
+
+	if (sd == NULL) {
+		ShowError("buildin_setfavoriteitemidx: No player attached.\n");
+		return false;
+	}
+
+	if (idx < 0 || idx >= sd->status.inventorySize) {
+		ShowError("buildin_setfavoriteitemidx: Invalid inventory index %d (min: %d, max: %d).\n", idx, 0, (sd->status.inventorySize - 1));
+		return false;
+	} else if (sd->inventory_data[idx] == NULL || sd->inventory_data[idx]->nameid <= 0) {
+		ShowWarning("buildin_setfavoriteitemidx: Current inventory index %d has no data.\n", idx);
+		return false;
+	} else if (sd->status.inventory[idx].equip > 0) {
+		ShowWarning("buildin_setfavoriteitemidx: Cant change favorite flag of an equipped item.\n");
+		return false;
+	} else {
+		sd->status.inventory[idx].favorite = cap_value(value, 0, 1);
+		clif->favorite_item(sd, idx);
+	}
+
+	return true;
+}
+
+static BUILDIN(autofavoriteitem)
+{
+	int nameid = script_getnum(st, 2);
+	int flag = script_getnum(st, 3);
+	struct item_data *item_data;
+
+	if ((item_data = itemdb->exists(nameid)) == NULL) {
+		ShowError("buildin_autofavoriteitem: Invalid item '%d'.\n", nameid);
+		return false;
+	}
+
+	item_data->flag.auto_favorite = cap_value(flag, 0, 1);
+	return true;
+}
+
 /** place holder for the translation macro **/
 static BUILDIN(_)
 {
@@ -26059,6 +26102,8 @@ static void script_parse_builtin(void)
 
 		BUILDIN_DEF(closeroulette, ""),
 		BUILDIN_DEF(openrefineryui, ""),
+		BUILDIN_DEF(setfavoriteitemidx, "ii"),
+		BUILDIN_DEF(autofavoriteitem, "ii"),
 	};
 	int i, len = ARRAYLENGTH(BUILDIN);
 	RECREATE(script->buildin, char *, script->buildin_count + len); // Pre-alloc to speed up


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- `setfavoriteitemidx()` set an item as favorite item or not
- if an item is set to favorite item, it will be moved into favorite
tab, else move out from favorite tab.
- only non-equipped item can adjust the favorite item state.
- `autofavoriteitem()` will auto set an item as favorite state or not whenever obtained. (affect globally)

-----------------------------

<!-- Describe the changes that this pull request makes. -->
Sample Script: `autofavoriteitem(<itemID>, <flag>)`
<details>

```
prontera,155,181,4	script	Sample	4_F_KAFRA1,{
	.@item_id = 909;
	mes getitemname(.@item_id);
	// mes "auto favorite: "+getiteminfo2(.@item_id, 21);
	.@flag = select("disable favorite", "enable favorite") - 1;
	autofavoriteitem(.@item_id, .@flag);
	close;
}
```
</details>

Sample Script: `setfavoriteitemidx(<idx>, <flag>)`
<details>

```
prontera,155,181,4	script	Sample	4_F_KAFRA1,{
	do {
		getinventorylist;
		.@menu$ = "";
		for (.@i = 0; .@i < @inventorylist_count; .@i++) {
			.@c = (@inventorylist_card1[.@i] > 0) + (@inventorylist_card2[.@i] > 0) + (@inventorylist_card3[.@i] > 0) + (@inventorylist_card4[.@i] > 0);
			.@menu$ += "[idx- "+@inventorylist_idx[.@i]+"] " + getitemname(@inventorylist_id[.@i]);
			if (.@c) 
				.@menu$ += "["+.@c+" cards]";
			.@menu$ += " "+ (@inventorylist_favorite[.@i] ? "^0055FF- favorite^000000":"") + ":";
		}
		.@i = select(.@menu$) - 1;
		// based on inventory index
		setfavoriteitemidx(@inventorylist_idx[.@i], !@inventorylist_favorite[.@i]);
	} while (true);
	close;
}
```

`@inventorylist_favorite[.@i]` [from this PR](https://github.com/HerculesWS/Hercules/pull/2426), but not really dependant on it. Since it can be just set with the value `0 or 1`. Bonus if have it.
</details>

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
