### PR TITLE
Refactor scripts that use OnTouch Logic to use areawarp instead

### DIFF
--- a/npc/jobs/2-1/wizard.txt
+++ b/npc/jobs/2-1/wizard.txt
@@ -1527,7 +1527,7 @@ OnTimer183000:
 	end;
 
 OnTimer184000:
-	enablenpc "Room of Fire#Failed";
+	areawarp("job_wiz", 30, 83, 62, 115, "geffen", 120, 110);
 	end;
 
 OnTimer185000:
@@ -1535,8 +1535,6 @@ OnTimer185000:
 	end;
 
 OnTimer186000:
-	disablenpc "Room of Fire#Failed";
-	donpcevent "Room of Fire::OnDisable";
 	donpcevent "Arena Assistant::OnStart";
 	end;
 }
@@ -1604,7 +1602,7 @@ OnTimer120000:
 	end;
 
 OnTimer121000:
-	enablenpc "Room of Fire#Failed";
+	areawarp("job_wiz", 30, 83, 62, 115, "geffen", 120, 110);
 	end;
 
 OnTimer122000:
@@ -1612,19 +1610,8 @@ OnTimer122000:
 	end;
 
 OnTimer123000:
-	disablenpc "Room of Fire#Failed";
 	donpcevent "Room of Fire#Door::OnDisable";
 	donpcevent "Arena Assistant::OnStart";
-}
-
-job_wiz,46,99,0	script	Room of Fire#Failed	FAKE_NPC,16,16,{
-OnInit:
-	disablenpc "Room of Fire#Failed";
-	end;
-
-OnTouch:
-	warp "geffen",120,110;
-	end;
 }
 
 job_wiz,1,7,1	script	Test Helper#wiz	1_F_01,{

--- a/npc/quests/quests_juperos.txt
+++ b/npc/quests/quests_juperos.txt
@@ -4914,7 +4914,7 @@ OnTouch:
 	case 1:
 		specialeffect(EF_LIGHTSPHERE, AREA, playerattached());
 		close2;
-		stopnpctimer;
+		stopnpctimer(1);
 		warp "juperos_02",130,142;
 		break;
 	case 2:
@@ -4922,7 +4922,7 @@ OnTouch:
 		mes "Not now!";
 		mes "I can't leave yet!";
 		close2;
-		stopnpctimer;
+		stopnpctimer(1);
 		warp "jupe_gate",50,168;
 		break;
 	}
@@ -4930,23 +4930,7 @@ OnTouch:
 
 OnTimer10000:
 	warp "juperos_02",128,278;
-	enablenpc "gate#start#2";
-	disablenpc "gate#start";
-	end;
-}
-
-jupe_gate,50,171,0	script	gate#start#2	FAKE_NPC,2,2,{
-OnInit:
-	disablenpc "gate#start#2";
-	end;
-
-OnTouch:
-	warp "juperos_02",130,142;
-	end;
-
-OnTimer2000:
-	enablenpc "gate#start";
-	disablenpc "gate#start#2";
+	areawarp("jupe_gate", 48, 169, 52, 173, "juperos_02", 130, 142);
 	end;
 }
 

--- a/npc/quests/quests_lighthalzen.txt
+++ b/npc/quests/quests_lighthalzen.txt
@@ -9774,27 +9774,17 @@ OnTouch:
 }
 
 lhz_in01,177,44,0	script	Timer_Sneak	FAKE_NPC,8,12,{
-
-OnTouch:
-	warp "lhz_in01",191,49;
-	end;
-
-OnInit:
-	disablenpc "Timer_Sneak";
-	end;
-
 OnEnter:
 	stopnpctimer;
 	initnpctimer;
 	end;
 
 OnTimer180000:
-	enablenpc "Timer_Sneak";
+	areawarp("lhz_in01", 169, 32, 185, 56, "lhz_in01", 191, 49);
 	end;
 
 OnTimer190000:
 	stopnpctimer;
-	disablenpc "Timer_Sneak";
 	end;
 }
 

--- a/npc/quests/seals/god_weapon_creation.txt
+++ b/npc/quests/seals/god_weapon_creation.txt
@@ -807,40 +807,14 @@ OnTimer610000:
 	end;
 
 OnTimer612000:
-	donpcevent "god_wep_warpmaster::OnEnable";
+	areawarp("que_god01", 130, 55, 190, 135, "prontera", 156, 324);
 	end;
 
 OnTimer615000:
