### PR TITLE
Prevent unequipping items on login before calculating the character's status data

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10850,6 +10850,12 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 		clif->updatestatus(sd, SP_SKILLPOINT);
 		clif->initialstatus(sd);
 
+		// Unequip items which can't be equipped by the character.
+		for (int i = 0; i < EQI_MAX; i++) {
+			if (sd->equip_index[i] >= 0 && pc->isequip(sd , sd->equip_index[i]) == 0)
+				pc->unequipitem(sd, sd->equip_index[i], PCUNEQUIPITEM_FORCE);
+		}
+
 		if (pc_isfalcon(sd)) {
 			int sc_icn = status->get_sc_icon(SC_FALCON);
 			int sc_typ = status->get_sc_relevant_bl_types(SC_FALCON);

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -5858,11 +5858,6 @@ static int pc_setpos(struct map_session_data *sd, unsigned short map_index, int 
 			status_change_end(&sd->bl, SC_CLOAKINGEXCEED, INVALID_TIMER);
 		}
 
-		for (int i = 0; i < EQI_MAX; i++) {
-			if (sd->equip_index[i] >= 0 && pc->isequip(sd , sd->equip_index[i]) == 0)
-				pc->unequipitem(sd, sd->equip_index[i], PCUNEQUIPITEM_FORCE);
-		}
-
 		if ((battle_config.clear_unit_onwarp & BL_PC) != 0)
 			skill->clear_unitgroup(&sd->bl);
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`pc_setpos()` checks for invalid equipment and unequips it if required. On login, the character's status data was not yet calculated at this point and thus the server could crash due to missing memory allocation.
To fix this, the equipment check should be moved to `clif_parse_LoadEndAck()` because it's called after the character's status data was initially calculated in `pc_reg_received()`.

**Issues addressed:** None. Private report via Discord.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
