### PR TITLE
Console command fixes

### DIFF
--- a/src/common/console.c
+++ b/src/common/console.c
@@ -322,6 +322,7 @@ static void console_parse_create(char *name, CParseFunc func)
 	nullpo_retv(name);
 	safestrncpy(sublist, name, CP_CMD_LENGTH * 5);
 	tok = strtok(sublist,":");
+	nullpo_retv(tok);
 
 	ARR_FIND(0, VECTOR_LENGTH(console->input->command_list), i, strcmpi(tok, VECTOR_INDEX(console->input->command_list, i)->cmd) == 0);
 
@@ -404,6 +405,10 @@ static void console_parse_sub(char *line)
 	nullpo_retv(line);
 	memcpy(bline, line, 200);
 	tok = strtok(line, " ");
+	if (tok == NULL) {
+		// Ignore empty commands
+		return;
+	}
 
 	ARR_FIND(0, VECTOR_LENGTH(console->input->command_list), i, strcmpi(tok, VECTOR_INDEX(console->input->command_list, i)->cmd) == 0);
 	if (i == VECTOR_LENGTH(console->input->command_list)) {
@@ -417,6 +422,12 @@ static void console_parse_sub(char *line)
 
 	if (cmd->type == CPET_FUNCTION) {
 		tok = strtok(NULL, "");
+		if (tok != NULL) {
+			while (tok[0] == ' ')
+				tok++;
+			if (tok[0] == '\0')
+				tok = NULL;
+		}
 		cmd->u.func(tok);
 		return;
 	}
@@ -444,6 +455,12 @@ static void console_parse_sub(char *line)
 		entry = VECTOR_INDEX(cmd->u.children, i);
 		if (entry->type == CPET_FUNCTION) {
 			tok = strtok(NULL, "");
+			if (tok != NULL) {
+				while (tok[0] == ' ')
+					tok++;
+				if (tok[0] == '\0')
+					tok = NULL;
+			}
 			entry->u.func(tok);
 			return;
 		}

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -45,7 +45,6 @@
 #include "map/mapreg.h"
 #include "map/mercenary.h"
 #include "map/mob.h"
-#include "map/npc.h"
 #include "map/npc.h" // npc_setcells(), npc_unsetcells()
 #include "map/party.h"
 #include "map/path.h"
@@ -6305,6 +6304,7 @@ static CPCMD(gm_position)
 	map->cpsd->bl.x = x;
 	map->cpsd->bl.y = y;
 	map->cpsd->bl.m = m;
+	map->cpsd->mapindex = map_id2index(m);
 }
 static CPCMD(gm_use)
 {
@@ -6333,6 +6333,8 @@ static void map_cp_defaults(void)
 	map->cpsd->bl.x = mapindex->default_x;
 	map->cpsd->bl.y = mapindex->default_y;
 	map->cpsd->bl.m = map->mapname2mapid(mapindex->default_map);
+	Assert_retv(map->cpsd->bl.m >= 0);
+	map->cpsd->mapindex = map_id2index(map->cpsd->bl.m);
 
 	console->input->addCommand("gm:info",CPCMD_A(gm_position));
 	console->input->addCommand("gm:use",CPCMD_A(gm_use));


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Fixed the `gm:info` console command to correctly set the mapindex for the dummy console SD
- Fixed a crash in the console message parser, when processing a string consisting of only spaces (i.e. press Space, then Return on the console)
- Fixed console command argument processing: when multiple spaces are passed at the beginning of a command, now they're correctly stripped before calling the command handler


**Issues addressed:** None

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
