### PR TITLE
Dehardcode DB files path

### DIFF
--- a/conf/common/map-index.conf
+++ b/conf/common/map-index.conf
@@ -1,0 +1,34 @@
+//================= Hercules Configuration ================================
+//=       _   _                     _
+//=      | | | |                   | |
+//=      | |_| | ___ _ __ ___ _   _| | ___  ___
+//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      | | | |  __/ | | (__| |_| | |  __/\__ \
+//=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
+//================= License ===============================================
+//= This file is part of Hercules.
+//= http://herc.ws - http://github.com/HerculesWS/Hercules
+//=
+//= Copyright (C) 2014-2019  Hercules Dev Team
+//=
+//= Hercules is free software: you can redistribute it and/or modify
+//= it under the terms of the GNU General Public License as published by
+//= the Free Software Foundation, either version 3 of the License, or
+//= (at your option) any later version.
+//=
+//= This program is distributed in the hope that it will be useful,
+//= but WITHOUT ANY WARRANTY; without even the implied warranty of
+//= MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//= GNU General Public License for more details.
+//=
+//= You should have received a copy of the GNU General Public License
+//= along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//=========================================================================
+//= Map Index configuration file.
+//=========================================================================
+
+mapindex_configuration: {
+    // Full path to the map_index.txt file
+    // Default: db/map_index.txt
+    file_path: "db/map_index.txt"
+}

--- a/src/char/char.c
+++ b/src/char/char.c
@@ -120,8 +120,6 @@ char char_achievement_db[256] = "char_achievements";
 static struct char_interface char_s;
 struct char_interface *chr;
 
-char db_path[1024] = "db";
-
 static char wisp_server_name[NAME_LENGTH] = "Server";
 static char login_ip_str[128];
 static uint32 login_ip = 0;
@@ -5791,7 +5789,8 @@ static bool char_config_read_database(const char *filename, const struct config_
 		if (autosave_interval <= 0)
 			autosave_interval = DEFAULT_AUTOSAVE_INTERVAL;
 	}
-	libconfig->setting_lookup_mutable_string(setting, "db_path", db_path, sizeof(db_path));
+	libconfig->setting_lookup_mutable_string(setting, "db_path", chr->db_path, sizeof(chr->db_path));
+	libconfig->set_db_path(chr->db_path);
 	libconfig->setting_lookup_bool_real(setting, "log_char", &chr->enable_logs);
 	return true;
 }
@@ -6453,6 +6452,8 @@ void char_defaults(void)
 	chr = &char_s;
 
 	memset(chr->server, 0, sizeof(chr->server));
+	sprintf(chr->db_path, "db");
+	libconfig->set_db_path(chr->db_path);
 
 	chr->login_fd = 0;
 	chr->char_fd = -1;

