### PR TITLE
Fix some issues in the Steal skill

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2237,6 +2237,14 @@ static void mob_log_damage(struct mob_data *md, struct block_list *src, int dama
 			md->dmglog[minpos].flag= flag;
 			md->dmglog[minpos].dmg = damage;
 		}
+#if (PACKETVER >= 20120404 && PACKETVER < 20131223)
+		// Show HP bar to all chars who hit the mob (fixes TF_STEAL not showing HP bar right away but only when target leaves/re-enters sight range)
+		if (battle_config.show_monster_hp_bar != 0 && (md->status.mode & MD_BOSS) == 0) {
+			struct map_session_data *sd = map->charid2sd(char_id);
+			if (sd != NULL && check_distance_bl(&md->bl, &sd->bl, AREA_SIZE)) // check if in range
+				clif->monster_hp_bar(md, sd);
+		}
+#endif
 	}
 	return;
 }

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -40,7 +40,6 @@ struct hplugin_data_store;
 //The number of drops all mobs have and the max drop-slot that the steal skill will attempt to steal from.
 #define MAX_MOB_DROP 10
 #define MAX_MVP_DROP 3
-#define MAX_STEAL_DROP 7
 
 //Min time between AI executions
 #define MIN_MOBTHINKTIME 100

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -5583,15 +5583,17 @@ static int pc_steal_item(struct map_session_data *sd, struct block_list *bl, uin
 
 	// Try dropping one item, in the order from first to last possible slot.
 	// Droprate is affected by the skill success rate.
-	for (i = 0; i < MAX_STEAL_DROP; i++) {
+	for (i = 0; i < MAX_MOB_DROP; i++) {
 		if (md->db->dropitem[i].nameid == 0)
 			continue;
 		if ((data = itemdb->exists(md->db->dropitem[i].nameid)) == NULL)
 			continue;
+		if (data->type == IT_CARD)
+			continue;
 		if (rnd() % 10000 < apply_percentrate(md->db->dropitem[i].p, rate, 100))
 			break;
 	}
-	if (i == MAX_STEAL_DROP)
+	if (i == MAX_MOB_DROP)
 		return 0;
 
 	itemid = md->db->dropitem[i].nameid;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes two issues with the TF_STEAL skill:

- The HP bar of the target is now sent to all the party members in case of successful cast, as soon as the mob is added to the damage log. Previously, party members needed to leave and re-enter the view area. This only affects packetvers between 20120404 and 20131223.
- The Steal skill now explicitly ignores cards, to match the official behavior. This was affected by a regression when the item DB was converted to the libconfig format in ed72a947a6c97804c1eef5b80bfa49d99f7d7586, as the cards are no longer in a fixed position in the drops array.

**Issues addressed:** None

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
