### PR TITLE
Deprecate set() script command.

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -1394,9 +1394,12 @@ assignment instead.
 ---------------------------------------
 
 *setd("<variable name>", <value>)
+*setd(<reference to variable>, <value>)
 
-Works almost identically as set(), except the variable name is
-identified as a string and can thus be constructed dynamically.
+Works almost identically to set(). It sets the value of a variable or an array.
+The variable's name is passed as a string and thus can dynamically be constructed.
+Passing a reference to a variable is supported, too. This is useful when using
+getvariableofnpc(), getvariableofpc(), getd() or getarg().
 
 This command is equivalent to:
   set(getd("variable name"), <value>);
@@ -1408,6 +1411,16 @@ Examples:
 
   setd(".@" + .@var$ + "123$", "Poporing is cool");
   mes(.@Poporing123$); // Displays "Poporing is cool".
+
+  setd(getvariableofnpc(.var$, "TargetNPC"), "Poring party!");
+  mes(getvariableofnpc(.var$, "TargetNPC")); // Displays "Poring party!".
+
+  input(.@acc_id);
+  setd(getvariableofpc(@var$, .@acc_id), "Hello world!");
+  mes(getvariableofpc(@var$, .@acc_id)); // Displays "Hello world!".
+
+  setd(getd(".@var$"), "Hercules!");
+  mes(getd(".@var$")); // Displays "Hercules!".
 
 ---------------------------------------
 

--- a/npc/custom/battleground/bg_common.txt
+++ b/npc/custom/battleground/bg_common.txt
@@ -47,9 +47,9 @@ bat_room,148,150,4	script	Teleporter#bat	4_F_TELEPORTER,{
 		close;
 	}
 
-	set .@spoint$, getsavepoint(0);
-	set .@x, getsavepoint(1);
-	set .@y, getsavepoint(2);
+	.@spoint$ = getsavepoint(0);
+	.@x = getsavepoint(1);
+	.@y = getsavepoint(2);
 	mes "[Teleporter]";
 	mes "You will be sent back to " + .@spoint$ + ".";
 	close2;