--- a/src/char/char.h
+++ b/src/char/char.h
@@ -124,6 +124,8 @@ struct char_interface {
 	bool show_save_log; ///< Show loading/saving messages.
 	bool enable_logs;   ///< Whether to log char server operations.
 
+	char db_path[256]; //< Database directory (db)
+
 	int (*waiting_disconnect) (int tid, int64 tick, int id, intptr_t data);
 	int (*delete_char_sql) (int char_id);
 	struct DBData (*create_online_char_data) (union DBKey key, va_list args);

--- a/src/char/geoip.c
+++ b/src/char/geoip.c
@@ -23,6 +23,7 @@
 #include "geoip.h"
 
 #include "common/cbasetypes.h"
+#include "common/conf.h"
 #include "common/memmgr.h"
 #include "common/showmsg.h"
 
@@ -141,7 +142,9 @@ static void geoip_init(void)
 
 	geoip->data->active = true;
 
-	db = fopen("./db/GeoIP.dat","rb");
+	char file_path[256];
+	libconfig->format_db_path("GeoIP.dat", file_path, sizeof(file_path));
+	db = fopen(file_path, "rb");
 	if (db == NULL) {
 		ShowError("geoip_readdb: Error reading GeoIP.dat!\n");
 		geoip->final(false);

--- a/src/char/int_guild.c
+++ b/src/char/int_guild.c
@@ -747,7 +747,7 @@ static int inter_guild_sql_init(void)
 	inter_guild->castle_db = idb_alloc(DB_OPT_RELEASE_DATA);
 
 	//Read exp file
-	sv->readdb("db", DBPATH"exp_guild.txt", ',', 1, 1, MAX_GUILDLEVEL, inter_guild->exp_parse_row);
+	sv->readdb(chr->db_path, DBPATH"exp_guild.txt", ',', 1, 1, MAX_GUILDLEVEL, inter_guild->exp_parse_row);
 
 	timer->add_func_list(inter_guild->save_timer, "inter_guild->save_timer");
 	timer->add(timer->gettick() + 10000, inter_guild->save_timer, 0, 0);

--- a/src/common/conf.c
+++ b/src/common/conf.c
@@ -22,6 +22,7 @@
 
 #include "conf.h"
 
+#include "common/nullpo.h" // nullpo_retv
 #include "common/showmsg.h" // ShowError
 #include "common/strlib.h" // safestrncpy
 #include "common/utils.h" // exists
@@ -31,6 +32,31 @@
 /* interface source */
 static struct libconfig_interface libconfig_s;
 struct libconfig_interface *libconfig;
+
+/**
+ * Sets the server's db_path to be used by config_format_db_path
+ * @param db_path path to the folder where the db files are at
+ */
+static void config_set_db_path(const char *db_path)
+{
+	nullpo_retv(db_path);
+	safestrncpy(libconfig->db_path, db_path, sizeof(libconfig->db_path));
+}
+
+/**
+ * Writes into path_buf the fullpath to the db file in filename.
+ * Basically this prepends map->db_path to filename.
+ * @param filename File name to format (e.g. re/item_db.conf)
+ * @param path_buf Where to save the path to
+ * @param buffer_len Maximun length of path_buf
+ */
+static void config_format_db_path(const char *filename, char *path_buf, int buffer_len)
+{
+	nullpo_retv(filename);
+	nullpo_retv(path_buf);
+	
+	safesnprintf(path_buf, buffer_len, "%s/%s", libconfig->db_path, filename);
+}
 
 /**
  * Initializes 'config' and loads a configuration file.
@@ -450,6 +476,10 @@ static int config_lookup_int64_real(const struct config_t *config, const char *f
 void libconfig_defaults(void) {
 	libconfig = &libconfig_s;
 
+	snprintf(libconfig->db_path, sizeof(libconfig->db_path), "db");
+	libconfig->set_db_path = config_set_db_path;
+	libconfig->format_db_path = config_format_db_path;
+	/* */
 	libconfig->read = config_read;
 	libconfig->write = config_write;
 	/* */

--- a/src/common/conf.h
+++ b/src/common/conf.h
@@ -29,6 +29,10 @@
  * The libconfig interface -- specially for plugins, but we enforce it throughout the core to be consistent
  **/
 struct libconfig_interface {
+	char db_path[256];
+	void (*set_db_path) (const char *db_path);
+	void (*format_db_path) (const char *filename, char *path_buf, int buffer_len);
+	/* */
 	int (*read) (struct config_t *config, FILE *stream);
 	void (*write) (const struct config_t *config, FILE *stream);
 	/* */

--- a/src/common/mapindex.c
+++ b/src/common/mapindex.c
@@ -23,6 +23,7 @@
 #include "mapindex.h"
 
 #include "common/cbasetypes.h"
+#include "common/conf.h"
 #include "common/db.h"
 #include "common/mmo.h"
 #include "common/nullpo.h"
@@ -159,8 +160,61 @@ static const char *mapindex_id2name_sub(uint16 id, const char *file, int line, c
 	return mapindex->list[id].name;
 }
 
+/**
+ * Reads the db_path config of mapindex configuration file
+ * @param filename File being read (used when displaying errors)
+ * @param config Config structure being read
+ * @returns true if it read the all the configs, false otherwise
+ */
+static bool mapindex_config_read_dbpath(const char *filename, const struct config_t *config)
+{
+	nullpo_retr(false, config);
+
+	const struct config_setting_t *setting = NULL;
+
+	if ((setting = libconfig->lookup(config, "mapindex_configuration")) == NULL) {
+		ShowError("mapindex_config_read: mapindex_configuration was not found in %s!\n", filename);
+		return false;
+	}
+
+	// mapindex_configuration/file_path
+	if (libconfig->setting_lookup_mutable_string(setting, "file_path", mapindex->config_file, sizeof(mapindex->config_file)) == CONFIG_TRUE) {
+		ShowInfo("map_index file %s\n", mapindex->config_file);
+	} else {
+		ShowInfo("Failed to load map_index path, defaulting to db/map_index.txt\n");
+		safestrncpy(mapindex->config_file, "db/map_index.txt", sizeof(mapindex->config_file));
+	}
+
+	return true;
+}
+
+/**
+ * Reads conf/common/map-index.conf config file
+ * @returns true if it successfully read the file and configs, false otherwise
+ */
+static bool mapindex_config_read(void)
+{
+	struct config_t config;
+	const char *filename = "conf/common/map-index.conf";
+	
+	if (!libconfig->load_file(&config, filename))
+		return false; // Error message is already shown by libconfig->load_file
+
+	if (!mapindex_config_read_dbpath(filename, &config)) {
+		libconfig->destroy(&config);
+		return false;
+	}
+
+	ShowInfo("Done reading %s.\n", filename);
+	libconfig->destroy(&config);
+	return true;
+}
+
 static int mapindex_init(void)
 {
+	if (!mapindex_config_read())
+		ShowError("Failed to load map_index configuration. Continuing with default values...\n");
+
 	FILE *fp;
 	char line[1024];
 	int last_index = -1;
@@ -233,6 +287,9 @@ void mapindex_defaults(void)
 	mapindex->default_y = MAP_DEFAULT_Y;
 	memset (&mapindex->list, 0, sizeof (mapindex->list));
 
+	/* */
+	mapindex->config_read = mapindex_config_read;
+	mapindex->config_read_dbpath = mapindex_config_read_dbpath;
 	/* */
 	mapindex->init = mapindex_init;
 	mapindex->final = mapindex_final;

--- a/src/common/mapindex.h
+++ b/src/common/mapindex.h
@@ -21,6 +21,7 @@
 #ifndef COMMON_MAPINDEX_H
 #define COMMON_MAPINDEX_H
 
+#include "common/conf.h"
 #include "common/hercules.h"
 #include "common/mmo.h"
 
@@ -97,6 +98,9 @@ struct mapindex_interface {
 	struct {
 		char name[MAP_NAME_LENGTH];
 	} list[MAX_MAPINDEX];
+	/* */
+	bool (*config_read_dbpath) (const char *filename, const struct config_t *config);
+	bool (*config_read) (void);
 	/* */
 	int (*init) (void);
 	void (*final) (void);

--- a/src/config/const.h
+++ b/src/config/const.h
@@ -49,10 +49,13 @@
 /**
  * Path within the /db folder to (non-)renewal specific db files
  **/
+#define DBPATH_RE "re/"
+#define DBPATH_PRE "pre-re/"
+
 #ifdef RENEWAL
-	#define DBPATH "re/"
+	#define DBPATH DBPATH_RE
 #else
-	#define DBPATH "pre-re/"
+	#define DBPATH DBPATH_PRE
 #endif
 
 /**

--- a/src/map/achievement.c
+++ b/src/map/achievement.c
@@ -1099,7 +1099,8 @@ static bool achievement_get_rewards(struct map_session_data *sd, const struct ac
  */
 static void achievement_readdb_ranks(void)
 {
-	const char *filename = "db/achievement_rank_db.conf";
+	char filename[256];
+	libconfig->format_db_path("achievement_rank_db.conf", filename, sizeof(filename));
 	struct config_t ar_conf = { 0 };
 	struct config_setting_t *ardb = NULL, *conf = NULL;
 	int entry = 0;
@@ -1777,7 +1778,8 @@ static void achievement_readdb_additional_fields(const struct config_setting_t *
  */
 static void achievement_readb(void)
 {
-	const char *filename = "db/"DBPATH"achievement_db.conf";
+	char filename[256];
+	libconfig->format_db_path(DBPATH"achievement_db.conf", filename, sizeof(filename));
 	struct config_t ach_conf = { 0 };
 	struct config_setting_t *achdb = NULL, *conf = NULL;
 	int entry = 0, count = 0;

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -19784,7 +19784,8 @@ static void clif_cashshop_db(void)
 {
 	struct config_t cashshop_conf;
 	struct config_setting_t *cashshop = NULL, *cats = NULL;
-	const char *config_filename = "db/cashshop_db.conf"; // FIXME hardcoded name
+	char config_filename[256];
+	libconfig->format_db_path("cashshop_db.conf", config_filename, sizeof(config_filename));
 	int i, item_count_t = 0;
 	for( i = 0; i < CASHSHOP_TAB_MAX; i++ ) {
 		CREATE(clif->cs.data[i], struct hCSData *, 1);
@@ -21055,7 +21056,8 @@ static bool clif_parse_roulette_db(void)
 {
 	struct config_t roulette_conf;
 	struct config_setting_t *roulette = NULL, *levels = NULL;
-	const char *config_filename = "db/roulette_db.conf"; // FIXME hardcoded name
+	char config_filename[256];
+	libconfig->format_db_path("roulette_db.conf", config_filename, sizeof(config_filename));
 	int i, j, item_count_t = 0;
 
 	for( i = 0; i < MAX_ROULETTE_LEVEL; i++ ) {
@@ -22539,7 +22541,8 @@ static bool clif_parse_attendance_db(void)
 {
 	struct config_t attendance_conf;
 	struct config_setting_t *attendance = NULL, *it = NULL;
-	const char *config_filename = "db/attendance_db.conf"; // FIXME hardcoded name
+	char config_filename[256];
+	libconfig->format_db_path("attendance_db.conf", config_filename, sizeof(config_filename));
 	int i = 0;
 
 	if (!libconfig->load_file(&attendance_conf, config_filename))

--- a/src/map/guild.c
+++ b/src/map/guild.c
@@ -152,7 +152,8 @@ static bool guild_read_castledb_libconfig(void)
 {
 	struct config_t castle_conf;
 	struct config_setting_t *castle_db = NULL, *it = NULL;
-	const char *config_filename = "db/castle_db.conf"; // FIXME hardcoded name
+	char config_filename[256];
+	libconfig->format_db_path("castle_db.conf", config_filename, sizeof(config_filename));
 	int i = 0;
 
 	if (libconfig->load_file(&castle_conf, config_filename) == 0)

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -846,11 +846,8 @@ static void itemdb_read_groups(void)
 {
 	struct config_t item_group_conf;
 	struct config_setting_t *itg = NULL, *it = NULL;
-#ifdef RENEWAL
-	const char *config_filename = "db/re/item_group.conf"; // FIXME hardcoded name
-#else
-	const char *config_filename = "db/pre-re/item_group.conf"; // FIXME hardcoded name
-#endif
+	char config_filename[256];
+	libconfig->format_db_path(DBPATH"item_group.conf", config_filename, sizeof(config_filename));
 	const char *itname;
 	int i = 0, count = 0, c;
 	unsigned int *gsize = NULL;
@@ -1144,11 +1141,8 @@ static void itemdb_read_packages(void)
 {
 	struct config_t item_packages_conf;
 	struct config_setting_t *itg = NULL, *it = NULL, *t = NULL;
-#ifdef RENEWAL
-	const char *config_filename = "db/re/item_packages.conf"; // FIXME hardcoded name
-#else
-	const char *config_filename = "db/pre-re/item_packages.conf"; // FIXME hardcoded name
-#endif
+	char config_filename[256];
+	libconfig->format_db_path(DBPATH"item_packages.conf", config_filename, sizeof(config_filename));
 	const char *itname;
 	int i = 0, count = 0, c = 0, highest_gcount = 0;
 	unsigned int *must = NULL, *random = NULL, *rgroup = NULL, **rgroups = NULL;
@@ -1393,7 +1387,8 @@ static void itemdb_read_options(void)
 	struct config_t item_options_db;
 	struct config_setting_t *ito = NULL, *conf = NULL;
 	int index = 0, count = 0;
-	const char *filepath = "db/item_options.conf";
+	char filepath[256];
+	libconfig->format_db_path("item_options.conf", filepath, sizeof(filepath));
 	VECTOR_DECL(int) duplicate_id;
 
 	if (!libconfig->load_file(&item_options_db, filepath))
@@ -1494,11 +1489,8 @@ static void itemdb_read_chains(void)
 {
 	struct config_t item_chain_conf;
 	struct config_setting_t *itc = NULL;
-#ifdef RENEWAL
-	const char *config_filename = "db/re/item_chain.conf"; // FIXME hardcoded name
-#else
-	const char *config_filename = "db/pre-re/item_chain.conf"; // FIXME hardcoded name
-#endif
+	char config_filename[256];
+	libconfig->format_db_path(DBPATH"item_chain.conf", config_filename, sizeof(config_filename));
 	int i = 0, count = 0;
 
 	if (!libconfig->load_file(&item_chain_conf, config_filename))

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -4055,6 +4055,7 @@ static bool map_config_read_database(const char *filename, struct config_t *conf
 		return false;
 	}
 	libconfig->setting_lookup_mutable_string(setting, "db_path", map->db_path, sizeof(map->db_path));
+	libconfig->set_db_path(map->db_path);
 	libconfig->setting_lookup_int(setting, "save_settings", &map->save_settings);
 
 	if (libconfig->setting_lookup_int(setting, "autosave_time", &map->autosave_interval) == CONFIG_TRUE) {
@@ -5574,12 +5575,8 @@ static void read_map_zone_db(void)
 {
 	struct config_t map_zone_db;
 	struct config_setting_t *zones = NULL;
-	/* TODO: #ifndef required for re/pre-re */
-#ifdef RENEWAL
-	const char *config_filename = "db/re/map_zone_db.conf"; // FIXME hardcoded name
-#else
-	const char *config_filename = "db/pre-re/map_zone_db.conf"; // FIXME hardcoded name
-#endif
+	char config_filename[256];
+	libconfig->format_db_path(DBPATH"map_zone_db.conf", config_filename, sizeof(config_filename));
 	if (!libconfig->load_file(&map_zone_db, config_filename))
 		return;
 
@@ -6774,6 +6771,7 @@ void map_defaults(void)
 	map->extra_scripts_count = 0;
 
 	sprintf(map->db_path ,"db");
+	libconfig->set_db_path(map->db_path);
 	sprintf(map->help_txt ,"conf/help.txt");
 	sprintf(map->charhelp_txt ,"conf/charhelp.txt");
 

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -4078,10 +4078,8 @@ static bool mob_read_optdrops_group(struct config_setting_t *group, int n)
  */
 static bool mob_read_optdrops_db(void)
 {
-	const char *filename = "option_drop_groups.conf"; // FIXME hardcoded name
-
 	char filepath[256];
-	safesnprintf(filepath, sizeof(filepath), "%s/%s", map->db_path, filename);
+	libconfig->format_db_path("option_drop_groups.conf", filepath, sizeof(filepath));
 
 	struct config_t option_groups;
 	if (libconfig->load_file(&option_groups, filepath) == CONFIG_FALSE) {

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -11533,12 +11533,9 @@ static bool pc_read_exp_db(void)
 	struct config_t exp_db_conf;
 	struct config_setting_t *edb = NULL;
 	int entry_count = 0;
-
-#ifdef RENEWAL
-	const char *config_filename = "db/re/exp_group_db.conf";
-#else
-	const char *config_filename = "db/pre-re/exp_group_db.conf";
-#endif
+	char config_filename[256];
+	
+	libconfig->format_db_path(DBPATH"exp_group_db.conf", config_filename, sizeof(config_filename));
 
 	if (!libconfig->load_file(&exp_db_conf, config_filename))
 		return false;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -5150,7 +5150,8 @@ static uint8 script_add_language(const char *name)
 static void script_load_translations(void)
 {
 	struct config_t translations_conf;
-	const char *config_filename = "db/translations.conf"; // FIXME hardcoded name
+	char config_filename[256];
+	libconfig->format_db_path("translations.conf", config_filename, sizeof(config_filename));
 	struct config_setting_t *translations = NULL;
 	int i, size;
 	int total = 0;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -21105,7 +21105,7 @@ static bool skill_read_skilldb(const char *filename)
 
 	nullpo_retr(false, filename);
 
-	sprintf(filepath,"db/%s",filename);
+	libconfig->format_db_path(filename, filepath, sizeof(filepath));
 
 	if (!libconfig->load_file(&skilldb, filepath)) {
 		return false; // Libconfig error report.

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -13339,10 +13339,12 @@ static void status_read_job_db(void)
 	int i = 0;
 	struct config_t job_db_conf;
 	struct config_setting_t *jdb = NULL;
+	char config_filename[256];
+	
 #ifdef RENEWAL_ASPD
-	const char *config_filename = "db/re/job_db.conf";
+	libconfig->format_db_path(DBPATH_RE"job_db.conf", config_filename, sizeof(config_filename));
 #else
-	const char *config_filename = "db/pre-re/job_db.conf";
+	libconfig->format_db_path(DBPATH_PRE"job_db.conf", config_filename, sizeof(config_filename));
 #endif
 
 	if (!libconfig->load_file(&job_db_conf, config_filename))

--- a/src/map/stylist.c
+++ b/src/map/stylist.c
@@ -40,7 +40,8 @@ static bool stylist_read_db_libconfig(void)
 {
 	struct config_t stylist_conf;
 	struct config_setting_t *stylist_db = NULL, *it = NULL;
-	const char *config_filename = "db/stylist_db.conf"; // FIXME hardcoded name
+	char config_filename[256];
+	libconfig->format_db_path("stylist_db.conf", config_filename, sizeof(config_filename));
 	int i = 0;
 
 	if (!libconfig->load_file(&stylist_conf, config_filename))

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -4178,6 +4178,10 @@ typedef enum parsefunc_rcode (*HPMHOOK_pre_PRIV__lclif_parse_CA_CHARSERVERCONNEC
 typedef enum parsefunc_rcode (*HPMHOOK_post_PRIV__lclif_parse_CA_CHARSERVERCONNECT) (enum parsefunc_rcode retVal___, int fd, struct login_session_data *sd);
 #endif // LOGIN_LCLIF_P_H
 #ifdef COMMON_CONF_H /* libconfig */
+typedef void (*HPMHOOK_pre_libconfig_set_db_path) (const char **db_path);
+typedef void (*HPMHOOK_post_libconfig_set_db_path) (const char *db_path);
+typedef void (*HPMHOOK_pre_libconfig_format_db_path) (const char **filename, char **path_buf, int *buffer_len);
+typedef void (*HPMHOOK_post_libconfig_format_db_path) (const char *filename, char *path_buf, int buffer_len);
 typedef int (*HPMHOOK_pre_libconfig_read) (struct config_t **config, FILE **stream);
 typedef int (*HPMHOOK_post_libconfig_read) (int retVal___, struct config_t *config, FILE *stream);
 typedef void (*HPMHOOK_pre_libconfig_write) (const struct config_t **config, FILE **stream);
@@ -5144,6 +5148,10 @@ typedef int (*HPMHOOK_pre_mapif_parse_ClanMemberCount) (int *fd, int *clan_id, i
 typedef int (*HPMHOOK_post_mapif_parse_ClanMemberCount) (int retVal___, int fd, int clan_id, int kick_interval);
 #endif // CHAR_MAPIF_H
 #ifdef COMMON_MAPINDEX_H /* mapindex */
+typedef bool (*HPMHOOK_pre_mapindex_config_read_dbpath) (const char **filename, const struct config_t **config);
+typedef bool (*HPMHOOK_post_mapindex_config_read_dbpath) (bool retVal___, const char *filename, const struct config_t *config);
+typedef bool (*HPMHOOK_pre_mapindex_config_read) (void);
+typedef bool (*HPMHOOK_post_mapindex_config_read) (bool retVal___);
 typedef int (*HPMHOOK_pre_mapindex_init) (void);
 typedef int (*HPMHOOK_post_mapindex_init) (int retVal___);
 typedef void (*HPMHOOK_pre_mapindex_final) (void);

--- a/src/plugins/HPMHooking/HPMHooking_char.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_char.HPMHooksCore.inc
@@ -778,6 +778,10 @@ struct {
 	struct HPMHookPoint *HP_inter_storage_parse_frommap_post;
 	struct HPMHookPoint *HP_inter_storage_retrieve_bound_items_pre;
 	struct HPMHookPoint *HP_inter_storage_retrieve_bound_items_post;
+	struct HPMHookPoint *HP_libconfig_set_db_path_pre;
+	struct HPMHookPoint *HP_libconfig_set_db_path_post;
+	struct HPMHookPoint *HP_libconfig_format_db_path_pre;
+	struct HPMHookPoint *HP_libconfig_format_db_path_post;
 	struct HPMHookPoint *HP_libconfig_read_pre;
 	struct HPMHookPoint *HP_libconfig_read_post;
 	struct HPMHookPoint *HP_libconfig_write_pre;
@@ -1252,6 +1256,10 @@ struct {
 	struct HPMHookPoint *HP_mapif_parse_ClanMemberKick_post;
 	struct HPMHookPoint *HP_mapif_parse_ClanMemberCount_pre;
 	struct HPMHookPoint *HP_mapif_parse_ClanMemberCount_post;
+	struct HPMHookPoint *HP_mapindex_config_read_dbpath_pre;
+	struct HPMHookPoint *HP_mapindex_config_read_dbpath_post;
+	struct HPMHookPoint *HP_mapindex_config_read_pre;
+	struct HPMHookPoint *HP_mapindex_config_read_post;
 	struct HPMHookPoint *HP_mapindex_init_pre;
 	struct HPMHookPoint *HP_mapindex_init_post;
 	struct HPMHookPoint *HP_mapindex_final_pre;
@@ -2391,6 +2399,10 @@ struct {
 	int HP_inter_storage_parse_frommap_post;
 	int HP_inter_storage_retrieve_bound_items_pre;
 	int HP_inter_storage_retrieve_bound_items_post;
+	int HP_libconfig_set_db_path_pre;
+	int HP_libconfig_set_db_path_post;
+	int HP_libconfig_format_db_path_pre;
+	int HP_libconfig_format_db_path_post;
 	int HP_libconfig_read_pre;
 	int HP_libconfig_read_post;
 	int HP_libconfig_write_pre;
@@ -2865,6 +2877,10 @@ struct {
 	int HP_mapif_parse_ClanMemberKick_post;
 	int HP_mapif_parse_ClanMemberCount_pre;
 	int HP_mapif_parse_ClanMemberCount_post;
+	int HP_mapindex_config_read_dbpath_pre;
+	int HP_mapindex_config_read_dbpath_post;
+	int HP_mapindex_config_read_pre;
+	int HP_mapindex_config_read_post;
 	int HP_mapindex_init_pre;
 	int HP_mapindex_init_post;
 	int HP_mapindex_final_pre;

--- a/src/plugins/HPMHooking/HPMHooking_char.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_char.HookingPoints.inc
@@ -425,6 +425,8 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(inter_storage->parse_frommap, HP_inter_storage_parse_frommap) },
 	{ HP_POP(inter_storage->retrieve_bound_items, HP_inter_storage_retrieve_bound_items) },
 /* libconfig_interface */
+	{ HP_POP(libconfig->set_db_path, HP_libconfig_set_db_path) },
+	{ HP_POP(libconfig->format_db_path, HP_libconfig_format_db_path) },
 	{ HP_POP(libconfig->read, HP_libconfig_read) },
 	{ HP_POP(libconfig->write, HP_libconfig_write) },
 	{ HP_POP(libconfig->set_options, HP_libconfig_set_options) },
@@ -665,6 +667,8 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(mapif->parse_ClanMemberKick, HP_mapif_parse_ClanMemberKick) },
 	{ HP_POP(mapif->parse_ClanMemberCount, HP_mapif_parse_ClanMemberCount) },
 /* mapindex_interface */
+	{ HP_POP(mapindex->config_read_dbpath, HP_mapindex_config_read_dbpath) },
+	{ HP_POP(mapindex->config_read, HP_mapindex_config_read) },
 	{ HP_POP(mapindex->init, HP_mapindex_init) },
 	{ HP_POP(mapindex->final, HP_mapindex_final) },
 	{ HP_POP(mapindex->addmap, HP_mapindex_addmap) },

--- a/src/plugins/HPMHooking/HPMHooking_char.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_char.Hooks.inc
@@ -10116,6 +10116,58 @@ bool HP_inter_storage_retrieve_bound_items(int char_id, int account_id, int guil
 	return retVal___;
 }
 /* libconfig_interface */
+void HP_libconfig_set_db_path(const char *db_path) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_libconfig_set_db_path_pre > 0) {
+		void (*preHookFunc) (const char **db_path);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_set_db_path_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_libconfig_set_db_path_pre[hIndex].func;
+			preHookFunc(&db_path);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.libconfig.set_db_path(db_path);
+	}
+	if (HPMHooks.count.HP_libconfig_set_db_path_post > 0) {
+		void (*postHookFunc) (const char *db_path);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_set_db_path_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_libconfig_set_db_path_post[hIndex].func;
+			postHookFunc(db_path);
+		}
+	}
+	return;
+}
+void HP_libconfig_format_db_path(const char *filename, char *path_buf, int buffer_len) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_libconfig_format_db_path_pre > 0) {
+		void (*preHookFunc) (const char **filename, char **path_buf, int *buffer_len);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_format_db_path_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_libconfig_format_db_path_pre[hIndex].func;
+			preHookFunc(&filename, &path_buf, &buffer_len);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.libconfig.format_db_path(filename, path_buf, buffer_len);
+	}
+	if (HPMHooks.count.HP_libconfig_format_db_path_post > 0) {
+		void (*postHookFunc) (const char *filename, char *path_buf, int buffer_len);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_format_db_path_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_libconfig_format_db_path_post[hIndex].func;
+			postHookFunc(filename, path_buf, buffer_len);
+		}
+	}
+	return;
+}
 int HP_libconfig_read(struct config_t *config, FILE *stream) {
 	int hIndex = 0;
 	int retVal___ = 0;
@@ -16415,6 +16467,60 @@ int HP_mapif_parse_ClanMemberCount(int fd, int clan_id, int kick_interval) {
 	return retVal___;
 }
 /* mapindex_interface */
+bool HP_mapindex_config_read_dbpath(const char *filename, const struct config_t *config) {
+	int hIndex = 0;
+	bool retVal___ = false;
+	if (HPMHooks.count.HP_mapindex_config_read_dbpath_pre > 0) {
+		bool (*preHookFunc) (const char **filename, const struct config_t **config);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mapindex_config_read_dbpath_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_mapindex_config_read_dbpath_pre[hIndex].func;
+			retVal___ = preHookFunc(&filename, &config);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.mapindex.config_read_dbpath(filename, config);
+	}
+	if (HPMHooks.count.HP_mapindex_config_read_dbpath_post > 0) {
+		bool (*postHookFunc) (bool retVal___, const char *filename, const struct config_t *config);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mapindex_config_read_dbpath_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_mapindex_config_read_dbpath_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, filename, config);
+		}
+	}
+	return retVal___;
+}
+bool HP_mapindex_config_read(void) {
+	int hIndex = 0;
+	bool retVal___ = false;
+	if (HPMHooks.count.HP_mapindex_config_read_pre > 0) {
+		bool (*preHookFunc) (void);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mapindex_config_read_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_mapindex_config_read_pre[hIndex].func;
+			retVal___ = preHookFunc();
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.mapindex.config_read();
+	}
+	if (HPMHooks.count.HP_mapindex_config_read_post > 0) {
+		bool (*postHookFunc) (bool retVal___);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mapindex_config_read_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_mapindex_config_read_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___);
+		}
+	}
+	return retVal___;
+}
 int HP_mapindex_init(void) {
 	int hIndex = 0;
 	int retVal___ = 0;

--- a/src/plugins/HPMHooking/HPMHooking_login.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_login.HPMHooksCore.inc
@@ -212,6 +212,10 @@ struct {
 	struct HPMHookPoint *HP_PRIV__lclif_parse_CA_REQ_HASH_post;
 	struct HPMHookPoint *HP_PRIV__lclif_parse_CA_CHARSERVERCONNECT_pre;
 	struct HPMHookPoint *HP_PRIV__lclif_parse_CA_CHARSERVERCONNECT_post;
+	struct HPMHookPoint *HP_libconfig_set_db_path_pre;
+	struct HPMHookPoint *HP_libconfig_set_db_path_post;
+	struct HPMHookPoint *HP_libconfig_format_db_path_pre;
+	struct HPMHookPoint *HP_libconfig_format_db_path_post;
 	struct HPMHookPoint *HP_libconfig_read_pre;
 	struct HPMHookPoint *HP_libconfig_read_post;
 	struct HPMHookPoint *HP_libconfig_write_pre;
@@ -1013,6 +1017,10 @@ struct {
 	int HP_PRIV__lclif_parse_CA_REQ_HASH_post;
 	int HP_PRIV__lclif_parse_CA_CHARSERVERCONNECT_pre;
 	int HP_PRIV__lclif_parse_CA_CHARSERVERCONNECT_post;
+	int HP_libconfig_set_db_path_pre;
+	int HP_libconfig_set_db_path_post;
+	int HP_libconfig_format_db_path_pre;
+	int HP_libconfig_format_db_path_post;
 	int HP_libconfig_read_pre;
 	int HP_libconfig_read_post;
 	int HP_libconfig_write_pre;

--- a/src/plugins/HPMHooking/HPMHooking_login.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_login.HookingPoints.inc
@@ -131,6 +131,8 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(lclif->p->parse_CA_REQ_HASH, HP_PRIV__lclif_parse_CA_REQ_HASH) },
 	{ HP_POP(lclif->p->parse_CA_CHARSERVERCONNECT, HP_PRIV__lclif_parse_CA_CHARSERVERCONNECT) },
 /* libconfig_interface */
+	{ HP_POP(libconfig->set_db_path, HP_libconfig_set_db_path) },
+	{ HP_POP(libconfig->format_db_path, HP_libconfig_format_db_path) },
 	{ HP_POP(libconfig->read, HP_libconfig_read) },
 	{ HP_POP(libconfig->write, HP_libconfig_write) },
 	{ HP_POP(libconfig->set_options, HP_libconfig_set_options) },

--- a/src/plugins/HPMHooking/HPMHooking_login.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_login.Hooks.inc
@@ -2518,6 +2518,58 @@ enum parsefunc_rcode HP_PRIV__lclif_parse_CA_CHARSERVERCONNECT(int fd, struct lo
 	return retVal___;
 }
 /* libconfig_interface */
+void HP_libconfig_set_db_path(const char *db_path) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_libconfig_set_db_path_pre > 0) {
+		void (*preHookFunc) (const char **db_path);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_set_db_path_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_libconfig_set_db_path_pre[hIndex].func;
+			preHookFunc(&db_path);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.libconfig.set_db_path(db_path);
+	}
+	if (HPMHooks.count.HP_libconfig_set_db_path_post > 0) {
+		void (*postHookFunc) (const char *db_path);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_set_db_path_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_libconfig_set_db_path_post[hIndex].func;
+			postHookFunc(db_path);
+		}
+	}
+	return;
+}
+void HP_libconfig_format_db_path(const char *filename, char *path_buf, int buffer_len) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_libconfig_format_db_path_pre > 0) {
+		void (*preHookFunc) (const char **filename, char **path_buf, int *buffer_len);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_format_db_path_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_libconfig_format_db_path_pre[hIndex].func;
+			preHookFunc(&filename, &path_buf, &buffer_len);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.libconfig.format_db_path(filename, path_buf, buffer_len);
+	}
+	if (HPMHooks.count.HP_libconfig_format_db_path_post > 0) {
+		void (*postHookFunc) (const char *filename, char *path_buf, int buffer_len);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_format_db_path_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_libconfig_format_db_path_post[hIndex].func;
+			postHookFunc(filename, path_buf, buffer_len);
+		}
+	}
+	return;
+}
 int HP_libconfig_read(struct config_t *config, FILE *stream) {
 	int hIndex = 0;
 	int retVal___ = 0;

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -3286,6 +3286,10 @@ struct {
 	struct HPMHookPoint *HP_itemdb_read_libconfig_lapineddukddak_sub_post;
 	struct HPMHookPoint *HP_itemdb_read_libconfig_lapineddukddak_sub_sources_pre;
 	struct HPMHookPoint *HP_itemdb_read_libconfig_lapineddukddak_sub_sources_post;
+	struct HPMHookPoint *HP_libconfig_set_db_path_pre;
+	struct HPMHookPoint *HP_libconfig_set_db_path_post;
+	struct HPMHookPoint *HP_libconfig_format_db_path_pre;
+	struct HPMHookPoint *HP_libconfig_format_db_path_post;
 	struct HPMHookPoint *HP_libconfig_read_pre;
 	struct HPMHookPoint *HP_libconfig_read_post;
 	struct HPMHookPoint *HP_libconfig_write_pre;
@@ -3756,6 +3760,10 @@ struct {
 	struct HPMHookPoint *HP_map_merge_zone_post;
 	struct HPMHookPoint *HP_map_zone_clear_single_pre;
 	struct HPMHookPoint *HP_map_zone_clear_single_post;
+	struct HPMHookPoint *HP_mapindex_config_read_dbpath_pre;
+	struct HPMHookPoint *HP_mapindex_config_read_dbpath_post;
+	struct HPMHookPoint *HP_mapindex_config_read_pre;
+	struct HPMHookPoint *HP_mapindex_config_read_post;
 	struct HPMHookPoint *HP_mapindex_init_pre;
 	struct HPMHookPoint *HP_mapindex_init_post;
 	struct HPMHookPoint *HP_mapindex_final_pre;
@@ -10099,6 +10107,10 @@ struct {
 	int HP_itemdb_read_libconfig_lapineddukddak_sub_post;
 	int HP_itemdb_read_libconfig_lapineddukddak_sub_sources_pre;
 	int HP_itemdb_read_libconfig_lapineddukddak_sub_sources_post;
+	int HP_libconfig_set_db_path_pre;
+	int HP_libconfig_set_db_path_post;
+	int HP_libconfig_format_db_path_pre;
+	int HP_libconfig_format_db_path_post;
 	int HP_libconfig_read_pre;
 	int HP_libconfig_read_post;
 	int HP_libconfig_write_pre;
@@ -10569,6 +10581,10 @@ struct {
 	int HP_map_merge_zone_post;
 	int HP_map_zone_clear_single_pre;
 	int HP_map_zone_clear_single_post;
+	int HP_mapindex_config_read_dbpath_pre;
+	int HP_mapindex_config_read_dbpath_post;
+	int HP_mapindex_config_read_pre;
+	int HP_mapindex_config_read_post;
 	int HP_mapindex_init_pre;
 	int HP_mapindex_init_post;
 	int HP_mapindex_final_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -1683,6 +1683,8 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(itemdb->read_libconfig_lapineddukddak_sub, HP_itemdb_read_libconfig_lapineddukddak_sub) },
 	{ HP_POP(itemdb->read_libconfig_lapineddukddak_sub_sources, HP_itemdb_read_libconfig_lapineddukddak_sub_sources) },
 /* libconfig_interface */
+	{ HP_POP(libconfig->set_db_path, HP_libconfig_set_db_path) },
+	{ HP_POP(libconfig->format_db_path, HP_libconfig_format_db_path) },
 	{ HP_POP(libconfig->read, HP_libconfig_read) },
 	{ HP_POP(libconfig->write, HP_libconfig_write) },
 	{ HP_POP(libconfig->set_options, HP_libconfig_set_options) },
@@ -1922,6 +1924,8 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(map->merge_zone, HP_map_merge_zone) },
 	{ HP_POP(map->zone_clear_single, HP_map_zone_clear_single) },
 /* mapindex_interface */
+	{ HP_POP(mapindex->config_read_dbpath, HP_mapindex_config_read_dbpath) },
+	{ HP_POP(mapindex->config_read, HP_mapindex_config_read) },
 	{ HP_POP(mapindex->init, HP_mapindex_init) },
 	{ HP_POP(mapindex->final, HP_mapindex_final) },
 	{ HP_POP(mapindex->addmap, HP_mapindex_addmap) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -43234,6 +43234,58 @@ bool HP_itemdb_read_libconfig_lapineddukddak_sub_sources(struct config_setting_t
 	return retVal___;
 }
 /* libconfig_interface */
+void HP_libconfig_set_db_path(const char *db_path) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_libconfig_set_db_path_pre > 0) {
+		void (*preHookFunc) (const char **db_path);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_set_db_path_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_libconfig_set_db_path_pre[hIndex].func;
+			preHookFunc(&db_path);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.libconfig.set_db_path(db_path);
+	}
+	if (HPMHooks.count.HP_libconfig_set_db_path_post > 0) {
+		void (*postHookFunc) (const char *db_path);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_set_db_path_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_libconfig_set_db_path_post[hIndex].func;
+			postHookFunc(db_path);
+		}
+	}
+	return;
+}
+void HP_libconfig_format_db_path(const char *filename, char *path_buf, int buffer_len) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_libconfig_format_db_path_pre > 0) {
+		void (*preHookFunc) (const char **filename, char **path_buf, int *buffer_len);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_format_db_path_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_libconfig_format_db_path_pre[hIndex].func;
+			preHookFunc(&filename, &path_buf, &buffer_len);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.libconfig.format_db_path(filename, path_buf, buffer_len);
+	}
+	if (HPMHooks.count.HP_libconfig_format_db_path_post > 0) {
+		void (*postHookFunc) (const char *filename, char *path_buf, int buffer_len);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_libconfig_format_db_path_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_libconfig_format_db_path_post[hIndex].func;
+			postHookFunc(filename, path_buf, buffer_len);
+		}
+	}
+	return;
+}
 int HP_libconfig_read(struct config_t *config, FILE *stream) {
 	int hIndex = 0;
 	int retVal___ = 0;
@@ -49663,6 +49715,60 @@ void HP_map_zone_clear_single(struct map_zone_data *zone) {
 	return;
 }
 /* mapindex_interface */
+bool HP_mapindex_config_read_dbpath(const char *filename, const struct config_t *config) {
+	int hIndex = 0;
+	bool retVal___ = false;
+	if (HPMHooks.count.HP_mapindex_config_read_dbpath_pre > 0) {
+		bool (*preHookFunc) (const char **filename, const struct config_t **config);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mapindex_config_read_dbpath_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_mapindex_config_read_dbpath_pre[hIndex].func;
+			retVal___ = preHookFunc(&filename, &config);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.mapindex.config_read_dbpath(filename, config);
+	}
+	if (HPMHooks.count.HP_mapindex_config_read_dbpath_post > 0) {
+		bool (*postHookFunc) (bool retVal___, const char *filename, const struct config_t *config);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mapindex_config_read_dbpath_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_mapindex_config_read_dbpath_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, filename, config);
+		}
+	}
+	return retVal___;
+}
+bool HP_mapindex_config_read(void) {
+	int hIndex = 0;
+	bool retVal___ = false;
+	if (HPMHooks.count.HP_mapindex_config_read_pre > 0) {
+		bool (*preHookFunc) (void);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mapindex_config_read_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_mapindex_config_read_pre[hIndex].func;
+			retVal___ = preHookFunc();
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.mapindex.config_read();
+	}
+	if (HPMHooks.count.HP_mapindex_config_read_post > 0) {
+		bool (*postHookFunc) (bool retVal___);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mapindex_config_read_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_mapindex_config_read_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___);
+		}
+	}
+	return retVal___;
+}
 int HP_mapindex_init(void) {
 	int hIndex = 0;
 	int retVal___ = 0;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
This pull request aims at dehardcoding all `db/*` file paths, allowing users to change which folder to load the database files from. It applies to all files used by char and map servers.

For char-server, the `db_path` global variable in `char.c` got moved to the `chr` interface in `char.h` so it is possible to use it in other files.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None, as far as I know

Special thanks to @4144 for giving me some ideas
<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
