### PR TITLE
Fix redefine HPM structs in multy file plugins

### DIFF
--- a/src/common/HPMi.h
+++ b/src/common/HPMi.h
@@ -241,9 +241,15 @@ struct HPMi_interface {
 #ifdef HERCULES_CORE
 #define HPM_SYMBOL(n, s) (HPM->share((s), (n)), true)
 #else // ! HERCULES_CORE
+#ifdef HERCULES_CORE_HPMI_SKIP
+extern struct HPMi_interface HPMi_s;
+extern struct HPMi_interface *HPMi;
+extern void *(*import_symbol) (char *name, unsigned int pID);
+#else
 HPExport struct HPMi_interface HPMi_s;
 HPExport struct HPMi_interface *HPMi;
 HPExport void *(*import_symbol) (char *name, unsigned int pID);
+#endif
 #define HPM_SYMBOL(n, s) ((s) = import_symbol((n),HPMi->pid))
 #endif // !HERCULES_CORE
 

--- a/src/plugins/HPMHooking.h
+++ b/src/plugins/HPMHooking.h
@@ -41,7 +41,11 @@ struct HPMHooking_core_interface {
 	const char *(*Hooked)(bool *fr);
 };
 #else // ! HERCULES_CORE
+#ifdef HERCULES_CORE_HPMI_SKIP
+extern struct HPMHooking_interface HPMHooking_s;
+#else
 HPExport struct HPMHooking_interface HPMHooking_s;
+#endif
 
 #include "HPMHooking/HPMHooking.Defs.inc"
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
With some compilers if build complex plugins, can exists redefine issue for HPM interfaces.
In this pr added special check for avoid this issue.
