### PR TITLE
Fixed issue with Perl v5.2x

### DIFF
--- a/tools/itemdbconverter.pl
+++ b/tools/itemdbconverter.pl
@@ -109,9 +109,9 @@ sub parsedb (@) {
 			(?<eLV>[0-9]*)[^,:]*(?<hasmaxlv>:[\s\t]*(?<eLVmax>[0-9]*))?[^,]*,[\s\t]*
 			(?<Refineable>[0-9]*)[^,]*,[\s\t]*
 			(?<View>[0-9]*)[^,]*,[\s\t]*
-			{(?<Script>.*)},
-			{(?<OnEquip>.*)},
-			{(?<OnUnequip>.*)}
+			\{(?<Script>.*)},
+			\{(?<OnEquip>.*)},
+			\{(?<OnUnequip>.*)}
 		/x ) {
 			my %cols = map { $_ => $+{$_} } keys %+;
 			print "/*\n" if $cols{prefix};


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** None

In perl v5.22, using a literal { in a regular expression was deprecated, and will emit a warning if it isn't escaped: \{. In v5.26, this won't just warn, it'll cause a syntax error.

Before:
![Before](https://i.imgur.com/TyzYKKq.jpg)

After:
![After](https://i.imgur.com/49KcATn.jpg)
<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
