### PR TITLE
Changed view ID of 2 NPCs to GUILD_FLAG in npc/woe-se/arug_cas01.txt.

### DIFF
--- a/npc/woe-se/arug_cas01.txt
+++ b/npc/woe-se/arug_cas01.txt
@@ -65,7 +65,7 @@ arug_cas01,98,232,0	script	LF-09#arug_cas01	HIDDEN_NPC,{ callfunc "LinkFlag","Ar
 arug_cas01,101,232,0	script	LF-10#arug_cas01	HIDDEN_NPC,{ callfunc "LinkFlag","Convenience Facility",121,357; }
 arug_cas01,72,176,0	script	Mardol#LF_ar01_1::LF_ar01_1	HIDDEN_NPC,{ callfunc "LinkFlag","Emperium Center",67,193; }
 arug_cas01,103,186,0	duplicate(LF_ar01_1)	Mardol#LF_ar01_2	HIDDEN_NPC
-arug_cas01,92,126,4	script	Mardol#LF_ar01_3::LF_ar01_2	HIDDEN_NPC,{
+arug_cas01,92,126,4	script	Mardol#LF_ar01_3::LF_ar01_2	GUILD_FLAG,{
 	callfunc "LinkFlag","Emperium Center",67,193;
 	end;
 OnAgitInit2:
@@ -73,7 +73,7 @@ OnRecvCastleAr01:
 	flagemblem getcastledata("arug_cas01",1);
 	end;
 }
-arug_cas01,127,126,4	duplicate(LF_ar01_2)	Mardol#LF_ar01_3	HIDDEN_NPC
+arug_cas01,127,126,4	duplicate(LF_ar01_2)	Mardol#LF_ar01_3	GUILD_FLAG
 arug_cas01,150,102,0	duplicate(LF_ar01_1)	Mardol#LF_ar01_4	HIDDEN_NPC
 arug_cas01,208,68,0	duplicate(LF_ar01_1)	Mardol#LF_ar01_5	HIDDEN_NPC
 arug_cas01,249,52,0	duplicate(LF_ar01_1)	Mardol#LF_ar01_6	HIDDEN_NPC


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Since `Mardol#LF_ar01_3::LF_ar01_2` is a flag NPC and `Mardol#LF_ar01_3` is a duplicate of it, both NPCs should use GUILD_FLAG/722 as view ID.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
