### PR TITLE
Updated items which used SC_ARMORPROPERTY or SC_ARMOR_RESIST.

### DIFF
--- a/db/pre-re/item_db.conf
+++ b/db/pre-re/item_db.conf
@@ -67261,7 +67261,10 @@ item_db: (
 	Buy: 2
 	Weight: 10
 	BuyingStore: true
-	Script: <" sc_start4 SC_ARMORPROPERTY,1200000,-15,0,20,0; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_FIRE, 1200000, 20);
+		sc_start(SC_RESIST_PROPERTY_WATER, 1200000, -15, 10000, SCFLAG_NOAVOID | SCFLAG_NOICON);
+	">
 },
 {
 	Id: 12119
@@ -67271,7 +67274,10 @@ item_db: (
 	Buy: 2
 	Weight: 10
 	BuyingStore: true
-	Script: <" sc_start4 SC_ARMORPROPERTY,1200000,20,0,0,-15; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_WATER, 1200000, 20);
+		sc_start(SC_RESIST_PROPERTY_WIND, 1200000, -15, 10000, SCFLAG_NOAVOID | SCFLAG_NOICON);
+	">
 },
 {
 	Id: 12120
@@ -67281,7 +67287,10 @@ item_db: (
 	Buy: 2
 	Weight: 10
 	BuyingStore: true
-	Script: <" sc_start4 SC_ARMORPROPERTY,1200000,0,20,-15,0; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_GROUND, 1200000, 20);
+		sc_start(SC_RESIST_PROPERTY_FIRE, 1200000, -15, 10000, SCFLAG_NOAVOID | SCFLAG_NOICON);
+	">
 },
 {
 	Id: 12121
@@ -67291,7 +67300,10 @@ item_db: (
 	Buy: 2
 	Weight: 10
 	BuyingStore: true
-	Script: <" sc_start4 SC_ARMORPROPERTY,1200000,0,-15,0,20; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_WIND, 1200000, 20);
+		sc_start(SC_RESIST_PROPERTY_GROUND, 1200000, -15, 10000, SCFLAG_NOAVOID | SCFLAG_NOICON);
+	">
 },
 {
 	Id: 12122
@@ -69521,7 +69533,12 @@ item_db: (
 	Name: "Undead Elemental Scroll"
 	Type: "IT_USABLE"
 	Weight: 10
-	Script: <" sc_start4 SC_ARMOR_RESIST,300000,20,20,20,20; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_FIRE, 300000, 20);
+		sc_start(SC_RESIST_PROPERTY_WATER, 300000, 20);
+		sc_start(SC_RESIST_PROPERTY_WIND, 300000, 20);
+		sc_start(SC_RESIST_PROPERTY_GROUND, 300000, 20);
+	">
 },
 {
 	Id: 12280

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -86890,7 +86890,10 @@ item_db: (
 	Buy: 2
 	Weight: 10
 	BuyingStore: true
-	Script: <" sc_start4 SC_ARMORPROPERTY,1200000,-15,0,20,0; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_FIRE, 1200000, 20);
+		sc_start(SC_RESIST_PROPERTY_WATER, 1200000, -15, 10000, SCFLAG_NOAVOID | SCFLAG_NOICON);
+	">
 },
 {
 	Id: 12119
@@ -86900,7 +86903,10 @@ item_db: (
 	Buy: 2
 	Weight: 10
 	BuyingStore: true
-	Script: <" sc_start4 SC_ARMORPROPERTY,1200000,20,0,0,-15; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_WATER, 1200000, 20);
+		sc_start(SC_RESIST_PROPERTY_WIND, 1200000, -15, 10000, SCFLAG_NOAVOID | SCFLAG_NOICON);
+	">
 },
 {
 	Id: 12120
@@ -86910,7 +86916,10 @@ item_db: (
 	Buy: 2
 	Weight: 10
 	BuyingStore: true
-	Script: <" sc_start4 SC_ARMORPROPERTY,1200000,0,20,-15,0; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_GROUND, 1200000, 20);
+		sc_start(SC_RESIST_PROPERTY_FIRE, 1200000, -15, 10000, SCFLAG_NOAVOID | SCFLAG_NOICON);
+	">
 },
 {
 	Id: 12121
@@ -86920,7 +86929,10 @@ item_db: (
 	Buy: 2
 	Weight: 10
 	BuyingStore: true
-	Script: <" sc_start4 SC_ARMORPROPERTY,1200000,0,-15,0,20; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_WIND, 1200000, 20);
+		sc_start(SC_RESIST_PROPERTY_GROUND, 1200000, -15, 10000, SCFLAG_NOAVOID | SCFLAG_NOICON);
+	">
 },
 {
 	Id: 12122
@@ -89170,7 +89182,12 @@ item_db: (
 	Name: "Undead Elemental Scroll"
 	Type: "IT_USABLE"
 	Weight: 10
-	Script: <" sc_start4 SC_ARMOR_RESIST,300000,20,20,20,20; ">
+	Script: <"
+		sc_start(SC_RESIST_PROPERTY_FIRE, 300000, 20);
+		sc_start(SC_RESIST_PROPERTY_WATER, 300000, 20);
+		sc_start(SC_RESIST_PROPERTY_WIND, 300000, 20);
+		sc_start(SC_RESIST_PROPERTY_GROUND, 300000, 20);
+	">
 },
 {
 	Id: 12280


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
**For the 4 elemental resistance potions:**
They used `SC_ARMORPROPERTY` to apply multiple elemental resistance modifications at the same time.
But in `status_change_end_()`, `clif->sc_end()` is called for `SC_ARMORPROPERTY`, which has no effect because this status change was never send to the client.
Actually one or more of these status changes needs to be ended client side, depending on the consumed potion: `SC_RESIST_PROPERTY_WATER`, `SC_RESIST_PROPERTY_GROUND`, `SC_RESIST_PROPERTY_FIRE`, `SC_RESIST_PROPERTY_WIND`
Because of this issue, the status changes should be started separately, to make sure, the correct status change will be ended client side.

**For Undead Elemental Scroll:**
It used ` SC_ARMOR_RESIST` which won't show a status change icon client side.
Since its Aegis script uses `SubDamageTM_Prop` (same as the 4 elemental resistance potions), to increase the elemental resistances, all 4 icons should be shown.
To achieve this, all 4 elemental resistance boosts should be applied separately, to make sure, the icons will be shown and the correct status changes will be ended client side.


**Issues addressed:** #2593


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
