### PR TITLE
Add case for BL_SKILL to unit_bl2ud() to not trigger assert-returning

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -130,6 +130,8 @@ static const struct unit_data *unit_cbl2ud(const struct block_list *bl)
 		return &BL_UCCAST(BL_MER, bl)->ud;
 	case BL_ELEM:
 		return &BL_UCCAST(BL_ELEM, bl)->ud;
+	case BL_SKILL: // No assertion to not spam the server console when attacking a skill type unit such as Ice Wall.
+		return NULL;
 	default:
 		Assert_retr(NULL, false);
 	}

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -96,6 +96,8 @@ static struct unit_data *unit_bl2ud(struct block_list *bl)
 		return &BL_UCAST(BL_MER, bl)->ud;
 	case BL_ELEM:
 		return &BL_UCAST(BL_ELEM, bl)->ud;
+	case BL_SKILL: // No assertion to not spam the server console when attacking a skill type unit such as Ice Wall.
+		return NULL;
 	default:
 		Assert_retr(NULL, false);
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The assert-returning for unknown bl-types in `unit_bl2ud()` (introduced in https://github.com/HerculesWS/Hercules/pull/2546/commits/88cca0d976bdd6fbe07c8646939fc1512e97cf72) caused "failed assertion" message spamming in the map-server console when a `BL_SKILL` unit was attacked. (For example Ice Wall.)

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
