### PR TITLE
Fix errors in the ci builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -825,51 +825,12 @@ re:debian-testing:
 pre_re:centos-previous:
   <<: *branch_exceptions
   stage: platforms
-  image: centos:6
-  services:
-    - mysql:5.5
-  variables:
-    <<: *base_vars
-    SQLHOST: mysql
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - yum -y update
-    - yum install -y make mysql-devel pcre-devel git zlib-devel mysql centos-release-scl
-    - yum install -y devtoolset-6-toolchain
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
-    - ./tools/ci/travis.sh getplugins || true
-  script:
-    - 'source /opt/rh/devtoolset-6/enable && ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal'
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
-
-re:centos-previous:
-  <<: *branch_exceptions
-  stage: platforms
-  image: centos:6
-  services:
-    - mysql:5.5
-  variables:
-    <<: *base_vars
-    SQLHOST: mysql
-  before_script:
-    - echo "Building $CI_BUILD_NAME"
-    - uname -a
-    - yum -y update
-    - yum install -y make mysql-devel pcre-devel git zlib-devel mysql centos-release-scl
-    - yum install -y devtoolset-6-toolchain
-    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
-    - ./tools/ci/travis.sh getplugins || true
-  script:
-    - 'source /opt/rh/devtoolset-6/enable && ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot'
-    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
-
-pre_re:centos-current:
-  <<: *branch_exceptions
-  stage: platforms
   image: centos:7
   services:
     - mariadb:5.5
+  variables:
+    <<: *base_vars
+    SQLHOST: mariadb
   before_script:
     - echo "Building $CI_BUILD_NAME"
     - uname -a
@@ -877,9 +838,47 @@ pre_re:centos-current:
     - yum install -y gcc make mariadb-devel pcre-devel git zlib-devel mariadb
     - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
     - ./tools/ci/travis.sh getplugins || true
+  script:
+    - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+re:centos-previous:
+  <<: *branch_exceptions
+  stage: platforms
+  image: centos:7
+  services:
+    - mariadb:5.5
   variables:
     <<: *base_vars
     SQLHOST: mariadb
+  before_script:
+    - echo "Building $CI_BUILD_NAME"
+    - uname -a
+    - yum -y update
+    - yum install -y gcc make mariadb-devel pcre-devel git zlib-devel mariadb
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
+    - ./tools/ci/travis.sh getplugins || true
+  script:
+    - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
+    - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
+
+pre_re:centos-current:
+  <<: *branch_exceptions
+  stage: platforms
+  image: centos:8
+  services:
+    - mariadb:10.3
+  variables:
+    <<: *base_vars
+    SQLHOST: mariadb
+  before_script:
+    - echo "Building $CI_BUILD_NAME"
+    - uname -a
+    - yum -y update
+    - yum install -y gcc make mariadb-devel pcre-devel git zlib-devel mariadb python2
+    - alternatives --set python /usr/bin/python2
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
+    - ./tools/ci/travis.sh getplugins || true
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot --disable-renewal
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST
@@ -887,19 +886,20 @@ pre_re:centos-current:
 re:centos-current:
   <<: *branch_exceptions
   stage: platforms
-  image: centos:7
+  image: centos:8
   services:
-    - mariadb:5.5
+    - mariadb:10.3
+  variables:
+    <<: *base_vars
+    SQLHOST: mariadb
   before_script:
     - echo "Building $CI_BUILD_NAME"
     - uname -a
     - yum -y update
-    - yum install -y gcc make mariadb-devel pcre-devel git zlib-devel mariadb
+    - yum install -y gcc make mariadb-devel pcre-devel git zlib-devel mariadb python2
+    - alternatives --set python /usr/bin/python2
     - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
     - ./tools/ci/travis.sh getplugins || true
-  variables:
-    <<: *base_vars
-    SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build --enable-debug --enable-Werror --enable-buildbot
     - ./tools/ci/travis.sh test ragnarok ragnarok ragnarok $SQLHOST

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -3692,8 +3692,8 @@ static int set_reg(struct script_state *st, struct map_session_data *sd, int64 n
 		const char *str = (const char*)value;
 
 		if (script->is_permanent_variable(name) && strlen(str) > SCRIPT_STRING_VAR_LENGTH) {
-			ShowError("script:set_reg: Value of variable %s is too long: %lu! Maximum is %d. Skipping...\n",
-				  name, strlen(str), SCRIPT_STRING_VAR_LENGTH);
+			ShowError("script:set_reg: Value of variable %s is too long: %d! Maximum is %d. Skipping...\n",
+				  name, (int)strlen(str), SCRIPT_STRING_VAR_LENGTH);
 
 			if (st != NULL) {
 				script->reportsrc(st);

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -20662,8 +20662,8 @@ static void skill_validate_name(struct config_setting_t *conf, struct s_skill_db
 		ShowError("%s: No name specified for skill ID %d in %s! Skipping skill...\n",
 			  __func__, sk->nameid, conf->file);
 	else if (strlen(name) >= sizeof(sk->name))
-		ShowError("%s: Specified name %s for skill ID %d in %s is too long: %lu! Maximum is %lu. Skipping skill...\n",
-			  __func__, name, sk->nameid, conf->file, strlen(name), sizeof(sk->name) - 1);
+		ShowError("%s: Specified name %s for skill ID %d in %s is too long: %d! Maximum is %d. Skipping skill...\n",
+			  __func__, name, sk->nameid, conf->file, (int)strlen(name), (int)sizeof(sk->name) - 1);
 	else if (skill->name_contains_invalid_character(name))
 		ShowError("%s: Specified name %s for skill ID %d in %s contains invalid characters! Allowed characters are letters, numbers and underscores. Skipping skill...\n",
 			  __func__, name, sk->nameid, conf->file);
@@ -20719,8 +20719,8 @@ static void skill_validate_description(struct config_setting_t *conf, struct s_s
 
 	if (libconfig->setting_lookup_string(conf, "Description", &description) == CONFIG_TRUE && *description != '\0') {
 		if (strlen(description) >= sizeof(sk->desc))
-			ShowWarning("%s: Specified description '%s' for skill ID %d in %s is too long: %lu! Maximum is %lu. Trimming...\n",
-				    __func__, description, sk->nameid, conf->file, strlen(description), sizeof(sk->desc) - 1);
+			ShowWarning("%s: Specified description '%s' for skill ID %d in %s is too long: %d! Maximum is %d. Trimming...\n",
+				    __func__, description, sk->nameid, conf->file, (int)strlen(description), (int)sizeof(sk->desc) - 1);
 
 		safestrncpy(sk->desc, description, sizeof(sk->desc));
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes two build failure reasons in the gitlab-ci builds:

- i386 builds are failing because of format string errors (`size_t` is not compatible with `%lu`). It's been replaced with a typecast to int and `%d`.
- centos6 builds are failing because the devtoolseet-6 package doesn't seem to be available anymore. CentOS 6 is no longer officially supported by Hercules and as such it won't be fixed. It's been replaced with centos8 builds, since it's now the latest version, released in september 2019.

**Issues addressed:** N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
