### PR TITLE
Disable HP bar on Emperium and MVP by default

### DIFF
--- a/conf/map/battle/monster.conf
+++ b/conf/map/battle/monster.conf
@@ -239,10 +239,13 @@ mvp_tomb_enabled: true
 // Default: 10000 (10 seconds)
 mvp_tomb_spawn_delay: 10000
 
-// Show hp bar on monsters? (Note 1)
+// Show hp bar on monsters? (Note 3)
 // NOTE: only works on client 2012-04-04aRagexeRE onwards
-// (Default: true)
-show_monster_hp_bar: true
+// 1 = Show hp bar on all monsters except Emperium and MVP
+// 2 = Enable hp bar on Emperium
+// 4 = Enable hp bar on MVP
+// (Default: 1)
+show_monster_hp_bar: 1
 
 // Whether or not the size of specially summoned mobs influences experience, drop rates,
 // and stats. The rates will be doubled for large mobs, and halved for small ones.

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7441,7 +7441,7 @@ static const struct battle_data {
 	{ "mob_icewall_walk_block",             &battle_config.mob_icewall_walk_block,          75,     0,      255,            },
 	{ "boss_icewall_walk_block",            &battle_config.boss_icewall_walk_block,         0,      0,      255,            },
 	{ "features/roulette",                  &battle_config.feature_roulette,                1,      0,      1,              },
-	{ "show_monster_hp_bar",                &battle_config.show_monster_hp_bar,             1,      0,      1,              },
+	{ "show_monster_hp_bar",                &battle_config.show_monster_hp_bar,             1,      0,      1|2|4,          },
 	{ "fix_warp_hit_delay_abuse",           &battle_config.fix_warp_hit_delay_abuse,        0,      0,      1,              },
 	{ "costume_refine_def",                 &battle_config.costume_refine_def,              1,      0,      1,              },
 	{ "shadow_refine_def",                  &battle_config.shadow_refine_def,               1,      0,      1,              },

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -980,7 +980,8 @@ struct clif_interface {
 	void (*skillname_ack) (int fd, struct block_list *bl);
 	void (*itemname_ack) (int fd, struct block_list *bl);
 	void (*unknownname_ack) (int fd, struct block_list *bl);
-	void (*monster_hp_bar) ( struct mob_data* md, struct map_session_data *sd );
+	void (*monster_hp_bar) (struct mob_data *md, struct map_session_data *sd);
+	bool (*show_monster_hp_bar) (struct block_list *bl);
 	int (*hpmeter) (struct map_session_data *sd);
 	void (*hpmeter_single) (int fd, int id, unsigned int hp, unsigned int maxhp);
 	int (*hpmeter_sub) (struct block_list *bl, va_list ap);

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2379,7 +2379,7 @@ static void mob_damage(struct mob_data *md, struct block_list *src, int damage)
 
 #if PACKETVER >= 20131223
 	// Resend ZC_NOTIFY_MOVEENTRY to Update the HP
-	if (battle_config.show_monster_hp_bar)
+	if (clif->show_monster_hp_bar(&md->bl))
 		clif->set_unit_walking(&md->bl, NULL, unit->bl2ud(&md->bl), AREA);
 #endif
 
@@ -3116,7 +3116,7 @@ static void mob_heal(struct mob_data *md, unsigned int heal)
 		clif->blname_ack(0, &md->bl);
 #if PACKETVER >= 20131223
 	// Resend ZC_NOTIFY_MOVEENTRY to Update the HP
-	if (battle_config.show_monster_hp_bar)
+	if (clif->show_monster_hp_bar(&md->bl))
 		clif->set_unit_walking(&md->bl, NULL, unit->bl2ud(&md->bl), AREA);
 #endif
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Disable HP bar on Emperium and MVP by default
Added configuration via battle conf to enable again
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
https://github.com/HerculesWS/Hercules/issues/744#issuecomment-171254762

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
