### PR TITLE
fix missing scoreboard for battleground type 2

### DIFF
--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -5028,7 +5028,7 @@ static const char *npc_parse_mapflag(const char *w1, const char *w2, const char 
 		struct map_zone_data *zone;
 		if (state != 0) {
 			if (w4 != NULL && sscanf(w4, "%d", &state) == 1)
-				map->list[m].flag.battleground = (state != 0) ? 1 : 0;
+				map->list[m].flag.battleground = cap_value(state, 0, 2);
 			else
 				map->list[m].flag.battleground = 1; // Default value
 		} else {


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
https://github.com/HerculesWS/Hercules/issues/2848

### Changes Proposed
cap the value as 1 or 2 only
if it is 0, it becomes 1(default), and if it is over 2, becomes 2

```
guild_vs2	mapflag	battleground
```
tested is 1, because the sscanf return 0 didn't found w4

### Affected Branches
* Master

### Known Issues and TODO List
blame https://github.com/HerculesWS/Hercules/pull/2654 ... yeah its @Emistry again
![](https://raw.githubusercontent.com/AnnieRuru/customs/master/screenshots/missing_battlegounrd_scoreboard.png)