### PR TITLE
Fix Tarot Card breaking equipment behavior

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -8463,7 +8463,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 							status_fix_damage(src, bl, 1000, 0);
 							clif->damage(src,bl,0,0,1000,0,BDT_NORMAL,0);
 							if( !status->isdead(bl) ) {
-								int where[] = { EQP_ARMOR, EQP_SHIELD, EQP_HELM, EQP_SHOES, EQP_GARMENT };
+								int where[] = {EQP_ARMOR, EQP_SHIELD, EQP_HELM};
 								skill->break_equip(bl, where[rnd() % ARRAYLENGTH(where)], 10000, BCT_ENEMY);
 							}
 						}


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
The current behavior of Tarot Card breaking card is to break any equipment except weapon, however after referring to Aegis both for EP12.1 and EP14.3 the code clearly showed it only break Left Arm (Shield), Armor and Helm.
as an extra for future reference chemical protection is not bypassed by this breaking behavior.

The aeigs code snippets is as the following
``` C
{
	CPCBattle::ReflectDamage(v2, other, 1000);
	if ( !v5 )
	{
		v7 = GetServerRandom(0, 20000) % 3;
		if ( !v7 )
		{
			CPC::OnDamagedArmor((CPC *)other);
			return 4;
		}
		if ( v7 == 1 )
		{
			CPC::OnDamageEquipment((CPC *)other, 256);
			return 4;
		}
		CPC::OnDamageEquipment((CPC *)other, 32);
	}
	result = 4;
}
```

All inner functions has been checked for any other behaviors and confirmed as well.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
