### PR TITLE
Adjust server messages on login and map change

### DIFF
--- a/conf/map/battle/client.conf
+++ b/conf/map/battle/client.conf
@@ -235,3 +235,6 @@ display_config_messages: 0x1F1
 // 0x2 - Display overweight messages upon map change. (Default.)
 // Default: 0x3 (Official behavior.)
 display_overweight_messages: 0x3
+
+// Show tip of the day window upon login?
+show_tip_window: true

--- a/conf/map/battle/client.conf
+++ b/conf/map/battle/client.conf
@@ -228,3 +228,10 @@ display_rate_messages: 0x1
 //
 // Default: 0x1F1 (Official behavior.)
 display_config_messages: 0x1F1
+
+// When to display the overweight messages?
+// 0x0 - Never display overweight messages.
+// 0x1 - Display overweight messages upon login. (Default.)
+// 0x2 - Display overweight messages upon map change. (Default.)
+// Default: 0x3 (Official behavior.)
+display_overweight_messages: 0x3

--- a/conf/map/battle/client.conf
+++ b/conf/map/battle/client.conf
@@ -202,3 +202,11 @@ ping_time: 20
 // Drop or not connection after client send disconnect request packet
 // Official is false
 drop_connection_on_quit: false
+
+// When to display the rate modifier messages?
+// 0x0 - Never display rate modifier messages.
+// 0x1 - Display rate modifier messages upon login.
+// 0x2 - Display rate modifier messages upon map change.
+// 0x4 - Display rate modifier messages upon teleporting (regardless of changing maps).
+// Default: 0x1 (Official behavior.)
+display_rate_messages: 0x1

--- a/conf/map/battle/client.conf
+++ b/conf/map/battle/client.conf
@@ -210,3 +210,21 @@ drop_connection_on_quit: false
 // 0x4 - Display rate modifier messages upon teleporting (regardless of changing maps).
 // Default: 0x1 (Official behavior.)
 display_rate_messages: 0x1
+
+// When to display the configuration messages and which? (Note 3)
+//
+// Flags for when to display the configuration messages:
+// 0x000 - Never display configuration messages.
+// 0x001 - Display configuration messages upon login. (Default. Should always be set.)
+// 0x002 - Display configuration messages upon map change.
+// 0x004 - Display configuration messages upon teleporting (regardless of changing maps).
+//
+// Flags for which configuration messages are displayed:
+// 0x010 - Character's party invitation state. (Default.)
+// 0x020 - Character's view equipment state. (Default.)
+// 0x040 - Character's Urgent Call state. (Default.)
+// 0x080 - Character's pet auto-feed state. (Default.)
+// 0x100 - Character's homunculus auto-feed state. (Default.)
+//
+// Default: 0x1F1 (Official behavior.)
+display_config_messages: 0x1F1

--- a/conf/map/battle/guild.conf
+++ b/conf/map/battle/guild.conf
@@ -59,11 +59,13 @@ require_glory_guild: false
 // Default is 3
 max_guild_alliance: 3
 
-// When to re-display the guild notice
-// Upon teleporting (regardless of changing maps): 2 (official)
-// Upon changing maps: 1
-// Do not re-display: 0 (disabled)
-guild_notice_changemap: 2
+// When to display the guild notice?
+// 0x0 - Never display guild notice.
+// 0x1 - Display guild notice upon login.
+// 0x2 - Display guild notice upon map change.
+// 0x4 - Display guild notice upon teleporting (regardless of changing maps).
+// Default: 0x7 (Official behavior.)
+guild_notice_changemap: 0x7
 
 // Can guild members invite/expel members inside guild castles in WoE/GvG? (Note 1)
 // default: false

--- a/conf/map/battle/party.conf
+++ b/conf/map/battle/party.conf
@@ -80,3 +80,30 @@ party_even_share_bonus: 0
 // Display party name regardless if player is in a guild.
 // Official servers do not display party name unless the user is in a guild. (Note 1)
 display_party_name: false
