### PR TITLE
Fixes mistreatment of int return from Asura Strike fixes

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -5895,7 +5895,7 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 			else
 				y = 0;
 
-			if (unit->movepos(src, src->x + x, src->y + y, 1, 1) == 1) {
+			if (unit->movepos(src, src->x + x, src->y + y, 1, 1) != 0) {
 				//Display movement + animation.
 				clif->slide(src, src->x, src->y);
 				clif->spiritball(src);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This changes the check added in #2248 for the return from `unit->movepos` so it accepts anything `!= 0` as `true` (as it originally was) instead of only the return value `1`. `unit->movepos` currently only returns 0/1, but as noted by @skyleo in https://github.com/HerculesWS/Hercules/pull/2248#discussion_r378590141 , it could introduce an unexpected side-effect.

**Issues addressed:** <!-- Write here the issue number, if any. -->
Fixes #2629 

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
