### PR TITLE
Fix updating SQL data when removing party member or options are changed in inter_party_check_lv()

### DIFF
--- a/src/char/int_party.c
+++ b/src/char/int_party.c
@@ -577,9 +577,9 @@ static bool inter_party_leave(int party_id, int account_id, int char_id)
 	if (p->party.member[i].online == 1)
 		p->party.member[i].online = 0;
 
+	inter_party->tosql(&p->party, PS_DELMEMBER, i);
 	memset(&p->party.member[i], 0, sizeof(struct party_member));
 	inter_party->calc_state(p); /// Count online/offline members and check family state and even share range.
-	inter_party->tosql(&p->party, PS_DELMEMBER, i);
 
 	if (inter_party->check_empty(p) == 0)
 		mapif->party_info(-1, &p->party, 0);

--- a/src/char/int_party.c
+++ b/src/char/int_party.c
@@ -67,6 +67,7 @@ static int inter_party_check_lv(struct party_data *p)
 	if (p->party.exp == 1 && inter_party->check_exp_share(p) == 0) {
 		p->party.exp = 0;
 		mapif->party_optionchanged(0, &p->party, 0, 0);
+		inter_party->tosql(&p->party, PS_BASIC, 0);
 		return 0;
 	}
 


### PR DESCRIPTION
# Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- In `inter_party_leave()` the removed party member's data is cleared before calling `inter_party_tosql()` which causes the SQL update to fail because no account ID is found.
Due to this the character is removed from the party only when its data gets saved and offline characters are not removed correctly.
- If party options are changed automatically in `inter_party_check_lv()` the party's data isn't saved.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
