### PR TITLE
Save a pet's rename flag when returning it to its egg

### DIFF
--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -404,6 +404,7 @@ static int pet_return_egg(struct map_session_data *sd, struct pet_data *pd)
 	if (i != sd->status.inventorySize) {
 		sd->status.inventory[i].attribute &= ~ATTR_BROKEN;
 		sd->status.inventory[i].bound = IBT_NONE;
+		sd->status.inventory[i].card[3] = pd->pet.rename_flag;
 	} else {
 		// The pet egg wasn't found: it was probably hatched with the old system that deleted the egg.
 		struct item tmp_item = {0};


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

A pet's rename flag isn't applied to its egg item's `card[3]` field and thus not being saved to the database.
This leads to a missing "Beloved" prefix for eggs of renamed pets.

**Issues addressed:** #2743


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
