### PR TITLE
Fix a missing end in Slipslowrun NPC that allowed to reset the timer

### DIFF
--- a/npc/other/arena/arena_party.txt
+++ b/npc/other/arena/arena_party.txt
@@ -165,6 +165,8 @@ OnTouch:
 }
 
 force_1-2,99,31,4	script	Slipslowrun#party	4_F_TELEPORTER,{
+	end;
+
 OnStart:
 	initnpctimer;
 	$arena_minptst = gettime(GETTIME_MINUTE);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Adding an end; so you can't infinitely reset the timer.
  
This bug allowed you to have no time limit on the party mode of
Izlude Arena, making it quite easy for you to farm OCAs.

Thanks to Vector from oRO Staff for finding this!

**Issues addressed:** none

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
