### PR TITLE
Add some pet features and minor pet code clean up

### DIFF
--- a/conf/map/battle/pet.conf
+++ b/conf/map/battle/pet.conf
@@ -99,3 +99,7 @@ pet_max_atk2: 1000
 // If set to true, pets are automatically returned to egg when entering castles during WoE times
 // and hatching is forbidden within as well.
 pet_disable_in_gvg: false
+
+// Should the pet immediately be removed when its intimacy drops to 0? (Note 1)
+// If set to false the pet will randomly walk around the map before being removed.
+pet_remove_immediately: true

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -2855,7 +2855,7 @@ ACMD(pethungry)
 	}
 
 	if (hungry != pd->pet.hungry) { // No need to update the pet's status if hunger value won't change.
-		pd->pet.hungry = hungry;
+		pet->set_hunger(pd, hungry);
 		clif->send_petstatus(sd);
 	}
 

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -2810,10 +2810,8 @@ ACMD(petfriendly)
 		return false;
 	}
 
-	if (friendly != pd->pet.intimate) { // No need to update the pet's status if intimacy value won't change.
+	if (friendly != pd->pet.intimate) // No need to update the pet's status if intimacy value won't change.
 		pet->set_intimate(pd, friendly);
-		clif->send_petstatus(sd);
-	}
 
 	clif->message(fd, msg_fd(fd, 182)); // Pet intimacy changed. (Send message regardless of value has changed or not.)
 
@@ -2854,10 +2852,8 @@ ACMD(pethungry)
 		return false;
 	}
 
-	if (hungry != pd->pet.hungry) { // No need to update the pet's status if hunger value won't change.
+	if (hungry != pd->pet.hungry) // No need to update the pet's status if hunger value won't change.
 		pet->set_hunger(pd, hungry);
-		clif->send_petstatus(sd);
-	}
 
 	clif->message(fd, msg_fd(fd, 185)); // Pet hunger changed. (Send message regardless of value has changed or not.)
 

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -2881,6 +2881,15 @@ ACMD(petrename)
 	}
 
 	pd->pet.rename_flag = 0;
