### PR TITLE
Update Homunculus obtain EXP from master

### DIFF
--- a/conf/map/battle/homunc.conf
+++ b/conf/map/battle/homunc.conf
@@ -66,3 +66,6 @@ homunculus_max_level: 99
 
 // Max level for Homunculus S
 homunculus_S_max_level: 150
+
+// Bonus EXP homunculus received from master? (Note 2)
+hom_bonus_exp_from_master: 10

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7437,6 +7437,7 @@ static const struct battle_data {
 	{ "hit_min_limit",                      &battle_config.hit_min,                         1,      1,      INT_MAX,        },
 	{ "hit_max_limit",                      &battle_config.hit_max,                         SHRT_MAX, 1,    INT_MAX,        },
 	{ "autoloot_adjust",                    &battle_config.autoloot_adjust,                 0,      0,      1,              },
+	{ "hom_bonus_exp_from_master",          &battle_config.hom_bonus_exp_from_master,      10,      0,      100,            },
 };
 
 static bool battle_set_value_sub(int index, int value)

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -478,6 +478,7 @@ struct Battle_Config {
 	int client_emblem_max_blank_percent;
 	int hom_max_level;
 	int hom_S_max_level;
+	int hom_bonus_exp_from_master;
 
 	// [BattleGround Settings]
 	int bg_update_interval;

--- a/src/map/homunculus.c
+++ b/src/map/homunculus.c
@@ -552,6 +552,12 @@ static int homunculus_gainexp(struct homun_data *hd, unsigned int exp)
 
 	hd->homunculus.exp += exp;
 
+	if (hd->master->state.showexp && hd->exp_next > 0) {
+		char output[256];
+		sprintf(output, "Homunculus Experience Gained Base:%u (%.2f%%)", exp, ((float)exp / (float)hd->exp_next * (float)100));
+		clif_disp_onlyself(hd->master, output);
+	}
+
 	if(hd->homunculus.exp < hd->exp_next) {
 		clif->hominfo(hd->master,hd,0);
 		return 0;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -7143,6 +7143,11 @@ static bool pc_gainexp(struct map_session_data *sd, struct block_list *src, uint
 		clif_disp_onlyself(sd, output);
 	}
 
+	// Share master EXP to homunculus
+	if (sd->hd != NULL && battle_config.hom_bonus_exp_from_master > 0) {
+		homun->gainexp(sd->hd, apply_percentrate((int)base_exp, battle_config.hom_bonus_exp_from_master, 100));
+	}
+
 	return true;
 }
 


### PR DESCRIPTION

<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- homunculus will obtain a portion or full EXP (`1~100%`) from master.  (`0% = disable`)
- `@showexp` shall display homunculus EXP gain.

homunculus gain `10%` bonus exp from master. (default = `10%`)
```
Battle configuration has been reloaded.
Experience Gained Base:56 (0.00%) Job:60 (0.06%)
Homunculus Experience Gained Base:5 (0.23%)
```
<details>

homunculus gain `50%` bonus exp from master.
```
Battle configuration has been reloaded.
Experience Gained Base:56 (0.00%) Job:60 (0.06%)
Homunculus Experience Gained Base:28 (1.29%)
```
homunculus gain `100%` bonus exp from master.
```
Gained exp is now shown.
Experience Gained Base:56 (0.00%) Job:60 (0.06%)
Homunculus Experience Gained Base:56 (2.57%)
```
</details>
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
https://github.com/HerculesWS/Hercules/issues/2313

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
