### PR TITLE
Fix W_RIFLE damage calculation being too low than intended

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4977,6 +4977,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				switch (sd->weapontype) {
 					case W_BOW:
 					case W_REVOLVER:
+					case W_RIFLE:
 					case W_GATLING:
 					case W_SHOTGUN:
 					case W_GRENADE:


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Rifle type weapons had a broken call to battle_calc_base_damage2 since
they were passing the flag value 18 and flag&16 != 0 as stated by the
documentation shall only be the case when no gun or bow is equipped. 
  
*This bug likely didn't affect Renewal as it seems like flag&16 isn't used there.*
  
This bug existed since 2006 and got introduced by the commit e24d467f1ae47475e3441d7453f549e22f46f541 .

**Issues addressed:** *None?*

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
