### PR TITLE
Restore the ability for HPM Hooks to hook to private interfaces

### DIFF
--- a/src/plugins/HPMHooking.h
+++ b/src/plugins/HPMHooking.h
@@ -50,9 +50,19 @@ HPExport struct HPMHooking_interface HPMHooking_s;
 		HPMi->hooking->AddHook(HOOK_TYPE_PRE, #ifname "->" #funcname, (hook), HPMi->pid) \
 		)
 
+#define addHookPrePriv(ifname, funcname, hook) ( \
+		(void)((HPMHOOK_pre_PRIV__ ## ifname ## _ ## funcname)0 == (hook)), \
+		HPMi->hooking->AddHook(HOOK_TYPE_PRE, #ifname "->p->" #funcname, (hook), HPMi->pid) \
+		)
+
 #define addHookPost(ifname, funcname, hook) ( \
 		(void)((HPMHOOK_post_ ## ifname ## _ ## funcname)0 == (hook)), \
 		HPMi->hooking->AddHook(HOOK_TYPE_POST, #ifname "->" #funcname, (hook), HPMi->pid) \
+		)
+
+#define addHookPostPriv(ifname, funcname, hook) ( \
+		(void)((HPMHOOK_post_PRIV__ ## ifname ## _ ## funcname)0 == (hook)), \
+		HPMi->hooking->AddHook(HOOK_TYPE_POST, #ifname "->p->" #funcname, (hook), HPMi->pid) \
 		)
 
 /* need better names ;/ */


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
- Starting from 5db7c799055c6ae9c4463f6cf4c88a35597d5d31 the ability to hook to private interfaces was removed, this commit restores this ability by introducing two new macros for specifically.
* addHookPrePriv to add a pre-hook for private interface member
* addHookPostPriv to add a post-hook for private interface member

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
