### PR TITLE
Check for homunculus skills requisites before leveling it up.

### DIFF
--- a/src/map/homunculus.c
+++ b/src/map/homunculus.c
@@ -321,13 +321,13 @@ static void homunculus_skillup(struct homun_data *hd, uint16 skill_id)
 	{
 		bool stop = false;
 		// Check if pre-requisites were met
-		if (!battle_config.skillfree) {
+		if (battle_config.skillfree == 0) {
 			int c = hd->homunculus.class_ - HM_CLASS_BASE;
 			if (hd->homunculus.intimacy < homun->dbs->skill_tree[c][i].intimacylv)
 				stop = true;
 			if (!stop) {
 				for (int j = 0; j < MAX_HOM_SKILL_REQUIRE; j++) {
-					if (homun->dbs->skill_tree[c][i].need[j].id &&
+					if (homun->dbs->skill_tree[c][i].need[j].id != 0 &&
 					   homun->checkskill(hd, homun->dbs->skill_tree[c][i].need[j].id) < homun->dbs->skill_tree[c][i].need[j].lv) {
 						stop = true;
 						break;
@@ -338,9 +338,9 @@ static void homunculus_skillup(struct homun_data *hd, uint16 skill_id)
 		// Level up skill if requisites were met
 		if (!stop) {
 			hd->homunculus.hskill[i].lv++;
-			hd->homunculus.skillpts-- ;
+			hd->homunculus.skillpts--;
 			status_calc_homunculus(hd, SCO_NONE);
-			if (hd->master) {
+			if (hd->master != NULL) {
 				clif->homskillup(hd->master, skill_id);
 				clif->hominfo(hd->master, hd, 0);
 				clif->homskillinfoblock(hd->master);

--- a/src/map/homunculus.c
+++ b/src/map/homunculus.c
@@ -312,7 +312,7 @@ static void homunculus_skillup(struct homun_data *hd, uint16 skill_id)
 		return;
 
 	i = skill_id - HM_SKILLBASE;
-	Assert_retv(i >= 0 && i < MAX_HOMUNSKILL);
+	Assert_retv(i >= 0 && i < MAX_HOMUNSKILL && i < MAX_SKILL_TREE);
 	if (hd->homunculus.skillpts > 0 &&
 		hd->homunculus.hskill[i].id &&
 		hd->homunculus.hskill[i].flag == SKILL_FLAG_PERMANENT && //Don't allow raising while you have granted skills. [Skotlex]
@@ -323,7 +323,8 @@ static void homunculus_skillup(struct homun_data *hd, uint16 skill_id)
 		// Check if pre-requisites were met
 		if (battle_config.skillfree == 0) {
 			int c = hd->homunculus.class_ - HM_CLASS_BASE;
-			if (hd->homunculus.intimacy < homun->dbs->skill_tree[c][i].intimacylv)
+			Assert_retv(c >= 0 && c < MAX_HOMUNCULUS_CLASS);
+			if ((int)hd->homunculus.intimacy < homun->dbs->skill_tree[c][i].intimacylv)
 				stop = true;
 			if (!stop) {
 				for (int j = 0; j < MAX_HOM_SKILL_REQUIRE; j++) {


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Check for homunculus skills requisites before leveling it up.

Does nothing if player.skillfree was set on battle configuration.
This allows non-evolved homunculus to make use of pre-requisites DB.

PS. I'll be very happy if someone else takes this patch for me.
I feel there are better ways to do this which I don't have enough skill to pursue.

Note: The code was copied from homunculus_calc_skilltree()

The former function is only called in the following cases:
* clif->send_homdata when intimacy >= 910 (hardcoded?) and evolved homun
  (won't cause this code to run)
* status_calc_homunculus_ which is aliased as status_calc_homunculus
  * Here, after the skill points has been consumed and the skill updated,
    but is skipped except for evolved homuns. [Not sure if does anything]
    (won't cause this code to run)
  * homun->evolve
  * homun->mutate
  * homun->gainexp (during level up) (won't cause this code to run)
  * homun->create
  * homun-shuffle (won't cause this code to run)
  * ACMD(homlevel) (won't cause this code to run)
* homun->change_class


**Issues addressed:** None

### Testing Done

It compiled, using Evol2 plugin.
However, I still haven't got time to test it..

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