+
+	int i;
+
+	ARR_FIND(0, sd->status.inventorySize, i, sd->status.inventory[i].card[0] == CARD0_PET
+		 && pd->pet.pet_id == MakeDWord(sd->status.inventory[i].card[1], sd->status.inventory[i].card[2]));
+
+	if (i != sd->status.inventorySize)
+		sd->status.inventory[i].card[3] = pet->get_card4_value(pd->pet.rename_flag, pd->pet.intimate);
+
 	intif->save_petdata(sd->status.account_id, &pd->pet);
 	clif->send_petstatus(sd);
 	clif->message(fd, msg_fd(fd,187)); // You can now rename your pet.

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -8562,7 +8562,7 @@ ACMD(itemlist)
 
 		if( it->card[0] == CARD0_PET ) {
 			// pet egg
-			if (it->card[3])
+			if ((it->card[3] & 1) != 0)
 				StrBuf->Printf(&buf, msg_fd(fd,1348), (unsigned int)MakeDWord(it->card[1], it->card[2])); //  -> (pet egg, pet id: %u, named)
 			else
 				StrBuf->Printf(&buf, msg_fd(fd,1349), (unsigned int)MakeDWord(it->card[1], it->card[2])); //  -> (pet egg, pet id: %u, unnamed)

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7101,6 +7101,7 @@ static const struct battle_data {
 	{ "pet_max_atk1",                       &battle_config.pet_max_atk1,                    750,    0,      INT_MAX,        },
 	{ "pet_max_atk2",                       &battle_config.pet_max_atk2,                    1000,   0,      INT_MAX,        },
 	{ "pet_disable_in_gvg",                 &battle_config.pet_no_gvg,                      0,      0,      1,              },
+	{ "pet_remove_immediately",             &battle_config.pet_remove_immediately,          1,      0,      1,              },
 	{ "skill_min_damage",                   &battle_config.skill_min_damage,                2|4,    0,      1|2|4,          },
 	{ "finger_offensive_type",              &battle_config.finger_offensive_type,           0,      0,      1,              },
 	{ "heal_exp",                           &battle_config.heal_exp,                        0,      0,      INT_MAX,        },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -230,6 +230,7 @@ struct Battle_Config {
 	int pet_max_atk2; //[Skotlex]
 	int pet_no_gvg; //Disables pets in gvg. [Skotlex]
 	int pet_equip_required;
+	int pet_remove_immediately;
 
 	int skill_min_damage;
 	int finger_offensive_type;

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10806,10 +10806,7 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 			clif->message(sd->fd, msg_sd(sd, 866)); // "Pets are not allowed in Guild Wars."
 			pet->menu(sd, 3); // Option 3 is return to egg.
 		} else {
-			map->addblock(&sd->pd->bl);
-			clif->spawn(&sd->pd->bl);
-			clif->send_petdata(sd,sd->pd, 0, 0);
-			clif->send_petstatus(sd);
+			pet->spawn(sd, false);
 		}
 	}
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -2519,8 +2519,8 @@ static void clif_addcards(struct EQUIPSLOTINFO *buf, struct item *item)
 	if (item->card[0] == CARD0_PET) { //pet eggs
 		buf->card[0] = 0;
 		buf->card[1] = 0;
-		buf->card[2] = 0;
-		buf->card[3] = item->card[3]; //Pet renamed flag.
+		buf->card[2] = (item->card[3] >> 1); // Pet intimacy level.
+		buf->card[3] = (item->card[3] & 1); // Pet renamed flag.
 		return;
 	}
 	if (item->card[0] == CARD0_FORGE || item->card[0] == CARD0_CREATE) { //Forged/created items

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -8148,10 +8148,8 @@ static int pc_dead(struct map_session_data *sd, struct block_list *src)
 	if (sd->status.pet_id > 0 && sd->pd != NULL) {
 		struct pet_data *pd = sd->pd;
 
-		if (map->list[sd->bl.m].flag.noexppenalty == 0) {
+		if (map->list[sd->bl.m].flag.noexppenalty == 0)
 			pet->set_intimate(pd, pd->pet.intimate - pd->petDB->die);
-			clif->send_petdata(sd, sd->pd, 1, pd->pet.intimate);
-		}
 
 		if (sd->pd != NULL && sd->pd->target_id != 0) // Unlock all targets.
 			pet->unlocktarget(sd->pd);

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -8153,7 +8153,7 @@ static int pc_dead(struct map_session_data *sd, struct block_list *src)
 			clif->send_petdata(sd, sd->pd, 1, pd->pet.intimate);
 		}
 
-		if (sd->pd->target_id != 0) // Unlock all targets.
+		if (sd->pd != NULL && sd->pd->target_id != 0) // Unlock all targets.
 			pet->unlocktarget(sd->pd);
 	}
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -727,6 +727,9 @@ END_ZEROED_BLOCK;
 /// Rune Knight Dragon
 #define pc_isridingdragon(sd) ( (sd)->sc.option&OPTION_DRAGON )
 
+// Check if character has a pet.
+#define pc_has_pet(sd) ( (sd)->status.pet_id != 0 && (sd)->pd != NULL && (sd)->pd->pet.intimate > PET_INTIMACY_NONE )
+
 #define pc_stop_walking(sd, type) (unit->stop_walking(&(sd)->bl, (type)))
 #define pc_stop_attack(sd)        (unit->stop_attack(&(sd)->bl))
 

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -580,7 +580,6 @@ static int pet_birth_process(struct map_session_data *sd, struct s_pet *petinfo)
 #if PACKETVER >= 20180704
 		clif->send_petdata(sd, sd->pd, 6, 1);
 #endif
-		clif->send_petdata(NULL, sd->pd, 3, sd->pd->vd.head_bottom);
 		clif->send_petstatus(sd);
 	}
 	Assert_retr(1, sd->status.pet_id == 0 || sd->pd == 0 || sd->pd->msd == sd);
@@ -626,7 +625,6 @@ static int pet_recv_petdata(int account_id, struct s_pet *p, int flag)
 			clif->spawn(&sd->pd->bl);
 			clif->send_petdata(sd,sd->pd,0,0);
 			clif->send_petdata(sd,sd->pd,5,battle_config.pet_hair_style);
-			clif->send_petdata(NULL, sd->pd, 3, sd->pd->vd.head_bottom);
 			clif->send_petstatus(sd);
 		}
 	}
