### PR TITLE
Added an initial dmg_taken_rate value to clone spawns.

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -3742,6 +3742,7 @@ static int mob_clone_spawn(struct map_session_data *sd, int16 m, int16 x, int16 
 	strcpy(db->name, sd->status.name);
 	strcpy(db->jname, sd->status.name);
 	db->lv = status->get_lv(&sd->bl);
+	db->dmg_taken_rate = 100;
 	memcpy(mstatus, &sd->base_status, sizeof(struct status_data));
 	mstatus->rhw.atk2 = mstatus->dex + mstatus->rhw.atk + mstatus->rhw.atk2; /// Max ATK.
 	mstatus->rhw.atk = mstatus->dex; /// Min ATK.


### PR DESCRIPTION

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Mobs, spawned by `mob_clone_spawn()`, were invulnerable, because their `dmg_taken_rate` was never set and thus became `0`. Now, `dmg_taken_rate` will be set to `100`, to remove that invulnerability.

**Issues addressed:** #2607


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
