### PR TITLE
Fix (un)equip script execution for map zone restrcited items

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1051,6 +1051,24 @@ static int pc_isequip(struct map_session_data *sd, int n)
 			return 0;
 		}
 	}
+
+	if ( battle_config.unequip_restricted_equipment & 1 ) {
+		int i;
+		for ( i = 0; i < map->list[sd->bl.m].zone->disabled_items_count; i++ )
+			if ( map->list[sd->bl.m].zone->disabled_items[i] == sd->status.inventory[n].nameid )
+				return 0;
+	}
+
+	if ( battle_config.unequip_restricted_equipment & 2 ) {
+		if ( !itemdb_isspecial( sd->status.inventory[n].card[0] ) ) {
+			int i, slot;
+			for ( slot = 0; slot < MAX_SLOTS; slot++ )
+				for ( i = 0; i < map->list[sd->bl.m].zone->disabled_items_count; i++ )
+					if ( map->list[sd->bl.m].zone->disabled_items[i] == sd->status.inventory[n].card[slot] )
+						return 0;
+		}
+	}
+
 	if (sd->sc.count) {
 
 		if(item->equip & EQP_ARMS && item->type == IT_WEAPON && sd->sc.data[SC_NOEQUIPWEAPON]) // Also works with left-hand weapons [DracoRPG]
@@ -1104,23 +1122,6 @@ static int pc_isequip(struct map_session_data *sd, int n)
 				break;
 		}
 		return 0;
-	}
-
-	if ( battle_config.unequip_restricted_equipment & 1 ) {
-		int i;
-		for ( i = 0; i < map->list[sd->bl.m].zone->disabled_items_count; i++ )
-			if ( map->list[sd->bl.m].zone->disabled_items[i] == sd->status.inventory[n].nameid )
-				return 0;
-	}
-
-	if ( battle_config.unequip_restricted_equipment & 2 ) {
-		if ( !itemdb_isspecial( sd->status.inventory[n].card[0] ) ) {
-			int i, slot;
-			for ( slot = 0; slot < MAX_SLOTS; slot++ )
-				for ( i = 0; i < map->list[sd->bl.m].zone->disabled_items_count; i++ )
-					if ( map->list[sd->bl.m].zone->disabled_items[i] == sd->status.inventory[n].card[slot] )
-						return 0;
-		}
 	}
 
 	return 1;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -10263,8 +10263,12 @@ static int pc_equipitem(struct map_session_data *sd, int n, int req_pos)
 		clif->skillinfoblock(sd);
 
 	//OnEquip script [Skotlex]
-	if (id->equip_script)
-		script->run_item_equip_script(sd, id, npc->fake_nd->bl.id);
+	if (id->equip_script != NULL) {
+		ARR_FIND(0, map->list[sd->bl.m].zone->disabled_items_count, i, map->list[sd->bl.m].zone->disabled_items[i] == id->nameid);
+
+		if (i == map->list[sd->bl.m].zone->disabled_items_count)
+			script->run_item_equip_script(sd, id, npc->fake_nd->bl.id);
+	}
 
 	if(itemdb_isspecial(sd->status.inventory[n].card[0]))
 		; //No cards
@@ -10274,8 +10278,14 @@ static int pc_equipitem(struct map_session_data *sd, int n, int req_pos)
 			if (!sd->status.inventory[n].card[i])
 				continue;
 			if ( ( data = itemdb->exists(sd->status.inventory[n].card[i]) ) != NULL ) {
-				if (data->equip_script)
-					script->run_item_equip_script(sd, data, npc->fake_nd->bl.id);
+				if (data->equip_script != NULL) {
+					int j;
+
+					ARR_FIND(0, map->list[sd->bl.m].zone->disabled_items_count, j, map->list[sd->bl.m].zone->disabled_items[j] == sd->status.inventory[n].card[i]);
+
+					if (j == map->list[sd->bl.m].zone->disabled_items_count)
+						script->run_item_equip_script(sd, data, npc->fake_nd->bl.id);
+				}
 			}
 		}
 	}

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -10464,12 +10464,8 @@ static int pc_unequipitem(struct map_session_data *sd, int n, int flag)
 	//OnUnEquip script [Skotlex]
 	if (sd->inventory_data[n] != NULL) {
 		if (sd->inventory_data[n]->unequip_script != NULL) {
-			if (battle_config.unequip_restricted_equipment & 1) {
-				ARR_FIND(0, map->list[sd->bl.m].zone->disabled_items_count, i, map->list[sd->bl.m].zone->disabled_items[i] == sd->status.inventory[n].nameid);
-				if (i == map->list[sd->bl.m].zone->disabled_items_count)
-					script->run_item_unequip_script(sd, sd->inventory_data[n], npc->fake_nd->bl.id);
-			}
-			else
+			ARR_FIND(0, map->list[sd->bl.m].zone->disabled_items_count, i, map->list[sd->bl.m].zone->disabled_items[i] == sd->status.inventory[n].nameid);
+			if (i == map->list[sd->bl.m].zone->disabled_items_count)
 				script->run_item_unequip_script(sd, sd->inventory_data[n], npc->fake_nd->bl.id);
 		}
 		if (itemdb_isspecial(sd->status.inventory[n].card[0]) == false) {
@@ -10480,14 +10476,10 @@ static int pc_unequipitem(struct map_session_data *sd, int n, int flag)
 
 				if ((data = itemdb->exists(sd->status.inventory[n].card[i])) != NULL) {
 					if (data->unequip_script) {
-						if (battle_config.unequip_restricted_equipment & 2) {
-							int j;
-							ARR_FIND(0, map->list[sd->bl.m].zone->disabled_items_count, j, map->list[sd->bl.m].zone->disabled_items[j] == sd->status.inventory[n].card[i]);
-							if (j == map->list[sd->bl.m].zone->disabled_items_count)
-								script->run_item_unequip_script(sd, data, npc->fake_nd->bl.id);
-						} else {
+						int j;
+						ARR_FIND(0, map->list[sd->bl.m].zone->disabled_items_count, j, map->list[sd->bl.m].zone->disabled_items[j] == sd->status.inventory[n].card[i]);
+						if (j == map->list[sd->bl.m].zone->disabled_items_count)
 							script->run_item_unequip_script(sd, data, npc->fake_nd->bl.id);
-						}
 					}
 				}
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

 * Prevent the execution of an item's (un)equip script, regardless of the `unequip_restricted_equipment` configuration, if the item is restricted in that zone.
 * Force the execution of an item's unequip script when entering a zone where the item is restricted, even if the item won't be unequipped.

This replaces #2207, since there seems to be no more progress.

@MishimaHaruna
This may be merged manually after #2600, since that PR applies code style to `clif_parse_LoadEndAck()`.

**Issues addressed:** #2180


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
