### PR TITLE
Fixes close merchant vending

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -14298,7 +14298,7 @@ static void clif_parse_CloseVending(int fd, struct map_session_data *sd) __attri
 /// 012e
 static void clif_parse_CloseVending(int fd, struct map_session_data *sd)
 {
-	if (pc_istrading(sd) || pc_isdead(sd))
+	if (sd->npc_id || sd->state.buyingstore || sd->state.trading)
 		return;
 
 	vending->close(sd);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
This PR removes some checks that were preventing players to close their vending (from merchant skill). The issue was basically because we had a check that prevented a player in any trading state (including vending) to close it.

I also removed the check for a dead player, because the client itself allows that, and the same problem would happen.

**Issues addressed:** <!-- Write here the issue number, if any. -->
Fixes #2554 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
