### PR TITLE
Replace NULL pointer report with returning error code in unit_steptimer()

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -270,9 +270,8 @@ static int unit_steptimer(int tid, int64 tick, int id, intptr_t data)
 	} else {
 		// If a player has target_id set and target is in range, attempt attack
 		struct block_list *tbl = map->id2bl(target_id);
-		nullpo_retr(2, tbl);
-		if (status->check_visibility(bl, tbl) == 0) // Target not visible
-			return 1;
+		if (tbl == NULL || status->check_visibility(bl, tbl) == 0)
+			return 1; // Target does not exist (player offline, monster died, etc.) or target is not visible to source.
 		if (ud->stepskill_id == 0)
 			unit->attack(bl, tbl->id, ud->state.attack_continue + 2); // Execute normal attack
 		else


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Since it's kind of expectable to occasionally be unable to retrieve the target's `block_list` by its ID in `unit_steptimer()`, the `NULL` pointer report should be replaced with returning an error code.

**Issues addressed:** #2707


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
