### PR TITLE
Make SC_NOCHAT gets affected by battle config changes

### DIFF
--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -687,7 +687,7 @@ END_ZEROED_BLOCK;
 #define pc_ishiding(sd)       ( (sd)->sc.option&(OPTION_HIDE|OPTION_CLOAK|OPTION_CHASEWALK) )
 #define pc_iscloaking(sd)     ( !((sd)->sc.option&OPTION_CHASEWALK) && ((sd)->sc.option&OPTION_CLOAK) )
 #define pc_ischasewalk(sd)    ( (sd)->sc.option&OPTION_CHASEWALK )
-#define pc_ismuted(sc,type)   ( (sc)->data[SC_NOCHAT] && (sc)->data[SC_NOCHAT]->val1&(type) )
+#define pc_ismuted(sc, type)  ( (sc)->data[SC_NOCHAT] != NULL && (battle_config.manner_system & (type)) != 0 )
 #define pc_isvending(sd)      ((sd)->state.vending || (sd)->state.prevend || (sd)->state.buyingstore)
 
 #ifdef NEW_CARTS

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -8052,7 +8052,6 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 				// This is done this way because the message that the client displays is hardcoded, and only
 				// shows how many minutes are remaining. [Panikon]
 				total_tick = 60000;
-				val1 = battle_config.manner_system; //Mute filters.
 				if (sd)
 				{
 					clif->changestatus(sd,SP_MANNER,sd->status.manner);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Change `SC_NOCHAT` validation to compare against `battle_config.manner_system` instead of `val1` to get affected by battle config changes.

**Issues addressed:** #227


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
