### PR TITLE
Fix C4018 compiler warning in src\char\int_party.c.

### DIFF
--- a/src/char/int_party.c
+++ b/src/char/int_party.c
@@ -490,7 +490,7 @@ static bool inter_party_leave(int party_id, int account_id, int char_id)
 }
 
 // When member goes to other map or levels up.
-static bool inter_party_change_map(int party_id, int account_id, int char_id, unsigned short map, int online, unsigned int lv)
+static bool inter_party_change_map(int party_id, int account_id, int char_id, unsigned short map, int online, int lv)
 {
 	struct party_data *p;
 	int i;

--- a/src/char/int_party.c
+++ b/src/char/int_party.c
@@ -46,10 +46,9 @@ struct inter_party_interface *inter_party;
 static int inter_party_check_lv(struct party_data *p)
 {
 	int i;
-	unsigned int lv;
 	nullpo_ret(p);
-	p->min_lv = UINT_MAX;
-	p->max_lv = 0;
+	p->min_lv = MAX_LEVEL;
+	p->max_lv = 1;
 	for(i=0;i<MAX_PARTY;i++){
 		/**
 		 * - If not online OR if it's a family party and this is the child (doesn't affect exp range)
@@ -57,9 +56,8 @@ static int inter_party_check_lv(struct party_data *p)
 		if(!p->party.member[i].online || p->party.member[i].char_id == p->family )
 			continue;
 
-		lv=p->party.member[i].lv;
-		if (lv < p->min_lv) p->min_lv = lv;
-		if (lv > p->max_lv) p->max_lv = lv;
+		p->min_lv = min(p->min_lv, p->party.member[i].lv);
+		p->max_lv = max(p->max_lv, p->party.member[i].lv);
 	}
 
 	if (p->party.exp && !inter_party->check_exp_share(p)) {

--- a/src/char/int_party.c
+++ b/src/char/int_party.c
@@ -72,8 +72,6 @@ static void inter_party_calc_state(struct party_data *p)
 {
 	int i;
 	nullpo_retv(p);
-	p->min_lv = UINT_MAX;
-	p->max_lv = 0;
 	p->party.count =
 	p->size =
 	p->family = 0;
@@ -100,22 +98,8 @@ static void inter_party_calc_state(struct party_data *p)
 			p->party.member[2].char_id
 		);
 	}
-	//max/min levels.
-	for (i = 0; i < MAX_PARTY; i++) {
-		unsigned int lv = p->party.member[i].lv;
-		if (!lv) continue;
-		if (p->party.member[i].online
-		 && p->party.member[i].char_id != p->family /* In families, the kid is not counted towards exp share rules. */
-		) {
-			if( lv < p->min_lv ) p->min_lv=lv;
-			if( p->max_lv < lv ) p->max_lv=lv;
-		}
-	}
 
-	if (p->party.exp && !inter_party->check_exp_share(p)) {
-		p->party.exp = 0; //Set off even share.
-		mapif->party_optionchanged(0, &p->party, 0, 0);
-	}
+	inter_party->check_lv(p);
 }
 
 // Save party to mysql

