### PR TITLE
Fix mobs get stuck when trying to loot

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -728,10 +728,13 @@ static int unit_walktobl(struct block_list *bl, struct block_list *tbl, int rang
 	if(!unit->can_move(bl))
 		return 0;
 
-	if (unit->walk_toxy_sub(bl) == 0 && (flag & 2) != 0) {
-		set_mobstate(bl);
+	if (unit->walk_toxy_sub(bl) == 0) {
+		if ((flag & 2) != 0)
+			set_mobstate(bl);
+
 		return 1;
 	}
+
 	return 0;
 }
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Monsters get stuck when trying to loot, which is caused by a misplaced condition in `unit_walktobl()`.

**Issues addressed:** https://herc.ws/board/topic/18014-bug-looter-monster


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
