### PR TITLE
Add missing pet ID assignment to inter_pet_fromsql()

### DIFF
--- a/src/char/int_pet.c
+++ b/src/char/int_pet.c
@@ -194,6 +194,7 @@ static int inter_pet_fromsql(int pet_id, struct s_pet *p)
 	}
 
 	SQL->StmtFree(stmt);
+	p->pet_id = pet_id;
 
 	if (chr->show_save_log)
 		ShowInfo("Pet loaded %d - %s.\n", pet_id, p->name);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

A missing pet ID assignment in `inter_pet_fromsql()` (introduced in https://github.com/HerculesWS/Hercules/pull/2600/commits/70edf6f2d4f042b470cb1f62e408c076f5c8d76b) caused a bug where pets could no be hatched correctly.

**Issues addressed:** #2683 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
