### PR TITLE
Tombstone fixes

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -239,6 +239,14 @@ static void mvptomb_destroy(struct mob_data *md)
 
 		m = nd->bl.m;
 
+		struct s_mapiterator *iter = mapit_geteachpc();
+		for (struct map_session_data *sd = BL_UCAST(BL_PC, mapit->first(iter)); mapit->exists(iter); sd = BL_UCAST(BL_PC, mapit->next(iter))) {
+			if (sd->npc_id == nd->bl.id) {
+				sd->state.npc_unloaded = 1;
+			}
+		}
+		mapit->free(iter);
+
 		clif->clearunit_area(&nd->bl,CLR_OUTSIGHT);
 
 		map->delblock(&nd->bl);

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -1258,6 +1258,9 @@ static void run_tomb(struct map_session_data *sd, struct npc_data *nd)
 	char time[10];
 
 	nullpo_retv(nd);
+
+	sd->npc_id = nd->bl.id;
+
 	strftime(time, sizeof(time), "%H:%M", localtime(&nd->u.tomb.kill_time));
 
 	// TODO: Find exact color?
@@ -1373,8 +1376,10 @@ static int npc_scriptcont(struct map_session_data *sd, int id, bool closing)
 	if( sd->progressbar.npc_id && DIFF_TICK(sd->progressbar.timeout,timer->gettick()) > 0 )
 		return 1;
 
-	if( !sd->st )
+	if( !sd->st ) {
+		sd->npc_id = 0;
 		return 1;
+	}
 
 	if( closing && sd->st->state == CLOSE )
 		sd->st->state = END;

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -1349,8 +1349,10 @@ static int npc_scriptcont(struct map_session_data *sd, int id, bool closing)
 		return 1;
 	}
 
-	if(id != npc->fake_nd->bl.id) { // Not item script
-		if ((npc->checknear(sd,target)) == NULL){
+	if (id != npc->fake_nd->bl.id) { // Not item script
+		if (sd->state.npc_unloaded != 0) {
+			sd->state.npc_unloaded = 0;
+		} else if ((npc->checknear(sd,target)) == NULL) {
 			ShowWarning("npc_scriptcont: failed npc->checknear test.\n");
 			return 1;
 		}

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -238,6 +238,7 @@ struct map_session_data {
 		unsigned int loggingout : 1;
 		unsigned int warp_clean : 1;
 		unsigned int refine_ui : 1;
+		unsigned int npc_unloaded : 1; ///< The player is talking with an unloaded NPCs (respawned tombstones)
 	} state;
 	struct {
 		unsigned char no_weapon_damage, no_magic_damage, no_misc_damage;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR includes two fixes related to the MVP tombstones:

- When a player is talking to the tombstone while it disappears, it no longer gets stuck and requires to relog.
- When a player clicks (multiple times) a tombstone to read its message, it no longer prints the message several times inside the same NPC dialog.

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
