### PR TITLE
Fixed heap-buffer-overflow on npcshopdelitem

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18030,10 +18030,12 @@ static BUILDIN(npcshopdelitem)
 		unsigned int nameid = script_getnum(st,i);
 
 		ARR_FIND(0, size, n, nd->u.shop.shop_item[n].nameid == nameid);
-		if (n < size) {
-			memmove(&nd->u.shop.shop_item[n], &nd->u.shop.shop_item[n+1], sizeof(nd->u.shop.shop_item[0])*(size-n));
-			size--;
+		if (n == size) {
+			continue;
+		} else if (n < size - 1) {
+			memmove(&nd->u.shop.shop_item[n], &nd->u.shop.shop_item[n+1], sizeof(nd->u.shop.shop_item[0]) * (size - n - 1));
 		}
+		size--;
 	}
 
 	RECREATE(nd->u.shop.shop_item, struct npc_item_list, size);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
npcshopdelitem now moves data within structure size.
Wrong limit was used, which is fixed in this PR.

**Issues addressed:** <!-- Write here the issue number, if any. -->
NA

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
