### PR TITLE
Update instancing window display and documentation of instance_create() script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9664,12 +9664,18 @@ For examples of usage, see /doc/sample/npc_rodex.txt
 //=====================================
 ---------------------------------------
 
-*instance_create("<instance name>", <owner id>{, <optional owner_type>})
+*instance_create("<instance_name>", <owner_id>{, <owner_type>})
 
-Create an instance using the name "<instance name>" for the <owner_id> of
-owner_type (when not provided, defaults to IOT_PARTY). Most instance_*
+Creates an instance using the name "<instance_name>" for the <owner_id> of
+<owner_type> (when not provided, defaults to IOT_PARTY). Most instance_*
 commands are used in conjunction with this command and depend on the
 ID this command returns.
+
+Valid <owner_type> values:
+- IOT_NONE  (0) - <owner_id> can be any arbitrary number.
+- IOT_CHAR  (1) - <owner_id> is account ID.
+- IOT_PARTY (2) - <owner_id> is party ID.
+- IOT_GUILD (3) - <owner_id> is guild ID.
 
 Example:
 	// Store the Party ID of the invoking character.
@@ -9681,11 +9687,9 @@ Example:
 		// ...
 	} else if (.@id == -2) { // Invalid Party ID
 		// ...
-	} else if (.@id == -3) { // No free instances (MAX_INSTANCE exceeded)
-		// ...
 	} else if (.@id == -4) { // Already exists
 		// ...
-	} else (.@id < 0) { // Unspecified error while queuing instance.
+	} else if (.@id < 0) { // Unspecified error while queuing instance.
 		// ...
 	}
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11067,6 +11067,19 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 #if PACKETVER >= 20090218
 	quest->questinfo_refresh(sd); // NPC quest/event icon check. [Kisuka]
 #endif
+
+	if (first_time) {
+		int i;
+
+		ARR_FIND(0, instance->instances, i, instance->list[i].owner_type == IOT_CHAR && instance->list[i].owner_id == sd->status.account_id);
+
+		if (i < instance->instances) {
+			sd->instances = 1;
+			CREATE(sd->instance, short, 1);
+			sd->instance[0] = instance->list[i].id;
+			clif->instance_join(sd->fd, instance->list[i].id);
+		}
+	}
 }
 
 /// Server's tick (ZC_NOTIFY_TIME).

--- a/src/map/guild.c
+++ b/src/map/guild.c
@@ -887,6 +887,12 @@ static void guild_member_joined(struct map_session_data *sd)
 			channel->join(g->channel, sd, "", true);
 		}
 
+		for (int j = 0; j < g->instances; j++) {
+			if (g->instance[j] >= 0) {
+				clif->instance_join(sd->fd, g->instance[j]);
+				break;
+			}
+		}
 	}
 }
 
@@ -938,6 +944,13 @@ static int guild_member_added(int guild_id, int account_id, int char_id, int fla
 	// Makes the character join their respective guild's channel for #ally chat
 	if (channel->config->ally && channel->config->ally_autojoin) {
 		channel->join(g->channel, sd, "", true);
+	}
+
+	for (int i = 0; i < g->instances; i++) {
+		if (g->instance[i] >= 0) {
+			clif->instance_join(sd->fd, g->instance[i]);
+			break;
+		}
 	}
 
 	return 0;

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -68,7 +68,7 @@ static bool instance_is_valid(int instance_id)
 /*--------------------------------------
  * name : instance name
  * Return value could be
- * -4 = already exists | -3 = no free instances | -2 = owner not found | -1 = invalid type
+ * -4 = already exists | -2 = owner not found | -1 = invalid type
  * On success return instance_id
  *--------------------------------------*/
 static int instance_create(int owner_id, const char *name, enum instance_owner_type type)

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -734,7 +734,7 @@ static void instance_force_destroy(struct map_session_data *sd)
 		switch (instance->list[i].owner_type) {
 		case IOT_CHAR:
 		{
-			if (instance->list[i].owner_id != sd->status.char_id)
+			if (instance->list[i].owner_id != sd->status.account_id)
 				continue;
 			break;
 		}

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -353,8 +353,6 @@ static int party_recv_info(const struct party *sp, int char_id)
 		clif->party_info(p,NULL);
 		for( j = 0; j < p->instances; j++ ) {
 			if( p->instance[j] >= 0 ) {
-				if( instance->list[p->instance[j]].idle_timer == INVALID_TIMER && instance->list[p->instance[j]].progress_timer == INVALID_TIMER )
-					continue;
 				clif->instance_join(sd->fd, p->instance[j]);
 				break;
 			}
@@ -488,8 +486,6 @@ static void party_member_joined(struct map_session_data *sd)
 		p->data[i].sd = sd;
 		for( j = 0; j < p->instances; j++ ) {
 			if( p->instance[j] >= 0 ) {
-				if( instance->list[p->instance[j]].idle_timer == INVALID_TIMER && instance->list[p->instance[j]].progress_timer == INVALID_TIMER )
-					continue;
 				clif->instance_join(sd->fd, p->instance[j]);
 				break;
 			}
@@ -551,8 +547,6 @@ static int party_member_added(int party_id, int account_id, int char_id, int fla
 
 	for( j = 0; j < p->instances; j++ ) {
 		if( p->instance[j] >= 0 ) {
-			if( instance->list[p->instance[j]].idle_timer == INVALID_TIMER && instance->list[p->instance[j]].progress_timer == INVALID_TIMER )
-				continue;
 			clif->instance_join(sd->fd, p->instance[j]);
 			break;
 		}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Use account ID instead of character ID for `IOT_CHAR` in `instance_force_destroy()`.
- Remove nonexistent return value `-3` from documentation of `instance_create()`.
- Show instancing window on login for party instances if instance state is `INSTANCE_IDLE`, too.
- Show instancing window on login for guild instances, too.
- Show instancing window on login for character instances, too. (This also fixes an issue where a player could create unlimited instances of owner type  `IOT_CHAR` with identical names because `sd->instances` and `sd->instance` are reset on logout.)
- Update documentation of `instance_create()` script command.
  - Fix some typos.
  - Add a paragraph about owner types and the corresponding owner ID to use.
  - Remove nonexistent return value `-3` from example.

**Issues addressed:** #2326


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
