### PR TITLE
Fix SC_LEXAETERNA not getting removed when player receive SC_STONE or…

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7395,6 +7395,9 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 			//Undead are immune to Freeze/Stone
 			if (undead_flag && !(flag&SCFLAG_NOAVOID))
 				return 0;
+			// SC_LEXAETERNA should be removed when applying SC_STONE or SC_FREEZE
+			if (sc->data[SC_LEXAETERNA] != NULL)
+				status_change_end(bl, SC_LEXAETERNA, INVALID_TIMER);
 			FALLTHROUGH
 		case SC_SLEEP:
 		case SC_STUN:


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This a fix for issue #2559
Current code base prevents from applying Lex Aeterna on players while stonned or frozen, however it should also remove it when those status applied

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#2559 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
