### PR TITLE
Fix some stats calculation issues by reverting basic stats type from uint32 to uint16

### DIFF
--- a/src/map/status.h
+++ b/src/map/status.h
@@ -2058,8 +2058,9 @@ typedef struct weapon_atk {
 struct status_data {
 	uint32
 		hp, sp,  // see status_cpy before adding members before hp and sp
-		max_hp, max_sp,
-		str, agi, vit, int_, dex, luk,
+		max_hp, max_sp;
+	uint16 str, agi, vit, int_, dex, luk;
+	uint32
 		batk,
 		matk_min, matk_max,
 		speed,


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix some stats calculation issues by reverting basic stats type from uint32 to uint16.
