### PR TITLE
Make the stylist db load before the npcs

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -6701,13 +6701,13 @@ int do_init(int argc, char *argv[])
 	elemental->init(minimal);
 	quest->init(minimal);
 	achievement->init(minimal);
+	stylist->init(minimal);
 	npc->init(minimal);
 	unit->init(minimal);
 	bg->init(minimal);
 	duel->init(minimal);
 	vending->init(minimal);
 	rodex->init(minimal);
-	stylist->init(minimal);
 
 	if (map->scriptcheck) {
 		bool failed = map->extra_scripts_count > 0 ? false : true;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

the database loading message shows after the npcs are loaded which is inconsistent with the other databases

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
