### PR TITLE
Fix condition for deleting skill units when unloading NPC

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -17766,13 +17766,20 @@ static int skill_get_new_group_id(void)
 
 static struct skill_unit_group *skill_initunitgroup(struct block_list *src, int count, uint16 skill_id, uint16 skill_lv, int unit_id, int limit, int interval)
 {
-	struct unit_data* ud = unit->bl2ud( src );
 	struct skill_unit_group* group;
 	int i;
 
 	if(!(skill_id && skill_lv)) return 0;
 
 	nullpo_retr(NULL, src);
+
+	struct unit_data *ud;
+
+	if (src->type == BL_NPC)
+		ud = unit->bl2ud2(src);
+	else
+		ud = unit->bl2ud(src);
+
 	nullpo_retr(NULL, ud);
 
 	// find a free spot to store the new unit group


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Currently it's almost impossible to fulfil the condition for calling `skill_clear_unitgroup()` in `npc_unload()` since `nd->ud` always is `NULL` or `&npc->base_ud` if `unit_bl2ud2()` was never called for the NPC's block_list (for example by `npcspeed()`).
I changed `skill_initunitgroup()` to call `unit_bl2ud2()` instead of `unit_bl2ud()` if `src` is of type `BL_NPC`.

**Issues addressed:** #768 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
