### PR TITLE
Adds Option DB and Option Drop Groups DB to be loaded on minimal mode

### DIFF
--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -2449,6 +2449,8 @@ static void itemdb_read(bool minimal)
 
 	itemdb->other->foreach(itemdb->other, itemdb->addname_sub);
 
+	itemdb->read_options();
+	
 	if (minimal)
 		return;
 
@@ -2458,7 +2460,6 @@ static void itemdb_read(bool minimal)
 	itemdb->read_groups();
 	itemdb->read_chains();
 	itemdb->read_packages();
-	itemdb->read_options();
 }
 
 /**

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -5519,7 +5519,8 @@ static bool mob_readdb_itemratio(char *str[], int columns, int current)
 static void mob_load(bool minimal)
 {
 	if (minimal) {
-		// Only read the mob db in minimal mode
+		// Only read the mob db and option drops in minimal mode
+		mob->read_optdrops_db();
 		mob->readdb();
 		return;
 	}


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR makes option_drop_groups.conf and item_options.conf be loaded when running map-server in minimal mode. This fixes errors when map-server loads mob db in minimal mode and it can't find option_drop_groups to be assigned to mob drops.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Indirectly reported on #2484 (The actual issue was different, but the error was written in it)

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
