### PR TITLE
Fixed several issues in itemdb_search_name function

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -3559,7 +3559,7 @@ ACMD(idsearch)
 
 	safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,77), item_name); // Search results for '%s' (name: id):
 	clif->message(fd, atcmd_output);
-	match = itemdb->search_name_array(item_array, MAX_SEARCH, item_name, 0);
+	match = itemdb->search_name_array(item_array, MAX_SEARCH, item_name, IT_SEARCH_NAME_PARTIAL);
 	if (match > MAX_SEARCH) {
 		safesnprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd,269), MAX_SEARCH, match);
 		clif->message(fd, atcmd_output);
@@ -7441,7 +7441,7 @@ ACMD(iteminfo)
 		return false;
 	}
 	if ((item_array[0] = itemdb->exists(atoi(message))) == NULL)
-		count = itemdb->search_name_array(item_array, MAX_SEARCH, message, 0);
+		count = itemdb->search_name_array(item_array, MAX_SEARCH, message, IT_SEARCH_NAME_PARTIAL);
 
 	if (!count) {
 		clif->message(fd, msg_fd(fd,19)); // Invalid item ID or name.
@@ -7492,7 +7492,7 @@ ACMD(whodrops)
 		return false;
 	}
 	if ((item_array[0] = itemdb->exists(atoi(message))) == NULL)
-		count = itemdb->search_name_array(item_array, MAX_SEARCH, message, 0);
+		count = itemdb->search_name_array(item_array, MAX_SEARCH, message, IT_SEARCH_NAME_PARTIAL);
 
 	if (!count) {
 		clif->message(fd, msg_fd(fd,19)); // Invalid item ID or name.

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -15268,7 +15268,7 @@ static void clif_parse_GM_Monster_Item(int fd, struct map_session_data *sd)
 
 	safestrncpy(item_monster_name, p->str, sizeof(item_monster_name));
 
-	if ( (count=itemdb->search_name_array(item_array, 10, item_monster_name, 1)) > 0 ) {
+	if ( (count=itemdb->search_name_array(item_array, 10, item_monster_name, IT_SEARCH_NAME_EXACT)) > 0 ) {
 		for(i = 0; i < count; i++) {
 			if( !item_array[i] )
 				continue;

--- a/src/map/itemdb.h
+++ b/src/map/itemdb.h
@@ -412,6 +412,16 @@ enum ItemOptionTypes {
 	IT_OPT_MAX
 };
 
+/**
+ * Item name search flags
+ **/
+
+enum item_name_search_flag {
+	IT_SEARCH_NAME_PARTIAL,
+	IT_SEARCH_NAME_EXACT,
+	IT_SEARCH_NAME_MAX,
+};
+
 /** Convenience item list (entry) used in various functions */
 struct itemlist_entry {
 	int id;       ///< Item ID or (inventory) index
@@ -633,7 +643,7 @@ struct itemdb_interface {
 	/* */
 	struct item_data* (*name2id) (const char *str);
 	struct item_data* (*search_name) (const char *name);
-	int (*search_name_array) (struct item_data** data, int size, const char *str, int flag);
+	int (*search_name_array) (struct item_data **data, const int size, const char *str, enum item_name_search_flag flag);
 	struct item_data* (*load)(int nameid);
 	struct item_data* (*search)(int nameid);
 	struct item_data* (*exists) (int nameid);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18804,7 +18804,7 @@ static BUILDIN(searchitem)
 	if ((items[0] = itemdb->exists(atoi(itemname)))) {
 		count = 1;
 	} else {
-		count = itemdb->search_name_array(items, ARRAYLENGTH(items), itemname, 0);
+		count = itemdb->search_name_array(items, ARRAYLENGTH(items), itemname, IT_SEARCH_NAME_PARTIAL);
 		if (count > MAX_SEARCH) count = MAX_SEARCH;
 	}
 

--- a/src/plugins/constdb2doc.c
+++ b/src/plugins/constdb2doc.c
@@ -22,7 +22,8 @@
 /// db/constants.conf -> doc/constants.md generator plugin
 
 #include "common/hercules.h"
-//#include "common/memmgr.h"
+#include "common/db.h"
+#include "common/memmgr.h"
 #include "common/nullpo.h"
 #include "common/strlib.h"
 #include "map/itemdb.h"
@@ -143,17 +144,26 @@ struct item_data *constdb2doc_itemdb_search(int nameid)
 
 void constdb2doc_itemdb(void)
 {
-	int i;
-
 	nullpo_retv(out_fp);
 
 	fprintf(out_fp, "## Items (db/"DBPATH"item_db.conf)\n");
-	for (i = 0; i < ARRAYLENGTH(itemdb->array); i++) {
+	for (int i = 0; i < ARRAYLENGTH(itemdb->array); i++) {
 		struct item_data *id = constdb2doc_itemdb_search(i);
 		if (id == NULL || id->name[0] == '\0')
 			continue;
 		fprintf(out_fp, "- `%s`: %d\n", id->name, id->nameid);
 	}
+
+	if (db_size(itemdb->other) > 0) {
+		struct DBIterator *iter = db_iterator(itemdb->other);
+		for (struct item_data *itd = dbi_first(iter); dbi_exists(iter); itd = dbi_next(iter)) {
+			if (itd == &itemdb->dummy)
+				continue;
+			fprintf(out_fp, "- `%s`: %d\n", itd->name, itd->nameid);
+		}
+		dbi_destroy(iter);
+	}
+
 	fprintf(out_fp, "\n");
 }
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Rewrote item name checks in both functions to be more readable
Changed flag to be enum item_name_search_flag and made itemdb_searchname_array_sub respect flag given to parent function
Corrected item count returned by parent function when dbmap search is performed
Fixed a memory violation caused by the old code when dbmap search is performed
Fixed dbmap searching having static array size which did not adhire to the size passed to the function

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
