### PR TITLE
Enlarge field size of npc_item_flag in struct script_state according to possible values

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7378,7 +7378,7 @@ static const struct battle_data {
 	{ "item_restricted_consumption_type",   &battle_config.item_restricted_consumption_type,1,      0,      1,              },
 	{ "unequip_restricted_equipment",       &battle_config.unequip_restricted_equipment,    0,      0,      3,              },
 	{ "max_walk_path",                      &battle_config.max_walk_path,                   17,     1,      MAX_WALKPATH,   },
-	{ "item_enabled_npc",                   &battle_config.item_enabled_npc,                1,      0,      INT_MAX,        },
+	{ "item_enabled_npc",                   &battle_config.item_enabled_npc,                1,      0,      3,              },
 	{ "gm_ignore_warpable_area",            &battle_config.gm_ignore_warpable_area,         0,      2,      100,            },
 	{ "packet_obfuscation",                 &battle_config.packet_obfuscation,              1,      0,      3,              },
 	{ "client_accept_chatdori",             &battle_config.client_accept_chatdori,          0,      0,      INT_MAX,        },

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -703,7 +703,7 @@ struct script_state {
 	int bk_npcid;
 	unsigned freeloop : 1;// used by buildin_freeloop
 	unsigned op2ref : 1;// used by op_2
-	unsigned npc_item_flag : 1;
+	unsigned npc_item_flag : 2;
 	unsigned int id;
 };
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The `item_enabled_npc` battle flag's maximum value is 3. Thus the `npc_item_flag` field in `struct script_state` should be enlarged accordingly.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
