### PR TITLE
Fix memory leak in npc_expanded_barter_fromsql() function

### DIFF
--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -1799,6 +1799,7 @@ static void npc_expanded_barter_fromsql(void)
 		) {
 		SqlStmt_ShowDebug(stmt);
 		SQL->StmtFree(stmt);
+		StrBuf->Destroy(&buf);
 		return;
 	}
 


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The `StringBuf` in `npc_expanded_barter_fromsql()` function isn't freed if the statement preparation/execution fails and thus generates a memory leak.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
