### PR TITLE
Extend *pcblock script commands

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6575,16 +6575,21 @@ Examples:
 
 ---------------------------------------
 
-*setpcblock(<type>,<option>)
-*checkpcblock()
+*setpcblock(<type>, <option>{, <account id>})
+*checkpcblock({<account id>})
 
-Prevents the player from doing the following action.
+Prevents a character from doing the following action.
 
 For setpcblock, when the <option> is true(1) will block them, and false(0)
 will allow those actions again.
 
+The setpcblock command returns 1 on success or 0 if no character was attached.
+
 The checkpcblock command returned value is a bit mask of the currently
 enabled block flags (or PCBLOCK_NONE when none is set).
+
+Parameter <account id> is optional for both commands.
+If omitted, the currently attached character is used.
 
 The <type> listed are a bit mask of the following:
 	PCBLOCK_NONE (only used by checkpcblock)

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19267,7 +19267,7 @@ static BUILDIN(pcblockmove)
 
 static BUILDIN(setpcblock)
 {
-	struct map_session_data *sd = script->rid2sd(st);
+	struct map_session_data *sd = script_hasdata(st, 4) ? script->id2sd(st, script_getnum(st, 4)) : script->rid2sd(st);
 	enum pcblock_action_flag type = script_getnum(st, 2);
 	int state = (script_getnum(st, 3) > 0) ? 1 : 0;
 
@@ -27085,7 +27085,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(pcfollow,"ii"),
 		BUILDIN_DEF(pcstopfollow,"i"),
 		BUILDIN_DEF_DEPRECATED(pcblockmove,"ii"), // Deprecated 2018-05-04
-		BUILDIN_DEF(setpcblock, "ii"),
+		BUILDIN_DEF(setpcblock, "ii?"),
 		BUILDIN_DEF(checkpcblock, ""),
 		// <--- [zBuffer] List of player cont commands
 		// [zBuffer] List of mob control commands --->

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19271,8 +19271,10 @@ static BUILDIN(setpcblock)
 	enum pcblock_action_flag type = script_getnum(st, 2);
 	int state = (script_getnum(st, 3) > 0) ? 1 : 0;
 
-	if (sd == NULL)
+	if (sd == NULL) {
+		script_pushint(st, 0);
 		return true;
+	}
 
 	if ((type & PCBLOCK_MOVE) != 0)
 		sd->block_action.move = state;
@@ -19301,6 +19303,7 @@ static BUILDIN(setpcblock)
 	if ((type & PCBLOCK_NPC) != 0)
 		sd->block_action.npc = state;
 
+	script_pushint(st, 1);
 	return true;
 }
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19309,7 +19309,7 @@ static BUILDIN(setpcblock)
 
 static BUILDIN(checkpcblock)
 {
-	struct map_session_data *sd = script->rid2sd(st);
+	struct map_session_data *sd = script_hasdata(st, 2) ? script->id2sd(st, script_getnum(st, 2)) : script->rid2sd(st);
 	int retval = PCBLOCK_NONE;
 
 	if (sd == NULL) {
@@ -27089,7 +27089,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(pcstopfollow,"i"),
 		BUILDIN_DEF_DEPRECATED(pcblockmove,"ii"), // Deprecated 2018-05-04
 		BUILDIN_DEF(setpcblock, "ii?"),
-		BUILDIN_DEF(checkpcblock, ""),
+		BUILDIN_DEF(checkpcblock, "?"),
 		// <--- [zBuffer] List of player cont commands
 		// [zBuffer] List of mob control commands --->
 		BUILDIN_DEF(getunittype,"i"),


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Someone asked me to add a parameter for the account ID to `setpcblock()` to restore the usability of `pcblockmove()`. In my opinion this is a reasonable enhancement and should be added to Hercules.
Additionally I added that parameter to `checkpcblock()`, too.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
