### PR TITLE
Passive Guild Skill status should not reset with SC_ALL

### DIFF
--- a/db/sc_config.conf
+++ b/db/sc_config.conf
@@ -2340,6 +2340,7 @@ SC_LEADERSHIP: {
 		NoDispelReset: true
 		NoClearanceReset: true
 		NoMadoReset: true
+		NoAllReset: true
 	}
 }
 SC_GLORYWOUNDS: {
@@ -2348,6 +2349,7 @@ SC_GLORYWOUNDS: {
 		NoDispelReset: true
 		NoClearanceReset: true
 		NoMadoReset: true
+		NoAllReset: true
 	}
 }
 SC_SOULCOLD: {
@@ -2356,6 +2358,7 @@ SC_SOULCOLD: {
 		NoDispelReset: true
 		NoClearanceReset: true
 		NoMadoReset: true
+		NoAllReset: true
 	}
 }
 SC_HAWKEYES: {
@@ -2364,6 +2367,7 @@ SC_HAWKEYES: {
 		NoDispelReset: true
 		NoClearanceReset: true
 		NoMadoReset: true
+		NoAllReset: true
 	}
 }
 SC_GDSKILL_REGENERATION: {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Removing these status using `sc_end(SC_ALL)` results in some weird behavior as it gets stuck reapplying and removing the effect due to some data not being cleaned properly (we should probably look into that at some point).

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
