### PR TITLE
Fix conditions for calling pet_ai_sub_hard()

### DIFF
--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -1128,12 +1128,22 @@ static int pet_ai_sub_hard(struct pet_data *pd, struct map_session_data *sd, int
 	return 0;
 }
 
+/**
+ * Calls pet_ai_sub_hard() for a character's pet if conditions are fulfilled.
+ *
+ * @param sd The character.
+ * @param ap Additional arguments. In this case only the time stamp of pet AI timer execution.
+ * @return Always 0.
+ *
+ **/
 static int pet_ai_sub_foreachclient(struct map_session_data *sd, va_list ap)
 {
-	int64 tick = va_arg(ap,int64);
 	nullpo_ret(sd);
+
+	int64 tick = va_arg(ap, int64);
+
 	if (sd->bl.prev != NULL && sd->status.pet_id != 0 && sd->pd != NULL && sd->pd->bl.prev != NULL)
-		pet->ai_sub_hard(sd->pd,sd,tick);
+		pet->ai_sub_hard(sd->pd, sd, tick);
 
 	return 0;
 }

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -1132,7 +1132,7 @@ static int pet_ai_sub_foreachclient(struct map_session_data *sd, va_list ap)
 {
 	int64 tick = va_arg(ap,int64);
 	nullpo_ret(sd);
-	if(sd->status.pet_id && sd->pd)
+	if (sd->bl.prev != NULL && sd->status.pet_id != 0 && sd->pd != NULL && sd->pd->bl.prev != NULL)
 		pet->ai_sub_hard(sd->pd,sd,tick);
 
 	return 0;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The `pet_ai_hard` timer is executed before the pet's block and the pet master's block are added to the map, which causes nullpo errors in `pet_ai_sub_hard()`.
This wasn't noticed before #2600 was merged, because 0 was returned silently instead of using `nullpo_ret()`.
To fix this, the conditions for calling `pet_ai_sub_hard()` in `pet_ai_sub_foreachclient()` should be adjusted to check `sd->bl.prev` and `sd->pd->bl.prev` for `NULL`.

**Issues addressed:** https://herc.ws/board/topic/18186-error-petc-1018/


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
