### PR TITLE
Add MSC_MAGICATTACKED cast condition for monster skills

### DIFF
--- a/doc/mob_skill_db.md
+++ b/doc/mob_skill_db.md
@@ -175,6 +175,7 @@ MSC_MASTERHPLTMAXRATE | The monster master's HP in percent is less than `Conditi
 MSC_MASTERATTACKED    | The monster's master is attacked.
 MSC_ALCHEMIST         | The monster was summoned by an Alchemist class character.
 MSC_SPAWN             | The monster spawns.
+MSC_MAGICATTACKED     | The monster has received magic damage.
 
 ### ConditionData
 Additional cast condition data. Meaning depends on the situation. See `CastCondition` table.

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -3758,6 +3758,8 @@ static int mobskill_event(struct mob_data *md, struct block_list *src, int64 tic
 		res = mob->skill_use(md, tick, MSC_CLOSEDATTACKED);
 	else if (flag&BF_LONG && !(flag&BF_MAGIC)) //Long-attacked should not include magic.
 		res = mob->skill_use(md, tick, MSC_LONGRANGEATTACKED);
+	else if ((flag & BF_MAGIC) != 0)
+		res = mob->skill_use(md, tick, MSC_MAGICATTACKED);
 
 	if (res != 0)
 	//Restore previous target only if skill condition failed to trigger. [Skotlex]
@@ -5679,7 +5681,7 @@ static bool mob_skill_db_libconfig_sub_skill(struct config_setting_t *it, int n,
 	}
 
 	i32 = MSC_ALWAYS;
-	if (mob->lookup_const(it, "CastCondition", &i32) && (i32 < MSC_ALWAYS || i32 > MSC_SPAWN)) {
+	if (mob->lookup_const(it, "CastCondition", &i32) && (i32 < MSC_ALWAYS || i32 > MSC_MAGICATTACKED)) {
 		ShowWarning("%s: Invalid skill condition %d for skill id %d (%s) in %s %d, defaulting to MSC_ALWAYS.\n",
 			    __func__, i32, skill_id, skill_name, mob_str, mob_id);
 		i32 = MSC_ALWAYS;

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -321,6 +321,7 @@ enum {
 	MSC_MASTERATTACKED,
 	MSC_ALCHEMIST,
 	MSC_SPAWN,
+	MSC_MAGICATTACKED,
 };
 
 /** Special monster(-name) constants used to assign skills to a group of monsters. **/

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -27868,6 +27868,7 @@ static void script_hardcoded_constants(void)
 	script->set_constant("MSC_MASTERATTACKED", MSC_MASTERATTACKED, false, false);
 	script->set_constant("MSC_ALCHEMIST", MSC_ALCHEMIST, false, false);
 	script->set_constant("MSC_SPAWN", MSC_SPAWN, false, false);
+	script->set_constant("MSC_MAGICATTACKED", MSC_MAGICATTACKED, false, false);
 
 	script->constdb_comment("monster skill targets");
 	script->set_constant("MST_TARGET", MST_TARGET, false, false);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add MSC_MAGICATTACKED cast condition for monster skills to trigger when a monster has received magic damage.

**Issues addressed:** #2578


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
