### PR TITLE
Fix wrong return-value on success by unit->walktobl

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -730,7 +730,7 @@ static int unit_walktobl(struct block_list *bl, struct block_list *tbl, int rang
 
 	if (unit->walk_toxy_sub(bl) == 0 && (flag & 2) != 0) {
 		set_mobstate(bl);
-		return 0;
+		return 1;
 	}
 	return 0;
 }


### PR DESCRIPTION
This bugged aggressive monsters for example, as they wouldn't move to
you and just do a move animation on 1 cell, stationary.

Introduced by fe378985d5267bee1f73049c826ad4f1e9c2b9c4

### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Return 1 instead of 0 on success, as unit->walktobl still uses "non-standard" error-codes.

**Issues addressed:** None?

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
