### PR TITLE
Fix racial crit bonuses not being affected by katar crit bonus

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4661,12 +4661,16 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 	{
 		short cri = sstatus->cri;
 		if (sd != NULL) {
+			// Racial crit bonuses are affected by katar's crit bonus.
+			if (battle_config.show_katar_crit_bonus && sd->weapontype == W_KATAR)
+				cri += sd->critaddrace[tstatus->race] * 2;
+			else
+				cri += sd->critaddrace[tstatus->race];
+
 			// if show_katar_crit_bonus is enabled, it already done the calculation in status.c
 			if (!battle_config.show_katar_crit_bonus && sd->weapontype == W_KATAR) {
 				cri <<= 1;
 			}
-
-			cri+= sd->critaddrace[tstatus->race];
 
 			if (flag.arrow) {
 				cri += sd->bonus.arrow_cri;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Make racial crit bonuses affected by the katar crit bonus.
(Such as Goblin Steamrider Card for example)

### Proof/Test
First: We're assuming that this part of katar crit bonus didn't change in Renewal.
Test was done on 11.3 Ep Aegis Server.
Assassin had 42 LUK.
Equipment was Specialty Jur[4] with 4x Goblin Steamrider Cards and 2x Critical Rings.
Crit Shield of Sleeper is 5.6
Crit without Goblin Steamrider Cards is 50 - 5.6 = 44.4
IF katar crit bonus doesn't affect goblin steamrider cards then that would be 72,4 Crit against Sleepers.
Since it does affect them it's 100,4 as the test showed.

**Issues addressed:** None?

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