@@ -94,7 +94,7 @@ bat_room,160,159,3	script	General Guillaume	4_M_KY_KIYOM,{
 	mes "[General Guillaume]";
 	mes "Welcome to my army, comrade.";
 	mes "Your eyes tell me that you're a soldier that I can trust.";
-	set Bat_Team,1;
+	Bat_Team = 1;
 	next;
 	mes "[General Guillaume]";
 	mes "Now, go upstairs and apply for battle with your comrades. I'm sure they'll welcome you whole-heartedly!";
@@ -127,7 +127,7 @@ bat_room,160,140,3	script	Prince Croix	4_M_CRU_CRUA,{
 	}
 	mes "[Prince Croix]";
 	mes "Thank you so much. I feel like I can win with the help of adventurers like you. Now, please go downstairs and join your comrades in sharpening their skills to fight the enemy!";
-	set Bat_Team,2;
+	Bat_Team = 2;
 	close2;
 	cutin "",255;
 	end;
@@ -136,35 +136,35 @@ bat_room,160,140,3	script	Prince Croix	4_M_CRU_CRUA,{
 // Time calculation Function
 // *********************************************************************
 function	script	Time2Str	{
-	set .@time_left, getarg(0) - gettimetick(2);
+	.@time_left = getarg(0) - gettimetick(2);
 
-	set .@Days, .@time_left / 86400;
-	set .@time_left, .@time_left - (.@Days * 86400);
-	set .@Hours, .@time_left / 3600;
-	set .@time_left, .@time_left - (.@Hours * 3600);
-	set .@Minutes, .@time_left / 60;
-	set .@time_left, .@time_left - (.@Minutes * 60);
+	.@Days = .@time_left / 86400;
+	.@time_left = .@time_left - (.@Days * 86400);
+	.@Hours = .@time_left / 3600;
+	.@time_left = .@time_left - (.@Hours * 3600);
+	.@Minutes = .@time_left / 60;
+	.@time_left = .@time_left - (.@Minutes * 60);
 
-	set .@Time$, "";
+	.@Time$ = "";
 	if( .@Days > 1 )
-		set .@Time$, .@Time$ + .@Days + " days, ";
+		.@Time$ = .@Time$ + .@Days + " days, ";
 	else if( .@Days > 0 )
-		set .@Time$, .@Time$ + .@Days + " day, ";
+		.@Time$ = .@Time$ + .@Days + " day, ";
 
 	if( .@Hours > 1 )
-		set .@Time$, .@Time$ + .@Hours + " hours, ";
+		.@Time$ = .@Time$ + .@Hours + " hours, ";
 	else if( .@Hours > 0 )
-		set .@Time$, .@Time$ + .@Hours + " hour, ";
+		.@Time$ = .@Time$ + .@Hours + " hour, ";
 
 	if( .@Minutes > 1 )
-		set .@Time$, .@Time$ + .@Minutes + " minutes, ";
+		.@Time$ = .@Time$ + .@Minutes + " minutes, ";
 	else if( .@Minutes > 0 )
-		set .@Time$, .@Time$ + .@Minutes + " minute, ";
+		.@Time$ = .@Time$ + .@Minutes + " minute, ";
 
 	if( .@time_left > 1 || .@time_left == 0 )
-		set .@Time$, .@Time$ + .@time_left + " seconds.";
+		.@Time$ = .@Time$ + .@time_left + " seconds.";
 	else if( .@time_left == 1 )
-		set .@Time$, .@Time$ + .@time_left + " second.";
+		.@Time$ = .@Time$ + .@time_left + " second.";
 
 	return .@Time$;
 }
@@ -1161,7 +1161,7 @@ bat_room,161,158,3	duplicate(bat_aid)	General Guillaume's Aid::bat_aid4	4_M_KY_H
 	end;
 
 OnTouch:
-	set BG_Delay_Tick, gettimetick(2) + 30;
+	BG_Delay_Tick = gettimetick(2) + 30;
 	warp "bat_room",154,149;
 	end;
 }
@@ -1250,15 +1250,15 @@ bat_room,160,150,3	script	Erundek	4_M_MANAGER,{
 			mes "What kind of item do you want to exchange?";
 			next;
 			deletearray .@Item_DB[0],127;
-			set .@Badge, 7828;
+			.@Badge = 7828;
 
 			switch( select("Weapons", "Garment", "Footgear", "Armor", "Accessory") )
 			{
-				case 1: setarray .@Item_DB[0],13036,13411,1425,1632,1634,1543,1924,1978,1574,1824,1183,1380,13305,1279,1739,13108,13172; set .@Value, 100; break;
-				case 2: setarray .@Item_DB[0],2538,2539,2540; set .@Value, 50; break;
-				case 3: setarray .@Item_DB[0],2435,2436,2437; set .@Value, 50; break;
-				case 4: setarray .@Item_DB[0],2376,2377,2378,2379,2380,2381,2382; set .@Value, 80; break;
-				case 5: setarray .@Item_DB[0],2720,2721,2722,2723,2724,2725,2733; set .@Value, 500; break;
+				case 1: setarray .@Item_DB[0],13036,13411,1425,1632,1634,1543,1924,1978,1574,1824,1183,1380,13305,1279,1739,13108,13172; .@Value = 100; break;
+				case 2: setarray .@Item_DB[0],2538,2539,2540; .@Value = 50; break;
+				case 3: setarray .@Item_DB[0],2435,2436,2437; .@Value = 50; break;
+				case 4: setarray .@Item_DB[0],2376,2377,2378,2379,2380,2381,2382; .@Value = 80; break;
+				case 5: setarray .@Item_DB[0],2720,2721,2722,2723,2724,2725,2733; .@Value = 500; break;
 			}
 
 			break;
@@ -1268,15 +1268,15 @@ bat_room,160,150,3	script	Erundek	4_M_MANAGER,{
 			mes "What kind of item do you want to exchange?";
 			next;
 			deletearray .@Item_DB[0],127;
-			set .@Badge, 7829;
+			.@Badge = 7829;
 
 			switch( select("Weapons", "Garment", "Footgear", "Armor", "Accessory") )
 			{
-				case 1: setarray .@Item_DB[0],13037,13410,1633,1635,1542,1923,1977,1575,1823,1184,1482,1379,13306,1280,1738,13171,13173,13174; set .@Value, 100; break;
-				case 2: setarray .@Item_DB[0],2538,2539,2540; set .@Value, 50; break;
-				case 3: setarray .@Item_DB[0],2435,2436,2437; set .@Value, 50; break;
-				case 4: setarray .@Item_DB[0],2376,2377,2378,2379,2380,2381,2382; set .@Value, 80; break;
-				case 5: setarray .@Item_DB[0],2720,2721,2722,2723,2724,2725,2733; set .@Value, 500; break;
+				case 1: setarray .@Item_DB[0],13037,13410,1633,1635,1542,1923,1977,1575,1823,1184,1482,1379,13306,1280,1738,13171,13173,13174; .@Value = 100; break;
+				case 2: setarray .@Item_DB[0],2538,2539,2540; .@Value = 50; break;
+				case 3: setarray .@Item_DB[0],2435,2436,2437; .@Value = 50; break;
+				case 4: setarray .@Item_DB[0],2376,2377,2378,2379,2380,2381,2382; .@Value = 80; break;
+				case 5: setarray .@Item_DB[0],2720,2721,2722,2723,2724,2725,2733; .@Value = 500; break;
 			}
 
 			break;
@@ -1292,12 +1292,12 @@ bat_room,160,150,3	script	Erundek	4_M_MANAGER,{
 	mes "If you are not sure, check the catalog.";
 	next;
 
-	set .@menu$, "";
-	set .@count, getarraysize(.@Item_DB);
-	for( set .@i, 0; .@i < .@count; set .@i, .@i + 1 )
-		set .@menu$, .@menu$ + getitemname(.@Item_DB[.@i]) + ":";
+	.@menu$ = "";
+	.@count = getarraysize(.@Item_DB);
+	for(.@i = 0; .@i < .@count; .@i++)
+		.@menu$ = .@menu$ + getitemname(.@Item_DB[.@i]) + ":";
 
-	set .@Item_ID, .@Item_DB[select(.@menu$) - 1];
+	.@Item_ID = .@Item_DB[select(.@menu$) - 1];
 
 	mes "[Erundek]";
 	mes "Would you like to exchange ^FF0000" + .@Value + " " + getitemname(.@Badge) + "^000000 for a ^0000FF" + getitemname(.@Item_ID) + "^000000?";

--- a/npc/dev/test.txt
+++ b/npc/dev/test.txt
@@ -645,7 +645,7 @@ function	script	HerculesSelfTestHelper	{
 	callsub(OnCheck, "setd", .@y, 1);
 	setd(.@y$, 2);
 	callsub(OnCheck, "setd arguments", .@y, 2);
-	set getd(".@x"), getd(".@y");
+	setd(getd(".@x"), getd(".@y"));
 	callsub(OnCheck, "set getd", .@x, .@y);
 	.@y = 1;
 	setd(".@x", getd(".@y"));
@@ -659,7 +659,7 @@ function	script	HerculesSelfTestHelper	{
 
 	// getvariableofnpc
 	.x = 2;
-	set getvariableofnpc(.x, "TestVarOfAnotherNPC"), 1;
+	setd(getvariableofnpc(.x, "TestVarOfAnotherNPC"), 1);
 	callsub(OnCheck, "Setting NPC variables of another NPC", getvariableofnpc(.x, "TestVarOfAnotherNPC"), 1);
 	callsub(OnCheck, "Setting NPC variables of another NPC (local variable overwrite check)", .x, 2);
 
@@ -691,7 +691,7 @@ function	script	HerculesSelfTestHelper	{
 	deletearray .@x;
 	deletearray .@y;
 	.x = 2;
-	set getvariableofnpc(.x, "TestVarOfAnotherNPC"), 1;
+	setd(getvariableofnpc(.x, "TestVarOfAnotherNPC"), 1);
 	callsub(OnCheck, "Callsub (return NPC variables from another NPC)", callsub(OnTestVarOfAnotherNPC, "TestVarOfAnotherNPC"), 1);
 	callsub(OnCheck, "Callsub (return NPC variables from another NPC - local variable overwrite check)", .x, 2);
 
@@ -740,7 +740,7 @@ function	script	HerculesSelfTestHelper	{
 	deletearray .x;
 	deletearray .y;
 	.x = 2;
-	set getvariableofnpc(.x, "TestVarOfAnotherNPC"), 1;
+	setd(getvariableofnpc(.x, "TestVarOfAnotherNPC"), 1);
 	callsub(OnCheck, "Callfunc (return NPC variables from another NPC)", callfunc("F_TestVarOfAnotherNPC", "TestVarOfAnotherNPC"), 1);
 	callsub(OnCheck, "Callfunc (return NPC variables from another NPC - local variable overwrite check)", .x, 2);
 
@@ -863,7 +863,7 @@ OnCheckStr:
 	}
 	return;
 OnSetReference:
-	set getarg(0), getarg(0) + 1;
+	setd(getarg(0), getarg(0) + 1);
 	return getarg(0);
 }
 

--- a/npc/events/nguild/nguild_treas.txt
+++ b/npc/events/nguild/nguild_treas.txt
@@ -49,18 +49,18 @@ function	script	F_GldTreas	{
 
 		// Only spawn one treasure chest for novice castles.
 		if (compare(getarg(0),"nguild"))
-			set getarg(2),1;
+			setd(getarg(2), 1);
 		else
-			set getarg(2),getcastledata(getarg(0),2)/5+4;
+			setd(getarg(2), getcastledata(getarg(0), 2) / 5 + 4);
 
 		if (getarg(2) <= 0) return;
 
 		//sets the counter variable = to the box number amount
-		set getarg(3), getarg(2);
+		setd(getarg(3), getarg(2));
 	}
 	for (.@i = 1; .@i <= getarg(3); ++.@i) {
 		// set treasure box ID
-		set getarg(4), getarg(5) + (.@i+1) % 2;
+		setd(getarg(4), getarg(5) + (.@i + 1) % 2);
 		areamonster getarg(0),getarg(6),getarg(7),getarg(8),getarg(9),"Treasure Chest",getarg(4),1,"Treasure_"+getarg(1)+"::OnDied";
 	}
 	return;

--- a/npc/jobs/2-1/assassin.txt
+++ b/npc/jobs/2-1/assassin.txt
@@ -1108,7 +1108,7 @@ OnStartArena:
 	}
 	donpcevent "Beholder#ASNTEST::OnEnable";
 	donpcevent "Keeper of the Door#ASN::OnDisable";
-	set getvariableofnpc(.DisableTraps,"Beholder#ASNTEST"),0;
+	setd(getvariableofnpc(.DisableTraps, "Beholder#ASNTEST"), 0);
 	disablewaitingroomevent;
 	end;
 

--- a/npc/jobs/2-1/priest.txt
+++ b/npc/jobs/2-1/priest.txt
@@ -1170,7 +1170,7 @@ OnTimer302000:
 	end;
 
 OnMyMobDead:
-	set getvariableofnpc(.MyMobs,"Zombie_Generator#prst"),getvariableofnpc(.MyMobs,"Zombie_Generator#prst") - 1;
+	setd(getvariableofnpc(.MyMobs, "Zombie_Generator#prst"), getvariableofnpc(.MyMobs, "Zombie_Generator#prst") - 1);
 	end;
 }
 

--- a/npc/jobs/2-2e/SoulLinker.txt
+++ b/npc/jobs/2-2e/SoulLinker.txt
@@ -353,7 +353,7 @@ job_soul,30,31,0	script	Maia#link2::SLTester	FAKE_NPC,3,3,{
 OnTouch:
 	if (Class == Job_Taekwon) {
 		if (JobLevel < 40) {
-			set getvariableofnpc(.SoulLinkerTest,"Kid#link1"),0;
+			setd(getvariableofnpc(.SoulLinkerTest, "Kid#link1"), 0);
 			mes "[Maia]";
 			mes "Hm? How did you come";
 			mes "here? You're not qualified";
@@ -471,12 +471,12 @@ OnTouch:
 			mes "spirits will be able to protect";
 			mes "you and help you fight in your battles. Farewell for now, friend.";
 			close2;
-			set getvariableofnpc(.SoulLinkerTest,"Kid#link1"),0;
+			setd(getvariableofnpc(.SoulLinkerTest, "Kid#link1"), 0);
 			donpcevent "Timer#link3::OnDisable";
 			warp "morocc",157,47;
 			end;
 		}
-		set getvariableofnpc(.SoulLinkerTest,"Kid#link1"),0;
+		setd(getvariableofnpc(.SoulLinkerTest, "Kid#link1"), 0);
 		mes "[Maia]";
 		mes "Hmm...?";
 		mes "The time for you";
@@ -487,7 +487,7 @@ OnTouch:
 		warp "morocc",157,47;
 		end;
 	}
-	set getvariableofnpc(.SoulLinkerTest,"Kid#link1"),0;
+	setd(getvariableofnpc(.SoulLinkerTest, "Kid#link1"), 0);
 	if (Class == Job_Soul_Linker) {
 		mes "[Maia]";
 		mes "The time has come for";
@@ -658,14 +658,14 @@ OnEnable:
 
 OnDisable:
 	stopnpctimer;
-	set getvariableofnpc(.SoulLinkerTest,"Kid#link1"),0;
+	setd(getvariableofnpc(.SoulLinkerTest, "Kid#link1"), 0);
 	end;
 
 OnTimer60000:
 OnTimer120000:
 	if (getmapusers("job_soul") == 0) {
 		stopnpctimer;
-		set getvariableofnpc(.SoulLinkerTest,"Kid#link1"),0;
+		setd(getvariableofnpc(.SoulLinkerTest, "Kid#link1"), 0);
 	}
 	end;
 
@@ -677,7 +677,7 @@ OnTimer182000:
 
 OnTimer183000:
 	mapwarp "job_soul","morocc",157,47;
-	set getvariableofnpc(.SoulLinkerTest,"Kid#link1"),0;
+	setd(getvariableofnpc(.SoulLinkerTest, "Kid#link1"), 0);
 	stopnpctimer;
 }
 
@@ -707,7 +707,7 @@ sec_in02,35,153,0	script	Soul Linker Var	4_M_OPERATION,{
 			mes "The Soul Linker";
 			mes "Job Quest NPCs";
 			mes "have been reset.";
-			set getvariableofnpc(.SoulLinkerTest,"Kid#link1"),0;
+			setd(getvariableofnpc(.SoulLinkerTest, "Kid#link1"), 0);
 			close;
 		case 2:
 			mes "[Soul Linker Var]";

--- a/npc/other/Global_Functions.txt
+++ b/npc/other/Global_Functions.txt
@@ -425,7 +425,7 @@ function	script	F_ShuffleNumbers	{
 		.@temparray[.@i] = .@i;
 	for (.@i = 0; .@i < .@count; ++.@i) {
 		.@rand = rand(.@range);
-		set getelementofarray( getarg(2), .@i ), .@temparray[.@rand] + .@static;
+		setd(getelementofarray( getarg(2), .@i ), .@temparray[.@rand] + .@static);
 		.@temparray[.@rand] = .@temparray[--.@range];
 	}
 	return .@count;

--- a/npc/other/hugel_bingo.txt
+++ b/npc/other/hugel_bingo.txt
@@ -888,7 +888,7 @@ function	script	Func_BingoResult	{
 	enablenpc ""+getarg(0)+"c#bingo";
 	enablenpc ""+getarg(0)+"d#bingo";
 	enablenpc ""+getarg(0)+"e#bingo";
-	set getarg(0),getarg(0) +1;
+	setd(getarg(0), getarg(0) + 1);
 	end;
 }
 

--- a/npc/quests/kiel_hyre_quest.txt
+++ b/npc/quests/kiel_hyre_quest.txt
@@ -5772,7 +5772,7 @@ OnTimer30000:
 	stopnpctimer;
 	specialeffect EF_SUMMONSLAVE;
 	disablenpc "Big_Door_1_Warp";
-	set getvariableofnpc(.KHDoor1Opened,"Big Door#BigDoorKHQ1"),0;
+	setd(getvariableofnpc(.KHDoor1Opened, "Big Door#BigDoorKHQ1"), 0);
 	end;
 
 OnTouch:
@@ -5828,7 +5828,7 @@ OnTimer30000:
 	stopnpctimer;
 	specialeffect EF_SUMMONSLAVE;
 	disablenpc "Big_Door_2_Warp";
-	set getvariableofnpc(.KHDoor2Opened,"Big Door#BigDoorKHQ2"),0;
+	setd(getvariableofnpc(.KHDoor2Opened, "Big Door#BigDoorKHQ2"), 0);
 	end;
 
 OnTouch:
@@ -5886,7 +5886,7 @@ OnTimer30000:
 	stopnpctimer;
 	specialeffect EF_SUMMONSLAVE;
 	disablenpc "Big_Door_3_Warp";
-	set getvariableofnpc(.KHDoor3Opened,"Big Door#BigDoorKHQ3"),0;
+	setd(getvariableofnpc(.KHDoor3Opened, "Big Door#BigDoorKHQ3"), 0);
 	end;
 
 OnTouch:
@@ -5941,7 +5941,7 @@ OnTimer30000:
 	stopnpctimer;
 	specialeffect EF_SUMMONSLAVE;
 	disablenpc "Big_Door_4_Warp";
-	set getvariableofnpc(.KHDoor4Opened,"Big Door#BigDoorKHQ4"),0;
+	setd(getvariableofnpc(.KHDoor4Opened, "Big Door#BigDoorKHQ4"), 0);
 	end;
 
 OnTouch:
@@ -6142,7 +6142,7 @@ OnTimer30000:
 	stopnpctimer;
 	specialeffect EF_SUMMONSLAVE;
 	disablenpc "Big_Door_5_Warp";
-	set getvariableofnpc(.KHDoor5Opened,"Big Door#BigDoorKHQ5"),0;
+	setd(getvariableofnpc(.KHDoor5Opened, "Big Door#BigDoorKHQ5"), 0);
 	end;
 
 OnInit:
@@ -6233,7 +6233,7 @@ kh_kiehl02,50,52,4	script	Kiehl#Original	4_M_KHKIEL,{
 		mes "then show me what you've got!";
 		close2;
 		cutin "",255;
-		set getvariableofnpc(.KHKilled,"KiehlRoom"),0;
+		setd(getvariableofnpc(.KHKilled, "KiehlRoom"), 0);
 		monster "kh_kiehl02",50,52,"Aliot",1740,1,"KiehlRoom::OnKiehlMobDead";
 		monster "kh_kiehl02",50,52,"Alicel",1739,1,"KiehlRoom::OnKiehlMobDead";
 		monster "kh_kiehl02",50,52,"Constant",1745,1,"KiehlRoom::OnKiehlMobDead";
@@ -6346,7 +6346,7 @@ kh_kiehl02,50,52,4	script	Kiehl#Original	4_M_KHKIEL,{
 		next;
 	}
 	if ((KielHyreQuest == 100) && (getvariableofnpc(.KHKilledBoss,"KiehlRoom") < 1)) {
-		set getvariableofnpc(.KHKilledBoss,"KiehlRoom"),0;
+		setd(getvariableofnpc(.KHKilledBoss, "KiehlRoom"), 0);
 		cutin "kh_kiel01",2;
 		mes "[Kiehl]";
 		mes "Ah, Schwaltzvalt Republic";
@@ -6726,7 +6726,7 @@ OnReset:
 	hideoffnpc "Kiehl#Original";
 	.KHKilledBoss = 0;
 	.KHKilled = 0;
-	set getvariableofnpc(.KHTrapSprung,"Kiehl_Room_Trap"),0;
+	setd(getvariableofnpc(.KHTrapSprung, "Kiehl_Room_Trap"), 0);
 	$@KHQuestBusy = 0;
 	end;
 }

--- a/npc/quests/newgears/2004_headgears.txt
+++ b/npc/quests/newgears/2004_headgears.txt
@@ -2471,7 +2471,7 @@ OnTouch:
 		mes "[Nine Tails]";
 		mes "Yelp! Yelp yelp!";
 		close2;
-		set getvariableofnpc(.MyMobs1,"SpawnManager#Kitsune"),1;
+		setd(getvariableofnpc(.MyMobs1, "SpawnManager#Kitsune"), 1);
 		switch(rand(1,25)) {
 		case 1:  .@x = 118; .@y =  66; break;
 		case 2:  .@x = 103; .@y = 194; break;
@@ -2570,7 +2570,7 @@ pay_dun03,48,84,4	script	Nine Tails#Kitsune Man	4_M_JPN2,{
 		mes "I will give you this ^0000FFKitsune Mask^000000 if you bring me what I asked. How does that sound? Remember, ^0000FF999 ^FF0000Nine Tail^000000.";
 		close;
 	}
-	set getvariableofnpc(.MyMobs2,"SpawnManager#Kitsune"),1;
+	setd(getvariableofnpc(.MyMobs2, "SpawnManager#Kitsune"), 1);
 	switch(rand(1,25)) {
 	case 1:  .@x = 118; .@y =  66; break;
 	case 2:  .@x = 103; .@y = 194; break;
@@ -2604,7 +2604,7 @@ pay_dun03,48,84,4	script	Nine Tails#Kitsune Man	4_M_JPN2,{
 	end;
 
 OnInit:
-	set getvariableofnpc(.MyMobs2,"SpawnManager#Kitsune"),1;
+	setd(getvariableofnpc(.MyMobs2, "SpawnManager#Kitsune"), 1);
 	monster "pay_dun03",48,83,"Nine Tail",1180,1,"SpawnManager#Kitsune::OnMyMobDead2";
 	disablenpc "Nine Tails#Kitsune Man";
 	end;

--- a/npc/quests/quests_airship.txt
+++ b/npc/quests/quests_airship.txt
@@ -1976,7 +1976,7 @@ OnTimer600000:
 	donpcevent("#AirshipWarp-4::OnHide");
 	mapannounce("airplane_01", _("The Airship is now taking off. Our next destination is Izlude."), bc_map, C_LIME);
 	stopnpctimer();
-	set(getvariableofnpc(.moninv, "International_Airship"), 2);
+	setd(getvariableofnpc(.moninv, "International_Airship"), 2);
 	donpcevent("International_Airship::OnEnable");
 	end;
 

--- a/npc/re/jobs/2e/kagerou_oboro.txt
+++ b/npc/re/jobs/2e/kagerou_oboro.txt
@@ -73,12 +73,12 @@ OnTouch:
 		next;
 		mes "The conversation stopped abruptly. Hidden place? Wall? Part of a test? What is all this about?";
 		setquest 5131;
-		set job_kagero,1;
+		job_kagero = 1;
 		close;
 	} else if (BaseJob != Job_Ninja && job_kagero > 0) {
-		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
+		for (.@i = 5131; .@i <= 5146; .@i++)
 			if (questprogress(.@i)) erasequest .@i;
-		set job_kagero,0;
+		job_kagero = 0;
 	}
 	end;
 }
@@ -125,9 +125,9 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 		close;
 	}
 	if (BaseJob != Job_Ninja) {
-		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
+		for (.@i = 5131; .@i <= 5146; .@i++)
 			if (questprogress(.@i)) erasequest .@i;
-		set job_kagero,0;
+		job_kagero = 0;
 		mes "[Kuuga Gai]";
 		mes "You are not in the clan of the Ninja.";
 		close2;
@@ -192,7 +192,7 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 		next;
 		erasequest 5131;
 		setquest 5132;
-		set job_kagero,2;
+		job_kagero = 2;
 		mes "[Old Man]";
 		mes "You'll have to lend me your ear for I have so much to tell you about the clan story.";
 		close2;
@@ -237,7 +237,7 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 		next;
 		erasequest 5132;
 		setquest 5133;
-		set job_kagero,3;
+		job_kagero = 3;
 		mes "^1A95E6The old man looks even more forlorn.^1A95E6";
 		close2;
 		cutin "",255;
@@ -285,7 +285,7 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 		next;
 		erasequest 5133;
 		setquest 5134;
-		set job_kagero,4;
+		job_kagero = 4;
 		mes "[Leader Gion]";
 		mes "If you are prepared to follow me, Leader Gion, on the "+ (Sex == SEX_MALE ? "Kagerou" : "Oboro") +" path, we will meet again.";
 		close2;
@@ -315,8 +315,8 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 		mes "I know you are curious what these tests are. Let me explain one by one.";
 		next;
 		while(1) {
-			set .@i, select("Test of Knowledge", "Test of Survival", "Test of Weaponry", "Test of Battle");
-			set .@test, .@test | (1<<(.@i-1));
+			.@i = select("Test of Knowledge", "Test of Survival", "Test of Weaponry", "Test of Battle");
+			.@test |= (1<<(.@i-1));
 			switch (.@i) {
 			case 1:
 				mes "[Leader Gion]";
@@ -401,17 +401,17 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 		next;
 		erasequest 5134;
 		setquest 5135;
-		set job_kagero,5;
+		job_kagero = 5;
 		mes "[Leader Gion]";
 		mes "Let's start right away after you are done with preparations.";
 		close2;
 		cutin "",255;
 		end;
 	} else if (job_kagero == 5) {
-		set .@ko_test_01, questprogress(5136);
-		set .@ko_test_02, questprogress(5137);
-		set .@ko_test_03, questprogress(5138);
-		set .@ko_test, .@ko_test_01 + .@ko_test_02 + .@ko_test_03;
+		.@ko_test_01 = questprogress(5136);
+		.@ko_test_02 = questprogress(5137);
+		.@ko_test_03 = questprogress(5138);
+		.@ko_test = .@ko_test_01 + .@ko_test_02 + .@ko_test_03;
 		if (.@ko_test == 0) {
 			cutin "job_ko03",2;
 			mes "[Leader Gion]";
@@ -457,21 +457,21 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 			cutin "job_ko01",2;
 			mes "[Leader Gion]";
 			if (.@ko_test_01 == 2) {
-				set .@menu$,":Test of Survival:Test of Weaponry";
+				.@menu$ = ":Test of Survival:Test of Weaponry";
 				mes "You've passed the Test of Knowledge.";
 				next;
 				mes "[Leader Gion]";
 				mes "My friend doesn't approve of others that easily but I guess he liked you.";
 				next;
 			} else if (.@ko_test_02 == 2) {
-				set .@menu$,"Test of Knowledge::Test of Weaponry";
+				.@menu$ = "Test of Knowledge::Test of Weaponry";
 				mes "You've passed the Test of Survival.";
 				next;
 				mes "[Leader Gion]";
 				mes "Looks like you went through hell with this test.";
 				next;
 			} else if (.@ko_test_03 == 2) {
-				set .@menu$,"Test of Knowledge:Test of Survival:";
+				.@menu$ = "Test of Knowledge:Test of Survival:";
 				mes "You've passed the Test of Weaponry.";
 				next;
 				mes "[Leader Gion]";
@@ -519,13 +519,13 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 			cutin "job_ko04",2;
 			mes "[Leader Gion]";
 			if (.@ko_test_01 == 2 && .@ko_test_02 == 2) {
-				set .@last_test,3;
+				.@last_test = 3;
 				mes "You've passed the ^339CCCTests of Knowledge and Survival^000000!";
 			} else if (.@ko_test_01 == 2 && .@ko_test_03 == 2) {
-				set .@last_test,2;
+				.@last_test = 2;
 				mes "You've passed the ^339CCCTests of Knowledge and Weaponry^000000!";
 			} else if (.@ko_test_02 == 2 && .@ko_test_03 == 2) {
-				set .@last_test,1;
+				.@last_test = 1;
 				mes "You've passed the ^339CCCTests of Survival and Weaponry^000000!";
 			}
 			next;
@@ -617,7 +617,7 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 			mes "[Leader Gion]";
 			mes "That's that. Now shouldn't you be preparing for the last test?";
 			next;
-			set job_kagero,6;
+			job_kagero = 6;
 			mes "[Leader Gion]";
 			mes "But you must be tired from all the tests so far. Take a rest.";
 			close2;
@@ -626,11 +626,11 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 		} else if (.@ko_test == 1 || .@ko_test == 3 || .@ko_test == 5) {
 			cutin "job_ko04",2;
 			if (.@ko_test_01 == 1)
-				set .@test_ko$, "Knowledge";
+				.@test_ko$ = "Knowledge";
 			else if (.@ko_test_02 == 1)
-				set .@test_ko$, "Survival";
+				.@test_ko$ = "Survival";
 			else if (.@ko_test_03 == 1)
-				set .@test_ko$, "Weaponry";
+				.@test_ko$ = "Weaponry";
 			mes "[Leader Gion]";
 			mes "Weren't you taking the Test of " + .@test_ko$ + " just now?";
 			next;
@@ -687,7 +687,7 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 		mes "May the blessings of '" + (Sex == SEX_MALE ? "Kagerou, dancing sun" : "Oboro, misty moonlight") + "' be with you.";
 		next;
 		setquest 5146;
-		set job_kagero,7;
+		job_kagero = 7;
 		mes "[Leader Gion]";
 		mes "Then let's go to the battle test field.";
 		close2;
@@ -733,9 +733,9 @@ job_ko,25,115,4	script	Old Man#ko	4_M_KAGE_OLD,{
 //callsub L_StartTest,<1=Knowledge,2=Survival,3=Weaponry>,<test number [1..3]>;
 L_StartTest:
 	switch (getarg(1)) {
-		case 1: set .@str$,"You are starting with the ^339CCCTest of %s^000000? "; break;
-		case 2: set .@str$,"You are taking the ^339CCCTest of %s^000000 as the second test? "; break;
-		case 3: set .@str$,"Your third test is the ^339CCCTest of %s^000000! "; break;
+		case 1: .@str$ = "You are starting with the ^339CCCTest of %s^000000? "; break;
+		case 2: .@str$ = "You are taking the ^339CCCTest of %s^000000 as the second test? "; break;
+		case 3: .@str$ = "Your third test is the ^339CCCTest of %s^000000! "; break;
 	}
 	mes "[Leader Gion]";
 	switch (getarg(0)) {
@@ -777,9 +777,9 @@ L_StartTest:
 //== Test of Knowledge =====================================
 job_ko,81,124,4	script	Kuuga Gai#ko	4_M_JOB_ASSASSIN,{
 	if (BaseJob != Job_Ninja) {
-		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
+		for (.@i = 5131; .@i <= 5146; .@i++)
 			if (questprogress(.@i)) erasequest .@i;
-		set job_kagero,0;
+		job_kagero = 0;
 		mes "[Kuuga Gai]";
 		mes "Sorry, your clan is not same as ours, is there something wrong?";
 		close2;
@@ -792,8 +792,8 @@ job_ko,81,124,4	script	Kuuga Gai#ko	4_M_JOB_ASSASSIN,{
 			mes "This is a test of knowledge, so why did you bring so many things?";
 			close;
 		}
-		set .@ko_test_01, questprogress(5136);
-		set .@ko_test_01_1, questprogress(5139);
+		.@ko_test_01 = questprogress(5136);
+		.@ko_test_01_1 = questprogress(5139);
 		if (.@ko_test_01 == 1 && .@ko_test_01_1 == 0) {
 			mes "[Kuuga Gai]";
 			mes "It's been a while.";
@@ -846,24 +846,24 @@ job_ko,81,124,4	script	Kuuga Gai#ko	4_M_JOB_ASSASSIN,{
 			mes "Let's start.";
 			next;
 
-			set .@questions,10;  // number of questions to ask
+			.@questions = 10;  // number of questions to ask
 
 			// shuffle array an array of questions to be asked
 			freeloop(1);
 			setarray .@n[0],
 				1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,
 				26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50;
-			for (set .@i,getarraysize(.@n)-1; .@i>0; set .@i,.@i-1) {
-				set .@rand, rand(.@i);
-				set .@tmp, .@n[.@i];
-				set .@n[.@i], .@n[.@rand];
-				set .@n[.@rand], .@tmp;
+			for (.@i = getarraysize(.@n) - 1; .@i > 0; .@i--) {
+				.@rand = rand(.@i);
+				.@tmp = .@n[.@i];
+				.@n[.@i] = .@n[.@rand];
+				.@n[.@rand] = .@tmp;
 			}
 			deletearray .@n[10],getarraysize(.@n) - .@questions;
 			freeloop(0);
 
-			set @job_ko_kuuga,0;
-			for (set .@i,1; .@i<=.@questions; set .@i,.@i+1) {
+			@job_ko_kuuga = 0;
+			for (.@i = 1; .@i <= .@questions; .@i++) {
 				mes "[Kuuga Gai]";
 				mes (.@i < .@questions)?"Question number "+.@i+":":"Last question:";
 				switch (.@n[.@i-1]) {
@@ -965,7 +965,7 @@ job_ko,81,124,4	script	Kuuga Gai#ko	4_M_JOB_ASSASSIN,{
 				warp "job_ko",16,113;
 				end;
 			}
-			set @job_ko_kuuga,0;
+			@job_ko_kuuga = 0;
 			close;
 		} else if (.@ko_test_01 == 2 && .@ko_test_01_1 == 0) {
 			mes "[Kuuga Gai]";
@@ -991,7 +991,7 @@ L_Question:
 	mes getarg(0);
 	next;
 	if(select(getarg(2)) == getarg(1))
-		set @job_ko_kuuga, @job_ko_kuuga + 10;
+		@job_ko_kuuga += 10;
 	return;
 }
 
@@ -1065,8 +1065,8 @@ function	script	F_KO_Survival_dice	{
 		callfunc "F_KO_Survival_warp",0;
 		end;
 	}
-	set job_kagero_lp, job_kagero_lp - getarg(1,1);
-	set .@dice, rand(1,6);
+	job_kagero_lp -= getarg(1, 1);
+	.@dice = rand(1,6);
 	emotion 57 + .@dice,1;
 	mes "The dice came out as " + .@dice + ".";
 	if (getarg(2,0))
@@ -1090,15 +1090,15 @@ function	script	F_KO_Survival_dice2	{
 		callfunc "F_KO_Survival_warp",0;
 		end;
 	}
-	set job_kagero_lp, job_kagero_lp - getarg(1,2);
+	job_kagero_lp -= getarg(1, 2);
 	mes "< Used " + getarg(1,2) + " LP >";
 	next;
-	set @job_ko_dice1, rand(1,6);
+	@job_ko_dice1 = rand(1, 6);
 	emotion 57 + @job_ko_dice1,1;
 	mes "First dice result is " + @job_ko_dice1 + ". Do you want to roll the second dice?";
 	next;
 	select("Roll the second dice.");
-	set @job_ko_dice2, rand(1,6);
+	@job_ko_dice2 = rand(1, 6);
 	emotion 57 + @job_ko_dice2,1;
 	return;
 }
@@ -1110,8 +1110,8 @@ function	script	F_KO_Survival_rps	{
 
 	mes "Rock! Paper! Scissors!";
 	next;
-	set .@pc, select("Give scissors.", "Give rock.", "Give paper.");
-	set .@npc, rand(1,3);
+	.@pc = select("Give scissors.", "Give rock.", "Give paper.");
+	.@npc = rand(1, 3);
 	emotion .@emote[.@pc],1;
 	emotion .@emote[.@npc];
 	mes "=Game Results=";
@@ -1142,13 +1142,13 @@ OnTouch:
 	mes "There are tiny letters on the sign.";
 	next;
 	switch (atoi(substr(strnpcinfo(NPC_NAME_HIDDEN),3,4))) {
-		case  2: set .@id,0; break;
-		case  7: set .@id,5; break;
-		case 11: set .@id,9; break;
-		case 23: set .@id,18; break;
-		case 26: set .@id,20; break;
-		case 30: set .@id,9; break;
-		case 35: set .@id,29; break;
+		case  2: .@id = 0; break;
+		case  7: .@id = 5; break;
+		case 11: .@id = 9; break;
+		case 23: .@id = 18; break;
+		case 26: .@id = 20; break;
+		case 30: .@id = 9; break;
+		case 35: .@id = 29; break;
 	}
 	mes "This block has a trap.";
 	mes "Press Close to go back to block " + .@id + ".";
@@ -1160,11 +1160,11 @@ OnTouch:
 	callfunc "F_KO_Survival_mes", atoi(substr(strnpcinfo(NPC_NAME_HIDDEN),3,4));
 	end;
 OnTouch:
-	set .@id, atoi(substr(strnpcinfo(NPC_NAME_HIDDEN),3,4));
+	.@id = atoi(substr(strnpcinfo(NPC_NAME_HIDDEN), 3, 4));
 	switch (.@id) {
-		case 10: set .@var$, "$20110808_vko01"; break;
-		case 28: set .@var$, "$20110808_vko03"; break;
-		//case 38: set .@var$, "$20110808_vko04"; break;
+		case 10: .@var$ = "$20110808_vko01"; break;
+		case 28: .@var$ = "$20110808_vko03"; break;
+		//case 38: .@var$ = "$20110808_vko04"; break;
 	}
 	mes "There are tiny letters on the sign.";
 	next;
@@ -1178,7 +1178,7 @@ OnTouch:
 		if(select("Install a trap.", "Roll the Dice.") == 1) {
 			if (job_kagero_lp > 9) {
 				mes "< Used 10 LP >";
-				set job_kagero_lp, job_kagero_lp - 10;
+				job_kagero_lp -= 10;
 				setd .@var$,1;
 				next;
 				mes "The trap is installed. Please roll the dice.";
@@ -1190,7 +1190,7 @@ OnTouch:
 			}
 		}
 	} else {
-		set job_kagero_lp,0;
+		job_kagero_lp = 0;
 		setd .@var$,0;
 		mes "You are caught in the trap installed.";
 		mes "Press Close to go back to block 0.";
@@ -1205,7 +1205,7 @@ OnTouch:
 	callfunc "F_KO_Survival_mes", atoi(substr(strnpcinfo(NPC_NAME_HIDDEN),3,4));
 	end;
 OnTouch:
-	set .@id, atoi(substr(strnpcinfo(NPC_NAME_HIDDEN),3,4));
+	.@id = atoi(substr(strnpcinfo(NPC_NAME_HIDDEN), 3, 4));
 	mes "There are tiny letters on the sign.";
 	next;
 	mes "This block is blessed.";
@@ -1214,7 +1214,7 @@ OnTouch:
 	next;
 	mes "< Recovered " + ((job_kagero_lp + 7 > 100) ? "" : "7") + " LP >";
 	next;
-	set job_kagero_lp, ((job_kagero_lp + 7 > 100) ? 100 : job_kagero_lp + 7);
+	job_kagero_lp = ((job_kagero_lp + 7 > 100) ? 100 : job_kagero_lp + 7);
 	callfunc "F_KO_Survival_dice",.@id;
 	end;
 }
@@ -1223,8 +1223,8 @@ OnTouch:
 	callfunc "F_KO_Survival_mes", atoi(substr(strnpcinfo(NPC_NAME_HIDDEN),3,4));
 	end;
 OnTouch:
-	set .@id, atoi(substr(strnpcinfo(NPC_NAME_HIDDEN),3,4));
-	set .@playtime, questprogress(5141,PLAYTIME);
+	.@id = atoi(substr(strnpcinfo(NPC_NAME_HIDDEN), 3, 4));
+	.@playtime = questprogress(5141, PLAYTIME);
 	if (!.@playtime) {
 		mes "There are tiny letters on the sign.";
 		next;
@@ -1232,7 +1232,7 @@ OnTouch:
 		next;
 		if(select("Use 5 LP", "Do not pay.") == 1) {
 			if (job_kagero_lp > 4) {
-				set job_kagero_lp, job_kagero_lp - 5;
+				job_kagero_lp -= 5;
 				mes "<Used 5 LP>";
 				mes "You can roll the dice.";
 				next;
@@ -1268,7 +1268,7 @@ OnTouch:
 	callfunc "F_KO_Survival_mes", atoi(substr(strnpcinfo(NPC_NAME_HIDDEN),3,4));
 	end;
 OnTouch:
-	set .@id, atoi(substr(strnpcinfo(NPC_NAME_HIDDEN),3,4));
+	.@id = atoi(substr(strnpcinfo(NPC_NAME_HIDDEN), 3, 4));
 	mes "There are tiny letters on the sign.";
 	next;
 	mes "Area cursed with 10 times the normal gravity. You will need 10 ^FD0260LP^000000 to roll the dice.";
@@ -1293,13 +1293,13 @@ OnTouch:
 		next;
 		callsub L_Description;
 		setquest 5140;
-		set job_kagero_lp,100;
+		job_kagero_lp = 100;
 		mes "You've gained 100 Life Points (LP).";
 		next;
 	} else {
 		if (questprogress(5141,PLAYTIME) > 0)
 			erasequest 5141;
-		set job_kagero_lp,100;
+		job_kagero_lp = 100;
 		mes "You've returned to the first block. Your LP is recovered.";
 		next;
 		callsub L_Description;
@@ -1329,15 +1329,15 @@ job_ko,49,16,4	script	Sight#ko_01	4_BULLETIN_BOARD2,1,1,{
 	callfunc "F_KO_Survival_mes",1;
 	end;
 OnTouch:
-	set .@life_p, job_kagero_lp;
+	.@life_p = job_kagero_lp;
 	mes "There are tiny letters on the sign.";
 	next;
 	mes "You are really bad at rolling dice. How can you get a 1 from the start? You can move to block 9 if you pay up 10 LP in this block.";
 	next;
 	if(select("Use 10 LP", "Roll the dice.") == 1) {
 		if (job_kagero_lp > 9) {
-			set .@reset_p, .@life_p - 10;
-			set job_kagero_lp, .@reset_p;
+			.@reset_p = .@life_p - 10;
+			job_kagero_lp = .@reset_p;
 			mes "< Used 10 LP >";
 			mes "Press Close to move to block 9.";
 			callfunc "F_KO_Survival_warp",9;
@@ -1367,7 +1367,7 @@ OnTouch:
 	select("Use 5 LP");
 	if (job_kagero_lp > 4) {
 		mes "< Used 5 LP >";
-		set job_kagero_lp, job_kagero_lp - 5;
+		job_kagero_lp -= 5;
 		callfunc "F_KO_Survival_dice",3;
 	} else {
 		mes "< Did not use 5 LP >";
@@ -1392,9 +1392,9 @@ OnTouch:
 	if(select("Use 5 LP and leave your name.", "Continue to roll the dice.") == 1) {
 		if (job_kagero_lp > 4) {
 			mes "< Used 5 LP >";
-			set job_kagero_lp, job_kagero_lp - 5;
+			job_kagero_lp -= 5;
 			next;
-			set $20110808_sko01$, strcharinfo(PC_NAME);
+			$20110808_sko01$ = strcharinfo(PC_NAME);
 			mes strcharinfo(PC_NAME)+" was here.";
 			mes "You left your name.";
 			next;
@@ -1490,7 +1490,7 @@ job_ko,54,60,4	script	Sight#ko_15	4_BULLETIN_BOARD2,1,1,{
 	callfunc "F_KO_Survival_mes",15;
 	end;
 OnTouch:
-	set .@playtime, questprogress(5141,PLAYTIME);
+	.@playtime = questprogress(5141, PLAYTIME);
 	if (!.@playtime) {
 		mes "There are tiny letters on the sign.";
 		next;
@@ -1531,8 +1531,8 @@ OnTouch:
 			next;
 		}
 	}
-	set @job_ko_dice1,0;
-	set @job_ko_dice2,0;
+	@job_ko_dice1 = 0;
+	@job_ko_dice2 = 0;
 	//mes "Second dice result is " + @job_ko_dice2 + ", which is the same number. Press Close to move block 30.";
 	mes "You got the same number. Press Close to move block 30.";
 	callfunc "F_KO_Survival_warp",30;
@@ -1554,10 +1554,10 @@ OnTouch:
 	callfunc "F_KO_Survival_dice2",18;
 	mes "Second dice result is " + @job_ko_dice2 + ".";
 	next;
-	set .@dice_sum, @job_ko_dice1 + @job_ko_dice2;
+	.@dice_sum = @job_ko_dice1 + @job_ko_dice2;
 	mes @job_ko_dice1 + " + " + @job_ko_dice2 + " = " + .@dice_sum;
-	set @job_ko_dice1,0;
-	set @job_ko_dice2,0;
+	@job_ko_dice1 = 0;
+	@job_ko_dice2 = 0;
 	if (.@dice_sum < 5) {
 		mes "You total is lower than 5. Press Close to move to block 30.";
 		callfunc "F_KO_Survival_warp",30;
@@ -1597,14 +1597,14 @@ OnTouch:
 		mes "If you leave your ^FD0260LP^000000 then the next person for test that arrives at the block will automatically pass the test.";
 		next;
 		if(select("Leave all your LP.", "Continue to roll the dice.") == 1) {
-			set job_kagero_lp,0;
-			set $20110808_vko02,1;
+			job_kagero_lp = 0;
+			$20110808_vko02 = 1;
 			mes "Leave all remaining ^FD0260LP^000000 here. Press Close and go back to block 0.";
 			callfunc "F_KO_Survival_warp",0;
 			end;
 		}
 	} else if ($20110808_vko02 == 1) {
-		set $20110808_vko02,0;
+		$20110808_vko02 = 0;
 		mes "Someone before you sacrificed all their ^FD0260LP^000000, so press Close and go to the last block.";
 		callfunc "F_KO_Survival_warp",40;
 		end;
@@ -1632,17 +1632,17 @@ OnTouch:
 	callfunc "F_KO_Survival_dice2",24;
 	mes "Second dice result is " + @job_ko_dice2 + ".";
 	next;
-	set .@dice_sum, @job_ko_dice1 + @job_ko_dice2;
+	.@dice_sum = @job_ko_dice1 + @job_ko_dice2;
 	if (.@dice_sum > 8) {
 		mes @job_ko_dice1 + " + " + @job_ko_dice2 + " = " + .@dice_sum;
-		set @job_ko_dice1,0;
-		set @job_ko_dice2,0;
+		@job_ko_dice1 = 0;
+		@job_ko_dice2 = 0;
 		mes "You total is larger than 8. Please choose a block to move between blocks 25 through 30.";
 		callfunc "F_KO_Survival_warp", select("Move to block 25", "Move to block 26", "Move to block 27", "Move to block 28", "Move to block 29", "Move to block 30") + 24;
 		end;
 	} else {
-		set @job_ko_dice1,0;
-		set @job_ko_dice2,0;
+		@job_ko_dice1 = 0;
+		@job_ko_dice2 = 0;
 		mes "You total is lower than 8. Press Close to move to block 19.";
 		callfunc "F_KO_Survival_warp",19;
 		end;
@@ -1653,7 +1653,7 @@ job_ko,25,23,4	script	Sight#ko_25	4_BULLETIN_BOARD2,1,1,{
 	callfunc "F_KO_Survival_mes",25;
 	end;
 OnTouch:
-	set .@playtime, questprogress(5141,PLAYTIME);
+	.@playtime = questprogress(5141, PLAYTIME);
 	if (!.@playtime) {
 		mes "There are tiny letters on the sign.";
 		next;
@@ -1747,8 +1747,8 @@ OnTouch:
 	next;
 	switch(select("Pay LP.", "Move forward a little bit at a time.")) {
 	case 1:
-		set .@sell_p, job_kagero_lp - 1;
-		set job_kagero_lp,1;
+		.@sell_p =  job_kagero_lp - 1;
+		job_kagero_lp = 1;
 		mes "< Used " + .@sell_p + " LP >";
 		next;
 		mes "Press Close to move to block 39.";
@@ -1783,13 +1783,13 @@ OnTouch:
 	switch(select("Try it the other way.", "Go by the rules.")) {
 	case 1:
 		//mes "The Other Way (2nd Rule)";
-		set .@dodoripo,0;
+		.@dodoripo = 0;
 		break;
 	case 2:
-		set .@dodoripo,1;
+		.@dodoripo = 1;
 		break;
 	}
-	set .@dice, callfunc("F_KO_Survival_dice",36,1,1);
+	.@dice = callfunc("F_KO_Survival_dice", 36, 1, 1);
 	if (.@dodoripo == 0) {
 		if (.@dice <= 3) {
 			mes "Press Close to move to the end.";
@@ -1817,7 +1817,7 @@ OnTouch:
 	next;
 	mes "If you get 1, 3, or 5, move to the arrival point; if you get 2, 4, or 6, go back to the starting point.";
 	next;
-	set .@dice, callfunc("F_KO_Survival_dice",37,1,1);
+	.@dice = callfunc("F_KO_Survival_dice", 37, 1, 1);
 	if (.@dice % 2) {
 		mes "Press Close to move to the last block.";
 		callfunc "F_KO_Survival_warp",40;
@@ -1842,9 +1842,9 @@ OnTouch:
 		next;
 		switch(select("Install a trap.", "Do not install.")) {
 		case 1:
-			set .@reset_p, job_kagero_lp - 1;
-			set job_kagero_lp,1;
-			set $20110808_vko04,1;
+			.@reset_p = job_kagero_lp - 1;
+			job_kagero_lp = 1;
+			$20110808_vko04 = 1;
 			mes "< Used " + .@reset_p + " LP >";
 			next;
 			mes "The trap is installed. Please roll the dice.";
@@ -1856,13 +1856,13 @@ OnTouch:
 			break;
 		}
 	} else {
-		set $20110808_vko04,0;
-		set job_kagero_lp,0;
+		$20110808_vko04 = 0;
+		job_kagero_lp = 0;
 		mes "You are caught in the trap installed. Press Close to go back to block 0.";
 		callfunc "F_KO_Survival_warp",0;
 		end;
 	}
-	set .@dice, callfunc("F_KO_Survival_dice",38,1,1);
+	.@dice = callfunc("F_KO_Survival_dice", 38, 1, 1);
 	mes "Press Close to move forward " + .@dice + " blocks.";
 	callfunc "F_KO_Survival_warp", ((.@dice == 1) ? .@dice + 38 : 40);
 	end;
@@ -1878,7 +1878,7 @@ OnTouch:
 	next;
 	mes "But you cannot go so easily. If you get a 3, you will go back to block 3.";
 	next;
-	set .@dice, callfunc("F_KO_Survival_dice",39,1,1);
+	.@dice = callfunc("F_KO_Survival_dice", 39, 1, 1);
 	if (.@dice == 3) {
 		mes "Press Close to move to the 3rd block.";
 		callfunc "F_KO_Survival_warp",3;
@@ -1914,7 +1914,7 @@ OnTouch:
 	completequest 5137;
 	erasequest 5140;
 	if (questprogress(5141)) erasequest 5141;
-	set job_kagero_lp,0;
+	job_kagero_lp = 0;
 	mes "Let's read all the writing on the sign.";
 	mes "You feel like you are moved to another place.";
 	close2;
@@ -1930,9 +1930,9 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	4_M_JOB_ASSASSIN,{
 		close;
 	}
 	if (BaseJob != Job_Ninja) {
-		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
+		for (.@i = 5131; .@i <= 5146; .@i++)
 			if (questprogress(.@i)) erasequest .@i;
-		set job_kagero,0;
+		job_kagero = 0;
 		mes "[Red Leopard Joe]";
 		mes "Sorry, your clan is not the same as ours, is there something wrong?";
 		close2;
@@ -1948,11 +1948,11 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	4_M_JOB_ASSASSIN,{
 		warp "amatsu",147,136;
 		end;
 	}
-	set .@ko_test_03_1, questprogress(5138);
-	set .@ko_test_03_2, questprogress(5142);
-	set .@ko_test_03_3, questprogress(5143);
-	set .@ko_test_03_4, questprogress(5144);
-	set .@ko_test_03_5, questprogress(5145);
+	.@ko_test_03_1 = questprogress(5138);
+	.@ko_test_03_2 = questprogress(5142);
+	.@ko_test_03_3 = questprogress(5143);
+	.@ko_test_03_4 = questprogress(5144);
+	.@ko_test_03_5 = questprogress(5145);
 	if (.@ko_test_03_1 == 1 && .@ko_test_03_2 == 0 && .@ko_test_03_3 == 0 && .@ko_test_03_4 == 0 && .@ko_test_03_5 == 0) {
 		mes "[Red Leopard Joe]";
 		mes "It's been a while!";
@@ -2082,13 +2082,13 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	4_M_JOB_ASSASSIN,{
 		mes "[Red Leopard Joe]";
 		mes "Looks like you've got some results.";
 		next;
-		set .@part, EQI_HAND_R;
+		.@part = EQI_HAND_R;
 		if (!getequipisequiped(.@part)) {
 			mes "[Red Leopard Joe]";
 			mes "Ahh! You have not equipped any weapons!";
 			close;
 		} else {
-			set .@equip_id, getequipid(.@part);
+			.@equip_id = getequipid(.@part);
 			if (.@equip_id == 13074 || .@equip_id == 13312) {
 				mes "[Red Leopard Joe]";
 				mes "Is that weapon yours? Let me have a look.";
@@ -2104,7 +2104,7 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	4_M_JOB_ASSASSIN,{
 		}
 		mes "Joe took a thorough look at the seal.";
 		next;
-		set .@equip_refine, getequiprefinerycnt(.@part);
+		.@equip_refine = getequiprefinerycnt(.@part);
 		if (.@equip_refine < 7) {
 			mes "[Red Leopard Joe]";
 			mes "Are you that low?";
@@ -2261,30 +2261,30 @@ job_ko,131,124,0	script	Crafting Tools#ko_01	CLEAR_NPC,{
 	callsub L_CheckMaterials;
 	while(1) {
 		switch(select("Melt Iron Ore.", "Melt Iron.", "Melt Steel.", "Melt Phracon.", "Melt Emveretarcon.", "Melt Rough Oridecon.", "Melt Rough Elunium.", "Stop.")) {
-			case 1: set .@item,1002; set .@val1,1; break;  //Iron_Ore
-			case 2: set .@item, 998; set .@val1,2; break;  //Iron
-			case 3: set .@item, 999; set .@val1,3; break;  //Steel
-			case 4: set .@item,1010; set .@val2,1; break;  //Phracon
-			case 5: set .@item,1011; set .@val2,2; break;  //Emveretarcon
-			case 6: set .@item, 756; set .@val2,3; break;  //Oridecon_Stone
-			case 7: set .@item, 757; set .@val3,5; break;  //Elunium_Stone
+			case 1: .@item = 1002; .@val1 = 1; break;  //Iron_Ore
+			case 2: .@item = 998; .@val1 = 2; break;  //Iron
+			case 3: .@item = 999; .@val1 = 3; break;  //Steel
+			case 4: .@item = 1010; .@val2 = 1; break;  //Phracon
+			case 5: .@item = 1011; .@val2 = 2; break;  //Emveretarcon
+			case 6: .@item = 756; .@val2 = 3; break;  //Oridecon_Stone
+			case 7: .@item = 757; .@val3 = 5; break;  //Elunium_Stone
 			case 8: close;
 		}
 		if (countitem(.@item)) {
 			delitem .@item,1;
 			if (.@val1) {         //Iron Ore, Iron, Steel
-				set .@ston_t01, .@ston_t01 + .@val1;
+				.@ston_t01 += .@val1;
 				if (.@ston_t02 > 0)
-					set .@ston_t02, .@ston_t02 - .@val1;
+					.@ston_t02 -= .@val1;
 			} else if (.@val2) {  //Phracon, Emveretarcon, Rough Oridecon
-				set .@ston_t02, .@ston_t02 + .@val2;
+				.@ston_t02 += .@val2;
 				if (.@ston_t01 > 0)
-					set .@ston_t01, .@ston_t01 - .@val2;
+					.@ston_t01 -= .@val2;
 			} else if (.@val3) {  //Rouch Elunium
 				if (.@ston_t01 > 0)
-					set .@ston_t01, .@ston_t01 - .@val3;
+					.@ston_t01 -= .@val3;
 				if (.@ston_t02 > 0)
-					set .@ston_t02, .@ston_t02 - .@val3;
+					.@ston_t02 -= .@val3;
 			}
 			specialeffect EF_DEMONSTRATION;
 			mes "Melted " + getitemname(.@item) + " in high temperature.";
@@ -2299,7 +2299,7 @@ job_ko,131,124,0	script	Crafting Tools#ko_01	CLEAR_NPC,{
 		mes "Which metal will be melted next?";
 		next;
 	}
-	set .@boll_01, ((.@ston_t01 > 49) ? .@ston_t01 : .@ston_t02);
+	.@boll_01 = ((.@ston_t01 > 49) ? .@ston_t01 : .@ston_t02);
 
 	// Part 2: Forging
 	// Grind and temper a weapon.
@@ -2309,11 +2309,11 @@ job_ko,131,124,0	script	Crafting Tools#ko_01	CLEAR_NPC,{
 	next;
 	switch(select("Dagger Mold", "Shuriken Mold")) {
 	case 1:
-		set .@weapon_who,0;
+		.@weapon_who = 0;
 		mes "Poured the melted metal into the dagger mold.";
 		break;
 	case 2:
-		set .@weapon_who,1;
+		.@weapon_who = 1;
 		mes "Poured the melted metal into the shuriken mold.";
 		break;
 	}
@@ -2321,8 +2321,8 @@ job_ko,131,124,0	script	Crafting Tools#ko_01	CLEAR_NPC,{
 	progressbar "ffff00",3;
 	mes "Looks like the metal is taking shape. Now what next?";
 	next;
-	set @job_ko_forge,0;
-	set @job_ko_lastaction,0;
+	@job_ko_forge = 0;
+	@job_ko_lastaction = 0;
 	callsub L_ForgeWeapon,":";
 	while(1) {
 		mes "Now what next?";
@@ -2330,21 +2330,21 @@ job_ko,131,124,0	script	Crafting Tools#ko_01	CLEAR_NPC,{
 		if (callsub(L_ForgeWeapon,":Final Touches") == 0)
 			break;
 	}
-	set .@boll_02, @job_ko_forge;
-	set @job_ko_forge,0;
-	set @job_ko_lastaction,0;
+	.@boll_02 = @job_ko_forge;
+	@job_ko_forge = 0;
+	@job_ko_lastaction = 0;
 
 	// Part 3: Create the Weapon
 	// Success rate based on previous two parts.
-	set .@boll_00, .@boll_01 + .@boll_02;
+	.@boll_00 = .@boll_01 + .@boll_02;
 	mes "Start to sharpen the tool using a whetstone for finishing touches.";
 	next;
 	progressbar "ffff00",3;
-	set .@success_pp, rand(1,100);
+	.@success_pp = rand(1,100);
 	if (.@boll_00 < 100) {
-		if (.@success_pp == 77) set .@success,1;
+		if (.@success_pp == 77) .@success = 1;
 	} else {
-		if (.@success_pp != 44) set .@success,1;
+		if (.@success_pp != 44) .@success = 1;
 	}
 	if (.@success) {
 		specialeffect(EF_PERFECTION, AREA, playerattached());
@@ -2377,7 +2377,7 @@ L_CheckMaterials:
 	return;
 
 L_ForgeWeapon:
-	set .@i, select("Grind the weapon", "Temper the weapon" + getarg(0));
+	.@i = select("Grind the weapon", "Temper the weapon" + getarg(0));
 	switch (.@i) {
 	case 1:
 		specialeffect(EF_DETOXICATION, AREA, playerattached());
@@ -2392,10 +2392,10 @@ L_ForgeWeapon:
 	}
 	next;
 	if (@job_ko_lastaction == .@i)
-		set @job_ko_forge, @job_ko_forge + 1;
+		@job_ko_forge++;
 	else
-		set @job_ko_forge, @job_ko_forge + 2;
-	set @job_ko_lastaction, .@i;
+		@job_ko_forge += 2;
+	@job_ko_lastaction = .@i;
 	return 1;
 }
 job_ko,129,129,0	duplicate(Crafting Tools#ko_01)	Crafting Tools#ko_02	CLEAR_NPC
@@ -2417,7 +2417,7 @@ job_ko,121,121,0	script	Refinement Tools#ko_01	CLEAR_NPC,{
 		mes "You turned off the tool.";
 		close;
 	}
-	set .@part, EQI_HAND_R;
+	.@part = EQI_HAND_R;
 	if (!getequipisequiped(.@part)) {
 		mes "Bzzzt";
 		mes "A warning beep comes from the tool.";
@@ -2426,7 +2426,7 @@ job_ko,121,121,0	script	Refinement Tools#ko_01	CLEAR_NPC,{
 		mes "This equipment does not work without an equipped item to refine.";
 		close;
 	} else {
-		set .@equip_id, getequipid(.@part);
+		.@equip_id = getequipid(.@part);
 		if (.@equip_id == 13074 || .@equip_id == 13312) {
 			mes "Analyzing the weapon.";
 			next;
@@ -2447,7 +2447,7 @@ job_ko,121,121,0	script	Refinement Tools#ko_01	CLEAR_NPC,{
 		mes "That weapon cannot be refined. Where did you get it?";
 		close;
 	}
-	set .@equip_refine, getequiprefinerycnt(.@part);
+	.@equip_refine = getequiprefinerycnt(.@part);
 	if (.@equip_refine >= 20) {
 		mes "Bzzzt";
 		mes "A warning beep comes from the tool.";
@@ -2468,21 +2468,21 @@ job_ko,121,121,0	script	Refinement Tools#ko_01	CLEAR_NPC,{
 		next;
 	}
 	progressbar "ffff00",1;
-	set .@rand, rand(1,100);
+	.@rand = rand(1,100);
 	if (.@equip_refine < 5) {          // 0>5 100%
-		set .@wlevel_up,1;
+		.@wlevel_up = 1;
 	} else if (.@equip_refine == 5) {  // 5>6  40%
-		if (.@rand < 41) set .@wlevel_up,1;
+		if (.@rand < 41) .@wlevel_up = 1;
 	} else if (.@equip_refine == 6) {  // 6>7  30%
-		if (.@rand < 31) set .@wlevel_up,1;
+		if (.@rand < 31) .@wlevel_up = 1;
 	} else if (.@equip_refine == 7) {  // 7>8  20%
-		if (.@rand < 21) set .@wlevel_up,1;
+		if (.@rand < 21) .@wlevel_up = 1;
 	} else if (.@equip_refine == 8) {  // 8>9  10%
-		if (.@rand < 11) set .@wlevel_up,1;
+		if (.@rand < 11) .@wlevel_up = 1;
 	} else if (.@equip_refine == 9) {  // 9>10  5%
-		if (.@rand < 6) set .@wlevel_up,1;
+		if (.@rand < 6) .@wlevel_up = 1;
 	} else {                           // 10>20 2%
-		if (.@rand < 3) set .@wlevel_up,1;
+		if (.@rand < 3) .@wlevel_up = 1;
 	}
 	if (.@wlevel_up) {
 		successrefitem .@part;
@@ -2584,11 +2584,11 @@ job_ko,148,46,4	script	Guide Gion#ko2	4_M_KAGE_OLD,{
 		mes "Puhahaha! Gai is all talk. I know I was know valuable to you than that Gai.";
 		next;
 		if (questprogress(5143) == 2) {
-			set .@item,13075; //Kurenai
-			set .@weapon$,"dagger";
+			.@item = 13075; //Kurenai
+			.@weapon$ = "dagger";
 		} else {
-			set .@item,13311; //Huuma_Shadow
-			set .@weapon$,"shuriken";
+			.@item = 13311; //Huuma_Shadow
+			.@weapon$ = "shuriken";
 		}
 		mes "[Red Leopard Joe]";
 		mes "I did some work on the prototype " + .@weapon$ + " you made.";
@@ -2613,9 +2613,9 @@ job_ko,148,46,4	script	Guide Gion#ko2	4_M_KAGE_OLD,{
 		mes "[Leader Gion]";
 		mes "You only need to look forward and never turn back.";
 		next;
-		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
+		for (.@i = 5131; .@i <= 5146; .@i++)
 			if (questprogress(.@i)) erasequest .@i;
-		set job_kagero,9;
+		job_kagero = 9;
 		getnameditem .@item,strcharinfo(PC_NAME);
 		jobchange(Sex == SEX_MALE ? Job_Kagerou : Job_Oboro);
 		donpcevent "Summon Target#ko::OnEnable";
@@ -2676,13 +2676,13 @@ OnTimer180000:
 OnEnable:
 	stopnpctimer;
 	switch (rand(1,7)) {
-		case 1: set .@mob,1002; break;
-		case 2: set .@mob,1031; break;
-		case 3: set .@mob,1113; break;
-		case 4: set .@mob,1063; break;
-		case 5: set .@mob,1010; break;
-		case 6: set .@mob,1049; break;
-		case 7: set .@mob,1050; break;
+		case 1: .@mob = 1002; break;
+		case 2: .@mob = 1031; break;
+		case 3: .@mob = 1113; break;
+		case 4: .@mob = 1063; break;
+		case 5: .@mob = 1010; break;
+		case 6: .@mob = 1049; break;
+		case 7: .@mob = 1050; break;
 	}
 	areamonster "job_ko",120,30,160,70,"Clan Secret",.@mob,1,"Summon Target#ko::OnMyMobDead";
 	end;
@@ -2693,7 +2693,7 @@ OnMyMobDead:
 	if (mobcount("job_ko","Summon Target#ko::OnMyMobDead") < 1) {
 		if (job_kagero == 7) {
 			donpcevent "Summon Target#ko::OnDisable";
-			set job_kagero,8;
+			job_kagero = 8;
 		} else
 			donpcevent "Summon Target#ko::OnEnable";
 	}
@@ -2814,20 +2814,20 @@ job_ko,4,1,4	script	Guide#ko_helper	4_M_KAGE_OLD,{
 		next;
 		switch(select("Complete Test of Knowledge", "Complete Test of Survival", "Complete Test of Weaponry")) {
 		case 1:
-			set job_kagero,5;
+			job_kagero = 5;
 			setquest 5136;
 			completequest 5136;
 			mes "The Test of Knowledge has been set as complete. I hope you have finished your initialization.";
 			break;
 		case 2:
-			set job_kagero,5;
-			set job_kagero_lp,0;
+			job_kagero = 5;
+			job_kagero_lp = 0;
 			setquest 5137;
 			completequest 5137;
 			mes "The Test of Survival has been set as complete. I hope you have finished your initialization.";
 			break;
 		case 3:
-			set job_kagero,5;
+			job_kagero = 5;
 			setquest 5138;
 			completequest 5138;
 			mes "The Test of Weaponry has been set as complete. I hope you have finished your initialization.";
@@ -2840,8 +2840,8 @@ job_ko,4,1,4	script	Guide#ko_helper	4_M_KAGE_OLD,{
 		mes "Please select a weapon.";
 		next;
 		switch(select("Dagger", "Shuriken")) {
-			case 1: set .@quest,5143; break;
-			case 2: set .@quest,5144; break;
+			case 1: .@quest = 5143; break;
+			case 2: .@quest = 5144; break;
 		}
 		setquest 5136;
 		completequest 5136;
@@ -2852,13 +2852,13 @@ job_ko,4,1,4	script	Guide#ko_helper	4_M_KAGE_OLD,{
 		setquest .@quest;
 		completequest .@quest;
 		setquest 5146;
-		set job_kagero,8;
+		job_kagero = 8;
 		mes "I've set the Pre-Transfer status. Good luck!!";
 		close;
 	case 4:
-		set job_kagero,0;
-		set job_kagero_lp,0;
-		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
+		job_kagero = 0;
+		job_kagero_lp = 0;
+		for (.@i = 5131; .@i <= 5146; .@i++)
 			if (questprogress(.@i)) erasequest .@i;
 		mes "The task of initialization is complete. You can confirm this through the [Current Status] option!";
 		close;

--- a/npc/re/jobs/novice/academy.txt
+++ b/npc/re/jobs/novice/academy.txt
@@ -3607,7 +3607,7 @@ izlude,115,181,5	script	Shop Helper#iz	4_F_KHELLISIA,{
 	while(true) {
 		mes("What would you like to know?");
 		next();
-		set .@menu$,"Shop types:Currency types:Cash Shop:"+(Class == Job_Novice && !questprogress(1238)?"Experience training.":"No, I know enough.");
+		.@menu$ = "Shop types:Currency types:Cash Shop:" + (Class == Job_Novice && !questprogress(1238) ? "Experience training." : "No, I know enough.");
 		switch(select(.@menu$)) {
 			case 1:
 				mes("[Shop Helper Leonie]");
@@ -4563,8 +4563,8 @@ iz_ac01,59,83,3	script	Battle Instructor#08	4_M_NOV_HUNT,{
 				next();
 				mes("[Battle Instructor Subino]");
 				mes("Try to talk to ^ff0000each job instructor^000000 on the 2nd floor of the Academy if you aren't sure what job you want still.");
-				for(set .@i,0; .@i<6; set .@i,.@i+1) {
-					set .@quest_id,11339+.@i;
+				for(.@i = 0; .@i < 6; .@i++) {
+					.@quest_id = 11339 + .@i;
 					setarray .@bexp[0],90,90,135,200,0,120;
 					setarray .@jexp[0],50,50,100,175,0,90;
 					setarray .@material[0],909,515,914,939,0,915;
@@ -7170,7 +7170,7 @@ iz_ac02,143,55,3	script	Cream Puff#ac	4_M_KID1,{
 			.@ele = .@i;
 		}
 	}
-	set .@who_job, .@ele + 1;
+	.@who_job = .@ele + 1;
 	mes("[Cream Puff]");
 	mes("All right!!!! It's done!!!!!!!!");
 	next();
@@ -12840,7 +12840,7 @@ izlude_d,153,126,1	duplicate(Refinery Owner Han#iz)	Refinery Owner Han#iz_d	4_M_
 	next();
 	setarray .@position$[1],"Head","Body","Left hand","Right hand","Robe","Shoes","Accessory 1","Accessory 2","Head 2","Head 3";
 	.@menu$ = "";
-	for(set .@i,1; .@i<=10; set .@i,.@i+1)
+	for(.@i = 1; .@i <= 10; .@i++)
 		.@menu$ = .@menu$+(getequipisequiped(.@i)?getequipname(.@i):.@position$[.@i]+" - [Unarmed]")+":";
 	.@part = select(.@menu$);
 	if (!getequipisequiped(.@part)) {

--- a/npc/re/quests/cupet.txt
+++ b/npc/re/quests/cupet.txt
@@ -201,7 +201,7 @@ function	script	cute_pet_manager	{
 		}
 		delitem .@hunt_id, .@hunt_amount;
 		delitem 6083, 1;
-		set getarg(5), getarg(5) + 1;
+		setd(getarg(5), getarg(5) + 1);
 		getitem .@tame_id, .@tame_amount;
 		mes "[Cute Pet Manager]";
 		mes "Wise choice.";

--- a/npc/woe-se/agit_main_se.txt
+++ b/npc/woe-se/agit_main_se.txt
@@ -1401,14 +1401,14 @@ OnEnable:
 	freeloop(1);
 	.@defence = getcastledata(strnpcinfo(NPC_NAME_HIDDEN),3);
 	callsub OnSummon,.@z;
-	if (.@defence > 70) set getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)),5;
-	else if (.@defence > 50) set getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)),4;
-	else if (.@defence > 30) set getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)),3;
-	else if (.@defence > 10) set getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)),2;
+	if (.@defence > 70) setd(getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)), 5);
+	else if (.@defence > 50) setd(getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)), 4);
+	else if (.@defence > 30) setd(getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)), 3);
+	else if (.@defence > 10) setd(getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)), 2);
 	if (.@w[4] && .@z)
 		guardian strnpcinfo(NPC_NAME_HIDDEN),.@w[4],.@w[5],"Guardian Soldier",1899,strnpcinfo(NPC_NAME)+"::OnGuardianDied";
 	else if (.@defence < 11) {
-		set getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)),2;
+		setd(getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)), 2);
 		.@i = (.@z)?2:0;
 		guardian strnpcinfo(NPC_NAME_HIDDEN),.@w[.@i],.@w[.@i+1],"Guardian Soldier",1899,strnpcinfo(NPC_NAME)+"::OnGuardianDied";
 	}
@@ -1430,7 +1430,7 @@ OnTimer3600000:
 	if (charat(strnpcinfo(NPC_NAME_VISIBLE),4) == "2") end;
 	.@var$ = ".timer_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN);
 	setd .@var$, getd(.@var$)+1;
-	set getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)),getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN))+1;
+	setd(getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)), getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)) + 1);
 	callsub OnSummon,getd(.@var$);
 	setarray .count$[5],"1st","2nd","3rd","4th","5th";
 	mapannounce strnpcinfo(NPC_NAME_HIDDEN),"The "+.count$[getd(.@var$)]+" Guardian has been summoned from the Gate House.",bc_map,"0xff4500";
@@ -1448,7 +1448,7 @@ OnTimer3900000:
 	if (!(charat(strnpcinfo(NPC_NAME_VISIBLE),4) == "2")) end;
 	.@var$ = ".timer_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN);
 	setd .@var$, getd(.@var$)+1;
-	set getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)),getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN))+1;
+	setd(getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)), getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)) + 1);
 	callsub OnSummon,getd(.@var$);
 	if (getd(.@var$) == 20) {
 		setd .@var$,0;
@@ -1463,9 +1463,9 @@ OnSummon:
 OnGuardianDied:
 	if (charat(strnpcinfo(NPC_NAME_VISIBLE),4) == "2")
 		.@z = 11;
-	set getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)),getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN))-1;
+	setd(getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)), getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)) - 1);
 	if (getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)) < 2) {
-		set getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN)),getd(".MyMobCount_"+charat(strnpcinfo(NPC_NAME_VISIBLE),4)+strnpcinfo(NPC_NAME_HIDDEN))+1;
+		setd(getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)), getd(".MyMobCount_" + charat(strnpcinfo(NPC_NAME_VISIBLE), 4) + strnpcinfo(NPC_NAME_HIDDEN)) + 1);
 		callsub OnSummon,10+.@z;
 	}
 	end;
