### PR TITLE
Fix ud->target_to not being cleared appropriately

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -459,10 +459,10 @@ static int unit_walktoxy_timer(int tid, int64 tick, int id, intptr_t data)
 		}
 		if (tbl->m == bl->m && check_distance_bl(bl, tbl, ud->chaserange)) {
 			//Reached destination.
+			ud->target_to = 0;
 			if (ud->state.attack_continue) {
 				//Aegis uses one before every attack, we should
 				//only need this one for syncing purposes. [Skotlex]
-				ud->target_to = 0;
 				clif->fixpos(bl);
 				unit->attack(bl, tbl->id, ud->state.attack_continue);
 			}
@@ -544,6 +544,8 @@ static int unit_walktoxy(struct block_list *bl, short x, short y, int flag)
 	ud->to_x = x;
 	ud->to_y = y;
 	unit->stop_attack(bl); //Sets target to 0
+	if ((flag & 8) == 0) // Stepaction might be delayed due to occupied cell
+		unit->stop_stepaction(bl); // unit->walktoxy removes any remembered stepaction and resets ud->target_to
 
 	sc = status->get_sc(bl);
 	if( sc ) {


### PR DESCRIPTION
Thanks to Marida from oRO Staff doing a heavy part in fixing and debugging this!

### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Clear ud->target_to when appropriate.

Changes have been tested thoroughly.

**Issues addressed:**
The following bugs are fixed by this:
- Hunters with auto-attack on that are clicking to move away from mob, constantly walking back to attack the mob and back to where they wanted to move.
- When the target of a monster died mid-chase, it would constantly walk towards the corpse back and forth (If no new targets are in sight)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
