### PR TITLE
Crash fixes

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -638,8 +638,11 @@ static int map_foreachinmap(int (*func)(struct block_list*, va_list), int16 m, i
 
 static int map_forcountinmap(int (*func)(struct block_list*, va_list), int16 m, int count, int type, ...)
 {
-	int returnCount;
+	int returnCount = 0;
 	va_list ap;
+
+	if (m < 0)
+		return returnCount;
 
 	va_start(ap, type);
 	returnCount = map->vforcountinarea(func, m, 0, 0, map->list[m].xs, map->list[m].ys, count, type, ap);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11775,6 +11775,13 @@ static BUILDIN(getunits)
 		const char *mapname = script_getstr(st, 5);
 		int16 m = map->mapname2mapid(mapname);
 
+		if (m == -1) {
+			ShowError("script:getunits: Invalid map(%s) provided.\n", mapname);
+			script->reportdata(data);
+			st->state = END;
+			return false;
+		}
+
 		if (script_hasdata(st, 9)) {
 			int16 x1 = script_getnum(st, 6);
 			int16 y1 = script_getnum(st, 7);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

There were 2 cases causing map-server to crash.
1) When getunits was called with invalid mapname, mapname2mapid would be called, and it will return -1, which would then call map_forcountinmap, which does not perform any checks. So, a error message is added to getunits, to know exactly where something went wrong.
2) Source can use map_forcountinmap without validating the inputs, or even passing wrong value of mapid, which would have caused the map-server crash.

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