--- a/src/char/int_party.h
+++ b/src/char/int_party.h
@@ -38,10 +38,11 @@ enum {
 };
 
 struct party_data {
-	struct party party;
-	unsigned int min_lv, max_lv;
-	int family; //Is this party a family? if so, this holds the child id.
-	unsigned char size; //Total size of party.
+	struct party party; // Party data.
+	int min_lv; // The lowest base level of all party members.
+	int max_lv; // The highest base level of all party members.
+	int family; // Is this party a family? If so, this holds the child's char ID.
+	int size; // Amount of party members, including offline members.
 };
 
 /**
@@ -66,7 +67,7 @@ struct inter_party_interface {
 	struct party_data *(*create) (const char *name, int item, int item2, const struct party_member *leader);
 	bool (*add_member) (int party_id, const struct party_member *member);
 	bool (*change_option) (int party_id, int account_id, int exp, int item, int map_fd);
-	bool (*change_map) (int party_id, int account_id, int char_id, unsigned short map, int online, unsigned int lv);
+	bool (*change_map) (int party_id, int account_id, int char_id, unsigned short map, int online, int lv);
 	bool (*disband) (int party_id);
 	bool (*change_leader) (int party_id, int account_id, int char_id);
 };

--- a/src/char/int_party.h
+++ b/src/char/int_party.h
@@ -55,6 +55,7 @@ struct inter_party_interface {
 	int (*is_family_party) (struct party_data *p);
 	void (*calc_state) (struct party_data *p);
 	int (*tosql) (struct party *p, int flag, int index);
+	int (*del_nonexistent_party) (int party_id);
 	struct party_data* (*fromsql) (int party_id);
 	int (*sql_init) (void);
 	void (*sql_final) (void);

--- a/src/char/int_party.h
+++ b/src/char/int_party.h
@@ -52,6 +52,7 @@ struct inter_party_interface {
 	struct party_data *pt;
 	struct DBMap *db;  // int party_id -> struct party_data*
 	int (*check_lv) (struct party_data *p);
+	int (*is_family_party) (struct party_data *p);
 	void (*calc_state) (struct party_data *p);
 	int (*tosql) (struct party *p, int flag, int index);
 	struct party_data* (*fromsql) (int party_id);

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -822,8 +822,8 @@ struct party_member {
 	int char_id;
 	char name[NAME_LENGTH];
 	int class;
+	int lv;
 	unsigned short map;
-	unsigned short lv;
 	unsigned leader : 1,
 	         online : 1;
 };

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -3556,8 +3556,8 @@ typedef bool (*HPMHOOK_pre_inter_party_add_member) (int *party_id, const struct 
 typedef bool (*HPMHOOK_post_inter_party_add_member) (bool retVal___, int party_id, const struct party_member *member);
 typedef bool (*HPMHOOK_pre_inter_party_change_option) (int *party_id, int *account_id, int *exp, int *item, int *map_fd);
 typedef bool (*HPMHOOK_post_inter_party_change_option) (bool retVal___, int party_id, int account_id, int exp, int item, int map_fd);
-typedef bool (*HPMHOOK_pre_inter_party_change_map) (int *party_id, int *account_id, int *char_id, unsigned short *map, int *online, unsigned int *lv);
-typedef bool (*HPMHOOK_post_inter_party_change_map) (bool retVal___, int party_id, int account_id, int char_id, unsigned short map, int online, unsigned int lv);
+typedef bool (*HPMHOOK_pre_inter_party_change_map) (int *party_id, int *account_id, int *char_id, unsigned short *map, int *online, int *lv);
+typedef bool (*HPMHOOK_post_inter_party_change_map) (bool retVal___, int party_id, int account_id, int char_id, unsigned short map, int online, int lv);
 typedef bool (*HPMHOOK_pre_inter_party_disband) (int *party_id);
 typedef bool (*HPMHOOK_post_inter_party_disband) (bool retVal___, int party_id);
 typedef bool (*HPMHOOK_pre_inter_party_change_leader) (int *party_id, int *account_id, int *char_id);

--- a/src/plugins/HPMHooking/HPMHooking_char.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_char.Hooks.inc
@@ -9115,11 +9115,11 @@ bool HP_inter_party_change_option(int party_id, int account_id, int exp, int ite
 	}
 	return retVal___;
 }
-bool HP_inter_party_change_map(int party_id, int account_id, int char_id, unsigned short map, int online, unsigned int lv) {
+bool HP_inter_party_change_map(int party_id, int account_id, int char_id, unsigned short map, int online, int lv) {
 	int hIndex = 0;
 	bool retVal___ = false;
 	if (HPMHooks.count.HP_inter_party_change_map_pre > 0) {
-		bool (*preHookFunc) (int *party_id, int *account_id, int *char_id, unsigned short *map, int *online, unsigned int *lv);
+		bool (*preHookFunc) (int *party_id, int *account_id, int *char_id, unsigned short *map, int *online, int *lv);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_inter_party_change_map_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_inter_party_change_map_pre[hIndex].func;
@@ -9134,7 +9134,7 @@ bool HP_inter_party_change_map(int party_id, int account_id, int char_id, unsign
 		retVal___ = HPMHooks.source.inter_party.change_map(party_id, account_id, char_id, map, online, lv);
 	}
 	if (HPMHooks.count.HP_inter_party_change_map_post > 0) {
-		bool (*postHookFunc) (bool retVal___, int party_id, int account_id, int char_id, unsigned short map, int online, unsigned int lv);
+		bool (*postHookFunc) (bool retVal___, int party_id, int account_id, int char_id, unsigned short map, int online, int lv);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_inter_party_change_map_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_inter_party_change_map_post[hIndex].func;
 			retVal___ = postHookFunc(retVal___, party_id, account_id, char_id, map, online, lv);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixed Visual Studio C4018 compiler warning, caused by `inter_party_check_exp_share()` function in src\char\int_party.c.

> ..\src\char\int_party.c(320,56): warning C4018: "<=": signed/unsigned mismatch

[C4018 reference](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018?view=vs-2019)

**Issues addressed:** #1434


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
