### PR TITLE
Fix errors in the HPM Hooks Generator

### DIFF
--- a/tools/HPMHookGen/HPMHookGen.pl
+++ b/tools/HPMHookGen/HPMHookGen.pl
@@ -371,7 +371,8 @@ foreach my $file (@files) { # Loop through the xml files
 				$t = ')(int fd, struct login_session_data *sd)'; # typedef LoginParseFunc
 				$def =~ s/^LoginParseFunc\s*\*\s*(.*)$/enum parsefunc_rcode(* $1) (int fd, struct login_session_data *sd)/;
 			}
-			next unless ref $t ne 'HASH' and $t =~ /^[^\[]/; # If it's not a string, or if it starts with an array subscript, we can skip it
+			next if ref $t eq 'HASH'; # Skip if it's not a string
+			next if $t =~ /^\)?\[.*\]$/; # Skip arrays or pointers to array
 
 			my $if = parse($t, $def);
 			next unless scalar keys %$if; # If it returns an empty hash reference, an error must've occurred


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This adds the interface variables of type pointer to array to the ignored variables when generating the hooks.

Fixes the following errors:

```
Error: unable to parse 'char(* atcommand_interface::atcmd_output)[(255+1)]'
Error: unable to parse 'char(* atcommand_interface::atcmd_player_name)[(23+1)]'
```

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
