### PR TITLE
Dokebi Battle Quest bugfix and exploit patch

### DIFF
--- a/npc/quests/quests_amatsu.txt
+++ b/npc/quests/quests_amatsu.txt
@@ -399,11 +399,14 @@ OnStartArena:
 	enablenpc "Grandma#ama1";
 	enablenpc "Grandpa#ama";
 	warpwaitingpc "ama_test",50,83;
-	donpcevent "Timer#ama::OnEnable";
+	enablenpc("Timer#ama");
+	initnpctimer("Timer#ama");
 	disablewaitingroomevent "Assistant#ama";
 	end;
 
 OnReset:
+	stopnpctimer("Timer#ama");
+	disablenpc("Timer#ama");
 	enablewaitingroomevent "Assistant#ama";
 	end;
 }
@@ -620,7 +623,6 @@ ama_test,50,100,3	script	Coach#ama	4_M_JPN2,15,15,{
 		mes "Don't lose your high self-esteem";
 		mes "in the future. Farewell.";
 		close2;
-		donpcevent "Timer#ama::OnDisable";
 		warp "amatsu",223,230;
 		disablenpc "Coach#ama";
 		donpcevent "Assistant#ama::OnReset";
@@ -665,7 +667,6 @@ ama_test,50,100,3	script	Coach#ama	4_M_JPN2,15,15,{
 			setquest 8128;
 			warp "amatsu",223,230;
 			disablenpc "Coach#ama";
-			donpcevent "Timer#ama::OnDisable";
 			donpcevent "Assistant#ama::OnReset";
 			end;
 		}
@@ -754,7 +755,6 @@ OnTouch:
 	changequest 8129,8130;
 	warp "amatsu",223,230;
 	disablenpc "Coach#after";
-	donpcevent "Timer#ama::OnDisable";
 	donpcevent "Assistant#ama::OnReset";
 	end;
 }
@@ -762,14 +762,6 @@ OnTouch:
 ama_test,34,18,0	script	Timer#ama	FAKE_NPC,{
 OnInit:
 	disablenpc "Timer#ama";
-	end;
-
-OnEnable:
-	enablenpc "Timer#ama";
-	initnpctimer;
-	end;
-OnDisable:
-	stopnpctimer;
 	end;
 
 OnTimer1000:
@@ -797,7 +789,6 @@ OnTimer362000:
 
 OnTimer362500:
 	donpcevent "Assistant#ama::OnReset";
-	donpcevent "Timer#ama::OnDisable";
 	end;
 }
 

--- a/npc/quests/quests_amatsu.txt
+++ b/npc/quests/quests_amatsu.txt
@@ -780,25 +780,11 @@ OnTimer361000:
 	end;
 
 OnTimer361500:
-	enablenpc "backwarp#ama";
-	end;
-
-OnTimer362000:
-	disablenpc "backwarp#ama";
+	areawarp("ama_test", 25, 75, 80, 130, "amatsu", 115, 95);
 	end;
 
 OnTimer362500:
 	donpcevent "Assistant#ama::OnReset";
-	end;
-}
-
-ama_test,50,100,0	script	backwarp#ama	FAKE_NPC,25,25,{
-OnInit:
-	disablenpc "backwarp#ama";
-	end;
-
-OnTouch:
-	warp "amatsu",115,95;
 	end;
 }
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

**First One:**
Fix Dokebi Battle Quest becoming undoable until server restart under certain circumstances.

Reproduce by having 1 person inside the battle area doing the quest, waiting for the timer to run out and have 1 person waiting in the waiting room / chat.
The waiting room will get disabled as intended but the timer will as well. If the person in the room now logs out or doesn't kill the Dokebis, the quest is bugged till server restart.

**Second One:**
 Fix possible exploit in Dokebi Battle Quest

As many players as wanted could remain in the battle area, where the
dokebis and am muts spawn, as long as you have a dialogue open, which
the script provides. One could even keep a certain part of the dialogue
open right before the am muts spawn. Making you able to abuse this quest
in order to have your own am mut farming map, since they drop loot
and give exp. If you have any NPC that you can whisper to trigger a
dialogue, you could even do this more efficiently and kill am muts per
run. First run you kill 3. Second you can kill 6. Third 9.
So once you got 10 players in there, you will have killed 135 Am Muts
and can kill 30 more.

*Both fixes are tested and working well*

**Issues addressed:** None?

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
