### PR TITLE
Validate duplicated item_db entries

### DIFF
--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -2033,6 +2033,10 @@ static int itemdb_readdb_libconfig_sub(struct config_setting_t *it, int n, const
 		}
 	}
 
+	if (itemdb->exists(id.nameid) && inherit == false) {
+		ShowWarning("itemdb_readdb_libconfig_sub: Duplicated item %d found in \"%s\".\n", id.nameid, source);
+	}
+
 	if( !libconfig->setting_lookup_string(it, "AegisName", &str) || !*str ) {
 		if( !inherit ) {
 			ShowWarning("itemdb_readdb_libconfig_sub: Missing AegisName in item %d of \"%s\", skipping.\n", id.nameid, source);


### PR DESCRIPTION

<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
- Enable user to detect "used" item_db (happen when server has custom item_db that clashed with latest update from Herc if any)
- able to detect duplicated items where inherit field aren't used.
- Enable user to detect "duplicated" item_db (happen when user aren't aware of multiple duplicated entries in the past, only happen if `inherit: true` aren't used.)
- Encourage user to use `inherit: true` field for their custom changes to existing item_db.

**Issues addressed:** <!-- Write here the issue number, if any. -->
Detect whichever item_db ID are currently clashed with each other (if any)
Lesser duplicated entries of item_db, especially server who has alot custom items.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
