### PR TITLE
Add loudhailer() script command

### DIFF
--- a/db/pre-re/item_db.conf
+++ b/db/pre-re/item_db.conf
@@ -68730,7 +68730,7 @@ item_db: (
 	}
 	Script: <"
 		input @megaphone$;
-		announce strcharinfo(PC_NAME) + ": " + @megaphone$,bc_all,0xFF0000;
+		loudhailer(@megaphone$);
 		end;
 	">
 },

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -88610,7 +88610,7 @@ item_db: (
 	}
 	Script: <"
 		input @megaphone$;
-		announce strcharinfo(PC_NAME) + ": " + @megaphone$,bc_all,0xFF0000;
+		loudhailer(@megaphone$);
 		end;
 	">
 },

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -7494,6 +7494,16 @@ if GID is not given use the attached player.
 //=====================================
 ---------------------------------------
 
+*loudhailer("<message>"{, "<color>"})
+
+Announces a colored text in '<char_name> Shouts : <message>' format.
+<color> must be a string in "RRGGBB" format. If <color> is omitted,
+white ("FFFFFF") will be used.
+This command is specially created for the Megaphone_ item (12221),
+but will work in NPCs, too.
+
+---------------------------------------
+
 *announce("<text>", <flag>{, <fontColor>{, <fontType>{, <fontSize>{, <fontAlign>{, <fontY>}}}}})
 
 This command will broadcast a message to all or most players, similar to

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -6224,7 +6224,7 @@ static void clif_displaymessage_sprintf(const int fd, const char *mes, ...)
 /// 009a <packet len>.W <message>.?B
 static void clif_broadcast(struct block_list *bl, const char *mes, int len, int type, enum send_target target)
 {
-	int lp = (type&BC_COLOR_MASK) ? 4 : 0;
+	int lp = ((type & BC_COLOR_MASK) != 0 || (type & BC_MEGAPHONE) != 0) ? 4 : 0;
 	unsigned char *buf = NULL;
 	nullpo_retv(mes);
 
@@ -6236,6 +6236,8 @@ static void clif_broadcast(struct block_list *bl, const char *mes, int len, int 
 		WBUFL(buf,4) = 0x65756c62; //If there's "blue" at the beginning of the message, game client will display it in blue instead of yellow.
 	else if( type&BC_WOE )
 		WBUFL(buf,4) = 0x73737373; //If there's "ssss", game client will recognize message as 'WoE broadcast'.
+	else if ((type & BC_MEGAPHONE) != 0)
+		WBUFL(buf, 4) = 0x6363696d; // If there's "micc" at the beginning of the message, the game client will recognize message as 'Megaphone shout'.
 	memcpy(WBUFP(buf, 4 + lp), mes, len);
 	clif->send(buf, WBUFW(buf,2), bl, target);
 

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -146,6 +146,8 @@ typedef enum broadcast_flags {
 	BC_WOE         = 0x20,
 	BC_COLOR_MASK  = 0x30, // BC_YELLOW|BC_BLUE|BC_WOE
 
+	BC_MEGAPHONE   = 0x40,
+
 	BC_DEFAULT     = BC_ALL|BC_PC|BC_YELLOW
 } broadcast_flags;
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Aegis uses the `LoudSpeaker` command for broadcasting megaphone messages.
Namely this is a special use case of packet `0x009a` where the message's first 34 bytes are reserved for string `micc` (4B) which identifies the broadcast as megaphone shout, the character's name (24B) and the text color (6B).
Side note: I had to use "loudhailer" because "megaphone" is already taken by item 7040. :disappointed_relieved:

**Issues addressed:** The "double clickable name" part of #2751


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
