### PR TITLE
Add *duplicate/remove npc  script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6828,6 +6828,20 @@ NPCs talking while hidden then revealing... you can wonder around =P).
 
 ---------------------------------------
 
+*duplicatenpc("<source_npc_name>","<new_npc_name>","<new_npc_hidden_name>","<mapname>",<map_x>,<map_y>,<dir>{, <sprite_id>{, <map_xs>, <map_ys>}});
+
+Duplicate any existing npc based on <source_npc_name>.
+Return 1 on success, 0 if failed.
+
+---------------------------------------
+
+*duplicateremove("<npc_name>");
+
+Remove any existing npc based on <npc_name>.
+*Note: Using this will never remove duplicated NPC itself.
+
+---------------------------------------
+
 *doevent("<NPC object name>::<event label>")
 
 This command will start a new execution thread in a specified NPC object

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -12183,6 +12183,98 @@ static BUILDIN(hideonnpc)
 	return true;
 }
 
+static BUILDIN(duplicatenpc)
+{
+	int txs = -1, tys = -1;
+
+	if (script_hasdata(st, 10))
+		txs = (script_getnum(st, 10) < -1) ? -1 : script_getnum(st, 10);
+	if (script_hasdata(st, 11))
+		tys = (script_getnum(st, 11) < -1) ? -1 : script_getnum(st, 10);
+
+	if (txs == -1 && tys != -1)
+		txs = 0;
+	if (txs != -1 && tys == -1)
+		tys = 0;
+
+	const char *npc_name = script_getstr(st, 2);
+	const char *dup_name = script_getstr(st, 3);
+	const char *dup_hidden_name = script_getstr(st, 4);
+
+	if (strlen(dup_name) + strlen(dup_hidden_name) > NAME_LENGTH) {
+		ShowError("buildin_duplicatenpc: %s is to long (max %d chars).\n", npc_name, NAME_LENGTH);
+		script_pushint(st, 0);
+		return false;
+	}
+
+	struct npc_data *nd_source = npc->name2id(npc_name);
+	int tclass_;
+	if (script_hasdata(st, 9))
+		tclass_ = (script_getnum(st, 9) < -1) ? -1 : script_getnum(st, 9);
+	else
+		tclass_ = nd_source->class_;
+
+	if (nd_source == NULL) {
+		ShowError("buildin_duplicatenpc: original npc not found for duplicate. (%s)\n", npc_name);
+		script_pushint(st, 0);
+		return false;
+	}
+
+	const char *tmap = script_getstr(st, 5);
+	int tmapid = map->mapname2mapid(tmap);
+	if (tmapid < 0) {
+		ShowError("buildin_duplicatenpc: target map not found. (%s)\n", tmap);
+		script_pushint(st, 0);
+		return false;
+	}
+
+	int tx = script_getnum(st, 6);
+	int ty = script_getnum(st, 7);
+	int tdir = script_getnum(st, 8);
+	struct npc_data *nd_target = npc->create_npc(nd_source->subtype, tmapid, tx, ty, tdir, tclass_);
+
+	char targetname[NAME_LENGTH] = "";
+	strcat(targetname, dup_name);
+	if (strcmp(dup_hidden_name, "") != 0) {
+		strncat(targetname, "#", 1);
+		strncat(targetname, dup_hidden_name, strlen(dup_hidden_name));
+	}
+
+	safestrncpy(nd_target->name, targetname, sizeof(nd_target->name));
+	safestrncpy(nd_target->exname, targetname, sizeof(nd_target->exname));
+
+	npc->duplicate_sub(nd_target, nd_source, txs, tys, NPO_ONINIT);
+
+	script_pushint(st, 1);
+	return true;
+}
+
+static BUILDIN(duplicateremove)
+{
+	struct npc_data *nd;
+
+	if (script_hasdata(st, 2)) {
+		nd = npc->name2id(script_getstr(st, 2));
+		if (nd == NULL) {
+			ShowError("buildin_duplicateremove: NPC not found. (%s)\n", script_getstr(st, 2));
+			script_pushint(st, 0);
+			return false;
+		}
+	} else {
+		nd = (struct npc_data *)map->id2bl(st->oid);
+	}
+
+	if (nd != NULL) {
+		if (nd->src_id == 0) //remove all dupicates for this source npc
+			map->foreachnpc(npc->unload_dup_sub, nd->bl.id);
+		else // just remove this duplicate
+			npc->unload(nd, true);
+	}
+
+	script_pushint(st, 1);
+	return true;
+}
+
 /* Starts a status effect on the target unit or on the attached player.
  *
  * sc_start  <effect_id>,<duration>,<val1>{,<rate>,<flag>,{<unit_id>}};
@@ -25623,6 +25715,8 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(disablenpc,"s"),
 		BUILDIN_DEF(hideoffnpc,"s"),
 		BUILDIN_DEF(hideonnpc,"s"),
+		BUILDIN_DEF(duplicatenpc, "ssssiii???"),
+		BUILDIN_DEF(duplicateremove, "?"),
 		BUILDIN_DEF(sc_start,"iii???"),
 		BUILDIN_DEF2(sc_start,"sc_start2","iiii???"),
 		BUILDIN_DEF2(sc_start,"sc_start4","iiiiii???"),


### PR DESCRIPTION

<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- `duplicatenpc(....)` duplicate any existing npc.
- `duplicateremove(...)` will remove any existing NPC other than itself.

If I recall correctly, recently kRO added an item that will create a Treasure Chest NPC nearby player to retrieve item. _(Saw the info at twRO forum previously, still searching for the link/info.)_
Anyway, its a useful script command.
Original src :  https://github.com/dastgirp/HPM-Plugins/blob/master/src/plugins/npc-duplicate.c

**Issues addressed:** <!-- Write here the issue number, if any. -->



**Known Issue: **
https://github.com/dastgirp/HPM-Plugins/issues/40

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
