### PR TITLE
Fix memory corruption on unloading npc

### DIFF
--- a/src/map/guild.c
+++ b/src/map/guild.c
@@ -2380,6 +2380,7 @@ static void guild_flag_remove(struct npc_data *nd)
 
 		if( cursor != i ) {
 			memmove(&guild->flags[cursor], &guild->flags[i], sizeof(guild->flags[0]));
+			guild->flags[i] = NULL;
 		}
 		cursor++;
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fix memory corruption on using command ``@unloadnpc`` or any other way for unload npc file.
