### PR TITLE
Fix missing file path in console.

### DIFF
--- a/src/map/homunculus.c
+++ b/src/map/homunculus.c
@@ -1375,7 +1375,7 @@ static void homunculus_exp_db_read(void)
 			homun->dbs->exptable[MAX_LEVEL - 1] = 0;
 		}
 		fclose(fp);
-		ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' levels in '"CL_WHITE"%s"CL_RESET"'.\n", j, filename[i]);
+		ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' levels in '"CL_WHITE"%s/%s"CL_RESET"'.\n", j, map->db_path, filename[i]);
 	}
 }
 

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -1655,7 +1655,7 @@ static void itemdb_read_combos(void)
 		count++;
 	}
 	fclose(fp);
-	ShowStatus("Done reading '"CL_WHITE"%"PRIu32""CL_RESET"' entries in '"CL_WHITE"item_combo_db"CL_RESET"'.\n", count);
+	ShowStatus("Done reading '"CL_WHITE"%"PRIu32""CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, DBPATH"item_combo_db.txt");
 
 	return;
 }
@@ -2407,7 +2407,7 @@ static int itemdb_readdb_libconfig(const char *filename)
 	}
 	db_destroy(duplicate_db);
 	libconfig->destroy(&item_db_conf);
-	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filename);
+	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filepath);
 	return count;
 }
 

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -4959,7 +4959,7 @@ static int mob_read_libconfig(const char *filename, bool ignore_missing)
 		}
 	}
 	libconfig->destroy(&mob_db_conf);
-	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filename);
+	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filepath);
 
 	return count;
 }
@@ -5082,7 +5082,7 @@ static int mob_read_randommonster(void)
 			summon[i].qty = 1;
 		}
 		fclose(fp);
-		ShowStatus("Done reading '"CL_WHITE"%u"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n",count,mobfile[i]);
+		ShowStatus("Done reading '"CL_WHITE"%u"CL_RESET"' entries in '"CL_WHITE"%s/%s"CL_RESET"'.\n",count, map->db_path, mobfile[i]);
 	}
 	return 0;
 }
@@ -5199,7 +5199,7 @@ static void mob_readchatdb(void)
 		count++;
 	}
 	fclose(fp);
