### PR TITLE
Clean up cached party/guild data when leaving/disbanding

### DIFF
--- a/src/char/int_party.c
+++ b/src/char/int_party.c
@@ -118,7 +118,6 @@ static void inter_party_calc_state(struct party_data *p)
 		p->party.exp = 0; //Set off even share.
 		mapif->party_optionchanged(0, &p->party, 0, 0);
 	}
-	return;
 }
 
 // Save party to mysql
@@ -472,8 +471,11 @@ static bool inter_party_leave(int party_id, int account_id, int char_id)
 	mapif->party_withdraw(party_id, account_id, char_id);
 
 	j = p->party.member[i].lv;
-	if (p->party.member[i].online > 0)
+	if (p->party.member[i].online > 0) {
+		p->party.member[i].online = 0;
 		p->party.count--;
+	}
+	inter_party->tosql(&p->party, PS_DELMEMBER, i);
 	memset(&p->party.member[i], 0, sizeof(struct party_member));
 	p->size--;
 	if (j == p->min_lv || j == p->max_lv || p->family) {
@@ -482,7 +484,6 @@ static bool inter_party_leave(int party_id, int account_id, int char_id)
 	}
 
 	if (inter_party->check_empty(p) == 0) {
-		inter_party->tosql(&p->party, PS_DELMEMBER, i);
 		mapif->party_info(-1, &p->party, 0);
 	}
 	return true;

--- a/src/map/guild.c
+++ b/src/map/guild.c
@@ -565,6 +565,7 @@ static int guild_check_member(const struct guild *g)
 		if (i == INDEX_NOT_FOUND) {
 			sd->status.guild_id=0;
 			sd->guild_emblem_id=0;
+			sd->guild = NULL;
 			ShowWarning("guild: check_member %d[%s] is not member\n",sd->status.account_id,sd->status.name);
 		}
 	}
@@ -581,8 +582,11 @@ static int guild_recv_noinfo(int guild_id)
 
 	iter = mapit_getallusers();
 	for (sd = BL_UCAST(BL_PC, mapit->first(iter)); mapit->exists(iter); sd = BL_UCAST(BL_PC, mapit->next(iter))) {
-		if( sd->status.guild_id == guild_id )
+		if (sd->status.guild_id == guild_id) {
 			sd->status.guild_id = 0; // erase guild
+			sd->guild_emblem_id = 0;
+			sd->guild = NULL;
+		}
 	}
 	mapit->free(iter);
 
@@ -872,6 +876,8 @@ static void guild_member_joined(struct map_session_data *sd)
 	i = guild->getindex(g, sd->status.account_id, sd->status.char_id);
 	if (i == INDEX_NOT_FOUND) {
 		sd->status.guild_id = 0;
+		sd->guild_emblem_id = 0;
+		sd->guild = NULL;
 	} else {
 		g->member[i].sd = sd;
 		sd->guild = g;

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -695,6 +695,7 @@ static int party_broken(int party_id)
 		if( p->data[i].sd!=NULL ) {
 			clif->party_withdraw(p,p->data[i].sd,p->party.member[i].account_id,p->party.member[i].name,0x10);
 			p->data[i].sd->status.party_id=0;
+			clif->charnameupdate(p->data[i].sd);
 		}
 	}
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

1. Clear the party ID from the saved character data, when leaving or getting kicked (causing database inconsistencies)
2. Clear the cached guild pointer when the guild ID is cleared, upon error (dangling pointer).
3. Clear the (clientside) party name from all the party members when a party is disabanded (just visual).

**Issues addressed:** Point 2 is a possible cause of the crash described in #1266

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