@@ -1678,8 +1678,8 @@ OnEnable:
 			}
 		}
 	}
-	if (.@num == 3) set getd(".MyMobCount_"+.@num+strnpcinfo(NPC_NAME_HIDDEN)),4;
-	else if (.@num) set getd(".MyMobCount_"+.@num+strnpcinfo(NPC_NAME_HIDDEN)),6;
+	if (.@num == 3) setd(getd(".MyMobCount_" + .@num+strnpcinfo(NPC_NAME_HIDDEN)), 4);
+	else if (.@num) setd(getd(".MyMobCount_" + .@num+strnpcinfo(NPC_NAME_HIDDEN)), 6);
 	setwall strnpcinfo(NPC_NAME_HIDDEN),.@wall[0],.@wall[1],.@wall[2],.@wall[3],.@wall[4],substr(strnpcinfo(NPC_NAME_HIDDEN),0,1)+substr(strnpcinfo(NPC_NAME_HIDDEN),8,9)+"_"+strnpcinfo(NPC_NAME_VISIBLE);
 	if (.@num == 0)
 		setcell(strnpcinfo(NPC_NAME_HIDDEN), .@x[0], .@y[0], .@x[getarraysize(.@x)-1], .@y[getarraysize(.@y)-1], cell_basilica, true);
