### PR TITLE
Update unitwarp script command.

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -957,7 +957,7 @@ static int unit_warp(struct block_list *bl, short m, short x, short y, enum clr_
 			return 2;
 
 		}
-	} else if (map->getcell(m, bl, x, y, CELL_CHKNOREACH)) {
+	} else if (bl->type != BL_NPC && map->getcell(m, bl, x, y, CELL_CHKNOREACH)) {
 		//Invalid target cell
 		ShowWarning("unit_warp: Specified non-walkable target cell: %d (%s) at [%d,%d]\n", m, map->list[m].name, x,y);
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- allow NPC to warp to non-walkable cell. Just like `*movenpc()` did.
- NPC are allow to stay on non-walkable target cell, hence this command shouldn't show the warning and should warp the NPC to that cell instead.

**Issues addressed:**
 Try to use `unitwarp()` function to warp a npc to a non-walkable target cell.

Reference https://github.com/rathena/rathena/issues/2270

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