-	donpcevent "god_wep_warpmaster::OnDisable";
 	donpcevent "#god_hopewarp1::OnReset";
 	stopnpctimer;
 	end;
 }
-
-que_god01,169,82,0	script	god_wep_warpmaster	FAKE_NPC,{
-OnEnable:
-	for(.@i = 1; .@i<=6; ++.@i)
-		enablenpc "god_failwarp#"+.@i;
-	end;
-OnDisable:
-	for(.@i = 1; .@i<=6; ++.@i)
-		disablenpc "god_failwarp#"+.@i;
-	end;
-}
-
-que_god01,154,67,0	script	god_failwarp#1	FAKE_NPC,4,7,{
-OnInit:
-	disablenpc strnpcinfo(NPC_NAME);
-	end;
-OnTouch:
-	warp "prontera",156,324;
-	end;
-}
-que_god01,154,82,0	duplicate(god_failwarp#1)	god_failwarp#2	FAKE_NPC,4,7
-que_god01,145,99,0	duplicate(god_failwarp#1)	god_failwarp#3	FAKE_NPC,9,9
-que_god01,164,99,0	duplicate(god_failwarp#1)	god_failwarp#4	FAKE_NPC,9,9
-que_god01,145,118,0	duplicate(god_failwarp#1)	god_failwarp#5	FAKE_NPC,9,9
-que_god01,164,118,0	duplicate(god_failwarp#1)	god_failwarp#6	FAKE_NPC,9,9
 
 // Original name: "Godly Item Quests Related#god"
 que_god01,293,3,0	script	Godly Item Quests#god	4_F_01,{
@@ -864,16 +838,8 @@ que_god01,293,3,0	script	Godly Item Quests#god	4_F_01,{
 		mes "[Use in case of emergency]";
 		mes "What services would you like to use?";
 		next;
-		switch(select("Turn off Warps.", "Reset Timer.", "Reset chat room.")) {
+		switch(select("Reset Timer.", "Reset chat room.")) {
 		case 1:
-			mes "[Use in case of emergency]";
-			mes "Press the 'Next' button to turn off warps.";
-			next;
-			donpcevent "god_wep_warpmaster::OnDisable";
-			mes "[Use in case of emergency]";
-			mes "You have successfully turned off warps.";
-			close;
-		case 2:
 			mes "[Use in case of emergency]";
 			mes "Press the 'Next' button to reset timer.";
 			next;
@@ -881,7 +847,7 @@ que_god01,293,3,0	script	Godly Item Quests#god	4_F_01,{
 			mes "[Use in case of emergency]";
 			mes "You have successfully reset timer.";
 			close;
-		case 3:
+		case 2:
 			mes "[Use in case of emergency]";
 			mes "Please press the 'Next' button to reset the arena chat room in que_god01.";
 			next;

--- a/npc/quests/the_sign_quest.txt
+++ b/npc/quests/the_sign_quest.txt
@@ -12317,34 +12317,18 @@ OnEnable:
 	end;
 }
 
-que_sign01,196,44,0	script	Warp#serin	FAKE_NPC,35,35,{
-OnDisable:
-OnInit:
-	disablenpc "Warp#serin";
-	end;
-
-OnTouch:
-	warp "niflheim",30,156;
-	end;
-
-OnEnable:
-	enablenpc "Warp#serin";
-	end;
-}
-
 que_sign01,1,0,0	script	Timer#serin	FAKE_NPC,{
 OnStart:
 	initnpctimer;
 	end;
 
 OnTimer600000:
-	donpcevent "Warp#serin::OnEnable";
+	areawarp("que_sign01", 161, 9, 231, 79, "niflheim", 30, 156);
 	end;
 
 OnTimer620000:
 	$@sign_w2 = 0;
 	donpcevent "Starter#serin::OnEnable";
-	donpcevent "Warp#serin::OnDisable";
 	donpcevent "Serin#serin::OnEnable";
 	donpcevent "Dark Lord#serin::OnDisable";
 	donpcevent "Serin#dummy::OnDisable";


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Replace all OnTouch areawarp logic with areawarp were appropriate.

This fixes a few bugs and possible exploits, some OnTouch-Warp-NPCs didn't cover the entire
area they intended to areawarp. If you have any NPC Dialogue open, you
will not trigger the OnTouch and thus not get warped. Areawarp though
will ensure that you are guaranteed to get warped.
This also fixes some poor timer usage in juperos quest for example,
where one of the NPCs just won't ever get enabled again.

**Issues addressed:** None?

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
