### PR TITLE
Fix on clif_skillinfo to check inf argument

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -5458,7 +5458,7 @@ static void clif_skillinfo(struct map_session_data *sd, int skill_id, int inf)
 	p->packetType = HEADER_ZC_SKILLINFO_UPDATE2;
 	int skill_lv = sd->status.skill[idx].lv;
 	p->id = skill_id;
-	p->inf = skill->get_inf(skill_id);
+	p->inf = inf?inf:skill->get_inf(skill_id);
 	p->level = skill_lv;
 	if (skill_lv > 0) {
 		p->sp = skill->get_sp(skill_id, skill_lv);


### PR DESCRIPTION


<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Send inf to client of some combo skills, in particular MO_EXTREMITYFIST, TK_JUMPKICK, SR_DRAGONCOMBO, SR_GATEOFHELL and SR_TIGERCANNON.

**Issues addressed:** <!-- Write here the issue number, if any. -->

When doing combos (ie: SR_DRAGONCOMBO -> SR_FALLENEMPIRE -> SR_GATEOFHELL), the named skills were not changing the target type (on combos it should be INF_SELF_SKILL since it auto target). Instead it was sending the target type defined on the skill_db (all this skills are enemy targeted) because it was not checking the passing arg `inf`.

<!-- You can safely ignore the links below:  -->


[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