@@ -865,7 +863,6 @@ static int pet_change_name_ack(struct map_session_data *sd, const char *name, in
 	aFree(newname);
 	clif->blname_ack(0,&pd->bl);
 	pd->pet.rename_flag = 1;
-	clif->send_petdata(NULL, sd->pd, 3, sd->pd->vd.head_bottom);
 	clif->send_petstatus(sd);
 	return 1;
 }

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -700,8 +700,6 @@ static int pet_catch_process2(struct map_session_data *sd, int target_id)
 		return 1;
 	}
 
-	//FIXME: Delete taming item here, if this was an item-invoked capture and the item was flagged as delay-consume. [ultramage]
-
 	// catch_target_class == 0 is used for universal lures (except bosses for now). [Skotlex]
 	if (sd->catch_target_class == 0 && (md->status.mode & MD_BOSS) == 0)
 		sd->catch_target_class = md->class_;

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -94,8 +94,11 @@ static int pet_hungry_val(struct pet_data *pd)
 static void pet_set_hunger(struct pet_data *pd, int value)
 {
 	nullpo_retv(pd);
+	nullpo_retv(pd->msd);
 
 	pd->pet.hungry = cap_value(value, PET_HUNGER_STARVING, PET_HUNGER_STUFFED);
+
+	clif->send_petdata(pd->msd, pd, 2, pd->pet.hungry);
 }
 
 /**
@@ -357,7 +360,6 @@ static int pet_hungry(int tid, int64 tick, int id, intptr_t data)
 			interval = pd->petDB->starving_delay;
 	}
 
-	clif->send_petdata(sd, pd, 2, pd->pet.hungry);
 	interval = interval * battle_config.pet_hungry_delay_rate / 100;
 	pd->pet_hungry_timer = timer->add(tick + max(interval, 1), pet->hungry, sd->bl.id, 0);
 
@@ -989,7 +991,6 @@ static int pet_food(struct map_session_data *sd, struct pet_data *pd)
 
 	status_calc_pet(pd, SCO_NONE);
 	pet->set_hunger(pd, pd->pet.hungry + pd->petDB->fullness);
-	clif->send_petdata(sd, pd, 2, pd->pet.hungry);
 	clif->pet_food(sd, pd->petDB->FoodID, 1);
 
 	return 0;

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -154,8 +154,10 @@ static void pet_set_intimate(struct pet_data *pd, int value)
 		if (i != sd->status.inventorySize)
 			pc->delitem(sd, i, 1, 0, DELITEM_NORMAL, LOG_TYPE_EGG);
 
-		pet_stop_attack(pd);
-		unit->remove_map(&pd->bl, CLR_OUTSIGHT, ALC_MARK);
+		if (battle_config.pet_remove_immediately != 0) {
+			pet_stop_attack(pd);
+			unit->remove_map(&pd->bl, CLR_OUTSIGHT, ALC_MARK);
+		}
 	}
 
 	status_calc_pc(sd, SCO_NONE);

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -954,6 +954,7 @@ static int pet_food(struct map_session_data *sd, struct pet_data *pd)
 {
 	nullpo_retr(1, sd);
 	nullpo_retr(1, pd);
+	Assert_retr(1, sd->status.pet_id == pd->pet.pet_id);
 
 	int i = pc->search_inventory(sd, pd->petDB->FoodID);
 

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -884,7 +884,6 @@ static int pet_change_name_ack(struct map_session_data *sd, const char *name, in
 	aFree(newname);
 	clif->blname_ack(0,&pd->bl);
 	pd->pet.rename_flag = 1;
-	clif->send_petstatus(sd);
 	return 1;
 }
 

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -405,6 +405,7 @@ static int pet_return_egg(struct map_session_data *sd, struct pet_data *pd)
 		sd->status.inventory[i].attribute &= ~ATTR_BROKEN;
 		sd->status.inventory[i].bound = IBT_NONE;
 		sd->status.inventory[i].card[3] = pd->pet.rename_flag;
+		clif->inventoryList(sd);
 	} else {
 		// The pet egg wasn't found: it was probably hatched with the old system that deleted the egg.
 		struct item tmp_item = {0};
@@ -422,7 +423,6 @@ static int pet_return_egg(struct map_session_data *sd, struct pet_data *pd)
 		}
 	}
 #if PACKETVER >= 20180704
-	clif->inventoryList(sd);
 	clif->send_petdata(sd, pd, 6, 0);
 #endif
 	pd->pet.incubate = 1;

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -158,6 +158,8 @@ static void pet_set_intimate(struct pet_data *pd, int value)
 			pet_stop_attack(pd);
 			unit->remove_map(&pd->bl, CLR_OUTSIGHT, ALC_MARK);
 		}
+	} else {
+		clif->send_petdata(sd, pd, 1, pd->pet.intimate);
 	}
 
 	status_calc_pc(sd, SCO_NONE);
@@ -350,7 +352,6 @@ static int pet_hungry(int tid, int64 tick, int id, intptr_t data)
 			return 0;
 
 		status_calc_pet(pd, SCO_NONE);
-		clif->send_petdata(sd, pd, 1, pd->pet.intimate);
 
 		if (pd->petDB->starving_delay > 0)
 			interval = pd->petDB->starving_delay;
@@ -989,7 +990,6 @@ static int pet_food(struct map_session_data *sd, struct pet_data *pd)
 	status_calc_pet(pd, SCO_NONE);
 	pet->set_hunger(pd, pd->pet.hungry + pd->petDB->fullness);
 	clif->send_petdata(sd, pd, 2, pd->pet.hungry);
-	clif->send_petdata(sd, pd, 1, pd->pet.intimate);
 	clif->pet_food(sd, pd->petDB->FoodID, 1);
 
 	return 0;

--- a/src/map/pet.h
+++ b/src/map/pet.h
@@ -160,6 +160,7 @@ struct pet_interface {
 	int (*performance) (struct map_session_data *sd, struct pet_data *pd);
 	int (*return_egg) (struct map_session_data *sd, struct pet_data *pd);
 	int (*data_init) (struct map_session_data *sd, struct s_pet *petinfo);
+	int (*spawn) (struct map_session_data *sd, bool birth_process);
 	int (*birth_process) (struct map_session_data *sd, struct s_pet *petinfo);
 	int (*recv_petdata) (int account_id, struct s_pet *p, int flag);
 	int (*select_egg) (struct map_session_data *sd, int egg_index);

--- a/src/map/pet.h
+++ b/src/map/pet.h
@@ -147,6 +147,7 @@ struct pet_interface {
 	/* */
 	int (*hungry_val) (struct pet_data *pd);
 	void (*set_hunger) (struct pet_data *pd, int value);
