### PR TITLE
Add bonuses to reduce received damage based on attacker's defense element

### DIFF
--- a/db/constants.conf
+++ b/db/constants.conf
@@ -652,6 +652,7 @@ constants_db: {
 	bSetMDefRace:             2060
 	bAddRaceTolerance:        2061
 	bAddMaxWeight:            2062
+	bSubDefEle:               2063
 
 	comment__: "Equip index"
 	/* reference to script.c::script_defaults():equip[] array used for easy-conversion */

--- a/db/constants.conf
+++ b/db/constants.conf
@@ -653,6 +653,7 @@ constants_db: {
 	bAddRaceTolerance:        2061
 	bAddMaxWeight:            2062
 	bSubDefEle:               2063
+	bMagicSubDefEle:          2064
 
 	comment__: "Equip index"
 	/* reference to script.c::script_defaults():equip[] array used for easy-conversion */

--- a/db/re/item_combo_db.conf
+++ b/db/re/item_combo_db.conf
@@ -3229,4 +3229,138 @@ combo_db: (
 	Items: ["Rigid_Nightmare_Terror_Card", "Nightmare_Card"]
 	Script: <" bonus(bMaxSPrate, 10); ">
 },
+{
+	Items: ["Rouban_Shoes", "Rouban_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Wind, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Wind, 5, 3);
+		bonus2(bSubEle, Ele_Wind, getequiprefinerycnt(EQI_HAND_L) * 2);
+	">
+},
+{
+	Items: ["Lumiere_Shoes", "Lumiere_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Holy, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Holy, 5, 3);
+		bonus2(bSubEle, Ele_Holy, getequiprefinerycnt(EQI_HAND_L) * 2);
+	">
+},
+{
+	Items: ["Lian_Shoes", "Lian_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Neutral, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Neutral, 5, 3);
+		bonus2(bSubEle, Ele_Neutral, getequiprefinerycnt(EQI_HAND_L));
+	">
+},
+{
+	Items: ["Sharel_Shoes", "Sharel_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Fire, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Fire, 5, 3);
+		bonus2(bSubEle, Ele_Fire, getequiprefinerycnt(EQI_HAND_L) * 2);
+	">
+},
+{
+	Items: ["Sombre_Shoes", "Sombre_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Dark, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Dark, 5, 3);
+		bonus2(bSubEle, Ele_Dark, getequiprefinerycnt(EQI_HAND_L) * 2);
+	">
+},
+{
+	Items: ["Sol_Shoes", "Sol_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Earth, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Earth, 5, 3);
+		bonus2(bSubEle, Ele_Earth, getequiprefinerycnt(EQI_HAND_L) * 2);
+	">
+},
+{
+	Items: ["Poison_Shoes", "Poison_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Poison, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Poison, 5, 3);
+		bonus2(bSubEle, Ele_Poison, getequiprefinerycnt(EQI_HAND_L) * 2);
+	">
+},
+{
+	Items: ["Flow_Shoes", "Flow_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Water, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Water, 5, 3);
+		bonus2(bSubEle, Ele_Water, getequiprefinerycnt(EQI_HAND_L) * 2);
+	">
+},
+{
+	Items: ["S_Basis_Armor", "S_Basis_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Neutral, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Neutral, 2, 3);
+	">
+},
+{
+	Items: ["S_Hallowed_Armor", "S_Hallowed_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Dark, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Dark, 2, 3);
+	">
+},
+{
+	Items: ["S_Saharic_Armor", "S_Saharic_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Dark, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Dark, 2, 3);
+	">
+},
+{
+	Items: ["S_Underneath_Armor", "S_Underneath_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Earth, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Earth, 2, 3);
+	">
+},
+{
+	Items: ["S_Flam_Armor", "S_Flam_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Fire, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Fire, 2, 3);
+	">
+},
+{
+	Items: ["S_Windy_Armor", "S_Windy_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Wind, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Wind, 2, 3);
+	">
+},
+{
+	Items: ["S_Envenom_Armor", "S_Envenom_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Poison, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Poison, 2, 3);
+	">
+},
+{
+	Items: ["S_Damned_Armor", "S_Damned_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Holy, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Holy, 2, 3);
+	">
+},
+{
+	Items: ["S_Geist_Armor", "S_Geist_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Ghost, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Ghost, 2, 3);
+	">
+},
+{
+	Items: ["S_Divine_Armor", "S_Divine_Shield"]
+	Script: <"
+		bonus3(bSubDefEle, Ele_Undead, 2, 3);
+		bonus3(bMagicSubDefEle, Ele_Undead, 2, 3);
+	">
+},
 )

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -152580,12 +152580,14 @@ item_db: (
 	AegisName: "S_Basis_Shield"
 	Name: "Basis Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Neutral property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Neutral property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Neutral property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Neutral, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Neutral, .@rate, 3);
 	">
 },
 {
@@ -152593,12 +152595,14 @@ item_db: (
 	AegisName: "S_Hallowed_Shield"
 	Name: "Hallowed Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Shadow property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Shadow property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Shadow property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Dark, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Dark, .@rate, 3);
 	">
 },
 {
@@ -152606,12 +152610,14 @@ item_db: (
 	AegisName: "S_Saharic_Shield"
 	Name: "Saharic Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Water property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Water property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Water property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Water, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Water, .@rate, 3);
 	">
 },
 {
@@ -152619,25 +152625,29 @@ item_db: (
 	AegisName: "S_Underneath_Shield"
 	Name: "Underneath Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Earth property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Earth property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Earth property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Earth, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Earth, .@rate, 3);
 	">
 },
 {
 	Id: 24202
 	AegisName: "S_Flam_Shield"
-	Name: "Flammable Shadow Shield"
+	Name: "Flame Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Fire property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Fire property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Fire property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Fire, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Fire, .@rate, 3);
 	">
 },
 {
@@ -152645,12 +152655,14 @@ item_db: (
 	AegisName: "S_Windy_Shield"
 	Name: "Windy Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Wind property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Wind property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Wind property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Wind, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Wind, .@rate, 3);
 	">
 },
 {
@@ -152658,12 +152670,14 @@ item_db: (
 	AegisName: "S_Envenom_Shield"
 	Name: "Envenom Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Poison property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Poison property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Poison property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Poison, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Poison, .@rate, 3);
 	">
 },
 {
@@ -152671,12 +152685,14 @@ item_db: (
 	AegisName: "S_Damned_Shield"
 	Name: "Damned Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Holy property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Holy property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Holy property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Holy, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Holy, .@rate, 3);
 	">
 },
 {
@@ -152684,12 +152700,14 @@ item_db: (
 	AegisName: "S_Geist_Shield"
 	Name: "Exorcism Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Ghost property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Ghost property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Ghost property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Ghost, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Ghost, .@rate, 3);
 	">
 },
 {
@@ -152697,12 +152715,14 @@ item_db: (
 	AegisName: "S_Divine_Shield"
 	Name: "Divine Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 10
+	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
-		/* Reduces physical and magical damage receive from Undead property monsters by 1%. */
-		/* Refined to +7, reduces physical and magical damage receive from Undead property monsters by 1%. */
-		/* Refined to +9, reduces physical and magical damage receive from Undead property monsters by 1%. */
+		.@refine = getrefine();
+		bonus(bMaxHP, .@refine * 10);
+		.@rate = ((.@refine > 8) ? 3 : ((.@refine > 6) ? 2 : 1));
+		bonus3(bSubDefEle, Ele_Undead, .@rate, 3);
+		bonus3(bMagicSubDefEle, Ele_Undead, .@rate, 3);
 	">
 },
 {

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -35836,7 +35836,7 @@ item_db: (
 	Loc: "EQP_ACC"
 	EquipLv: 20
 	Refine: false
-	Script: <" bonus2 bSubEle,Ele_Water,5; ">
+	Script: <" bonus3(bSubDefEle, Ele_Water, 5, 3); ">
 },
 {
 	Id: 2683
@@ -35853,7 +35853,7 @@ item_db: (
 	Loc: "EQP_ACC"
 	EquipLv: 20
 	Refine: false
-	Script: <" bonus2 bSubEle,Ele_Fire,5; ">
+	Script: <" bonus3(bSubDefEle, Ele_Fire, 5, 3); ">
 },
 {
 	Id: 2684
@@ -35870,7 +35870,7 @@ item_db: (
 	Loc: "EQP_ACC"
 	EquipLv: 20
 	Refine: false
-	Script: <" bonus2 bSubEle,Ele_Wind,5; ">
+	Script: <" bonus3(bSubDefEle, Ele_Wind, 5, 3); ">
 },
 {
 	Id: 2685
@@ -35887,7 +35887,7 @@ item_db: (
 	Loc: "EQP_ACC"
 	EquipLv: 20
 	Refine: false
-	Script: <" bonus2 bSubEle,Ele_Earth,5; ">
+	Script: <" bonus3(bSubDefEle, Ele_Earth, 5, 3); ">
 },
 {
 	Id: 2686

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -34272,7 +34272,7 @@ item_db: (
 {
 	Id: 2593
 	AegisName: "Flow_Manteau"
-	Name: "Froid Manteau"
+	Name: "Flow Manteau"
 	Type: "IT_ARMOR"
 	Buy: 20
 	Weight: 700
@@ -34280,6 +34280,11 @@ item_db: (
 	Slots: 1
 	Loc: "EQP_GARMENT"
 	EquipLv: 65
+	Script: <"
+		bonus3(bSubDefEle, Ele_Water, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Water, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Brute, -5);
+	">
 },
 {
 	Id: 2594
@@ -34290,6 +34295,23 @@ item_db: (
 	Weight: 100
 	Slots: 1
 	Loc: "EQP_GARMENT"
+},
+{
+	Id: 2595
+	AegisName: "Sombre_Manteau"
+	Name: "Sombre Manteau"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 700
+	Def: 20
+	Slots: 1
+	Loc: "EQP_GARMENT"
+	EquipLv: 65
+	Script: <"
+		bonus3(bSubDefEle, Ele_Dark, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Dark, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Undead, -5);
+	">
 },
 {
 	Id: 2596
@@ -34317,6 +34339,23 @@ item_db: (
 	Loc: "EQP_GARMENT"
 	EquipLv: 50
 	Script: <" bonus bCritAtkRate,3; ">
+},
+{
+	Id: 2598
+	AegisName: "Ramor_Manteau"
+	Name: "L'Amour Manteau"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 700
+	Def: 20
+	Slots: 1
+	Loc: "EQP_GARMENT"
+	EquipLv: 65
+	Script: <"
+		bonus3(bSubDefEle, Ele_Undead, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Undead, 5, 3);
+		bonus2(bAddRaceTolerance, RC_DemiPlayer, -5);
+	">
 },
 {
 	Id: 2599
@@ -146602,6 +146641,23 @@ item_db: (
 	">
 },
 {
+	Id: 20701
+	AegisName: "Sol_Manteau"
+	Name: "Sol Manteau"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 700
+	Def: 20
+	Slots: 1
+	Loc: "EQP_GARMENT"
+	EquipLv: 65
+	Script: <"
+		bonus3(bSubDefEle, Ele_Earth, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Earth, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Fish, -5);
+	">
+},
+{
 	Id: 20702
 	AegisName: "TE_Woe_Muffler"
 	Name: "TE Woe Muffler"
@@ -146695,6 +146751,23 @@ item_db: (
 	">
 },
 {
+	Id: 20705
+	AegisName: "Lumiere_Manteau"
+	Name: "Lumiere Manteau"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 700
+	Def: 20
+	Slots: 1
+	Loc: "EQP_GARMENT"
+	EquipLv: 65
+	Script: <"
+		bonus3(bSubDefEle, Ele_Holy, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Holy, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Dragon, -5);
+	">
+},
+{
 	Id: 20706
 	AegisName: "Amistr_Bag"
 	Name: "Amistr Bag"
@@ -146733,6 +146806,23 @@ item_db: (
 		bonus bDex,1;
 		bonus bAgi,1;
 		bonus bLuk,1;
+	">
+},
+{
+	Id: 20708
+	AegisName: "Poison_Manteau"
+	Name: "Poison Manteau"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 700
+	Def: 20
+	Slots: 1
+	Loc: "EQP_GARMENT"
+	EquipLv: 65
+	Script: <"
+		bonus3(bSubDefEle, Ele_Poison, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Poison, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Plant, -5);
 	">
 },
 {
@@ -147066,6 +147156,40 @@ item_db: (
 			bonus bAspdRate,3+(getrefine()/2);
 			bonus bAspd,((getrefine()>=10)?1:0);
 		}
+	">
+},
+{
+	Id: 20750
+	AegisName: "Rouban_Manteau"
+	Name: "Levain Manteau"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 700
+	Def: 20
+	Slots: 1
+	Loc: "EQP_GARMENT"
+	EquipLv: 65
+	Script: <"
+		bonus3(bSubDefEle, Ele_Wind, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Wind, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Insect, -5);
+	">
+},
+{
+	Id: 20753
+	AegisName: "Lian_Robe"
+	Name: "Lian Robe"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 700
+	Def: 20
+	Slots: 1
+	Loc: "EQP_GARMENT"
+	EquipLv: 65
+	Script: <"
+		bonus3(bSubDefEle, Ele_Neutral, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Neutral, 5, 3);
+		bonus2(bSubRace, RC_Formless, -5);
 	">
 },
 {

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -26316,7 +26316,6 @@ item_db: (
 	AegisName: "Rouban_Shield"
 	Name: "Levain Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 1300
 	Def: 50
 	Slots: 1
@@ -26334,7 +26333,6 @@ item_db: (
 	AegisName: "Lian_Shield"
 	Name: "Lian Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 1300
 	Def: 50
 	Slots: 1
@@ -34324,8 +34322,9 @@ item_db: (
 	Loc: "EQP_GARMENT"
 	EquipLv: 65
 	Script: <"
-		bonus2 bSubEle,Ele_Fire,5;
-		bonus2 bAddRaceTolerance,RC_Demon,5;
+		bonus3(bSubDefEle, Ele_Fire, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Fire, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Demon, -5);
 	">
 },
 {
@@ -61636,6 +61635,9 @@ item_db: (
 	Def: 6
 	Loc: ["EQP_HEAD_TOP", "EQP_HEAD_MID"]
 	ViewSprite: 491
+	Trade: {
+		nodrop: true
+	}
 	Script: <"
 		bonus(bInt, 3);
 		bonus(bMdef, 3);
@@ -61733,6 +61735,9 @@ item_db: (
 	Def: 6
 	Loc: "EQP_HEAD_TOP"
 	ViewSprite: 503
+	Trade: {
+		nodrop: true
+	}
 	Script: <"
 		bonus(bStr, 1);
 		bonus(bAgi, 2);
@@ -61752,6 +61757,9 @@ item_db: (
 	Def: 10
 	Loc: "EQP_HEAD_TOP"
 	ViewSprite: 504
+	Trade: {
+		nodrop: true
+	}
 	Script: <"
 		bonus(bStr, 2);
 		bonus(bVit, 1);
@@ -63237,6 +63245,9 @@ item_db: (
 	Slots: 1
 	Loc: ["EQP_HEAD_TOP", "EQP_HEAD_MID"]
 	ViewSprite: 549
+	Trade: {
+		nodrop: true
+	}
 	Script: <"
 		bonus(bBaseAtk, 10);
 		bonus(bMatk, 10);
@@ -124256,6 +124267,9 @@ item_db: (
 	Weight: 1000
 	Def: 25
 	Loc: "EQP_ARMOR"
+	Trade: {
+		nodrop: true
+	}
 	Script: <"
 		bonus(bMdef, 1);
 		bonus(bDefEle, Ele_Fire);
@@ -135931,6 +135945,12 @@ item_db: (
 	Loc: "EQP_HEAD_TOP"
 	EquipLv: 10
 	ViewSprite: 859
+	Trade: {
+		nodrop: true
+		nomail: true
+		noauction: true
+		nogstorage: true
+	}
 	Script: <"
 		bonus3(bSubDefEle, Ele_Water, 10, 3);
 		bonus5(bAutoSpellWhenHit, WZ_FROSTNOVA, 1, 1, BF_WEAPON, 1);
@@ -138690,7 +138710,6 @@ item_db: (
 	AegisName: "Isabella_Red_Ear"
 	Name: "Piamette's Red Ears"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 300
 	Def: 8
 	Slots: 1
@@ -138742,7 +138761,6 @@ item_db: (
 	AegisName: "Red_Flower_Hat"
 	Name: "Red Flower Hat"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 200
 	Def: 10
 	Slots: 1
@@ -147163,7 +147181,6 @@ item_db: (
 	AegisName: "Rouban_Manteau"
 	Name: "Levain Manteau"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 700
 	Def: 20
 	Slots: 1
@@ -147180,7 +147197,6 @@ item_db: (
 	AegisName: "Lian_Robe"
 	Name: "Lian Robe"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 700
 	Def: 20
 	Slots: 1
@@ -148647,7 +148663,6 @@ item_db: (
 	AegisName: "Sombre_Shoes"
 	Name: "Sombre Shoes"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 250
 	Def: 12
 	Slots: 1
@@ -148665,7 +148680,6 @@ item_db: (
 	AegisName: "Sol_Shoes"
 	Name: "Sol Shoes"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 250
 	Def: 12
 	Slots: 1
@@ -148683,7 +148697,6 @@ item_db: (
 	AegisName: "Sharel_Shoes"
 	Name: "Sharel Shoes"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 250
 	Def: 12
 	Slots: 1
@@ -148701,7 +148714,6 @@ item_db: (
 	AegisName: "Flow_Shoes"
 	Name: "Flow Shoes"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 250
 	Def: 12
 	Slots: 1
@@ -148736,7 +148748,6 @@ item_db: (
 	AegisName: "Lumiere_Shoes"
 	Name: "Lumiere Shoes"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 250
 	Def: 12
 	Slots: 1
@@ -148754,7 +148765,6 @@ item_db: (
 	AegisName: "Rouban_Shoes"
 	Name: "Levain Shoes"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 250
 	Def: 12
 	Slots: 1
@@ -148772,7 +148782,6 @@ item_db: (
 	AegisName: "Poison_Shoes"
 	Name: "Poison Shoes"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 250
 	Def: 12
 	Slots: 1
@@ -148809,7 +148818,6 @@ item_db: (
 	AegisName: "Lian_Shoes"
 	Name: "Lian Shoes"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Weight: 250
 	Def: 12
 	Slots: 1
@@ -152724,7 +152732,6 @@ item_db: (
 	AegisName: "S_Basis_Shield"
 	Name: "Basis Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();
@@ -152739,7 +152746,6 @@ item_db: (
 	AegisName: "S_Hallowed_Shield"
 	Name: "Hallowed Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();
@@ -152754,7 +152760,6 @@ item_db: (
 	AegisName: "S_Saharic_Shield"
 	Name: "Saharic Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();
@@ -152769,7 +152774,6 @@ item_db: (
 	AegisName: "S_Underneath_Shield"
 	Name: "Underneath Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();
@@ -152784,7 +152788,6 @@ item_db: (
 	AegisName: "S_Flam_Shield"
 	Name: "Flame Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();
@@ -152799,7 +152802,6 @@ item_db: (
 	AegisName: "S_Windy_Shield"
 	Name: "Windy Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();
@@ -152814,7 +152816,6 @@ item_db: (
 	AegisName: "S_Envenom_Shield"
 	Name: "Envenom Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();
@@ -152829,7 +152830,6 @@ item_db: (
 	AegisName: "S_Damned_Shield"
 	Name: "Damned Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();
@@ -152844,7 +152844,6 @@ item_db: (
 	AegisName: "S_Geist_Shield"
 	Name: "Exorcism Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();
@@ -152859,7 +152858,6 @@ item_db: (
 	AegisName: "S_Divine_Shield"
 	Name: "Divine Shadow Shield"
 	Type: "IT_ARMOR"
-	Buy: 20
 	Loc: "EQP_SHADOW_SHIELD"
 	Script: <"
 		.@refine = getrefine();

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -46776,8 +46776,8 @@ item_db: (
 	Weight: 10
 	Loc: "EQP_SHIELD"
 	Script: <"
-		bonus2 bSubEle,Ele_Neutral,20;
-		bonus2 bAddEle,Ele_Neutral,5;
+		bonus3(bSubDefEle, Ele_Neutral, 20, 3);
+		bonus2(bAddEle, Ele_Neutral, 5);
 	">
 },
 {
@@ -46789,8 +46789,8 @@ item_db: (
 	Weight: 10
 	Loc: "EQP_SHIELD"
 	Script: <"
-		bonus2 bSubEle,Ele_Water,20;
-		bonus2 bAddEle,Ele_Water,5;
+		bonus3(bSubDefEle, Ele_Water, 20, 3);
+		bonus2(bAddEle, Ele_Water, 5);
 	">
 },
 {
@@ -46802,8 +46802,8 @@ item_db: (
 	Weight: 10
 	Loc: "EQP_SHIELD"
 	Script: <"
-		bonus2 bSubEle,Ele_Earth,20;
-		bonus2 bAddEle,Ele_Earth,5;
+		bonus3(bSubDefEle, Ele_Earth, 20, 3);
+		bonus2(bAddEle, Ele_Earth, 5);
 	">
 },
 {
@@ -46815,8 +46815,8 @@ item_db: (
 	Weight: 10
 	Loc: "EQP_SHIELD"
 	Script: <"
-		bonus2 bSubEle,Ele_Wind,20;
-		bonus2 bAddEle,Ele_Wind,5;
+		bonus3(bSubDefEle, Ele_Wind, 20, 3);
+		bonus2(bAddEle, Ele_Wind, 5);
 	">
 },
 {
@@ -46844,8 +46844,8 @@ item_db: (
 	Weight: 10
 	Loc: "EQP_SHIELD"
 	Script: <"
-		bonus2 bSubEle,Ele_Poison,20;
-		bonus2 bAddEle,Ele_Poison,5;
+		bonus3(bSubDefEle, Ele_Poison, 20, 3);
+		bonus2(bAddEle, Ele_Poison, 5);
 	">
 },
 {
@@ -46857,8 +46857,8 @@ item_db: (
 	Weight: 10
 	Loc: "EQP_SHIELD"
 	Script: <"
-		bonus2 bSubEle,Ele_Holy,20;
-		bonus2 bAddEle,Ele_Holy,5;
+		bonus3(bSubDefEle, Ele_Holy, 20, 3);
+		bonus2(bAddEle, Ele_Holy, 5);
 	">
 },
 {
@@ -46870,8 +46870,8 @@ item_db: (
 	Weight: 10
 	Loc: "EQP_SHIELD"
 	Script: <"
-		bonus2 bSubEle,Ele_Dark,20;
-		bonus2 bAddEle,Ele_Dark,5;
+		bonus3(bSubDefEle, Ele_Dark, 20, 3);
+		bonus2(bAddEle, Ele_Dark, 5);
 	">
 },
 {

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -148643,6 +148643,78 @@ item_db: (
 	">
 },
 {
+	Id: 22048
+	AegisName: "Sombre_Shoes"
+	Name: "Sombre Shoes"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 250
+	Def: 12
+	Slots: 1
+	Loc: "EQP_SHOES"
+	EquipLv: 90
+	Script: <"
+		bonus(bMdef, 3);
+		bonus2(bSubEle, Ele_Dark, 5);
+		bonus(bMaxHPrate, getrefine());
+		bonus(bMaxSPrate, getrefine());
+	">
+},
+{
+	Id: 22049
+	AegisName: "Sol_Shoes"
+	Name: "Sol Shoes"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 250
+	Def: 12
+	Slots: 1
+	Loc: "EQP_SHOES"
+	EquipLv: 90
+	Script: <"
+		bonus(bMdef, 3);
+		bonus2(bSubEle, Ele_Earth, 5);
+		bonus(bMaxHPrate, getrefine());
+		bonus(bMaxSPrate, getrefine());
+	">
+},
+{
+	Id: 22055
+	AegisName: "Sharel_Shoes"
+	Name: "Sharel Shoes"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 250
+	Def: 12
+	Slots: 1
+	Loc: "EQP_SHOES"
+	EquipLv: 90
+	Script: <"
+		bonus(bMdef, 3);
+		bonus2(bSubEle, Ele_Fire, 5);
+		bonus(bMaxHPrate, getrefine());
+		bonus(bMaxSPrate, getrefine());
+	">
+},
+{
+	Id: 22057
+	AegisName: "Flow_Shoes"
+	Name: "Flow Shoes"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 250
+	Def: 12
+	Slots: 1
+	Loc: "EQP_SHOES"
+	EquipLv: 90
+	Script: <"
+		bonus(bMdef, 3);
+		bonus2(bSubEle, Ele_Water, 5);
+		bonus(bMaxHPrate, getrefine());
+		bonus(bMaxSPrate, getrefine());
+	">
+},
+{
 	Id: 22059
 	AegisName: "Aegir_Shoes"
 	Name: "Egir Shoes"
@@ -148657,6 +148729,60 @@ item_db: (
 		bonus bMaxHP, 500;
 		bonus bMaxSP, 50;
 		bonus bUnbreakableShoes, 0;
+	">
+},
+{
+	Id: 22061
+	AegisName: "Lumiere_Shoes"
+	Name: "Lumiere Shoes"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 250
+	Def: 12
+	Slots: 1
+	Loc: "EQP_SHOES"
+	EquipLv: 90
+	Script: <"
+		bonus(bMdef, 3);
+		bonus2(bSubEle, Ele_Holy, 5);
+		bonus(bMaxHPrate, getrefine());
+		bonus(bMaxSPrate, getrefine());
+	">
+},
+{
+	Id: 22063
+	AegisName: "Rouban_Shoes"
+	Name: "Levain Shoes"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 250
+	Def: 12
+	Slots: 1
+	Loc: "EQP_SHOES"
+	EquipLv: 90
+	Script: <"
+		bonus(bMdef, 3);
+		bonus2(bSubEle, Ele_Wind, 5);
+		bonus(bMaxHPrate, getrefine());
+		bonus(bMaxSPrate, getrefine());
+	">
+},
+{
+	Id: 22065
+	AegisName: "Poison_Shoes"
+	Name: "Poison Shoes"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 250
+	Def: 12
+	Slots: 1
+	Loc: "EQP_SHOES"
+	EquipLv: 90
+	Script: <"
+		bonus(bMdef, 3);
+		bonus2(bSubEle, Ele_Poison, 5);
+		bonus(bMaxHPrate, getrefine());
+		bonus(bMaxSPrate, getrefine());
 	">
 },
 {
@@ -148676,6 +148802,24 @@ item_db: (
 		skill ALL_CATCRY, 1;
 		bonus bUnbreakableShoes, 1;
 		autobonus3 "{ }", 1000, 7000, ALL_CATCRY, "{ montransform LOLI_RURI, 420000; }";
+	">
+},
+{
+	Id: 22069
+	AegisName: "Lian_Shoes"
+	Name: "Lian Shoes"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 250
+	Def: 12
+	Slots: 1
+	Loc: "EQP_SHOES"
+	EquipLv: 90
+	Script: <"
+		bonus(bMdef, 3);
+		bonus2(bSubEle, Ele_Neutral, 5);
+		bonus(bMaxHPrate, getrefine());
+		bonus(bMaxSPrate, getrefine());
 	">
 },
 {

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -61527,9 +61527,12 @@ item_db: (
 	Loc: ["EQP_HEAD_TOP", "EQP_HEAD_MID"]
 	ViewSprite: 491
 	Script: <"
-		bonus bMdef,3;
-		bonus bInt,3;
-		bonus5 bAutoSpellWhenHit,NPC_DARKSTRIKE,5,5,BF_WEAPON|BF_MAGIC,1;
+		bonus(bInt, 3);
+		bonus(bMdef, 3);
+		bonus3(bSubDefEle, Ele_Holy, -20, 3);
+		bonus3(bSubDefEle, Ele_Undead, 15, 3);
+		bonus3(bSubDefEle, Ele_Dark, 15, 3);
+		bonus(bVariableCastrate, -10);
 	">
 },
 {
@@ -61621,11 +61624,12 @@ item_db: (
 	Loc: "EQP_HEAD_TOP"
 	ViewSprite: 503
 	Script: <"
-		bonus bStr,1;
-		bonus bAgi,2;
-		bonus bMdef,1;
-		bonus2 bAddEle,Ele_Water,5;
-		bonus2 bSubEle,Ele_Water,10;
+		bonus(bStr, 1);
+		bonus(bAgi, 2);
+		bonus(bMdef, 1);
+		bonus2(bAddEle, Ele_Water, 5);
+		bonus3(bSubDefEle, Ele_Water, 10, 3);
+		bonus3(bMagicSubDefEle, Ele_Water, 10, 3);
 	">
 },
 {
@@ -61639,12 +61643,12 @@ item_db: (
 	Loc: "EQP_HEAD_TOP"
 	ViewSprite: 504
 	Script: <"
-		bonus bStr,2;
-		bonus bVit,1;
-		bonus bMdef,3;
-		bonus2 bAddEle,Ele_Fire,5;
-		bonus2 bSubEle,Ele_Earth,5;
-		bonus3 bAutoSpell,WZ_EARTHSPIKE,1,10;
+		bonus(bStr, 2);
+		bonus(bVit, 1);
+		bonus(bMdef, 3);
+		bonus5(bAutoSpellWhenHit, WZ_EARTHSPIKE, 1, 10, BF_WEAPON, 1);
+		bonus2(bSubEle, Ele_Fire, -5);
+		bonus3(bSubDefEle, Ele_Earth, 5, 3);
 	">
 },
 {
@@ -63124,20 +63128,13 @@ item_db: (
 	Loc: ["EQP_HEAD_TOP", "EQP_HEAD_MID"]
 	ViewSprite: 549
 	Script: <"
-		bonus bBaseAtk,10;
-		bonus bMatk,10;
-		bonus2 bAddRaceTolerance,RC_DemiPlayer,3;
-		bonus bDelayrate,-3;
-		if(getrefine()>6) {
-			bonus2 bSubEle,Ele_Neutral,5;
-			bonus2 bSubEle,Ele_Water,5;
-			bonus2 bSubEle,Ele_Earth,5;
-			bonus2 bSubEle,Ele_Fire,5;
-			bonus2 bSubEle,Ele_Wind,5;
-			bonus2 bSubEle,Ele_Holy,5;
-			bonus2 bSubEle,Ele_Dark,5;
-			bonus2 bSubEle,Ele_Ghost,5;
-		}
+		bonus(bBaseAtk, 10);
+		bonus(bMatk, 10);
+		bonus2(bAddRaceTolerance, RC_DemiPlayer, 3);
+		bonus(bDelayrate, -3);
+
+		if (getrefine() > 6)
+			bonus3(bSubDefEle, Ele_All, 5, 3);
 	">
 },
 {
@@ -135583,8 +135580,8 @@ item_db: (
 	Refine: false
 	ViewSprite: 844
 	Script: <"
-		bonus2 bSubRace,RC_Fish,15;
-		bonus3 bAddMonsterDropItem,579,RC_Fish,5;
+		bonus3(bSubDefEle, Ele_Water, 15, 3);
+		bonus3(bAddMonsterDropItem, Delicious_Fish, RC_Fish, 50);
 	">
 },
 {
@@ -135823,6 +135820,11 @@ item_db: (
 	Loc: "EQP_HEAD_TOP"
 	EquipLv: 10
 	ViewSprite: 859
+	Script: <"
+		bonus3(bSubDefEle, Ele_Water, 10, 3);
+		bonus5(bAutoSpellWhenHit, WZ_FROSTNOVA, 1, 1, BF_WEAPON, 1);
+		bonus5(bAutoSpellWhenHit, WZ_FROSTNOVA, 1, 1, BF_MAGIC, 1);
+	">
 },
 {
 	Id: 18715
@@ -138577,16 +138579,19 @@ item_db: (
 	AegisName: "Isabella_Red_Ear"
 	Name: "Piamette's Red Ears"
 	Type: "IT_ARMOR"
+	Buy: 20
 	Weight: 300
 	Def: 8
 	Slots: 1
 	Loc: "EQP_HEAD_TOP"
 	ViewSprite: 1030
 	Script: <"
-		bonus bStr,5;
-		bonus bMaxHPrate,5;
-		bonus2 bSubEle,Ele_Fire,10;
-		if(getrefine()>=9) { bonus bAspd,1+((getrefine()/2)-4); }
+		bonus(bStr, 5);
+		bonus(bMaxHPrate, 5);
+		bonus3(bSubDefEle, Ele_Fire, 10, 3);
+
+		if (getrefine() > 8)
+			bonus(bAspd, (getrefine() - 7) / 2);
 	">
 },
 {
@@ -138626,16 +138631,19 @@ item_db: (
 	AegisName: "Red_Flower_Hat"
 	Name: "Red Flower Hat"
 	Type: "IT_ARMOR"
+	Buy: 20
 	Weight: 200
 	Def: 10
 	Slots: 1
 	Loc: "EQP_HEAD_TOP"
 	ViewSprite: 1033
 	Script: <"
-		bonus bDex,5;
-		bonus2 bSubEle,Ele_Earth,3;
-		bonus2 bAddRaceTolerance,RC_DemiPlayer,10;
-		if(getrefine()>=12) { bonus bShortWeaponDamageReturn,5; }
+		bonus(bDex, 5);
+		bonus3(bSubDefEle, Ele_Earth, 3, 3);
+		bonus2(bAddRaceTolerance, RC_DemiPlayer, 10);
+
+		if (getrefine() > 11)
+			bonus(bShortWeaponDamageReturn, 5);
 	">
 },
 {

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -25637,7 +25637,7 @@ item_db: (
 {
 	Id: 2158
 	AegisName: "Ramor_Shield_Undead"
-	Name: "Ramorushirudo"
+	Name: "L'Amour Shield"
 	Type: "IT_ARMOR"
 	Buy: 20
 	Weight: 1300
@@ -25647,14 +25647,15 @@ item_db: (
 	EquipLv: 65
 	ViewSprite: 3
 	Script: <"
-		bonus2 bAddRaceTolerance, RC_Undead, 5;
-		bonus2 bAddRaceTolerance, RC_DemiPlayer, -5;
+		bonus3(bSubDefEle, Ele_Undead, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Undead, 5, 3);
+		bonus2(bAddRaceTolerance, RC_DemiPlayer, -5);
 	">
 },
 {
 	Id: 2159
 	AegisName: "Sharel_Shield"
-	Name: "Sharerushirudo"
+	Name: "Sharel Shield"
 	Type: "IT_ARMOR"
 	Buy: 20
 	Weight: 1300
@@ -25663,6 +25664,11 @@ item_db: (
 	Loc: "EQP_SHIELD"
 	EquipLv: 65
 	ViewSprite: 3
+	Script: <"
+		bonus3(bSubDefEle, Ele_Fire, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Fire, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Demon, -5);
+	">
 },
 {
 	Id: 2160
@@ -25738,7 +25744,7 @@ item_db: (
 {
 	Id: 2163
 	AegisName: "Flow_Shield"
-	Name: "Floor Shield"
+	Name: "Flow Shield"
 	Type: "IT_ARMOR"
 	Buy: 20
 	Weight: 1300
@@ -25747,11 +25753,16 @@ item_db: (
 	Loc: "EQP_SHIELD"
 	EquipLv: 65
 	ViewSprite: 3
+	Script: <"
+		bonus3(bSubDefEle, Ele_Water, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Water, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Brute, -5);
+	">
 },
 {
 	Id: 2164
 	AegisName: "Sombre_Shield"
-	Name: "Bull Son Shield"
+	Name: "Sombre Shield"
 	Type: "IT_ARMOR"
 	Buy: 20
 	Weight: 1300
@@ -25760,6 +25771,11 @@ item_db: (
 	Loc: "EQP_SHIELD"
 	EquipLv: 65
 	ViewSprite: 3
+	Script: <"
+		bonus3(bSubDefEle, Ele_Dark, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Dark, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Undead, -5);
+	">
 },
 {
 	Id: 2165
@@ -25773,6 +25789,11 @@ item_db: (
 	Loc: "EQP_SHIELD"
 	EquipLv: 65
 	ViewSprite: 3
+	Script: <"
+		bonus3(bSubDefEle, Ele_Earth, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Earth, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Plant, -5);
+	">
 },
 {
 	Id: 2166
@@ -25804,6 +25825,11 @@ item_db: (
 	Loc: "EQP_SHIELD"
 	EquipLv: 65
 	ViewSprite: 3
+	Script: <"
+		bonus3(bSubDefEle, Ele_Poison, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Poison, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Plant, -5);
+	">
 },
 {
 	Id: 2168
@@ -25912,6 +25938,11 @@ item_db: (
 	Loc: "EQP_SHIELD"
 	EquipLv: 65
 	ViewSprite: 3
+	Script: <"
+		bonus3(bSubDefEle, Ele_Holy, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Holy, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Dragon, -5);
+	">
 },
 {
 	Id: 2175
@@ -25925,6 +25956,10 @@ item_db: (
 	Loc: "EQP_SHIELD"
 	EquipLv: 65
 	ViewSprite: 3
+	Script: <"
+		bonus3(bSubDefEle, Ele_Ghost, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Angel, -5);
+	">
 },
 {
 	Id: 2176
@@ -26274,6 +26309,42 @@ item_db: (
 		bonus bMaxHP,500;
 		bonus bMaxSP,50;
 		if(getrefine()>=14) { skill MG_STONECURSE,5; }
+	">
+},
+{
+	Id: 2194
+	AegisName: "Rouban_Shield"
+	Name: "Levain Shield"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 1300
+	Def: 50
+	Slots: 1
+	Loc: "EQP_SHIELD"
+	EquipLv: 65
+	ViewSprite: 1
+	Script: <"
+		bonus3(bSubDefEle, Ele_Wind, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Wind, 5, 3);
+		bonus2(bAddRaceTolerance, RC_Insect, -5);
+	">
+},
+{
+	Id: 2195
+	AegisName: "Lian_Shield"
+	Name: "Lian Shield"
+	Type: "IT_ARMOR"
+	Buy: 20
+	Weight: 1300
+	Def: 50
+	Slots: 1
+	Loc: "EQP_SHIELD"
+	EquipLv: 65
+	ViewSprite: 3
+	Script: <"
+		bonus3(bSubDefEle, Ele_Neutral, 5, 3);
+		bonus3(bMagicSubDefEle, Ele_Neutral, 5, 3);
+		bonus2(bSubRace, RC_Formless, -5);
 	">
 },
 {

--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -124147,8 +124147,9 @@ item_db: (
 	Def: 25
 	Loc: "EQP_ARMOR"
 	Script: <"
-		bonus bMdef,1;
-		bonus2 bSubEle,Ele_Fire,5;
+		bonus(bMdef, 1);
+		bonus(bDefEle, Ele_Fire);
+		bonus3(bSubDefEle, Ele_Earth, 4, 3);
 	">
 },
 {

--- a/doc/item_bonus.md
+++ b/doc/item_bonus.md
@@ -275,6 +275,7 @@ bonus3 bAddEle,`e`,`n`,`bf`;         | +n% physical damage against element `e`
 bonus2 bSubEle,`e`,`n`;              | +n% Damage reduction against element `e`
 bonus3 bSubEle,`e`,`n`,`bf`;         | +n% Damage reduction against element `e`.
 bonus3 bSubDefEle,`e`,`n`,`i`;       | +n% Physical damage reduction against defense element `e`.<br/> i: <br/> Flags (bitfield)<br/> &1: Reduce damage from monsters.<br/> &2: Reduce damage from players.
+bonus3 bMagicSubDefEle,`e`,`n`,`i`;  | +n% Magical damage reduction against defense element `e`.<br/> i: <br/> Flags (bitfield)<br/> &1: Reduce damage from monsters.<br/> &2: Reduce damage from players.
 bonus2 bAddDamageClass,`c`,`x`;      | +n% extra physical damage against monsters of class `c`
 bonus2 bAddMagicDamageClass,`c`,`x`; | +n% extra magical damage against monsters of class `c`
 bonus2 bAddDefClass,`c`,`x`;         | +n% physical damage reduction against monsters of class `c`

--- a/doc/item_bonus.md
+++ b/doc/item_bonus.md
@@ -274,6 +274,7 @@ bonus2 bMagicAtkEle,`e`,`n`;         | Increases damage of element `e` magic by 
 bonus3 bAddEle,`e`,`n`,`bf`;         | +n% physical damage against element `e`
 bonus2 bSubEle,`e`,`n`;              | +n% Damage reduction against element `e`
 bonus3 bSubEle,`e`,`n`,`bf`;         | +n% Damage reduction against element `e`.
+bonus3 bSubDefEle,`e`,`n`,`i`;       | +n% Physical damage reduction against defense element `e`.<br/> i: <br/> Flags (bitfield)<br/> &1: Reduce damage from monsters.<br/> &2: Reduce damage from players.
 bonus2 bAddDamageClass,`c`,`x`;      | +n% extra physical damage against monsters of class `c`
 bonus2 bAddMagicDamageClass,`c`,`x`; | +n% extra magical damage against monsters of class `c`
 bonus2 bAddDefClass,`c`,`x`;         | +n% physical damage reduction against monsters of class `c`

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1234,6 +1234,20 @@ static int64 battle_calc_cardfix(int attack_type, struct block_list *src, struct
 							}
 							cardfix = cardfix * (100 - ele_fix_lh) / 100;
 						}
+
+						// Apply bSubDefEle damage reduction.
+						switch (src->type) {
+						case BL_MOB:
+							ele_fix = tsd->sub_def_ele[status_get_element(src)].rate_mob;
+							break;
+						case BL_PC:
+							ele_fix = tsd->sub_def_ele[status_get_element(src)].rate_pc;
+							break;
+						default:
+							break;
+						}
+
+						cardfix = cardfix * (100 - ele_fix) / 100;
 					}
 					cardfix = cardfix * (100-tsd->subsize[sstatus->size]) / 100;
 					cardfix = cardfix * (100-tsd->subrace2[s_race2]) / 100;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1068,6 +1068,19 @@ static int64 battle_calc_cardfix(int attack_type, struct block_list *src, struct
 							continue;
 						ele_fix += tsd->subele2[i].rate;
 					}
+
+					// Apply bMagicSubDefEle damage reduction.
+					switch (src->type) {
+					case BL_MOB:
+						ele_fix += tsd->magic_sub_def_ele[status_get_element(src)].rate_mob;
+						break;
+					case BL_PC:
+						ele_fix += tsd->magic_sub_def_ele[status_get_element(src)].rate_pc;
+						break;
+					default:
+						break;
+					}
+
 					cardfix = cardfix * (100 - ele_fix) / 100;
 				}
 				cardfix = cardfix * (100 - tsd->subsize[sstatus->size]) / 100;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1070,17 +1070,20 @@ static int64 battle_calc_cardfix(int attack_type, struct block_list *src, struct
 					}
 
 					// Apply bMagicSubDefEle damage reduction.
-					if ((src->type == BL_MOB || src->type == BL_PC)
-					    && !Assert_chk(sstatus->def_ele >= ELE_NEUTRAL && sstatus->def_ele < ELE_MAX)) {
-						switch (src->type) {
-						case BL_MOB:
-							ele_fix += tsd->magic_sub_def_ele[sstatus->def_ele].rate_mob;
-							break;
-						case BL_PC:
-							ele_fix += tsd->magic_sub_def_ele[sstatus->def_ele].rate_pc;
-							break;
-						default:
-							break;
+					if (src->type == BL_MOB || src->type == BL_PC) {
+						int ele = (int)sstatus->def_ele;
+
+						if (!Assert_chk(ele >= ELE_NEUTRAL && ele < ELE_MAX)) {
+							switch (src->type) {
+							case BL_MOB:
+								ele_fix += tsd->magic_sub_def_ele[ele].rate_mob;
+								break;
+							case BL_PC:
+								ele_fix += tsd->magic_sub_def_ele[ele].rate_pc;
+								break;
+							default:
+								break;
+							}
 						}
 					}
 
@@ -1252,20 +1255,23 @@ static int64 battle_calc_cardfix(int attack_type, struct block_list *src, struct
 						}
 
 						// Apply bSubDefEle damage reduction.
-						if ((src->type == BL_MOB || src->type == BL_PC)
-						    && !Assert_chk(sstatus->def_ele >= ELE_NEUTRAL && sstatus->def_ele < ELE_MAX)) {
-							switch (src->type) {
-							case BL_MOB:
-								ele_fix = tsd->sub_def_ele[sstatus->def_ele].rate_mob;
-								break;
-							case BL_PC:
-								ele_fix = tsd->sub_def_ele[sstatus->def_ele].rate_pc;
-								break;
-							default:
-								break;
-							}
+						if (src->type == BL_MOB || src->type == BL_PC) {
+							int ele = (int)sstatus->def_ele;
 
-							cardfix = cardfix * (100 - ele_fix) / 100;
+							if (!Assert_chk(ele >= ELE_NEUTRAL && ele < ELE_MAX)) {
+								switch (src->type) {
+								case BL_MOB:
+									ele_fix = tsd->sub_def_ele[ele].rate_mob;
+									break;
+								case BL_PC:
+									ele_fix = tsd->sub_def_ele[ele].rate_pc;
+									break;
+								default:
+									break;
+								}
+
+								cardfix = cardfix * (100 - ele_fix) / 100;
+							}
 						}
 					}
 					cardfix = cardfix * (100-tsd->subsize[sstatus->size]) / 100;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1070,16 +1070,14 @@ static int64 battle_calc_cardfix(int attack_type, struct block_list *src, struct
 					}
 
 					// Apply bMagicSubDefEle damage reduction.
-					enum elements def_ele = status_get_element(src);
-
 					if ((src->type == BL_MOB || src->type == BL_PC)
-					    && !Assert_chk(def_ele >= ELE_NEUTRAL && def_ele < ELE_MAX)) {
+					    && !Assert_chk(sstatus->def_ele >= ELE_NEUTRAL && sstatus->def_ele < ELE_MAX)) {
 						switch (src->type) {
 						case BL_MOB:
-							ele_fix += tsd->magic_sub_def_ele[def_ele].rate_mob;
+							ele_fix += tsd->magic_sub_def_ele[sstatus->def_ele].rate_mob;
 							break;
 						case BL_PC:
-							ele_fix += tsd->magic_sub_def_ele[def_ele].rate_pc;
+							ele_fix += tsd->magic_sub_def_ele[sstatus->def_ele].rate_pc;
 							break;
 						default:
 							break;
@@ -1254,16 +1252,14 @@ static int64 battle_calc_cardfix(int attack_type, struct block_list *src, struct
 						}
 
 						// Apply bSubDefEle damage reduction.
-						enum elements def_ele = status_get_element(src);
-
 						if ((src->type == BL_MOB || src->type == BL_PC)
-						    && !Assert_chk(def_ele >= ELE_NEUTRAL && def_ele < ELE_MAX)) {
+						    && !Assert_chk(sstatus->def_ele >= ELE_NEUTRAL && sstatus->def_ele < ELE_MAX)) {
 							switch (src->type) {
 							case BL_MOB:
-								ele_fix = tsd->sub_def_ele[def_ele].rate_mob;
+								ele_fix = tsd->sub_def_ele[sstatus->def_ele].rate_mob;
 								break;
 							case BL_PC:
-								ele_fix = tsd->sub_def_ele[def_ele].rate_pc;
+								ele_fix = tsd->sub_def_ele[sstatus->def_ele].rate_pc;
 								break;
 							default:
 								break;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1070,15 +1070,20 @@ static int64 battle_calc_cardfix(int attack_type, struct block_list *src, struct
 					}
 
 					// Apply bMagicSubDefEle damage reduction.
-					switch (src->type) {
-					case BL_MOB:
-						ele_fix += tsd->magic_sub_def_ele[status_get_element(src)].rate_mob;
-						break;
-					case BL_PC:
-						ele_fix += tsd->magic_sub_def_ele[status_get_element(src)].rate_pc;
-						break;
-					default:
-						break;
+					enum elements def_ele = status_get_element(src);
+
+					if ((src->type == BL_MOB || src->type == BL_PC)
+					    && !Assert_chk(def_ele >= ELE_NEUTRAL && def_ele < ELE_MAX)) {
+						switch (src->type) {
+						case BL_MOB:
+							ele_fix += tsd->magic_sub_def_ele[def_ele].rate_mob;
+							break;
+						case BL_PC:
+							ele_fix += tsd->magic_sub_def_ele[def_ele].rate_pc;
+							break;
+						default:
+							break;
+						}
 					}
 
 					cardfix = cardfix * (100 - ele_fix) / 100;
@@ -1249,18 +1254,23 @@ static int64 battle_calc_cardfix(int attack_type, struct block_list *src, struct
 						}
 
 						// Apply bSubDefEle damage reduction.
-						switch (src->type) {
-						case BL_MOB:
-							ele_fix = tsd->sub_def_ele[status_get_element(src)].rate_mob;
-							break;
-						case BL_PC:
-							ele_fix = tsd->sub_def_ele[status_get_element(src)].rate_pc;
-							break;
-						default:
-							break;
-						}
+						enum elements def_ele = status_get_element(src);
 
-						cardfix = cardfix * (100 - ele_fix) / 100;
+						if ((src->type == BL_MOB || src->type == BL_PC)
+						    && !Assert_chk(def_ele >= ELE_NEUTRAL && def_ele < ELE_MAX)) {
+							switch (src->type) {
+							case BL_MOB:
+								ele_fix = tsd->sub_def_ele[def_ele].rate_mob;
+								break;
+							case BL_PC:
+								ele_fix = tsd->sub_def_ele[def_ele].rate_pc;
+								break;
+							default:
+								break;
+							}
+
+							cardfix = cardfix * (100 - ele_fix) / 100;
+						}
 					}
 					cardfix = cardfix * (100-tsd->subsize[sstatus->size]) / 100;
 					cardfix = cardfix * (100-tsd->subrace2[s_race2]) / 100;

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -557,6 +557,7 @@ enum status_point_types { //we better clean up this enum and change it name [Hem
 	SP_SKILL_USE_SP,SP_MAGIC_ATK_ELE, SP_ADD_FIXEDCAST, SP_ADD_VARIABLECAST,  //2055-2058
 	SP_SET_DEF_RACE,SP_SET_MDEF_RACE, //2059-2060
 	SP_RACE_TOLERANCE,SP_ADDMAXWEIGHT, //2061-2062
+	SP_SUB_DEF_ELE, // 2063
 
 	/* must be the last, plugins add bonuses from this value onwards */
 	SP_LAST_KNOWN,

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -557,7 +557,7 @@ enum status_point_types { //we better clean up this enum and change it name [Hem
 	SP_SKILL_USE_SP,SP_MAGIC_ATK_ELE, SP_ADD_FIXEDCAST, SP_ADD_VARIABLECAST,  //2055-2058
 	SP_SET_DEF_RACE,SP_SET_MDEF_RACE, //2059-2060
 	SP_RACE_TOLERANCE,SP_ADDMAXWEIGHT, //2061-2062
-	SP_SUB_DEF_ELE, // 2063
+	SP_SUB_DEF_ELE, SP_MAGIC_SUB_DEF_ELE, // 2063-2064
 
 	/* must be the last, plugins add bonuses from this value onwards */
 	SP_LAST_KNOWN,

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -4054,6 +4054,29 @@ static int pc_bonus3(struct map_session_data *sd, int type, int type2, int type3
 			}
 
 			break;
+		case SP_MAGIC_SUB_DEF_ELE:
+			if ((type2 >= ELE_MAX && type2 != ELE_ALL) || type2 < ELE_NEUTRAL) {
+				ShowError("pc_bonus3: SP_MAGIC_SUB_DEF_ELE: Invalid element %d\n", type2);
+				break;
+			}
+
+			if (type2 == ELE_ALL) {
+				for (int j = ELE_NEUTRAL; j < ELE_MAX; j++) {
+					if ((val & 1) != 0)
+						sd->magic_sub_def_ele[j].rate_mob += type3;
+
+					if ((val & 2) != 0)
+						sd->magic_sub_def_ele[j].rate_pc += type3;
+				}
+			} else {
+				if ((val & 1) != 0)
+					sd->magic_sub_def_ele[type2].rate_mob += type3;
+
+				if ((val & 2) != 0)
+					sd->magic_sub_def_ele[type2].rate_pc += type3;
+			}
+
+			break;
 
 		default:
 			ShowWarning("pc_bonus3: unknown type %d %d %d %d!\n",type,type2,type3,val);

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -4031,6 +4031,29 @@ static int pc_bonus3(struct map_session_data *sd, int type, int type2, int type3
 				sd->bonus.sp_vanish_trigger = val;
 			}
 			break;
+		case SP_SUB_DEF_ELE:
+			if ((type2 >= ELE_MAX && type2 != ELE_ALL) || type2 < ELE_NEUTRAL) {
+				ShowError("pc_bonus3: SP_SUB_DEF_ELE: Invalid element %d\n", type2);
+				break;
+			}
+
+			if (type2 == ELE_ALL) {
+				for (int j = ELE_NEUTRAL; j < ELE_MAX; j++) {
+					if ((val & 1) != 0)
+						sd->sub_def_ele[j].rate_mob += type3;
+
+					if ((val & 2) != 0)
+						sd->sub_def_ele[j].rate_pc += type3;
+				}
+			} else {
+				if ((val & 1) != 0)
+					sd->sub_def_ele[type2].rate_mob += type3;
+
+				if ((val & 2) != 0)
+					sd->sub_def_ele[type2].rate_pc += type3;
+			}
+
+			break;
 
 		default:
 			ShowWarning("pc_bonus3: unknown type %d %d %d %d!\n",type,type2,type3,val);

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -400,6 +400,10 @@ BEGIN_ZEROED_BLOCK; // this block will be globally zeroed at the beginning of st
 		int rate_pc;    //!< Physical damage reduction against player's defense element.
 	} sub_def_ele[ELE_MAX]; //!< Bonus bSubDefEle data structure.
 	struct {
+		int rate_mob;         //!< Magical damage reduction against monster's defense element.
+		int rate_pc;          //!< Magical damage reduction against player's defense element.
+	} magic_sub_def_ele[ELE_MAX]; //!< Bonus bMagicSubDefEle data structure.
+	struct {
 		int atk_rate;
 		int arrow_atk,arrow_ele,arrow_cri,arrow_hit;
 		int nsshealhp,nsshealsp;

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -396,13 +396,9 @@ BEGIN_ZEROED_BLOCK; // this block will be globally zeroed at the beginning of st
 		int rate, tick;
 	} def_set_race[RC_MAX], mdef_set_race[RC_MAX];
 	struct {
-		int rate_mob;   //!< Physical damage reduction against monster's defense element.
-		int rate_pc;    //!< Physical damage reduction against player's defense element.
-	} sub_def_ele[ELE_MAX]; //!< Bonus bSubDefEle data structure.
-	struct {
-		int rate_mob;         //!< Magical damage reduction against monster's defense element.
-		int rate_pc;          //!< Magical damage reduction against player's defense element.
-	} magic_sub_def_ele[ELE_MAX]; //!< Bonus bMagicSubDefEle data structure.
+		int rate_mob; //!< Damage reduction rate against monster's defense element.
+		int rate_pc;  //!< Damage reduction rate against player's defense element.
+	} sub_def_ele[ELE_MAX], magic_sub_def_ele[ELE_MAX]; //!< Bonus bSubDefEle/bMagicSubDefEle data structure.
 	struct {
 		int atk_rate;
 		int arrow_atk,arrow_ele,arrow_cri,arrow_hit;

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -396,6 +396,10 @@ BEGIN_ZEROED_BLOCK; // this block will be globally zeroed at the beginning of st
 		int rate, tick;
 	} def_set_race[RC_MAX], mdef_set_race[RC_MAX];
 	struct {
+		int rate_mob;   //!< Physical damage reduction against monster's defense element.
+		int rate_pc;    //!< Physical damage reduction against player's defense element.
+	} sub_def_ele[ELE_MAX]; //!< Bonus bSubDefEle data structure.
+	struct {
 		int atk_rate;
 		int arrow_atk,arrow_ele,arrow_cri,arrow_hit;
 		int nsshealhp,nsshealsp;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Add `bonus3(bSubDefEle, <element>, <rate>, <flag>)` item bonus to emulate `SubDamage_Property User <element> <rate>` from Aegis.
- Add `bonus3(bMagicSubDefEle, <element>, <rate>, <flag>)` item bonus to emulate `SubMDamage_Property User <element> <rate>` from Aegis.
- Update/add several items and item combos which use those bonuses in RE database. (Pre-RE doesn't use them.)

**Note**:
I tested several skills processed in `battle_calc_misc_attack()` on Aegis and none of them was affected by `SubDamage_Property` or `SubMDamage_Property`. Thus I decided to not add code to the `BF_MISC` case in `battle_calc_cardfix()`.
If someone knows about any "misc" type damage which should be affected by those bonuses please let me know.

**Issues addressed:** #548


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
