### PR TITLE
Added official script for Flying Galapago headgear.

### DIFF
--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -68293,8 +68293,9 @@ item_db: (
 	EquipLv: 110
 	ViewSprite: 1358
 	Script: <"
-		bonus3 bAutoSpell,HT_BLITZBEAT,getskilllv(HT_BLITZBEAT),(10*getskilllv(HT_BLITZBEAT))+(readparam(bLuk)/3);
-		if(getskilllv(HT_STEELCROW)>0) { skill HT_BLITZBEAT,40; }
+		bonus(bAgi, 1);
+		bonus3(bAutoSpell, HT_BLITZBEAT, max(getskilllv(HT_BLITZBEAT), 1), 50 + (min(readparam(bLuk), 120) / 3) + (max(getskilllv(HT_BLITZBEAT), 1) * 2));
+		bonus2(bSkillAtk, HT_BLITZBEAT, getskilllv(HT_STEELCROW) * 40);
 	">
 },
 {


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The Flying Galapago on `db/re/item_db.conf` was not working like how it works on official and throws this error on console every time the script takes effect.

> [Error]: pc_skill: Skill level 40 too high. Max lv supported is 20

**Issues addressed:** None
<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
