### PR TITLE
Make mob DB field ViewData->HairStyleId defaulting to 1 instead of 0.

### DIFF
--- a/db/pre-re/mob_db.conf
+++ b/db/pre-re/mob_db.conf
@@ -102,7 +102,7 @@ mob_db: (
 		HeadTopId: top headgear id       (int, defaults to 0)
 		HeadMidId: middle headgear id    (int, defaults to 0)
 		HeadLowId: lower headgear id     (int, defaults to 0)
-		HairStyleId: hair style id       (int, defaults to 0)
+		HairStyleId: hair style id       (int, defaults to 1)
 		BodyStyleId: clothes id          (int, defaults to 0)
 		HairColorId: hair color id       (int, defaults to 0)
 		BodyColorId: clothes color id    (int, defaults to 0)

--- a/db/re/mob_db.conf
+++ b/db/re/mob_db.conf
@@ -102,7 +102,7 @@ mob_db: (
 		HeadTopId: top headgear id       (int, defaults to 0)
 		HeadMidId: middle headgear id    (int, defaults to 0)
 		HeadLowId: lower headgear id     (int, defaults to 0)
-		HairStyleId: hair style id       (int, defaults to 0)
+		HairStyleId: hair style id       (int, defaults to 1)
 		BodyStyleId: clothes id          (int, defaults to 0)
 		HairColorId: hair color id       (int, defaults to 0)
 		BodyColorId: clothes color id    (int, defaults to 0)

--- a/doc/mob_db.txt
+++ b/doc/mob_db.txt
@@ -82,7 +82,7 @@ mob_db: (
     HeadTopId: top headgear id       (int, defaults to 0)
     HeadMidId: middle headgear id    (int, defaults to 0)
     HeadLowId: lower headgear id     (int, defaults to 0)
-    HairStyleId: hair style id       (int, defaults to 0)
+    HairStyleId: hair style id       (int, defaults to 1)
     BodyStyleId: clothes id          (int, defaults to 0)
     HairColorId: hair color id       (int, defaults to 0)
     BodyColorId: clothes color id    (int, defaults to 0)
@@ -193,7 +193,7 @@ Element: Monster's element. Sets element type and level.
 Mode: Monster AI behaviour. If this block is omitted, monster doesn't react to anything.
       All the settings in this group are boolean values,
       Default value is false (mode not set) for any missing setting.
-      See /doc/sample/mob_db_mode_list.txt for more information about monsters Mode types.
+      See /doc/mob_db_mode_list.md for more information about monsters Mode types.
 
 MoveSpeed: Monster's speed. Sets speed (cells/sec).
            MoveSpeed is calculated to Hercules with this formula: 1000 / SPEED (CELLS/SEC)
@@ -278,3 +278,4 @@ DamageTakenRate:
 ViewData:
   Overrides the default view data sent to the client with the given values for:
     Sprite, Weapon, Shield, Robe, HeadTop, HeadMid, HeadLow, HairStyle, BodyStyle, HairColor, BodyColor, Gender, Options
+  Note: HairStyleId will only default to 1, if the ViewData block is defined.

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -4206,8 +4206,12 @@ static void mob_read_db_viewdata_sub(struct mob_db *entry, struct config_setting
 		entry->vd.head_mid = libconfig->setting_get_int(it);
 	if ((it = libconfig->setting_get_member(t, "HeadLowId")) != NULL)
 		entry->vd.head_bottom = libconfig->setting_get_int(it);
+
 	if ((it = libconfig->setting_get_member(t, "HairStyleId")) != NULL)
 		entry->vd.hair_style = libconfig->setting_get_int(it);
+	else
+		entry->vd.hair_style = 1;
+
 	if ((it = libconfig->setting_get_member(t, "BodyStyleId")) != NULL)
 		entry->vd.body_style = libconfig->setting_get_int(it);
 	if ((it = libconfig->setting_get_member(t, "HairColorId")) != NULL)


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

When using the `ViewData` block in mob_db.conf, `HairStyleId` currently defaults to 0.
This causes client errors, because there is no head sprite with ID 0.
So `HairStyleId` should default to 1 instead.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
