### PR TITLE
Fix @changesex not saving new gender to SQL DB

### DIFF
--- a/src/char/char.c
+++ b/src/char/char.c
@@ -3560,9 +3560,9 @@ static int char_changecharsex(int char_id, int sex)
 	}
 
 	const char *query = "SELECT `account_id`, `class`, `guild_id` FROM `%s` WHERE `char_id`=?";
-	int account_id;
-	int class;
-	int guild_id;
+	int account_id = 0;
+	int class = 0;
+	int guild_id = 0;
 
 	/** Abort changing gender if there was an error while loading the data. **/
 	if (SQL_ERROR == SQL->StmtPrepare(stmt, query, char_db)

--- a/src/char/char.c
+++ b/src/char/char.c
@@ -3538,10 +3538,6 @@ static int char_changecharsex(int char_id, int sex)
 	SQL->GetData(inter->sql_handle, 2, &data, NULL); guild_id = atoi(data);
 	SQL->FreeResult(inter->sql_handle);
 
-	if (SQL_ERROR == SQL->Query(inter->sql_handle, "UPDATE `%s` SET `sex` = '%c' WHERE `char_id` = '%d'", char_db, sex == SEX_MALE ? 'M' : 'F', char_id)) {
-		Sql_ShowDebug(inter->sql_handle);
-		return 1;
-	}
 	char_change_sex_sub(sex, account_id, char_id, class, guild_id);
 
 	// disconnect player if online on char-server

--- a/src/char/char.c
+++ b/src/char/char.c
@@ -2566,9 +2566,15 @@ static void char_change_sex_sub(int sex, int acc, int char_id, int class, int gu
 	if (SQL_ERROR == SQL->Query(inter->sql_handle, "UPDATE `%s` SET `equip`='0' WHERE `char_id`='%d'", inventory_db, char_id))
 		Sql_ShowDebug(inter->sql_handle);
 
+#if PACKETVER >= 20141016
+	char gender = (sex == SEX_MALE) ? 'M' : ((sex == SEX_FEMALE) ? 'F' : 'U');
+#else
+	char gender = 'U';
+#endif
+
 	if (SQL_ERROR == SQL->Query(inter->sql_handle, "UPDATE `%s` SET `class`='%d', `weapon`='0', `shield`='0', "
-				"`head_top`='0', `head_mid`='0', `head_bottom`='0' WHERE `char_id`='%d'",
-				char_db, class, char_id))
+				    "`head_top`='0', `head_mid`='0', `head_bottom`='0', `robe`='0', `sex`='%c' "
+				    "WHERE `char_id`='%d' ", char_db, class, gender, char_id))
 		Sql_ShowDebug(inter->sql_handle);
 	if (guild_id) // If there is a guild, update the guild_member data [Skotlex]
 		inter_guild->sex_changed(guild_id, acc, char_id, sex);