-	ShowStatus("Done reading '"CL_WHITE"%"PRIu32""CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, arc);
+	ShowStatus("Done reading '"CL_WHITE"%"PRIu32""CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filepath);
 }
 
 /*==========================================

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -1321,7 +1321,7 @@ static int pet_read_db_libconfig(const char *filename, bool ignore_missing)
 		count++;
 	}
 	libconfig->destroy(&pet_db_conf);
-	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filename);
+	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filepath);
 
 	return count;
 }

--- a/src/map/quest.c
+++ b/src/map/quest.c
@@ -585,7 +585,7 @@ static int quest_read_db(void)
 		count++;
 	}
 	libconfig->destroy(&quest_db_conf);
-	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filename);
+	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filepath);
 	return count;
 }
 

--- a/src/map/refine.c
+++ b/src/map/refine.c
@@ -624,7 +624,7 @@ static int refine_readdb_refine_libconfig(const char *filename)
 		}
 	}
 	libconfig->destroy(&refine_db_conf);
-	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filename);
+	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, filepath);
 
 	return count;
 }


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- show file path

<!-- Describe the changes that this pull request makes. -->
Current result: (display only file name without extension and path)
```
[Status]: Done reading '416' entries in 'item_combo_db'.
```
Updated result: (display file path + name)
```
[Status]: Done reading '416' entries in 'db/re/item_combo_db'.
```
<details>

```
[Status]: Done reading '64' command aliases in 'conf/atcommand.conf'.
[Status]: Done reading '4' channels in 'conf/channels.conf'.
[Status]: Done reading '10606' entries in 'db/re/item_db.conf'.
[Status]: Done reading '263' entries in 'db/re/item_db2.conf'.
[Status]: Done reading '186' entries in 'db/item_options.conf'.
[Status]: Done reading '416' entries in 'db/re/item_combo_db'.
[Status]: Done reading '57' entries in 'db/re/item_group.conf'.
[Status]: Done reading '4' entries in 'db/re/item_chain.conf'.
[Status]: Done reading '270' entries in 'db/re/item_packages.conf'.
[Status]: Done reading '16' entries in 'db/cashshop_db.conf'.
[Status]: Done reading '21' entries in 'db/attendance_db.conf'.
[Status]: Done reading '4' valid clans of '4' entries in 'conf/clans.conf'.
[Status]: Done reading '1124' entries in 'db/re/skill_db.conf'.
[Status]: Done reading '264' entries in 'db/produce_db.txt'.
[Status]: Done reading '136' entries in 'db/create_arrow_db.txt'.
[Status]: Done reading '205' entries in 'db/abra_db.txt'.
[Status]: Done reading '17' entries in 'db/spellbook_db.txt'.
[Status]: Done reading '23' entries in 'db/magicmushroom_db.txt'.
[Status]: Done reading '16' entries in 'db/skill_improvise_db.txt'.
[Status]: Done reading '74' entries in 'db/skill_changematerial_db.txt'.
[Status]: Done reading '16' zones in 'db/re/map_zone_db.conf'.
[Status]: Done reading '0' entries in 'db/mob_item_ratio.txt'.
[Status]: Done reading '0' entries in 'db/option_drop_groups.conf'.
[Status]: Done reading '40' entries in 'db/mob_chat_db.txt'.
[Status]: Done reading '1724' entries in 'db/re/mob_db.conf'.
[Status]: Done reading '370' entries in 'db/re/mob_db2.conf'.
[Status]: Done reading '1236' entries in 'db/re/mob_skill_db.conf'.
[Status]: Done reading '1' entries in 'db/mob_skill_db2.conf'.
[Status]: Done reading '0' entries in 'db/mob_avail.txt'.
[Status]: Done reading '480' entries in 'db/re/mob_branch.txt'.
[Status]: Done reading '14' entries in 'db/re/mob_poring.txt'.
[Status]: Done reading '47' entries in 'db/re/mob_boss.txt'.
[Status]: Done reading '331' entries in 'db/mob_pouch.txt'.
[Status]: Done reading '25' entries in 'db/mob_classchange.txt'.
[Status]: Done reading '8' entries in 'db/re/mob_race2_db.txt'.
[Status]: Done reading '18' entries in 'db/re/exp_group_db.conf'.
[Status]: Done reading '35' entries in 'db/re/level_penalty.txt'.
[Status]: Done reading '4' entries in 'db/re/attr_fix.txt'.
[Status]: Done reading '175' entries in 'db/re/statpoint.txt'.
[Status]: Done reading '9' groups in 'conf/groups.conf'.
[Status]: Done reading '5' entries in 'db/re/refine_db.conf'.
[Status]: Done reading '134' entries in 'db/job_db2.txt'.
[Status]: Done reading '3' entries in 'db/re/size_fix.txt'.
[Status]: Done reading '394' entries in 'db/sc_config.txt'.
[Status]: Done reading '116' entries in 'db/re/job_db.conf'.
[Status]: Done reading '35' entries in 'db/castle_db.conf'.
[Status]: Done reading '15' entries in 'db/guild_skill_tree.txt'.
[Status]: Done reading '80' entries in 'db/re/pet_db.conf'.
[Status]: Done reading '0' entries in 'db/pet_db2.conf'.
[Status]: Done reading '107' entries in 'db/re/homunculus_db.txt'.
[Status]: Done reading '150' levels in 'db/re/exp_homun.txt'.
[Status]: Done reading '82' entries in 'db/homun_skill_tree.txt'.
[Status]: Done reading '61' entries in 'db/mercenary_db.txt'.
[Status]: Done reading '157' entries in 'db/mercenary_skill_db.txt'.
[Status]: Done reading '12' elementals in 'db/elemental_db.txt'.
[Status]: Done reading '36' entries in 'db/elemental_skill_db.txt'.
[Status]: Done reading '3095' entries in 'db/quest_db.conf'.
[Status]: Done reading '342' entries in 'db/re/achievement_db.conf'.
[Status]: Done reading '11' entries in 'db/achievement_rank_db.conf'.
```
</details>

**Issues addressed:** <!-- Write here the issue number, if any. -->
missing file path info in console.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
