### PR TITLE
Update Siegfried Tokens support.

### DIFF
--- a/db/pre-re/item_chain.conf
+++ b/db/pre-re/item_chain.conf
@@ -59,6 +59,12 @@ ITMCHAIN_ORE: {
 	Emperium: 5
 }
 
+ITMCHAIN_SIEGFRIED: {
+	Token_Of_Siegfried: 1
+	F_Token_Of_Siegfried: 1
+	E_Token_Of_Siegfried: 1
+}
+
 ITMCHAIN_GEM: {
 	Dark_Red_Jewel: 80
 	Violet_Jewel: 30

--- a/db/re/item_chain.conf
+++ b/db/re/item_chain.conf
@@ -59,6 +59,12 @@ ITMCHAIN_ORE: {
 	Emperium: 5
 }
 
+ITMCHAIN_SIEGFRIED: {
+	Token_Of_Siegfried: 1
+	F_Token_Of_Siegfried: 1
+	E_Token_Of_Siegfried: 1
+}
+
 ITMCHAIN_GEM: {
 	Dark_Red_Jewel: 80
 	Violet_Jewel: 30

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -16398,10 +16398,14 @@ static void clif_parse_AutoRevive(int fd, struct map_session_data *sd)
 {
 	if (pc_istrading(sd) || pc_isvending(sd))
 		return;
+
 	if (!pc_isdead(sd))
 		return;
 
-	int item_position = pc->search_inventory(sd, ITEMID_TOKEN_OF_SIEGFRIED);
+	if (sd->sc.data[SC_HELLPOWER]) //Cannot res while under the effect of SC_HELLPOWER.
+		return;
+
+	int item_position = pc->have_item_chain(sd, ECC_SIEGFRIED);
 	int hpsp = 100;
 
 	if (item_position == INDEX_NOT_FOUND) {
@@ -16411,18 +16415,15 @@ static void clif_parse_AutoRevive(int fd, struct map_session_data *sd)
 			return;
 	}
 
-	if (sd->sc.data[SC_HELLPOWER]) //Cannot res while under the effect of SC_HELLPOWER.
-		return;
-
 	if (!status->revive(&sd->bl, hpsp, hpsp))
 		return;
 
 	if (item_position == INDEX_NOT_FOUND)
-		status_change_end(&sd->bl,SC_LIGHT_OF_REGENE,INVALID_TIMER);
+		status_change_end(&sd->bl, SC_LIGHT_OF_REGENE, INVALID_TIMER);
 	else
 		pc->delitem(sd, item_position, 1, 0, DELITEM_SKILLUSE, LOG_TYPE_CONSUME);
 
-	clif->skill_nodamage(&sd->bl,&sd->bl,ALL_RESURRECTION, 4, 1);
+	clif->skill_nodamage(&sd->bl, &sd->bl, ALL_RESURRECTION, 4, 1);
 }
 
 /// Information about character's status values (ZC_ACK_STATUS_GM).

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -1523,6 +1523,11 @@ static void itemdb_read_chains(void)
 	else
 		itemdb->chain_cache[ECC_ORE] = i;
 
+	if (!script->get_constant("ITMCHAIN_SIEGFRIED", &i))
+		ShowWarning("itemdb_read_chains: failed to find 'ITMCHAIN_SIEGFRIED' chain to link to cache!\n");
+	else
+		itemdb->chain_cache[ECC_SIEGFRIED] = i;
+
 	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", count, config_filename);
 }
 

--- a/src/map/itemdb.h
+++ b/src/map/itemdb.h
@@ -139,7 +139,6 @@ enum item_itemid {
 	ITEMID_COATING_BOTTLE        = 7139,
 	ITEMID_FRAGMENT_OF_CRYSTAL   = 7321,
 	ITEMID_SKULL_                = 7420,
-	ITEMID_TOKEN_OF_SIEGFRIED    = 7621,
 	ITEMID_SPECIAL_ALLOY_TRAP    = 7940,
 	ITEMID_CATNIP_FRUIT          = 11602,
 	ITEMID_RED_POUCH_OF_SURPRISE = 12024,
@@ -359,6 +358,7 @@ enum geneticist_item_list {
 //
 enum e_chain_cache {
 	ECC_ORE,
+	ECC_SIEGFRIED,
 	/* */
 	ECC_MAX,
 };

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -12215,6 +12215,29 @@ static int pc_have_magnifier(struct map_session_data *sd)
 }
 
 /**
+ * checks if player have any item that listed in item chain
+ * @param sd map_session_data of Player
+ * @param chain_id unsigned short of item chain id
+ * @return index of inventory, INDEX_NOT_FOUND if it is not found
+ */
+static int pc_have_item_chain(struct map_session_data *sd, unsigned short chain_id)
+{
+	if (chain_id >= itemdb->chain_count) {
+		ShowError("itemdb_chain_item: unknown chain id %d\n", chain_id);
+		return INDEX_NOT_FOUND;
+	}
+
+	for (int n = 0; n < itemdb->chains[chain_id].qty; n++) {
+		struct item_chain_entry *entry = &itemdb->chains[chain_id].items[n];
+		int index = pc->search_inventory(sd, entry->id);
+		if (index != INDEX_NOT_FOUND)
+			return index;
+	}
+
+	return INDEX_NOT_FOUND;
+}
+
+/**
  * Checks if player have basic skills learned.
  * @param  sd Player Data
  * @param  level Required Level of Novice Skill
@@ -12823,6 +12846,7 @@ void pc_defaults(void)
 	pc->update_idle_time = pc_update_idle_time;
 
 	pc->have_magnifier = pc_have_magnifier;
+	pc->have_item_chain = pc_have_item_chain;
 
 	pc->check_basicskill = pc_check_basicskill;
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -1184,6 +1184,7 @@ END_ZEROED_BLOCK; /* End */
 	void (*update_idle_time) (struct map_session_data* sd, enum e_battle_config_idletime type);
 
 	int (*have_magnifier) (struct map_session_data *sd);
+	int (*have_item_chain) (struct map_session_data *sd, unsigned short chain_id);
 
 	bool (*process_chat_message) (struct map_session_data *sd, const char *message);
 	int (*wis_message_to_gm) (const char *sender_name, int permission, const char *message);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
- allow player to revive themselves if their inventory consists of any type of siegfried tokens.
- support the following siegfried tokens:
https://github.com/HerculesWS/Hercules/blob/7063a6539316da89f33ccd8909aa7f718764c4f3/db/re/item_chain.conf#L62-L66

**Issues addressed:** <!-- Write here the issue number, if any. -->
Currently, if players has any of these siegfried token, only `7621` can be used to revive the players, the rest of the siegfried tokens will only enable the client to show the resurrection button but doesn't revive the players if clicked.


**Known Issue:**
I have no idea in what order of these tokens are consumed in official server. If the players have multiple different tokens, which shall be consumed first?
If anyone know, kindly let me know, so that I could update it.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
