### PR TITLE
Fix overflowing pointer in getiteminfo() script command

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -14952,10 +14952,10 @@ static BUILDIN(getiteminfo)
 		script_pushint(st, it->nameid);
 		break;
 	case ITEMINFO_AEGISNAME:
-		script_pushstr(st, it->name);
+		script_pushstrcopy(st, it->name);
 		break;
 	case ITEMINFO_NAME:
-		script_pushstr(st, it->jname);
+		script_pushstrcopy(st, it->jname);
 		break;
 	default:
 		ShowError("buildin_getiteminfo: Invalid item info type %d.\n", type);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Using `ITEMINFO_NAME` or `ITEMINFO_AEGISNAME` in `getiteminfo()` script command causes an overflowing pointer error when the respective stack element gets freed.

> [Error]: Memory manager: args of aFree 0x052B7B62 is overflowed pointer ...\src\map\script.c line 3774

Therefore `script_pushstrcopy()` should be used instead of `script_pushstr()` to push the item's name to the script stack.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
