### PR TITLE
Homunculus skill fixes

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -8758,12 +8758,20 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 				int r = rnd()%100;
 				int target = (skill_lv-1)%5;
 				int hp;
-				if(r<per[target][0]) //Self
+				if (r < per[target][0]) { //Self
 					bl = src;
-				else if(r<per[target][1]) //Master
+				} else if (r < per[target][1]) { //Master
 					bl = battle->get_master(src);
-				else //Enemy
-					bl = map->id2bl(battle->get_target(src));
+				} else if ((per[target][1] - per[target][0]) < per[target][0]
+					   && bl == battle->get_master(src)) {
+					/**
+					 * Skill rolled for enemy, but there's nothing the Homunculus is attacking.
+					 * So bl has been set to its master in unit->skilluse_id2.
+					 * If it's more likely that it will heal itself,
+					 * we let it heal itself.
+					 */
+					bl = src;
+				}
 
 				if (!bl) bl = src;
 				hp = skill->calc_heal(src, bl, skill_id, 1+rnd()%skill_lv, true);

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3789,7 +3789,7 @@ static int skill_check_condition_mercenary(struct block_list *bl, int skill_id, 
 		if (itemid[i] < 1) continue; // No item
 		index[i] = pc->search_inventory(sd, itemid[i]);
 		if (index[i] == INDEX_NOT_FOUND || sd->status.inventory[index[i]].amount < amount[i]) {
-			clif->skill_fail(sd, skill_id, USESKILL_FAIL_NEED_ITEM, amount[i], itemid[i] << 16);
+			clif->skill_fail(sd, skill_id, USESKILL_FAIL_NEED_ITEM, amount[i], itemid[i]);
 			return 0;
 		}
 	}

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1328,6 +1328,12 @@ static int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill
 
 	if (src->type==BL_HOM)
 		switch(skill_id) { //Homun-auto-target skills.
+			case HVAN_CHAOTIC:
+				target_id = ud->target; // Choose attack target for now
+				target = map->id2bl(target_id);
+				if (target != NULL)
+					break;
+				FALLTHROUGH // Attacking nothing, choose master as default target instead
 			case HLIF_HEAL:
 			case HLIF_AVOID:
 			case HAMI_DEFENCE:

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1410,13 +1410,6 @@ static int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill
 		}
 	}
 
-	if (src->type == BL_HOM) {
-		// In case of homunuculus, set the sd to the homunculus' master, as needed below
-		struct block_list *master = battle->get_master(src);
-		if (master)
-			sd = map->id2sd(master->id);
-	}
-
 	if (sd) {
 		/* temporarily disabled, awaiting for kenpachi to detail this so we can make it work properly */
 #if 0


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fix Chaotic Blessings never healing the enemy.
Fix Homunculus skill failure message not displaying required items. (eg: Healing Hands from Lif)
Fix Homunculus skill requirements being put on owner as well.

Last change meant for example that currently if the owner of an homunculus doesn't have enough SP, the homunculus won't be able to use skills requiring SP, even though the Homunculus might have enough SP. This is now fixed with this change.

Note:
All of these fixes have been tested and are proven to work.

**Issues addressed:** None?

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