+
+// When and how to send the party options? (Note 3)
+//
+// Flags for when to display the party options:
+// 0x00000 - Never send party options.
+// 0x00001 - Send party options upon login. (Default. Should always be set.)
+// 0x00002 - Send party options upon map change.
+// 0x00004 - Send party options upon teleporting (regardless of changing maps).
+// 0x00008 - Send party options upon successfully changing options manually. (Default. Should always be set.)
+// 0x00010 - Send party options upon unsuccessfully changing options manually. (Tried to enable EXP sharing if not allowed.) (Default.)
+// 0x00020 - Send party options upon changing options automatically. (Default. Should always be set.)
+// 0x00040 - Send party options upon joining party. (Default. Should always be set.)
+// 0x00080 - Send party options upon leaving party. (Default.)
+//
+// Flags for how to send the party options:
+// 0x00100 - Send party options to all party members upon unsuccessfully changing options manually. (Tried to enable EXP sharing if not allowed.) (Default.)
+// 0x00200 - Send all party options upon login.
+// 0x00400 - Send all party options upon map change.
+// 0x00800 - Send all party options upon teleporting (regardless of changing maps).
+// 0x01000 - Send all party options upon successfully changing options manually. (Default.)
+// 0x02000 - Send all party options upon unsuccessfully changing options manually. (Tried to enable EXP sharing if not allowed.) (Default.)
+// 0x04000 - Send all party options upon changing options automatically.
+// 0x08000 - Send all party options upon joining party.
+// 0x10000 - Send all party options upon leaving party.
+//
+// Default: 0x31F9 (Official behavior.)
+send_party_options: 0x31F9

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7432,6 +7432,7 @@ static const struct battle_data {
 	{ "option_drop_max_loop",               &battle_config.option_drop_max_loop,            10,     1,      100000,         },
 	{ "drop_connection_on_quit",            &battle_config.drop_connection_on_quit,         0,      0,      1,              },
 	{ "display_rate_messages",              &battle_config.display_rate_messages,           1,      0,      7,              },
+	{ "display_config_messages",            &battle_config.display_config_messages,         0x1F1,  0,      0x1F7,          },
 	{ "features/enable_refinery_ui",        &battle_config.enable_refinery_ui,              1,      0,      1,              },
 	{ "features/replace_refine_npcs",       &battle_config.replace_refine_npcs,             1,      0,      1,              },
 	{ "batk_min_limit",                     &battle_config.batk_min,                        0,      0,      INT_MAX,        },

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7345,6 +7345,7 @@ static const struct battle_data {
 	{ "searchstore_querydelay",             &battle_config.searchstore_querydelay,         10,      0,      INT_MAX,        },
 	{ "searchstore_maxresults",             &battle_config.searchstore_maxresults,         30,      1,      INT_MAX,        },
 	{ "display_party_name",                 &battle_config.display_party_name,              0,      0,      1,              },
+	{ "send_party_options",                 &battle_config.send_party_options,              0x31F9, 0,      0x1FFFF,        },
 	{ "cashshop_show_points",               &battle_config.cashshop_show_points,            0,      0,      1,              },
 	{ "mail_show_status",                   &battle_config.mail_show_status,                0,      0,      2,              },
 	{ "client_limit_unit_lv",               &battle_config.client_limit_unit_lv,            0,      0,      BL_ALL,         },

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7383,7 +7383,7 @@ static const struct battle_data {
 	{ "packet_obfuscation",                 &battle_config.packet_obfuscation,              1,      0,      3,              },
 	{ "client_accept_chatdori",             &battle_config.client_accept_chatdori,          0,      0,      INT_MAX,        },
 	{ "snovice_call_type",                  &battle_config.snovice_call_type,               0,      0,      1,              },
-	{ "guild_notice_changemap",             &battle_config.guild_notice_changemap,          2,      0,      2,              },
+	{ "guild_notice_changemap",             &battle_config.guild_notice_changemap,          7,      0,      7,              },
 	{ "features/banking",                   &battle_config.feature_banking,                 1,      0,      1,              },
 	{ "features/auction",                   &battle_config.feature_auction,                 0,      0,      2,              },
 	{ "idletime_criteria",                  &battle_config.idletime_criteria,            0x25,      1,      INT_MAX,        },

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7431,6 +7431,7 @@ static const struct battle_data {
 	{ "ping_time",                          &battle_config.ping_time,                       20,     0,      99999999,       },
 	{ "option_drop_max_loop",               &battle_config.option_drop_max_loop,            10,     1,      100000,         },
 	{ "drop_connection_on_quit",            &battle_config.drop_connection_on_quit,         0,      0,      1,              },
+	{ "display_rate_messages",              &battle_config.display_rate_messages,           1,      0,      7,              },
 	{ "features/enable_refinery_ui",        &battle_config.enable_refinery_ui,              1,      0,      1,              },
 	{ "features/replace_refine_npcs",       &battle_config.replace_refine_npcs,             1,      0,      1,              },
 	{ "batk_min_limit",                     &battle_config.batk_min,                        0,      0,      INT_MAX,        },

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7435,6 +7435,7 @@ static const struct battle_data {
 	{ "display_rate_messages",              &battle_config.display_rate_messages,           1,      0,      7,              },
 	{ "display_config_messages",            &battle_config.display_config_messages,         0x1F1,  0,      0x1F7,          },
 	{ "display_overweight_messages",        &battle_config.display_overweight_messages,     3,      0,      3,              },
+	{ "show_tip_window",                    &battle_config.show_tip_window,                 1,      0,      1,              },
 	{ "features/enable_refinery_ui",        &battle_config.enable_refinery_ui,              1,      0,      1,              },
 	{ "features/replace_refine_npcs",       &battle_config.replace_refine_npcs,             1,      0,      1,              },
 	{ "batk_min_limit",                     &battle_config.batk_min,                        0,      0,      INT_MAX,        },

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7434,6 +7434,7 @@ static const struct battle_data {
 	{ "drop_connection_on_quit",            &battle_config.drop_connection_on_quit,         0,      0,      1,              },
 	{ "display_rate_messages",              &battle_config.display_rate_messages,           1,      0,      7,              },
 	{ "display_config_messages",            &battle_config.display_config_messages,         0x1F1,  0,      0x1F7,          },
+	{ "display_overweight_messages",        &battle_config.display_overweight_messages,     3,      0,      3,              },
 	{ "features/enable_refinery_ui",        &battle_config.enable_refinery_ui,              1,      0,      1,              },
 	{ "features/replace_refine_npcs",       &battle_config.replace_refine_npcs,             1,      0,      1,              },
 	{ "batk_min_limit",                     &battle_config.batk_min,                        0,      0,      INT_MAX,        },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -594,6 +594,7 @@ struct Battle_Config {
 	int display_rate_messages;
 	int display_config_messages;
 	int display_overweight_messages;
+	int show_tip_window;
 	int enable_refinery_ui;
 	int replace_refine_npcs;
 

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -590,6 +590,7 @@ struct Battle_Config {
 	int option_drop_max_loop;
 
 	int drop_connection_on_quit;
+	int display_rate_messages;
 	int enable_refinery_ui;
 	int replace_refine_npcs;
 

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -593,6 +593,7 @@ struct Battle_Config {
 	int drop_connection_on_quit;
 	int display_rate_messages;
 	int display_config_messages;
+	int display_overweight_messages;
 	int enable_refinery_ui;
 	int replace_refine_npcs;
 

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -591,6 +591,7 @@ struct Battle_Config {
 
 	int drop_connection_on_quit;
 	int display_rate_messages;
+	int display_config_messages;
 	int enable_refinery_ui;
 	int replace_refine_npcs;
 

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -471,6 +471,7 @@ struct Battle_Config {
 	int searchstore_querydelay;
 	int searchstore_maxresults;
 	int display_party_name;
+	int send_party_options;
 	int cashshop_show_points;
 	int mail_show_status;
 	int client_limit_unit_lv;

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10938,11 +10938,6 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 		} else {
 			sd->state.warp_clean = 1;
 		}
-
-		if (sd->guild != NULL && ((battle_config.guild_notice_changemap == 1 && sd->state.changemap != 0)
-					  || battle_config.guild_notice_changemap == 2)) {
-			clif->guild_notice(sd, sd->guild);
-		}
 	}
 
 	bool change_map = (sd->state.changemap != 0);
@@ -11033,12 +11028,21 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 		clif->show_modifiers(sd);
 	}
 
-	// Init guild aura.
-	if (sd->state.gmaster_flag != 0) {
-		guild->aura_refresh(sd, GD_LEADERSHIP, guild->checkskill(sd->guild, GD_LEADERSHIP));
-		guild->aura_refresh(sd, GD_GLORYWOUNDS, guild->checkskill(sd->guild, GD_GLORYWOUNDS));
-		guild->aura_refresh(sd, GD_SOULCOLD, guild->checkskill(sd->guild, GD_SOULCOLD));
-		guild->aura_refresh(sd, GD_HAWKEYES, guild->checkskill(sd->guild, GD_HAWKEYES));
+	if (sd->guild != NULL) {
+		// Show guild notice.
+		if ((battle_config.guild_notice_changemap == 1 && change_map)
+		    || battle_config.guild_notice_changemap == 2
+		    || first_time) {
+			clif->guild_notice(sd, sd->guild);
+		}
+
+		// Init guild aura.
+		if (sd->state.gmaster_flag != 0) {
+			guild->aura_refresh(sd, GD_LEADERSHIP, guild->checkskill(sd->guild, GD_LEADERSHIP));
+			guild->aura_refresh(sd, GD_GLORYWOUNDS, guild->checkskill(sd->guild, GD_GLORYWOUNDS));
+			guild->aura_refresh(sd, GD_SOULCOLD, guild->checkskill(sd->guild, GD_SOULCOLD));
+			guild->aura_refresh(sd, GD_HAWKEYES, guild->checkskill(sd->guild, GD_HAWKEYES));
+		}
 	}
 
 	if (sd->state.vending != 0) { // Character is vending.
@@ -11062,10 +11066,6 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 	}
 
 	clif->weather_check(sd);
-
-	// This should be displayed last.
-	if (sd->guild != NULL && first_time)
-		clif->guild_notice(sd, sd->guild);
 
 	// For automatic triggering of NPCs after map loading. (So you don't need to walk 1 step first.)
 	if (map->getcell(sd->bl.m, &sd->bl, sd->bl.x, sd->bl.y, CELL_CHKNPC) != 0)

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10945,6 +10945,8 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 		}
 	}
 
+	bool change_map = (sd->state.changemap != 0);
+
 	if (sd->state.changemap != 0) { // Restore information that gets lost on map-change.
 #if PACKETVER >= 20070918
 		clif->partyinvitationstate(sd);
@@ -10957,8 +10959,6 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 		else
 			clif->zc_config(sd, CZ_CONFIG_HOMUNCULUS_AUTOFEEDING, false);
 #endif
-
-		clif->show_modifiers(sd);
 
 		bool flee_penalty = (battle_config.bg_flee_penalty != 100 || battle_config.gvg_flee_penalty != 100);
 		bool is_gvg = (map_flag_gvg2(sd->state.pmap) || map_flag_gvg2(sd->bl.m));
@@ -11007,6 +11007,12 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 
 	mail->clear(sd);
 	clif->maptypeproperty2(&sd->bl, SELF);
+
+	if (((battle_config.display_rate_messages & 0x1) != 0 && first_time)
+	    || ((battle_config.display_rate_messages & 0x2) != 0 && !first_time && change_map)
+	    || (battle_config.display_rate_messages & 0x4) != 0) {
+		clif->show_modifiers(sd);
+	}
 
 	// Init guild aura.
 	if (sd->state.gmaster_flag != 0) {

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11065,6 +11065,10 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 		// Notify everyone that this character logged in. [Skotlex]
 		map->foreachpc(clif->friendslist_toggle_sub, sd->status.account_id, sd->status.char_id, 1);
 
+#if PACKETVER >= 20171122
+		clif->open_ui_send(sd, ZC_TIPBOX_UI);
+#endif
+
 		// Run OnPCLoginEvent labels.
 		npc->script_event(sd, NPCE_LOGIN);
 	} else {

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10787,10 +10787,6 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 	// Check for and delete unavailable/disabled items.
 	pc->checkitem(sd);
 
-	// Send the character's weight to the client.
-	clif->updatestatus(sd, SP_WEIGHT);
-	clif->updatestatus(sd, SP_MAXWEIGHT);
-
 	// Send character's guild info to the client. Call this before clif->spawn() to show guild emblems correctly.
 	if (sd->status.guild_id != 0)
 		guild->send_memberinfoshort(sd, 1);
@@ -10818,6 +10814,17 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 	sd->state.callshop = 0; // Reset the callshop flag if the character changes map.
 	map->addblock(&sd->bl); // Add the character to the map.
 	clif->spawn(&sd->bl); // Spawn character client side.
+
+	if (((battle_config.display_overweight_messages & 0x1) != 0 && sd->state.connect_new != 0)
+	    || ((battle_config.display_overweight_messages & 0x2) != 0 && sd->state.connect_new == 0 && sd->state.changemap != 0)) {
+		// Send the character's weight to the client. (With displaying overweight messages.)
+		clif->updatestatus(sd, SP_MAXWEIGHT);
+		clif->updatestatus(sd, SP_WEIGHT);
+	} else {
+		// Send the character's weight to the client. (Without displaying overweight messages.)
+		clif->updatestatus(sd, SP_WEIGHT);
+		clif->updatestatus(sd, SP_MAXWEIGHT);
+	}
 
 	struct party_data *p = NULL;
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11000,10 +11000,7 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 		status_calc_bl(&sd->ed->bl, SCB_SPEED); // Elementals mimic their master's speed on each map change.
 	}
 
-	bool first_time = false;
-
 	if (sd->state.connect_new != 0) {
-		first_time = true;
 		sd->state.connect_new = 0;
 		clif->skillinfoblock(sd);
 		clif->hotkeysAll(sd);
@@ -11090,8 +11087,6 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 			sd->state.warp_clean = 1;
 		}
 	}
-
-	bool change_map = (sd->state.changemap != 0);
 
 	if (sd->state.changemap != 0) { // Restore information that gets lost on map-change.
 		bool flee_penalty = (battle_config.bg_flee_penalty != 100 || battle_config.gvg_flee_penalty != 100);

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11066,7 +11066,8 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 		map->foreachpc(clif->friendslist_toggle_sub, sd->status.account_id, sd->status.char_id, 1);
 
 #if PACKETVER >= 20171122
-		clif->open_ui_send(sd, ZC_TIPBOX_UI);
+		if (battle_config.show_tip_window != 0)
+			clif->open_ui_send(sd, ZC_TIPBOX_UI);
 #endif
 
 		// Run OnPCLoginEvent labels.

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -7305,6 +7305,7 @@ static void clif_party_inviteack(struct map_session_data *sd, const char *nick, 
 ///     0x02 = Options changed manually.
 ///     0x04 = Options changed automatically.
 ///     0x08 = Member added.
+///     0x10 = Member removed.
 ///     0x20 = Character logged in.
 static void clif_party_option(struct party_data *p, struct map_session_data *sd, int flag)
 {
@@ -7326,10 +7327,10 @@ static void clif_party_option(struct party_data *p, struct map_session_data *sd,
 	}
 	if(!sd) return;
 	WBUFW(buf,0)=cmd;
-	WBUFL(buf,2)=((flag&0x01)?2:p->party.exp);
+	WBUFL(buf, 2) = ((flag & 0x10) != 0) ? 0 : (((flag & 0x01) != 0) ? 2 : p->party.exp);
 #if PACKETVER >= 20090603
-	WBUFB(buf,6)=(p->party.item&1)?1:0;
-	WBUFB(buf,7)=(p->party.item&2)?1:0;
+	WBUFB(buf, 6) = ((flag & 0x10) != 0) ? 0 : (((p->party.item & 1) != 0) ? 1 : 0);
+	WBUFB(buf, 7) = ((flag & 0x10) != 0) ? 0 : (((p->party.item & 2) != 0) ? 1 : 0);
 #endif
 	if ((flag & 0x01) == 0 && ((flag & 0x04) != 0 || (flag & 0x02) != 0))
 		clif->send(buf,packet_len(cmd),&sd->bl,PARTY);

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10958,6 +10958,8 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 			clif->zc_config(sd, CZ_CONFIG_HOMUNCULUS_AUTOFEEDING, false);
 #endif
 
+		clif->show_modifiers(sd);
+
 		bool flee_penalty = (battle_config.bg_flee_penalty != 100 || battle_config.gvg_flee_penalty != 100);
 		bool is_gvg = (map_flag_gvg2(sd->state.pmap) || map_flag_gvg2(sd->bl.m));
 		bool is_bg = (map->list[sd->state.pmap].flag.battleground != 0 || map->list[sd->bl.m].flag.battleground != 0);

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10954,6 +10954,13 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 #endif
 
 #if PACKETVER_MAIN_NUM >= 20171025 || PACKETVER_RE_NUM >= 20170920
+		clif->zc_config(sd, CZ_CONFIG_CALL, sd->status.allow_call);
+
+		if (sd->pd != NULL)
+			clif->zc_config(sd, CZ_CONFIG_PET_AUTOFEEDING, sd->pd->pet.autofeed);
+		else
+			clif->zc_config(sd, CZ_CONFIG_PET_AUTOFEEDING, false);
+
 		if (sd->hd != NULL)
 			clif->zc_config(sd, CZ_CONFIG_HOMUNCULUS_AUTOFEEDING, sd->hd->homunculus.autofeed);
 		else

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11030,9 +11030,9 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 
 	if (sd->guild != NULL) {
 		// Show guild notice.
-		if ((battle_config.guild_notice_changemap == 1 && change_map)
-		    || battle_config.guild_notice_changemap == 2
-		    || first_time) {
+		if (((battle_config.guild_notice_changemap & 0x1) != 0 && first_time)
+		    || ((battle_config.guild_notice_changemap & 0x2) != 0 && !first_time && change_map)
+		    || (battle_config.guild_notice_changemap & 0x4) != 0) {
 			clif->guild_notice(sd, sd->guild);
 		}
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10948,25 +10948,6 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 	bool change_map = (sd->state.changemap != 0);
 
 	if (sd->state.changemap != 0) { // Restore information that gets lost on map-change.
-#if PACKETVER >= 20070918
-		clif->partyinvitationstate(sd);
-		clif->equpcheckbox(sd);
-#endif
-
-#if PACKETVER_MAIN_NUM >= 20171025 || PACKETVER_RE_NUM >= 20170920
-		clif->zc_config(sd, CZ_CONFIG_CALL, sd->status.allow_call);
-
-		if (sd->pd != NULL)
-			clif->zc_config(sd, CZ_CONFIG_PET_AUTOFEEDING, sd->pd->pet.autofeed);
-		else
-			clif->zc_config(sd, CZ_CONFIG_PET_AUTOFEEDING, false);
-
-		if (sd->hd != NULL)
-			clif->zc_config(sd, CZ_CONFIG_HOMUNCULUS_AUTOFEEDING, sd->hd->homunculus.autofeed);
-		else
-			clif->zc_config(sd, CZ_CONFIG_HOMUNCULUS_AUTOFEEDING, false);
-#endif
-
 		bool flee_penalty = (battle_config.bg_flee_penalty != 100 || battle_config.gvg_flee_penalty != 100);
 		bool is_gvg = (map_flag_gvg2(sd->state.pmap) || map_flag_gvg2(sd->bl.m));
 		bool is_bg = (map->list[sd->state.pmap].flag.battleground != 0 || map->list[sd->bl.m].flag.battleground != 0);
@@ -11014,6 +10995,37 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 
 	mail->clear(sd);
 	clif->maptypeproperty2(&sd->bl, SELF);
+
+	if (((battle_config.display_config_messages & 0x1) != 0 && first_time)
+	    || ((battle_config.display_config_messages & 0x2) != 0 && !first_time && change_map)
+	    || (battle_config.display_config_messages & 0x4) != 0) {
+#if PACKETVER >= 20070918
+		if ((battle_config.display_config_messages & 0x10) != 0)
+			clif->partyinvitationstate(sd);
+
+		if ((battle_config.display_config_messages & 0x20) != 0)
+			clif->equpcheckbox(sd);
+#endif
+
+#if PACKETVER_MAIN_NUM >= 20171025 || PACKETVER_RE_NUM >= 20170920
+		if ((battle_config.display_config_messages & 0x40) != 0)
+			clif->zc_config(sd, CZ_CONFIG_CALL, sd->status.allow_call);
+
+		if ((battle_config.display_config_messages & 0x80) != 0) {
+			if (sd->pd != NULL)
+				clif->zc_config(sd, CZ_CONFIG_PET_AUTOFEEDING, sd->pd->pet.autofeed);
+			else
+				clif->zc_config(sd, CZ_CONFIG_PET_AUTOFEEDING, false);
+		}
+
+		if ((battle_config.display_config_messages & 0x100) != 0) {
+			if (sd->hd != NULL)
+				clif->zc_config(sd, CZ_CONFIG_HOMUNCULUS_AUTOFEEDING, sd->hd->homunculus.autofeed);
+			else
+				clif->zc_config(sd, CZ_CONFIG_HOMUNCULUS_AUTOFEEDING, false);
+		}
+#endif
+	}
 
 	if (((battle_config.display_rate_messages & 0x1) != 0 && first_time)
 	    || ((battle_config.display_rate_messages & 0x2) != 0 && !first_time && change_map)

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -7304,6 +7304,7 @@ static void clif_party_inviteack(struct map_session_data *sd, const char *nick, 
 ///     0x01 = Cannot change EXP sharing. (Only set when tried to change options manually.)
 ///     0x02 = Options changed manually.
 ///     0x04 = Options changed automatically.
+///     0x08 = Member added.
 ///     0x20 = Character logged in.
 static void clif_party_option(struct party_data *p, struct map_session_data *sd, int flag)
 {

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -1658,6 +1658,7 @@ struct clif_interface {
 	bool (*attendance_timediff) (struct map_session_data *sd);
 	time_t (*attendance_getendtime) (void);
 	void (*pOpenUIRequest) (int fd, struct map_session_data *sd);
+	void (*open_ui_send) (struct map_session_data *sd, enum zc_ui_types ui_type);
 	void (*open_ui) (struct map_session_data *sd, enum cz_ui_types uiType);
 	void (*pAttendanceRewardRequest) (int fd, struct map_session_data *sd);
 	void (*ui_action) (struct map_session_data *sd, int32 UIType, int32 data);

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -750,6 +750,14 @@ enum removeGear_flag {
 	REMOVE_MOUNT_CART = 6,
 };
 
+/** Info types for PACKET_ZC_PERSONAL_INFOMATION (0x097b). **/
+enum detail_exp_info_type {
+	PC_EXP_INFO = 0x0,	//!< PCBang internet cafe modifiers. (http://pcbang.gnjoy.com/) (Unused.)
+	PREMIUM_EXP_INFO = 0x1,	//!< Premium user modifiers. Values aren't displayed in 20161207+ clients.
+	SERVER_EXP_INFO = 0x2,	//!< Server rates.
+	TPLUS_EXP_INFO = 0x3,	//!< Unknown. Values are displayed as "TPLUS" in kRO. (Unused.)
+};
+
 /**
  * Clif.c Interface
  **/

--- a/src/map/packets_struct.h
+++ b/src/map/packets_struct.h
@@ -3927,6 +3927,24 @@ struct PACKET_CZ_LAPINEUPGRADE_MAKE_ITEM {
 DEFINE_PACKET_HEADER(CZ_LAPINEUPGRADE_MAKE_ITEM, 0x0ab6);
 #endif  // PACKETVER_MAIN_NUM >= 20170111 || PACKETVER_RE_NUM >= 20170111 || defined(PACKETVER_ZERO)
 
+#if PACKETVER_MAIN_NUM >= 20120503 || PACKETVER_RE_NUM >= 20120502 || defined(PACKETVER_ZERO)
+struct PACKET_ZC_PERSONAL_INFOMATION_SUB {
+	int8 type;
+	int32 exp;
+	int32 death;
+	int32 drop;
+} __attribute__((packed));
+struct PACKET_ZC_PERSONAL_INFOMATION {
+	int16 packetType;
+	int16 length;
+	int32 total_exp;
+	int32 total_death;
+	int32 total_drop;
+	struct PACKET_ZC_PERSONAL_INFOMATION_SUB details[];
+} __attribute__((packed));
+DEFINE_PACKET_HEADER(ZC_PERSONAL_INFOMATION, 0x097b);
+#endif  // PACKETVER_MAIN_NUM >= 20120503 || PACKETVER_RE_NUM >= 20120502 || defined(PACKETVER_ZERO)
+
 #if !defined(sun) && (!defined(__NETBSD__) || __NetBSD_Version__ >= 600000000) // NetBSD 5 and Solaris don't like pragma pack but accept the packed attribute
 #pragma pack(pop)
 #endif // not NetBSD < 6 / Solaris

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -631,6 +631,7 @@ static int party_member_withdraw(int party_id, int account_id, int char_id)
 				prev_leader_accountId = p->party.member[i].account_id;
 			}
 
+			clif->party_option(p, sd, 0x10);
 			clif->party_withdraw(p,sd,account_id,p->party.member[i].name,0x0);
 			memset(&p->party.member[i], 0, sizeof(p->party.member[0]));
 			memset(&p->data[i], 0, sizeof(p->data[0]));

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -738,9 +738,8 @@ static int party_optionchanged(int party_id, int account_id, int exp, int item, 
 	//Flag&0x1: Exp change denied. Flag&0x10: Item change denied.
 	if(!(flag&0x01) && p->party.exp != exp)
 		p->party.exp=exp;
-	if(!(flag&0x10) && p->party.item != item) {
+	if (p->party.item != item)
 		p->party.item=item;
-	}
 
 	if (account_id == 0) {
 		flag |= 0x04;

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -330,6 +330,8 @@ static int party_recv_info(const struct party *sp, int char_id)
 		party->member_withdraw(sp->party_id, sd->status.account_id, sd->status.char_id);
 	}
 
+	int option_auto_changed = p->state.option_auto_changed; // Preserve state.
+
 	memcpy(&p->party, sp, sizeof(struct party));
 	memset(&p->state, 0, sizeof(p->state));
 	memset(&p->data, 0, sizeof(p->data));
@@ -342,6 +344,7 @@ static int party_recv_info(const struct party *sp, int char_id)
 			p->party.member[member_id].leader = 1;
 	}
 	party->check_state(p);
+	p->state.option_auto_changed = option_auto_changed;
 	while( added_count > 0 ) { // new in party
 		member_id = added[--added_count];
 		sd = p->data[member_id].sd;
@@ -536,6 +539,11 @@ static int party_member_added(int party_id, int account_id, int char_id, int fla
 
 	clif->party_member_info(p,sd);
 	clif->party_info(p,sd);
+
+	if (p->state.option_auto_changed != 0)
+		clif->party_option(p, sd, 0x04);
+	else
+		clif->party_option(p, sd, 0x08);
 
 	if( sd2 != NULL )
 		clif->party_inviteack(sd2,sd->status.name,2);

--- a/src/map/party.h
+++ b/src/map/party.h
@@ -51,6 +51,8 @@ struct party_data {
 		unsigned sg : 1;     ///< There's at least one Star Gladiator in party?
 		unsigned snovice :1; ///< There's a Super Novice
 		unsigned tk : 1;     ///< There's a taekwon
+		unsigned option_auto_changed : 1;  ///< Party options were changed automatically. (inter_party_check_lv())
+		unsigned member_level_changed : 1; ///< A party member's level has changed.
 	} state;
 	struct hplugin_data_store *hdata; ///< HPM Plugin Data Store
 };

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -12117,7 +12117,6 @@ static void pc_scdata_received(struct map_session_data *sd)
 {
 	nullpo_retv(sd);
 	pc->inventory_rentals(sd);
-	clif->show_modifiers(sd);
 
 	if (sd->expiration_time != 0) { // don't display if it's unlimited or unknow value
 		time_t exp_time = sd->expiration_time;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Implement `PACKET_ZC_PERSONAL_INFOMATION` (`0x097b`) and use it in `clif_show_modifiers()`.
- Add battle flag for rate modifier messages display.
- Add missing configuration messages `CZ_CONFIG_CALL` and `CZ_CONFIG_PET_AUTOFEEDING` to `clif_parse_LoadEndAck()`.
- Add battle flag for configuration messages display.
- Extend `guild_notice_changemap` battle flag with option for login.
- Add several cases where party options should be sent.
- Add battle flag for sending party options.
- Add battle flag for overweight messages display.
- Do the message sending in new `clif_load_end_ack_sub_messages()` function to have it centralized and be able to control the order.
- Add `clif_open_ui_send()` function to do the actual packet sending for opening an UI.
- Add battle flag for tip of the day window display.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
