### PR TITLE
Disable refresh atcommand when talk with NPC.

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -6752,6 +6752,9 @@ ACMD(mute)
  *------------------------------------------*/
 ACMD(refresh)
 {
+	if (sd->npc_id > 0)
+		return false;
+
 	clif->refresh(sd);
 	return true;
 }
@@ -6763,7 +6766,8 @@ ACMD(refreshall)
 
 	iter = mapit_getallusers();
 	for (iter_sd = BL_UCAST(BL_PC, mapit->first(iter)); mapit->exists(iter); iter_sd = BL_UCAST(BL_PC, mapit->next(iter)))
-		clif->refresh(iter_sd);
+		if (iter_sd->npc_id <= 0)
+			clif->refresh(iter_sd);
 	mapit->free(iter);
 	return true;
 }


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- using `@refresh`/`@refreshall` during NPC conversation will caused player stucked due to unable to close the NPC dialog that no longer visible.
- `@refresh` shall display failure message if interact with NPC.
- `@refreshall` shall skip the player if the target player are interact with NPC.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
