### PR TITLE
Fix two examples in scripting documentation

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2208,11 +2208,11 @@ Multiple statements can be grouped with { }, curly braces, just like with
 the 'if' statement.
 
 Example 1:
-	while (switch(select("Yes", "No") == 2))
+	while (select("Yes", "No") == 2)
 		mes("You picked no.");
 
 Example 2: multiple statements
-	while (switch(select("Yes", "No") == 2 )) {
+	while (select("Yes", "No") == 2) {
 		mes("Why did you pick no?");
 		mes("You should pick yes instead!");
 	}


### PR DESCRIPTION
#### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

You can't put a switch() statement inside a while statement.
I fixed 2 examples that had this mistake, which was probably caused by copy-pasting.

**Issues addressed:**
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
