### PR TITLE
Fix status changes falsely being recognized as unknown

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -446,6 +446,9 @@ static bool mob_ksprotected(struct block_list *src, struct block_list *target)
 	if( !battle_config.ksprotection )
 		return false; // KS Protection Disabled
 
+	if (status->isdead(target) != 0)
+		return false; // Target is dead.
+
 	if( !(md = BL_CAST(BL_MOB,target)) )
 		return false; // Target is not MOB
 

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -11296,7 +11296,7 @@ static int skill_castend_pos2(struct block_list *src, int x, int y, uint16 skill
 			FALLTHROUGH
 		case GS_GROUNDDRIFT: //Ammo should be deleted right away.
 			if ( skill_id == WM_SEVERE_RAINSTORM )
-				sc_start(src,src,SC_NO_SWITCH_EQUIP,100,0,skill->get_time(skill_id,skill_lv));
+				sc_start(src, src, type, 100, 0, skill->get_time(skill_id, skill_lv));
 			skill->unitsetting(src,skill_id,skill_lv,x,y,0);
 			break;
 		case WZ_ICEWALL:

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -696,6 +696,7 @@ static void initChangeTables(void)
 	status->set_sc( WM_BEYOND_OF_WARCRY       , SC_BEYOND_OF_WARCRY       , SCB_STR|SCB_CRI|SCB_MAXHP );
 	status->set_sc( WM_UNLIMITED_HUMMING_VOICE, SC_UNLIMITED_HUMMING_VOICE, SCB_NONE );
 	status->set_sc( WM_FRIGG_SONG             , SC_FRIGG_SONG             , SCB_MAXHP );
+	status->set_sc( WM_SEVERE_RAINSTORM       , SC_NO_SWITCH_EQUIP        , SCB_NONE );
 
 	/**
 	* Sorcerer

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7809,6 +7809,8 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 	calc_flag = status->dbs->ChangeFlagTable[type];
 	if(!(flag&SCFLAG_LOADED)) { // Do not parse val settings when loading SCs
 		switch(type) {
+			case SC_KSPROTECTED:
+				break; // Prevent calling status_change_start_unknown_sc().
 			case SC_ADORAMUS:
 				sc_start(src,bl,SC_BLIND,100,val1,skill->get_time(status->sc2skill(type),val1));
 				// Fall through to SC_INC_AGI

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7809,6 +7809,7 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 	calc_flag = status->dbs->ChangeFlagTable[type];
 	if(!(flag&SCFLAG_LOADED)) { // Do not parse val settings when loading SCs
 		switch(type) {
+			case SC_AUTOTRADE:
 			case SC_KSPROTECTED:
 				break; // Prevent calling status_change_start_unknown_sc().
 			case SC_ADORAMUS:


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Prevent `SC_AUTOTRADE`, `SC_KSPROTECTED` and `SC_NO_SWITCH_EQUIP` from falsely being recognized as unknown status changes.

**Issues addressed:** #2684 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
