### PR TITLE
Add identify/identifyidx script commands and identifyall atcommand

### DIFF
--- a/doc/atcommands.txt
+++ b/doc/atcommands.txt
@@ -584,6 +584,12 @@ Opens the Identification window if any unappraised items are in your inventory.
 
 ---------------------------------------
 
+@identifyall
+
+Identifies all unappraised items in your inventory.
+
+---------------------------------------
+
 @trade <player name>
 
 Opens the trade window with the specified player.

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3370,6 +3370,15 @@ enable (true) or disable (false) the effect on the player.
 
 ---------------------------------------
 
+*identify(<Item ID>)
+
+This function identifies the first <Item ID> item in attached player's inventory.
+
+Returns -2 if an error happens, -1 if no unidentified <Item ID> was found.
+Otherwise, returns the idx of the identified item.
+
+---------------------------------------
+
 *identifyidx(<Inventory Index>)
 
 This will identify item at attached player's <Inventory Index> inventory index.

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3369,6 +3369,15 @@ This will set a Hat Effect onto the player. The state field allows you to
 enable (true) or disable (false) the effect on the player.
 
 ---------------------------------------
+
+*identifyidx(<Inventory Index>)
+
+This will identify item at attached player's <Inventory Index> inventory index.
+
+Returns true if the item was identified, false otherwise.
+Note: If the item was already identified, it returns false.
+
+---------------------------------------
 //=====================================
 2.1 - End of Item-Related Commands
 //=====================================

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -6769,23 +6769,34 @@ ACMD(refreshall)
 }
 
 /*==========================================
- * @identify
+ * @identify / @identifyall
  * => GM's magnifier.
  *------------------------------------------*/
 ACMD(identify)
 {
 	int num = 0;
+	bool identifyall = (strcmpi(info->command, "identifyall") == 0);
 
-	for (int i = 0; i < sd->status.inventorySize; i++) {
-		if(sd->status.inventory[i].nameid > 0 && sd->status.inventory[i].identify!=1){
-			num++;
+	if (!identifyall) {
+		for (int i = 0; i < sd->status.inventorySize; i++) {
+			if (sd->status.inventory[i].nameid > 0 && sd->status.inventory[i].identify != 1) {
+				num++;
+			}
+		}
+	} else {
+		for (int i = 0; i < sd->status.inventorySize; i++) {
+			if (sd->status.inventory[i].nameid > 0 && sd->status.inventory[i].identify != 1) {
+				skill->identify(sd, i);
+				num++;
+			}
 		}
 	}
-	if (num > 0) {
-		clif->item_identify_list(sd);
-	} else {
+	
+	if (num == 0)
 		clif->message(fd,msg_fd(fd,1238)); // There are no items to appraise.
-	}
+	else if (!identifyall)
+		clif->item_identify_list(sd);
+
 	return true;
 }
 
@@ -10061,6 +10072,7 @@ static void atcommand_basecommands(void)
 		ACMD_DEF(refresh),
 		ACMD_DEF(refreshall),
 		ACMD_DEF(identify),
+		ACMD_DEF2("identifyall", identify),
 		ACMD_DEF(misceffect),
 		ACMD_DEF(mobsearch),
 		ACMD_DEF(cleanmap),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -25516,6 +25516,39 @@ static BUILDIN(openrefineryui)
 }
 
 /**
+ * identifyidx(idx)
+ * Identifies item at idx.
+ * Returns true if item is identified, false otherwise.
+ */
+static BUILDIN(identifyidx)
+{
+	struct map_session_data *sd = script_rid2sd(st);
+
+	if (sd == NULL) {
+		script_pushint(st, false);
+		return true;
+	}
+
+	int idx = script_getnum(st, 2);
+	if (idx < 0 || idx >= sd->status.inventorySize) {
+		ShowError("buildin_identifyidx: Invalid inventory index (%d), expected a value between 0 and %d\n", idx, sd->status.inventorySize);
+		script_pushint(st, false);
+		return true;
+	}
+	
+	if (sd->status.inventory[idx].nameid <= 0 || sd->status.inventory[idx].identify != 0) {
+		script_pushint(st, false);
+		return true;
+	}
+
+	sd->status.inventory[idx].identify = 1;
+	clif->item_identified(sd, idx, 0);
+	script_pushint(st, true);
+
+	return true;
+}
+
+/**
  * Adds a built-in script function.
  *
  * @param buildin Script function data
@@ -26275,6 +26308,8 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(openrefineryui, ""),
 		BUILDIN_DEF(setfavoriteitemidx, "ii"),
 		BUILDIN_DEF(autofavoriteitem, "ii"),
+
+		BUILDIN_DEF(identifyidx, "i"),
 	};
 	int i, len = ARRAYLENGTH(BUILDIN);
 	RECREATE(script->buildin, char *, script->buildin_count + len); // Pre-alloc to speed up

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -25516,6 +25516,42 @@ static BUILDIN(openrefineryui)
 }
 
 /**
+ * identify(<item id>)
+ * Identifies the first unidentified <item id> item on player's inventory.
+ * Returns -2 on error, -1 if no item to identify was found, identified idx otherwise.
+ */
+static BUILDIN(identify)
+{
+	struct map_session_data *sd = script_rid2sd(st);
+
+	if (sd == NULL) {
+		script_pushint(st, -2);
+		return true;
+	}
+
+	int itemid = script_getnum(st, 2);
+	if (itemdb->exists(itemid) == NULL) {
+		ShowError("buildin_identify: Invalid item ID (%d)\n", itemid);
+		script_pushint(st, -2);
+		return true;
+	}
+
+	int idx = -1;
+	ARR_FIND(0, sd->status.inventorySize, idx, (sd->status.inventory[idx].nameid == itemid && sd->status.inventory[idx].identify == 0));
+
+	if (idx < 0 || idx >= sd->status.inventorySize) {
+		script_pushint(st, -1);
+		return true;
+	}
+
+	sd->status.inventory[idx].identify = 1;
+	clif->item_identified(sd, idx, 0);
+	script_pushint(st, idx);
+
+	return true;
+}
+
+/**
  * identifyidx(idx)
  * Identifies item at idx.
  * Returns true if item is identified, false otherwise.
@@ -26309,6 +26345,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(setfavoriteitemidx, "ii"),
 		BUILDIN_DEF(autofavoriteitem, "ii"),
 
+		BUILDIN_DEF(identify, "i"),
 		BUILDIN_DEF(identifyidx, "i"),
 	};
 	int i, len = ARRAYLENGTH(BUILDIN);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
This PR implements script commands to identify items, although lots of scripts nowadays kind of fake that behavior by using a combination of `delitem2` + `getitem2`, this leads to wrong behavior when items have more information, like random options (as shown in this [forum post][post], where doing this leads to losing dropped options). New script commands:
- `identify(<Item ID>)`: Identifies the first unidentified item with ID = "Item ID"
- `identifyidx(<idx>)`: Identifies item at inventory index `idx`.

I took the chance to also add `@identifyall` atcommand, because it is quite boring to identify item per item when you are testing lots of drops.

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
[post]: https://herc.ws/board/topic/17079-random-options-on-monster-drops/?do=findComment&comment=91951