--- a/src/char/char.c
+++ b/src/char/char.c
@@ -2535,34 +2535,19 @@ static void char_changesex(int account_id, int sex)
 }
 
 /**
- * Performs the necessary operations when changing a character's sex, such as
- * correcting the job class and unequipping items, and propagating the
- * information to the guild data.
+ * Performs the necessary operations when changing a character's gender,
+ * such as correcting the job class and unequipping items,
+ * and propagating the information to the guild data.
  *
- * @param sex      The new sex (SEX_MALE or SEX_FEMALE).
- * @param acc      The character's account ID.
- * @param char_id  The character ID.
- * @param class    The character's current job class.
+ * @param sex The character's new gender (SEX_MALE or SEX_FEMALE).
+ * @param acc The character's account ID.
+ * @param char_id The character ID.
+ * @param class The character's current job class.
  * @param guild_id The character's guild ID.
- */
+ *
+ **/
 static void char_change_sex_sub(int sex, int acc, int char_id, int class, int guild_id)
 {
-	// job modification
-	if (class == JOB_BARD || class == JOB_DANCER)
-		class = (sex == SEX_MALE ? JOB_BARD : JOB_DANCER);
-	else if (class == JOB_CLOWN || class == JOB_GYPSY)
-		class = (sex == SEX_MALE ? JOB_CLOWN : JOB_GYPSY);
-	else if (class == JOB_BABY_BARD || class == JOB_BABY_DANCER)
-		class = (sex == SEX_MALE ? JOB_BABY_BARD : JOB_BABY_DANCER);
-	else if (class == JOB_MINSTREL || class == JOB_WANDERER)
-		class = (sex == SEX_MALE ? JOB_MINSTREL : JOB_WANDERER);
-	else if (class == JOB_MINSTREL_T || class == JOB_WANDERER_T)
-		class = (sex == SEX_MALE ? JOB_MINSTREL_T : JOB_WANDERER_T);
-	else if (class == JOB_BABY_MINSTREL || class == JOB_BABY_WANDERER)
-		class = (sex == SEX_MALE ? JOB_BABY_MINSTREL : JOB_BABY_WANDERER);
-	else if (class == JOB_KAGEROU || class == JOB_OBORO)
-		class = (sex == SEX_MALE ? JOB_KAGEROU : JOB_OBORO);
-
 	struct SqlStmt *stmt = SQL->StmtMalloc(inter->sql_handle);
 
 	/** If we can't save the data, there's nothing to do. **/
@@ -2581,6 +2566,22 @@ static void char_change_sex_sub(int sex, int acc, int char_id, int class, int gu
 		SQL->StmtFree(stmt);
 		return;
 	}
+
+	/** Correct the job class for gender specific jobs according to the passed gender. **/
+	if (class == JOB_BARD || class == JOB_DANCER)
+		class = (sex == SEX_MALE ? JOB_BARD : JOB_DANCER);
+	else if (class == JOB_CLOWN || class == JOB_GYPSY)
+		class = (sex == SEX_MALE ? JOB_CLOWN : JOB_GYPSY);
+	else if (class == JOB_BABY_BARD || class == JOB_BABY_DANCER)
+		class = (sex == SEX_MALE ? JOB_BABY_BARD : JOB_BABY_DANCER);
+	else if (class == JOB_MINSTREL || class == JOB_WANDERER)
+		class = (sex == SEX_MALE ? JOB_MINSTREL : JOB_WANDERER);
+	else if (class == JOB_MINSTREL_T || class == JOB_WANDERER_T)
+		class = (sex == SEX_MALE ? JOB_MINSTREL_T : JOB_WANDERER_T);
+	else if (class == JOB_BABY_MINSTREL || class == JOB_BABY_WANDERER)
+		class = (sex == SEX_MALE ? JOB_BABY_MINSTREL : JOB_BABY_WANDERER);
+	else if (class == JOB_KAGEROU || class == JOB_OBORO)
+		class = (sex == SEX_MALE ? JOB_KAGEROU : JOB_OBORO);
 
 #if PACKETVER >= 20141016
 	char gender = (sex == SEX_MALE) ? 'M' : ((sex == SEX_FEMALE) ? 'F' : 'U');
@@ -2604,7 +2605,8 @@ static void char_change_sex_sub(int sex, int acc, int char_id, int class, int gu
 
 	SQL->StmtFree(stmt);
 
-	if (guild_id) // If there is a guild, update the guild_member data [Skotlex]
+	/** Update guild member data if a guild ID was passed. **/
+	if (guild_id != 0)
 		inter_guild->sex_changed(guild_id, acc, char_id, sex);
 }
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Adjust the SQL query in `char_change_sex_sub()` to update the character's gender and robe view ID, too.
- Remove unnecessary gender update SQL query from `char_changecharsex()`. Gender gets updated in `char_change_sex_sub()` now, so we can safely skip it in `char_changecharsex()`.
- Adjust `char_change_sex_sub()` to use prepared statements.
- Adjust `char_changecharsex()` to use prepared statement.
- Apply code style to `char_change_sex_sub()`.
- Apply code style to `char_changecharsex()`.

**Issues addressed:** #2789


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
