### PR TITLE
Fix itemskill() script command

### DIFF
--- a/db/pre-re/item_db.conf
+++ b/db/pre-re/item_db.conf
@@ -68630,7 +68630,7 @@ item_db: (
 	Nouse: {
 		sitting: true
 	}
-	Script: <" itemskill(AL_INCAGI, 10, ISF_INSTANTCAST | ISF_CASTONSELF); ">
+	Script: <" itemskill(AL_INCAGI, 10, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF); ">
 },
 {
 	Id: 12217
@@ -68651,7 +68651,7 @@ item_db: (
 	Nouse: {
 		sitting: true
 	}
-	Script: <" itemskill(PR_ASPERSIO, 5, ISF_INSTANTCAST | ISF_CASTONSELF); ">
+	Script: <" itemskill(PR_ASPERSIO, 5, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF); ">
 },
 {
 	Id: 12218
@@ -68714,7 +68714,7 @@ item_db: (
 	Nouse: {
 		sitting: true
 	}
-	Script: <" itemskill(BS_ADRENALINE, 5, ISF_INSTANTCAST | ISF_CASTONSELF); ">
+	Script: <" itemskill(BS_ADRENALINE, 5, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF); ">
 },
 {
 	Id: 12221
@@ -69687,7 +69687,7 @@ item_db: (
 	}
 	Script: <"
 		percentheal(0, 5);
-		itemskill(AL_INCAGI, 5, ISF_INSTANTCAST | ISF_CASTONSELF);
+		itemskill(AL_INCAGI, 5, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF);
 	">
 },
 {
@@ -71124,7 +71124,7 @@ item_db: (
 	}
 	Script: <"
 		//if(strcharinfo(PC_MAP)=="job3_rune02") {
-		//	itemskill RK_CRUSHSTRIKE,1;
+		//	itemskill(RK_CRUSHSTRIKE, 1, ISF_CHECKCONDITIONS);
 		//}
 	">
 },
@@ -73501,7 +73501,7 @@ item_db: (
 		sitting: true
 	}
 	Stack: [20, 1]
-	Script: <" itemskill RK_CRUSHSTRIKE, 1; ">
+	Script: <" itemskill(RK_CRUSHSTRIKE, 1, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 12727
@@ -92168,7 +92168,7 @@ item_db: (
 	Name: "Chemical Protection Helm Scroll"
 	Type: "IT_USABLE"
 	Weight: 10
-	Script: <" itemskill(AM_CP_HELM, 5); ">
+	Script: <" itemskill(AM_CP_HELM, 5, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 14518
@@ -92176,7 +92176,7 @@ item_db: (
 	Name: "Chemical Protection Shield Scrol"
 	Type: "IT_USABLE"
 	Weight: 10
-	Script: <" itemskill(AM_CP_SHIELD, 5); ">
+	Script: <" itemskill(AM_CP_SHIELD, 5, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 14519
@@ -92184,7 +92184,7 @@ item_db: (
 	Name: "Chemical Protection Armor Scroll"
 	Type: "IT_USABLE"
 	Weight: 10
-	Script: <" itemskill(AM_CP_ARMOR, 5); ">
+	Script: <" itemskill(AM_CP_ARMOR, 5, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 14520
@@ -92192,7 +92192,7 @@ item_db: (
 	Name: "Chemical Protection Weapon Scroll"
 	Type: "IT_USABLE"
 	Weight: 10
-	Script: <" itemskill(AM_CP_WEAPON, 5); ">
+	Script: <" itemskill(AM_CP_WEAPON, 5, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 14521
@@ -93104,7 +93104,7 @@ item_db: (
 		noselltonpc: true
 		nogstorage: true
 	}
-	Script: <" itemskill(CASH_INCAGI, 10, ISF_INSTANTCAST | ISF_CASTONSELF); ">
+	Script: <" itemskill(CASH_INCAGI, 10, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF); ">
 },
 {
 	Id: 14590

--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -17694,6 +17694,9 @@ skill_db: (
 		Lv10: 240000
 	}
 	CoolDown: 0
+	Requirements: {
+		HPCost: 15
+	}
 },
 {
 	Id: 691

--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -18631,6 +18631,31 @@ skill_db: (
 	CoolDown: 0
 	Requirements: {
 		SPCost: 1
+		WeaponTypes: {
+			Daggers: true
+			1HSwords: true
+			2HSwords: true
+			1HSpears: true
+			2HSpears: true
+			1HAxes: true
+			2HAxes: true
+			Maces: true
+			2HMaces: true
+			Staves: true
+			Bows: true
+			Knuckles: true
+			Instruments: true
+			Whips: true
+			Books: true
+			Katars: true
+			Revolvers: true
+			Rifles: true
+			GatlingGuns: true
+			Shotguns: true
+			GrenadeLaunchers: true
+			FuumaShurikens: true
+			2HStaves: true
+		}
 	}
 },
 {

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -88273,7 +88273,7 @@ item_db: (
 	Nouse: {
 		sitting: true
 	}
-	Script: <" itemskill(AL_INCAGI, 10, ISF_INSTANTCAST | ISF_CASTONSELF); ">
+	Script: <" itemskill(AL_INCAGI, 10, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF); ">
 },
 {
 	Id: 12217
@@ -88294,7 +88294,7 @@ item_db: (
 	Nouse: {
 		sitting: true
 	}
-	Script: <" itemskill(PR_ASPERSIO, 5, ISF_INSTANTCAST | ISF_CASTONSELF); ">
+	Script: <" itemskill(PR_ASPERSIO, 5, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF); ">
 },
 {
 	Id: 12218
@@ -88357,7 +88357,7 @@ item_db: (
 	Nouse: {
 		sitting: true
 	}
-	Script: <" itemskill(BS_ADRENALINE, 5, ISF_INSTANTCAST | ISF_CASTONSELF); ">
+	Script: <" itemskill(BS_ADRENALINE, 5, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF); ">
 },
 {
 	Id: 12221
@@ -89349,7 +89349,7 @@ item_db: (
 	}
 	Script: <"
 		percentheal(0, 5);
-		itemskill(AL_INCAGI, 5, ISF_INSTANTCAST | ISF_CASTONSELF);
+		itemskill(AL_INCAGI, 5, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF);
 	">
 },
 {
@@ -90735,7 +90735,7 @@ item_db: (
 	}
 	Script: <"
 		if(strcharinfo(PC_MAP)=="job3_rune02") {
-			itemskill RK_CRUSHSTRIKE,1;
+			itemskill(RK_CRUSHSTRIKE, 1, ISF_CHECKCONDITIONS);
 		}
 	">
 },
@@ -94758,7 +94758,7 @@ item_db: (
 		sitting: true
 	}
 	Stack: [60, 1]
-	Script: <" itemskill RK_CRUSHSTRIKE, 1; ">
+	Script: <" itemskill(RK_CRUSHSTRIKE, 1, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 12727
@@ -121679,7 +121679,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <" itemskill(AM_CP_HELM, 5); ">
+	Script: <" itemskill(AM_CP_HELM, 5, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 14518
@@ -121696,7 +121696,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <" itemskill(AM_CP_SHIELD, 5); ">
+	Script: <" itemskill(AM_CP_SHIELD, 5, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 14519
@@ -121713,7 +121713,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <" itemskill(AM_CP_ARMOR, 5); ">
+	Script: <" itemskill(AM_CP_ARMOR, 5, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 14520
@@ -121730,7 +121730,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <" itemskill(AM_CP_WEAPON, 5); ">
+	Script: <" itemskill(AM_CP_WEAPON, 5, ISF_CHECKCONDITIONS); ">
 },
 {
 	Id: 14521
@@ -123049,7 +123049,7 @@ item_db: (
 		nomail: true
 		noauction: true
 	}
-	Script: <" itemskill(CASH_INCAGI, 10, ISF_INSTANTCAST | ISF_CASTONSELF); ">
+	Script: <" itemskill(CASH_INCAGI, 10, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF); ">
 },
 {
 	Id: 14590

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -19186,6 +19186,31 @@ skill_db: (
 	FixedCastTime: 1000
 	Requirements: {
 		SPCost: 1
+		WeaponTypes: {
+			Daggers: true
+			1HSwords: true
+			2HSwords: true
+			1HSpears: true
+			2HSpears: true
+			1HAxes: true
+			2HAxes: true
+			Maces: true
+			2HMaces: true
+			Staves: true
+			Bows: true
+			Knuckles: true
+			Instruments: true
+			Whips: true
+			Books: true
+			Katars: true
+			Revolvers: true
+			Rifles: true
+			GatlingGuns: true
+			Shotguns: true
+			GrenadeLaunchers: true
+			FuumaShurikens: true
+			2HStaves: true
+		}
 	}
 },
 {

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -18162,6 +18162,9 @@ skill_db: (
 		Lv10: 240000
 	}
 	FixedCastTime: -1
+	Requirements: {
+		HPCost: 15
+	}
 },
 {
 	Id: 691

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5659,18 +5659,20 @@ usable items. It will not work properly if there is a visible dialog
 window or menu.
 If the skill is self or auto-targeting, it will be used immediately.
 Otherwise, a target cursor is shown.
-Optional value <flag> is a bitmask to manipulate how the skill is casted.
+By default, all skill requirements are ignored.
+Optional argument <flag> is a bitmask to manipulate how the skill is cast.
 Since <flag> is a bitmask, the flags can be summed up.
 Possible flags are:
- - 0x00 - ISF_NONE		- Skill is casted as if has been used from skill tree.
+ - 0x00 - ISF_NONE		- Skill is cast as if it has been used from skill tree.
 				  (Same like <flag> was omitted.)
- - 0x01 - ISF_IGNORECONDITIONS	- Skill requirements are ignored and not consumed
- - 0x02 - ISF_INSTANTCAST	- Skill is casted instantaneously.
- - 0x04 - ISF_CASTONSELF	- Skill is forcefully casted on invoking character,
+ - 0x01 - ISF_CHECKCONDITIONS	- Skill requirements are checked and consumed.
+				  (SP are never checked/consumed.)
+ - 0x02 - ISF_INSTANTCAST	- Skill is cast instantaneously.
+ - 0x04 - ISF_CASTONSELF	- Skill is forcefully cast on invoking character,
 				  without showing the target selection cursor.
 
 Important: Items which use itemskill() should be of type IT_USABLE.
-           If the item type is IT_DELAYCONSUME and ISF_IGNORECONDITIONS is set,
+           If the item type is IT_DELAYCONSUME and ISF_CHECKCONDITIONS isn't set,
            the item won't be consumed when using the item!
 
 // When Anodyne is used, it will cast Endure, Level 1, as if the actual skill
@@ -5678,8 +5680,8 @@ Important: Items which use itemskill() should be of type IT_USABLE.
 	itemskill(SM_ENDURE, 1);
 
 // Instantaneously cast Level 10 Increase Agility on invoking character,
-// without checking/consuming skill requirements.
-	itemskill(AL_INCAGI, 10, ISF_IGNORECONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF);
+// with checking/consuming skill requirements (15 HP).
+	itemskill(AL_INCAGI, 10, ISF_CHECKCONDITIONS | ISF_INSTANTCAST | ISF_CASTONSELF);
 // Instaed of using the constants, one could also do it like this:
 	itemskill(AL_INCAGI, 10, 7);
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -5334,7 +5334,7 @@ static int pc_itemskill_clear(struct map_session_data *sd)
 	sd->itemskill_id = 0;
 	sd->itemskill_lv = 0;
 	sd->state.itemskill_conditions_checked = 0;
-	sd->state.itemskill_no_conditions = 0;
+	sd->state.itemskill_check_conditions = 0;
 	sd->state.itemskill_no_casttime = 0;
 	sd->state.itemskill_castonself = 0;
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -241,7 +241,7 @@ struct map_session_data {
 		unsigned int npc_unloaded : 1; ///< The player is talking with an unloaded NPCs (respawned tombstones)
 		unsigned int lapine_ui : 1;
 		unsigned int itemskill_conditions_checked : 1; // Used by itemskill() script command, to prevent second check of conditions after target was selected.
-		unsigned int itemskill_no_conditions : 1; // Used by itemskill() script command, to ignore skill conditions and don't consume them.
+		unsigned int itemskill_check_conditions : 1; // Used by itemskill() script command, to check skill conditions and consume them.
 		unsigned int itemskill_no_casttime : 1; // Used by itemskill() script command, to cast skill instantaneously.
 		unsigned int itemskill_castonself : 1; // Used by itemskill() script command, to forcefully cast skill on invoking character.
 	} state;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11008,7 +11008,7 @@ static BUILDIN(itemskill)
 
 	int flag = script_hasdata(st, 4) ? script_getnum(st, 4) : ISF_NONE;
 
-	sd->state.itemskill_no_conditions = ((flag & ISF_IGNORECONDITIONS) == ISF_IGNORECONDITIONS) ? 1 : 0; // Unset in pc_itemskill_clear().
+	sd->state.itemskill_no_conditions = ((flag & ISF_CHECKCONDITIONS) == ISF_CHECKCONDITIONS) ? 1 : 0; // Unset in pc_itemskill_clear().
 
 	if (sd->state.itemskill_no_conditions == 0) {
 		if (skill->check_condition_castbegin(sd, sd->skillitem, sd->skillitemlv) == 0
@@ -27860,7 +27860,7 @@ static void script_hardcoded_constants(void)
 
 	script->constdb_comment("itemskill option flags");
 	script->set_constant("ISF_NONE", ISF_NONE, false, false);
-	script->set_constant("ISF_IGNORECONDITIONS", ISF_IGNORECONDITIONS, false, false);
+	script->set_constant("ISF_CHECKCONDITIONS", ISF_CHECKCONDITIONS, false, false);
 	script->set_constant("ISF_INSTANTCAST", ISF_INSTANTCAST, false, false);
 	script->set_constant("ISF_CASTONSELF", ISF_CASTONSELF, false, false);
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11010,7 +11010,7 @@ static BUILDIN(itemskill)
 
 	sd->state.itemskill_check_conditions = ((flag & ISF_CHECKCONDITIONS) == ISF_CHECKCONDITIONS) ? 1 : 0; // Unset in pc_itemskill_clear().
 
-	if (sd->state.itemskill_check_conditions == 0) {
+	if (sd->state.itemskill_check_conditions == 1) {
 		if (skill->check_condition_castbegin(sd, sd->skillitem, sd->skillitemlv) == 0
 		    || skill->check_condition_castend(sd, sd->skillitem, sd->skillitemlv) == 0) {
 			pc->itemskill_clear(sd);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11001,6 +11001,7 @@ static BUILDIN(itemskill)
 	if (sd == NULL || sd->ud.skilltimer != INVALID_TIMER)
 		return true;
 
+	pc->itemskill_clear(sd);
 	sd->skillitem = script_isstringtype(st, 2) ? skill->name2id(script_getstr(st, 2)) : script_getnum(st, 2);
 	sd->skillitemlv = script_getnum(st, 3);
 	sd->state.itemskill_conditions_checked = 0; // Skill casting items will check the conditions prior to the target selection in AEGIS. Thus we need a flag to prevent checking them twice.
@@ -11012,6 +11013,7 @@ static BUILDIN(itemskill)
 	if (sd->state.itemskill_no_conditions == 0) {
 		if (skill->check_condition_castbegin(sd, sd->skillitem, sd->skillitemlv) == 0
 		    || skill->check_condition_castend(sd, sd->skillitem, sd->skillitemlv) == 0) {
+			pc->itemskill_clear(sd);
 			return true;
 		}
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11008,9 +11008,9 @@ static BUILDIN(itemskill)
 
 	int flag = script_hasdata(st, 4) ? script_getnum(st, 4) : ISF_NONE;
 
-	sd->state.itemskill_no_conditions = ((flag & ISF_CHECKCONDITIONS) == ISF_CHECKCONDITIONS) ? 1 : 0; // Unset in pc_itemskill_clear().
+	sd->state.itemskill_check_conditions = ((flag & ISF_CHECKCONDITIONS) == ISF_CHECKCONDITIONS) ? 1 : 0; // Unset in pc_itemskill_clear().
 
-	if (sd->state.itemskill_no_conditions == 0) {
+	if (sd->state.itemskill_check_conditions == 0) {
 		if (skill->check_condition_castbegin(sd, sd->skillitem, sd->skillitemlv) == 0
 		    || skill->check_condition_castend(sd, sd->skillitem, sd->skillitemlv) == 0) {
 			pc->itemskill_clear(sd);

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -569,7 +569,7 @@ enum mado_type {
  **/
 enum itemskill_flag {
 	ISF_NONE = 0x00,
-	ISF_IGNORECONDITIONS = 0x01, // Ignore skill conditions and don't consume them.
+	ISF_CHECKCONDITIONS = 0x01, // Check skill conditions and consume them.
 	ISF_INSTANTCAST = 0x02, // Cast skill instantaneously.
 	ISF_CASTONSELF = 0x04, // Forcefully cast skill on invoking character without showing the target selection cursor.
 };

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -14024,7 +14024,7 @@ static int skill_check_condition_castbegin(struct map_session_data *sd, uint16 s
 	if (sd->chat_id != 0)
 		return 0;
 
-	if ((sd->state.itemskill_conditions_checked == 1 || sd->state.itemskill_no_conditions == 1)
+	if ((sd->state.itemskill_conditions_checked == 1 || sd->state.itemskill_check_conditions == 1)
 	    && skill->is_item_skill(sd, skill_id, skill_lv)) {
 		return 1;
 	}
@@ -15013,7 +15013,7 @@ static int skill_check_condition_castend(struct map_session_data *sd, uint16 ski
 	if (sd->chat_id != 0)
 		return 0;
 
-	if ((sd->state.itemskill_conditions_checked == 1 || sd->state.itemskill_no_conditions == 1)
+	if ((sd->state.itemskill_conditions_checked == 1 || sd->state.itemskill_check_conditions == 1)
 	    && skill->is_item_skill(sd, skill_id, skill_lv)) {
 		return 1;
 	}
@@ -15219,7 +15219,7 @@ static int skill_consume_requirement(struct map_session_data *sd, uint16 skill_i
 
 	nullpo_ret(sd);
 
-	if (sd->state.itemskill_no_conditions == 1 && skill->is_item_skill(sd, skill_id, skill_lv))
+	if (sd->state.itemskill_check_conditions == 1 && skill->is_item_skill(sd, skill_id, skill_lv))
 		return 1;
 
 	req = skill->get_requirement(sd,skill_id,skill_lv);

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -14024,7 +14024,7 @@ static int skill_check_condition_castbegin(struct map_session_data *sd, uint16 s
 	if (sd->chat_id != 0)
 		return 0;
 
-	if ((sd->state.itemskill_conditions_checked == 1 || sd->state.itemskill_check_conditions == 1)
+	if ((sd->state.itemskill_conditions_checked == 1 || sd->state.itemskill_check_conditions == 0)
 	    && skill->is_item_skill(sd, skill_id, skill_lv)) {
 		return 1;
 	}
@@ -15013,7 +15013,7 @@ static int skill_check_condition_castend(struct map_session_data *sd, uint16 ski
 	if (sd->chat_id != 0)
 		return 0;
 
-	if ((sd->state.itemskill_conditions_checked == 1 || sd->state.itemskill_check_conditions == 1)
+	if ((sd->state.itemskill_conditions_checked == 1 || sd->state.itemskill_check_conditions == 0)
 	    && skill->is_item_skill(sd, skill_id, skill_lv)) {
 		return 1;
 	}
@@ -15219,7 +15219,7 @@ static int skill_consume_requirement(struct map_session_data *sd, uint16 skill_i
 
 	nullpo_ret(sd);
 
-	if (sd->state.itemskill_check_conditions == 1 && skill->is_item_skill(sd, skill_id, skill_lv))
+	if (sd->state.itemskill_check_conditions == 0 && skill->is_item_skill(sd, skill_id, skill_lv))
 		return 1;
 
 	req = skill->get_requirement(sd,skill_id,skill_lv);

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1046,7 +1046,7 @@ static int unit_skilluse_id(struct block_list *src, int target_id, uint16 skill_
 	int ret = unit->skilluse_id2(src, target_id, skill_id, skill_lv, casttime, castcancel);
 	struct map_session_data *sd = BL_CAST(BL_PC, src);
 
-	if (sd != NULL)
+	if (sd != NULL && (ret == 0 || !skill->is_item_skill(sd, skill_id, skill_lv)))
 		pc->itemskill_clear(sd);
 
 	return ret;
@@ -1683,7 +1683,7 @@ static int unit_skilluse_pos(struct block_list *src, short skill_x, short skill_
 	int ret = unit->skilluse_pos2(src, skill_x, skill_y, skill_id, skill_lv, casttime, castcancel);
 	struct map_session_data *sd = BL_CAST(BL_PC, src);
 
-	if (sd != NULL)
+	if (sd != NULL && (ret == 0 || !skill->is_item_skill(sd, skill_id, skill_lv)))
 		pc->itemskill_clear(sd);
 
 	return ret;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

 * To be able to use the `itemskill_*` flags in `skill_check_condition_castend()`, the conditions to call `pc_itemskill_clear()` in `unit_skilluse_id()` and `unit_skilluse_pos()` need to be extended. Otherwise those flags are unset prior to the execution of `skill_check_condition_castend()`, which leeds to unintended behaviour of some items.
 * Changed behaviour if `itemskill()` script command to ignore conditions by default. Now you have to explicitly set the `ISF_CHECKCONDITIONS` flag if conditions should be checked/consumed.
(Requested by @Asheraf to keep custom items unaffected.)
 * Added missing requirements to `CASH_INCAGI` (15 HPCost) and `RK_CRUSHSTRIKE` (equipped weapon) skills.

**Issues addressed:** #2646


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