@@ -1693,7 +1693,7 @@ OnEnable:
 OnBarrierDestroyed:
 	.@num = atoi(charat(strnpcinfo(NPC_NAME_VISIBLE),2));
 	if (!.@num) end;
-	set getd(".MyMobCount_"+.@num+strnpcinfo(NPC_NAME_HIDDEN)),getd(".MyMobCount_"+.@num+strnpcinfo(NPC_NAME_HIDDEN))-1;
+	setd(getd(".MyMobCount_" + .@num+strnpcinfo(NPC_NAME_HIDDEN)), getd(".MyMobCount_" + .@num+strnpcinfo(NPC_NAME_HIDDEN)) - 1);
 	if (getd(".MyMobCount_"+.@num+strnpcinfo(NPC_NAME_HIDDEN)) == 0) {
 		.@var$ = substr(strnpcinfo(NPC_NAME_HIDDEN),0,1)+substr(strnpcinfo(NPC_NAME_HIDDEN),8,9);
 		setd "$agit_"+.@var$+"["+(.@num+1)+"]",1;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18350,7 +18350,13 @@ static BUILDIN(setd)
 		if (not_server_variable(*buffer))
 			ref = NULL;
 	} else {
-		buffer = script_getstr(st, 2);
+		if (script_isstring(st, 2)) {
+			buffer = script_getstr(st, 2);
+		} else {
+			ShowError("script:%s: Invalid type for argument 1 (%s)! Must be string or reference.\n",
+				  script->getfuncname(st), script_getstr(st, 2));
+			return false;
+		}
 	}
 
 	/// Special case: Variable of type string was passed directly or by getd().
@@ -18359,7 +18365,7 @@ static BUILDIN(setd)
 			buffer = data->u.str; /// Get the value of the passed variable instead of its name.
 	}
 
-	if (sscanf(buffer, "%99[^[][%d]", varname, &idx) < 2 && idx == 0)
+	if (sscanf(buffer, "%99[^[][%10d]", varname, &idx) < 2 && idx == 0)
 		idx = 0;
 
 	for (; varname[++length] != '\0';);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
In my opinion it's pointless to have two script commands, which do the same thing in different ways.
That's why I'd like to deprecate `set()` completely, as already mentioned in doc/script_commands.txt, and where needed use `setd()` instead.

Modified `BUILDIN(setd)` to accept references to variables, too.
Marked `set()` as deprecated.
Updated doc/script_commands.txt.
Updated non-custom scripts to **not** use `set()` anymore. (Custom scripts will follow.)

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
