### PR TITLE
fix dancer with soul link didn't get the bard skills counterpart

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1624,35 +1624,10 @@ static int pc_calc_skilltree(struct map_session_data *sd)
 			sd->status.skill[i].lv = (sd->status.skill[i].flag == SKILL_FLAG_TEMPORARY) ? 0 : sd->status.skill[i].flag - SKILL_FLAG_REPLACED_LV_0;
 			sd->status.skill[i].flag = SKILL_FLAG_PERMANENT;
 		}
-
-		if (sd->sc.count && sd->sc.data[SC_SOULLINK] && sd->sc.data[SC_SOULLINK]->val2 == SL_BARDDANCER
-		 && ((skill->dbs->db[i].nameid >= BA_WHISTLE && skill->dbs->db[i].nameid <= BA_APPLEIDUN)
-		  || (skill->dbs->db[i].nameid >= DC_HUMMING && skill->dbs->db[i].nameid <= DC_SERVICEFORYOU))
-		) {
-			//Enable Bard/Dancer spirit linked skills.
-			int linked_nameid = skill->get_linked_song_dance_id(skill->dbs->db[i].nameid);
-			if (linked_nameid == 0) {
-				Assert_report("Linked bard/dance skill not found");
-				continue;
-			}
-			int copy_from_index;
-			int copy_to_index;
-			if (sd->status.sex == SEX_MALE && skill->dbs->db[i].nameid >= BA_WHISTLE && skill->dbs->db[i].nameid <= BA_APPLEIDUN) {
-				copy_from_index = i;
-				copy_to_index = skill->get_index(linked_nameid);
-			} else {
-				copy_from_index = skill->get_index(linked_nameid);
-				copy_to_index = i;
-			}
-			if (copy_from_index < copy_to_index)
-				continue; // Copy only after the source skill has been filled into the tree
-			if (sd->status.skill[copy_from_index].lv < 10)
-				continue; // Copy only if the linked skill has been mastered
-			sd->status.skill[copy_to_index].id = skill->dbs->db[copy_to_index].nameid;
-			sd->status.skill[copy_to_index].lv = sd->status.skill[copy_from_index].lv; // Set the level to the same as the linking skill
-			sd->status.skill[copy_to_index].flag = SKILL_FLAG_TEMPORARY; // Tag it as a non-savable, non-uppable, bonus skill
-		}
 	}
+
+	//Enable Bard/Dancer spirit linked skills.
+	skill->add_bard_dancer_soullink_songs(sd);
 
 	if( pc_has_permission(sd, PC_PERM_ALL_SKILL) ) {
 		for (int i = 0; i < MAX_SKILL_DB; i++) {

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -20613,6 +20613,48 @@ static bool skill_parse_row_changematerialdb(char *split[], int columns, int cur
 }
 
 /**
+ * Enable Bard/Dancer to learn songs from their counterpart when spirit link
+ * * @param *sd    the actual player gain the skills
+ */
+static void skill_add_bard_dancer_soullink_songs(struct map_session_data *sd)
+{
+	nullpo_retv(sd);
+	
+	if (sd->sc.count == 0 || sd->sc.data[SC_SOULLINK] == NULL || sd->sc.data[SC_SOULLINK]->val2 != SL_BARDDANCER)
+		return;
+	
+	const int bard_song_skillid[4] = {BA_WHISTLE, BA_ASSASSINCROSS, BA_POEMBRAGI, BA_APPLEIDUN};
+	const int dancer_song_skillid[4] = {DC_HUMMING, DC_DONTFORGETME, DC_FORTUNEKISS, DC_SERVICEFORYOU};
+	
+	STATIC_ASSERT(ARRAYLENGTH(bard_song_skillid) == ARRAYLENGTH(dancer_song_skillid), "bard_song_skillid and dancer_song_skillid must be the same size");
+
+	int copy_from_index;
+	int copy_to_index;
+	for (int i = 0; i < ARRAYLENGTH(bard_song_skillid); i++) {
+		if (sd->status.sex == SEX_MALE) {
+			copy_from_index = skill->get_index(bard_song_skillid[i]);
+			copy_to_index = skill->get_index(dancer_song_skillid[i]);
+		} else {
+			copy_from_index = skill->get_index(dancer_song_skillid[i]);
+			copy_to_index = skill->get_index(bard_song_skillid[i]);
+		}
+
+		if (copy_from_index == 0 || copy_to_index == 0) {
+			Assert_report("Linked bard/dancer skill not found");
+			continue;
+		}
+
+		if (sd->status.skill[copy_from_index].lv < 10) // Copy only if the linked skill has been mastered
+			continue;
+
+		sd->status.skill[copy_to_index].id = skill->dbs->db[copy_to_index].nameid;
+		sd->status.skill[copy_to_index].lv = sd->status.skill[copy_from_index].lv; // Set the level to the same as the linking skill
+		sd->status.skill[copy_to_index].flag = SKILL_FLAG_TEMPORARY; // Tag it as a non-savable, non-uppable, bonus skill
+	}
+	return;
+}
+
+/**
  * Sets Level based configuration for skill groups from skill_db.conf [ Smokexyz/Hercules ]
  * @param *conf    pointer to config setting.
  * @param *arr     pointer to array to be set.
@@ -24285,4 +24327,5 @@ void skill_defaults(void)
 	skill->check_npc_chaospanic = skill_check_npc_chaospanic;
 	skill->count_wos = skill_count_wos;
 	skill->get_linked_song_dance_id = skill_get_linked_song_dance_id;
+	skill->add_bard_dancer_soullink_songs = skill_add_bard_dancer_soullink_songs;
 }

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -2292,6 +2292,7 @@ struct skill_interface {
 	int (*check_npc_chaospanic) (struct block_list *bl, va_list args);
 	int (*count_wos) (struct block_list *bl, va_list ap);
 	int (*get_linked_song_dance_id) (int skill_id);
+	void (*add_bard_dancer_soullink_songs) (struct map_session_data *sd);
 };
 
 #ifdef HERCULES_CORE


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
https://github.com/HerculesWS/Hercules/issues/2815

### Changes Proposed
the actual reason why dancer didn't get the skill is because the dancer's skill index is lower than bard's
when it continue on the loop, it hit the condition above and set skill level into 0

so move the dancer/bard soul link check out of the loop

### Affected Branches
* Master

### Known Issues and TODO List
