### PR TITLE
Make skills check if equipped ammunition type is appropriate for equipped weapon

### DIFF
--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -16043,6 +16043,7 @@ skill_db: (
 		}
 		AmmoTypes: {
 			A_BULLET: true
+			A_GRENADE: true
 		}
 		AmmoAmount: 5
 	}

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -15170,10 +15170,8 @@ static int skill_check_condition_castend(struct map_session_data *sd, uint16 ski
 			clif->messagecolor_self(sd->fd, COLOR_RED, e_msg);
 			return 0;
 		}
-		if (!(require.ammo&1<<sd->inventory_data[i]->subtype)) { //Ammo type check. Send the "wrong weapon type" message
-			//which is the closest we have to wrong ammo type. [Skotlex]
-			clif->arrow_fail(sd,0); //Haplo suggested we just send the equip-arrows message instead. [Skotlex]
-			//clif->skill_fail(sd, skill_id, USESKILL_FAIL_THIS_WEAPON, 0, 0);
+		if ((require.ammo & (1 << sd->inventory_data[i]->subtype)) == 0 || !battle->check_arrows(sd)) { // Ammo type check.
+			clif->arrow_fail(sd, 0); // "Please equip the proper ammunition first."
 			return 0;
 		}
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Liete mentioned that skills don't check if the equipped ammunition type is appropriate for equipped weapon and thus can be cast with wrong ammunition type equipped.

> Liete
> Hello.
> Can anyone help me out with this issue:
> I have set certain skill - Spread Shot to be working with grenade launchers, but there is a problem it uses both bullets and grenades be it shotgun or launcher equipped.

The actual problem is that you can equip bullets or grenades regardless of the equipped weapon type. This issue has already been reported: #2579
Since this needs some more information before completely get fixed this PR is a quick workaround for the time being.

**Issues addressed:** #2661, Partially #2579
Closes #2661 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
