### PR TITLE
Makes HULD .po files read \r as a control character

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -5400,6 +5400,9 @@ static int script_load_translation_file(const char *file, uint8 lang_id)
 					if (line[i] == '\\' && line[i+1] == '"') {
 						VECTOR_PUSH(*msg_ptr, '"');
 						i++;
+					} else if (line[i] == '\\' && line[i+1] == 'r') {
+						VECTOR_PUSH(*msg_ptr, '\r');
+						i++;
 					} else {
 						VECTOR_PUSH(*msg_ptr, line[i]);
 					}
@@ -5417,6 +5420,9 @@ static int script_load_translation_file(const char *file, uint8 lang_id)
 			for (i = 9; i < len - 2; i++) {
 				if (line[i] == '\\' && line[i+1] == '"') {
 					msgctxt[cursor] = '"';
+					i++;
+				} else if (line[i] == '\\' && line[i+1] == 'r') {
+					msgctxt[cursor] = '\r';
 					i++;
 				} else {
 					msgctxt[cursor] = line[i];
@@ -5439,6 +5445,9 @@ static int script_load_translation_file(const char *file, uint8 lang_id)
 				if (line[i] == '\\' && line[i+1] == '"') {
 					VECTOR_PUSH(msgid, '"');
 					i++;
+				} else if (line[i] == '\\' && line[i+1] == 'r') {
+					VECTOR_PUSH(msgid, '\r');
+					i++;
 				} else {
 					VECTOR_PUSH(msgid, line[i]);
 				}
@@ -5457,6 +5466,9 @@ static int script_load_translation_file(const char *file, uint8 lang_id)
 				VECTOR_ENSURE(msgstr, 1, 512);
 				if (line[i] == '\\' && line[i+1] == '"') {
 					VECTOR_PUSH(msgstr, '"');
+					i++;
+				} else if (line[i] == '\\' && line[i+1] == 'r') {
+					VECTOR_PUSH(msgstr, '\r');
 					i++;
 				} else {
 					VECTOR_PUSH(msgstr, line[i]);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR adds a handling to read `\r` in `.po` files as a control character (i.e. carriage return) instead of two separate, normal, characters (i.e. `\` and `r`). Currently, HULD is not able to translate messages like:

```
mes("Oh...!\r"
	"Welcome to Alberta,\r"
	"young adventurer!");
```

Even though this is the recomended way (See: #1292 ). That happens because when parsing the NPC file, the script engine takes `\r` as a control character, but when loading a `.po` file, it considers it as 2 separate characters, not matching with the original string, thus not translating them.

This PR fixes this.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
