### PR TITLE
Fix Homunculi being partially vaporized.

### DIFF
--- a/src/map/homunculus.c
+++ b/src/map/homunculus.c
@@ -179,7 +179,7 @@ static int homunculus_vaporize(struct map_session_data *sd, enum homun_state sta
 	nullpo_ret(sd);
 
 	hd = sd->hd;
-	if (!hd || hd->homunculus.vaporize != HOM_ST_ACTIVE)
+	if (hd == NULL || hd->bl.prev == NULL || hd->homunculus.vaporize != HOM_ST_ACTIVE)
 		return 0;
 
 	if (status->isdead(&hd->bl))


### PR DESCRIPTION
Vanilmirth for example would get incompletely vaporized when using
HVAN_EXPLOSION, if the owner died due to it, and then it would be killed at the end of it.
This produced a bug which made it not ressurectable but callable, once it
was called it would be dead though and you'd be unable to control it,
requiring you to ressurect it after that.

This bug got introduced by 0eca88efc69becc591428fbb6b9fddd9237afd3d .

### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Make it impossible to vaporize homunculi when bl.prev == NULL, such as when delblock is used in HVAN_EXPLOSION.

**Issues addressed:** None?

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
