### PR TITLE
Prevent overflow when using gettimetick(0)

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3626,7 +3626,7 @@ If the player is not found, returns -1.
 *gettimetick(<type>)
 
 Valid types are :
-	0 - server's tick (milleseconds), unsigned int, loops every ~50 days
+	0 - server's tick (milleseconds), unsigned int, loops every ~25 days
 	1 - time since the start of the current day in seconds
 	2 - UNIX epoch time (number of seconds elapsed since 1st of January 1970)
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11272,7 +11272,8 @@ static BUILDIN(gettimetick)
 		case 0:
 		default:
 			//type 0:(System Ticks)
-			script_pushint(st,(int)timer->gettick()); // TODO: change this to int64 when we'll support 64 bit script values
+			// Conjunction with INT_MAX is done to prevent overflow. (Script variables are signed integers.)
+			script_pushint(st, timer->gettick() & INT_MAX); // TODO: change this to int64 when we'll support 64 bit script values
 			break;
 	}
 	return true;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Prevent overflow of script variables (`signed integer`) when using `gettimetick(0)` by doing a bitwise `AND` operation on `timer->gettick()`' and `INT_MAX`.
This decreases the tick loop interval from ~50 to ~25 days, but I think this is the best approach to fix this issue.

**Issues addressed:** #2779


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
