### PR TITLE
Fix misplaced return condition in unit_walk_toxy_timer()

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -326,7 +326,7 @@ static int unit_warpto_master(struct block_list *master_bl, struct block_list *s
 static int unit_walk_toxy_timer(int tid, int64 tick, int id, intptr_t data)
 {
 	struct block_list *bl = map->id2bl(id);
-	if (bl == NULL || bl->prev == NULL) // Stop moved because it is missing from the block_list
+	if (bl == NULL)
 		return 1;
 	struct unit_data *ud = unit->bl2ud(bl);
 	if (ud == NULL)
@@ -336,7 +336,11 @@ static int unit_walk_toxy_timer(int tid, int64 tick, int id, intptr_t data)
 		ShowError("unit_walk_timer mismatch %d != %d\n",ud->walktimer,tid);
 		return 1;
 	}
+
 	ud->walktimer = INVALID_TIMER;
+
+	if (bl->prev == NULL) // Stop moved because it is missing from the block_list.
+		return 1;
 
 	if (ud->walkpath.path_pos >= ud->walkpath.path_len)
 		return 1;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

A misplaced return condition in `unit_walk_toxy_timer()` (introduced in https://github.com/HerculesWS/Hercules/pull/2546/commits/fe378985d5267bee1f73049c826ad4f1e9c2b9c4) caused assertion errors in `timer_do_delete()` because `ud->walktimer` could not be unset.

**Issues addressed:** https://herc.ws/board/topic/18073-error-timer_do_delete-error


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