+	int (*get_card4_value) (int rename_flag, int intimacy);
 	void (*set_intimate) (struct pet_data *pd, int value);
 	int (*create_egg) (struct map_session_data *sd, int item_id);
 	int (*unlocktarget) (struct pet_data *pd);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -20518,6 +20518,8 @@ static BUILDIN(setunitdata)
 			break;
 		case UDT_LEVEL:
 			pd->pet.level = (short)val;
+			if (pd->msd != NULL)
+				clif->send_petstatus(pd->msd); // Send pet data.
 			break;
 		case UDT_HP:
 			status->set_hp(bl, (unsigned int)val, STATUS_HEAL_DEFAULT);
@@ -20639,7 +20641,6 @@ static BUILDIN(setunitdata)
 			return false;
 		}
 
-		clif->send_petstatus(pd->msd); // Send pet data.
 		break;
 	}
 	case BL_MER: {

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -20629,7 +20629,6 @@ static BUILDIN(setunitdata)
 			break;
 		case UDT_INTIMACY:
 			pet->set_intimate(pd, val);
-			clif->send_petdata(pd->msd, pd, 1, pd->pet.intimate);
 			break;
 		case UDT_HUNGER:
 			pet->set_hunger(pd, val);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Implement intimacy display in pet egg's item description window.
- Remove pet if intimacy drops to 0 instead of making it randomly running around. (Added battle flag to disable/enable this behaviour.)
- Send pet's intimacy data only in `pet_set_intimate()`.
- Send pet's hunger data only in `pet_set_hunger()`.
- Centralize pet spawn code in `pet_spawn()` function.
- Remove ancient `FIXME` comment related to deleting taming items of type `IT_DELAYCONSUME`.
- Add `pc_has_pet()` macro.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
