### PR TITLE
Fix left shift of negative value for GN_CRAZYWEED_ATK

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -11811,7 +11811,7 @@ static int skill_castend_pos2(struct block_list *src, int x, int y, uint16 skill
 					int tmpx = x - area + rnd()%(area * 2 + 1);
 					int tmpy = y - area + rnd()%(area * 2 + 1);
 
-					skill->addtimerskill(src,tick+r*250,0,tmpx,tmpy,GN_CRAZYWEED_ATK,skill_lv,-1,0);
+					skill->addtimerskill(src, tick + (int64)r * 250, 0, tmpx, tmpy, GN_CRAZYWEED_ATK, skill_lv, 0, 0);
 				}
 			}
 			break;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Pass `0` for `type` instead of `-1` when calling `skill_addtimerskill()` for `GN_CRAZYWEED`.
This value is later used to retrieve the skill's unit ID at the given index so `0` is the correct value for `GN_CRAZYWEED` since it has only one unit ID.

**Issues addressed:** #1151


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
