### PR TITLE
Fix an exploit in the autocast system

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11433,6 +11433,7 @@ static BUILDIN(itemskill)
 	if (sd->auto_cast_current.itemskill_check_conditions) {
 		if (skill->check_condition_castbegin(sd, sd->auto_cast_current.skill_id, sd->auto_cast_current.skill_lv) == 0
 		    || skill->check_condition_castend(sd, sd->auto_cast_current.skill_id, sd->auto_cast_current.skill_lv) == 0) {
+			pc->autocast_clear_current(sd);
 			return true;
 		}
 
@@ -11446,6 +11447,8 @@ static BUILDIN(itemskill)
 	VECTOR_PUSH(sd->auto_cast, sd->auto_cast_current);
 
 	clif->item_skill(sd, sd->auto_cast_current.skill_id, sd->auto_cast_current.skill_lv);
+
+	pc->autocast_clear_current(sd);
 
 	return true;
 }


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

A missing call to `pc->autocast_clear_current()` made it possible to bypass the deletion of skill requirements of a normally cast skill by using a scroll.

**Issues addressed:** N/A (privately reported)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
