### PR TITLE
Fix family check and EXP bug

### DIFF
--- a/src/char/char.c
+++ b/src/char/char.c
@@ -2273,6 +2273,8 @@ static int char_char_married(int pl1, int pl2)
 
 static int char_char_child(int parent_id, int child_id)
 {
+	if (parent_id == 0 || child_id == 0) // Failsafe, avoild querys and fix EXP bug dividing with lower level chars
+		return 0;
 	if( SQL_ERROR == SQL->Query(inter->sql_handle, "SELECT `child` FROM `%s` WHERE `char_id` = '%d'", char_db, parent_id) )
 		Sql_ShowDebug(inter->sql_handle);
 	else if( SQL_SUCCESS == SQL->NextRow(inter->sql_handle) )
@@ -2292,6 +2294,8 @@ static int char_char_child(int parent_id, int child_id)
 
 static int char_char_family(int cid1, int cid2, int cid3)
 {
+	if (cid1 == 0 || cid2 == 0 || cid3 == 0) //Failsafe, and avoid querys where there is no sense to keep executing if any of the inputs are 0
+		return 0;
 	if( SQL_ERROR == SQL->Query(inter->sql_handle, "SELECT `char_id`,`partner_id`,`child` FROM `%s` WHERE `char_id` IN ('%d','%d','%d')", char_db, cid1, cid2, cid3) )
 		Sql_ShowDebug(inter->sql_handle);
 	else while( SQL_SUCCESS == SQL->NextRow(inter->sql_handle) )


### PR DESCRIPTION

<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- failsafe function to not execute the query
- avoid EXP sharing bug
> This adds a failsafe function to not execute the query during the family check AND avoid an exp sharing bug when the child_id is == 0 AND the returning value from the SQL is 0 also, this makes the check on `char_child` function returns a FALSE 1(positive)

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
https://github.com/rathena/rathena/pull/3350

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
