### PR TITLE
Fix BaseClass misuse

### DIFF
--- a/npc/quests/bard_quest.txt
+++ b/npc/quests/bard_quest.txt
@@ -1923,12 +1923,12 @@ morocc,134,111,3	script	Bard#3	2_M_BARD_ORIENT,{
 				mes "There's no reason to be scared. The scary people with swords only use them on monsters, okay?";
 			} else if (BaseClass == Job_Acolyte) {
 				mes "You don't need to be scared, that person is a servant of God, okay?";
-			} else if (Class == Job_Thief || Class == Job_Rogue) {
+			} else if (BaseJob == Job_Thief || BaseJob == Job_Rogue) {
 				mes "There's no reason to be afraid of this riffraff, your Uncle Kino is here, okay?";
-			} else if (BaseClass == Job_Assassin) {
+			} else if (BaseJob == Job_Assassin) {
 				mes "There's no reason to be afraid. I know that person looks scary, but you're a good girl, so you'll be okay.";
-			} else if (BaseClass == Job_Blacksmith) {
-				mes "There's no reason to be scared, honey. It's just a Blacksmith.";
+			} else if (BaseJob == Job_Blacksmith) {
+				mesf("There's no reason to be scared, honey. It's just a %s.", jobname(Class));
 			} else {
 				mes "There's no reason to be scared. See...? That person won't hurt you.";
 			}

--- a/npc/quests/quests_13_1.txt
+++ b/npc/quests/quests_13_1.txt
@@ -11960,7 +11960,7 @@ mid_camp,255,269,0	script	Wet Firewood#moc2	CLEAR_NPC,{
 
 morocc,43,108,5	script	Sharp-Looking Boy#dan_07	4_KID01,{
 	mes "[Jack]";
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		mes "Almost half of this town has been destroyed,";
 		mes "and yet some people still come to visit.";
 		mes "I must say that it's amazing that our stronghold is still intact, and withstood all the devastation.";
@@ -11978,7 +11978,7 @@ morocc,43,108,5	script	Sharp-Looking Boy#dan_07	4_KID01,{
 
 morocc,45,110,0	script	que_job01#01	WARPNPC,2,2,{
 OnTouch:
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		warp "que_job01",9,94;
 		end;
 	}
@@ -12011,7 +12011,7 @@ que_job01,82,95,3	script	Bar Master#moc2_01	1_ETC_01,{
 		mes "to store some of your items.^000000";
 		close;
 	}
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		mes "[Karred]";
 		mes "Welcome.";
 		mes "Care for a drink?";
@@ -12037,7 +12037,7 @@ que_job01,82,95,3	script	Bar Master#moc2_01	1_ETC_01,{
 				close;
 			}
 			else {
-				if (BaseClass == Job_Assassin) {
+				if (BaseJob == Job_Assassin) {
 					if (Zeny < 800) {
 						mes "[Karred]";
 						mes "I can give you a special discount, but";
@@ -12083,7 +12083,7 @@ que_job01,82,95,3	script	Bar Master#moc2_01	1_ETC_01,{
 				close;
 			}
 			else {
-				if (BaseClass == Job_Assassin) {
+				if (BaseJob == Job_Assassin) {
 					if (Zeny < 800) {
 						mes "[Karred]";
 						mes "I can give you a special discount, but";
@@ -12125,7 +12125,7 @@ que_job01,82,95,3	script	Bar Master#moc2_01	1_ETC_01,{
 			close;
 		}
 	case 2:
-		if (BaseClass == Job_Assassin) {
+		if (BaseJob == Job_Assassin) {
 			mes "[Karred]";
 			mes "How many I help you?";
 			next;
@@ -12205,7 +12205,7 @@ que_job01,82,95,3	script	Bar Master#moc2_01	1_ETC_01,{
 
 que_job01,80,77,0	script	que_job01#04	WARPNPC,2,2,{
 OnTouch:
-	if (BaseClass == Job_Assassin || mao_request > 0 || mao_morocc2 > 4) {
+	if (BaseJob == Job_Assassin || mao_request > 0 || mao_morocc2 > 4) {
 		warp "que_job01",61,50;
 		end;
 	}
@@ -12313,7 +12313,7 @@ que_job01,81,79,5	script	Idle Knight#dan_08	4_M_JOB_KNIGHT1,{
 	mes "[Litheron]";
 	mes "What, haven't you seen a Knight before?";
 	mes "You think Knights don't belong here?";
-	if (BaseClass == Job_Knight)
+	if (BaseJob == Job_Knight)
 		mes "Looks like this is a case of the pot calling the kettle black.";
 	next;
 	mes "[Litheron]";
@@ -12326,7 +12326,7 @@ que_job01,65,50,0	warp	que_job01#05	2,2,que_job01,84,77
 
 que_job01,49,49,5	script	Tao#dan_09	4_F_YUNYANG,{
 	mes "[Tao]";
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		mes "Welcome, meow.";
 		mes "Say, how's it like outside? Meow?";
 		next;
@@ -12526,7 +12526,7 @@ OnTouch:
 
 que_job01,16,21,5	script	Valdes#moc_master_1	1_M_JOBTESTER,{
 	mes "[Valdes]";
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		mes "What is it? I have nothing to ask you to do.";
 		mes "Could you please leave me alone? I have a bad headache.";
 		next;

--- a/npc/quests/quests_ein.txt
+++ b/npc/quests/quests_ein.txt
@@ -594,7 +594,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 			close;
 		}
 	}
-	
+
 	function F_ForgeWeapon {
 		mes "[Uwe]";
 		mes "Well...";
@@ -620,7 +620,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "you a good weapon~";
 		close;
 	}
-	
+
 	function F_Cancel {
 		mes "[Uwe]";
 		mes "Oh...?";
@@ -628,9 +628,9 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "free to visit";
 		mes "me whenever";
 		mes "you want, 'kay?";
-		close;	
+		close;
 	}
-	
+
 	function F_RandCloseMsg {
 		switch (rand(1, 3)) {
 		case 1:
@@ -644,7 +644,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 			close;
 		}
 	}
-	
+
 	function F_Ingredients {
 		mes "[Uwe]";
 		mes "Now for beginners,";
@@ -679,7 +679,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "the next time~";
 		F_RandCloseMsg();
 	}
-	
+
 	function F_Cooking {
 		mes "[Uwe]";
 		mes "Mm...?";
@@ -731,7 +731,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "come back.";
 		F_RandCloseMsg();
 	}
-	
+
 	function F_Heart {
 		mes "[Uwe]";
 		mes "Ah, heart. Just like forging,";
@@ -749,7 +749,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "whenever you please.";
 		F_RandCloseMsg();
 	}
-	
+
 	function F_Skills {
 		mes "[Uwe]";
 		mes "When you're beginning to learn";
@@ -779,7 +779,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "the next time~";
 		F_RandCloseMsg();
 	}
-	
+
 	function F_Tools {
 		mes "[Uwe]";
 		mes "Cooking is a little";
@@ -822,7 +822,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "you like them~";
 		F_RandCloseMsg();
 	}
-	
+
 	function F_ToolsWithoutReward {
 		mes "[Uwe]";
 		mes "Cooking is a little";
@@ -847,7 +847,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "the next time~";
 		F_RandCloseMsg();
 	}
-	
+
 	function F_OverWeight {
 		mes "[Uwe]";
 		mes "Oh, I was going to give";
@@ -858,7 +858,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "in your Kafra Storage?";
 		close;
 	}
-	
+
 	function F_LargeJellopyForCoal {
 		if (countitem(Large_Jellopy) > 5) {
 			if (checkweight(Spawn, 199) == 0)
@@ -933,7 +933,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 			close;
 		}
 	}
-	
+
 	EinUwe = 0;
 	if (BaseJob == Job_Blacksmith) {
 		if (ein_cook > 999) {

--- a/npc/quests/quests_ein.txt
+++ b/npc/quests/quests_ein.txt
@@ -510,11 +510,11 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "of warmth or life. So... Just don't live here in your old age.";
 		next;
 		.@choice2$ = "I won't. Thanks for the advice.";
-		if (BaseClass == Job_Blacksmith)
+		if (BaseJob == Job_Blacksmith)
 			.@choice2$ = "But I like the city life~";
 		switch (select("Then why are you here?", .@choice2$)) {
 		case 1:
-			if (BaseClass == Job_Blacksmith) {
+			if (BaseJob == Job_Blacksmith) {
 				mes "[Uwe]";
 				mes "Well, sugar honey,";
 				mes "I've been waiting for";
@@ -545,7 +545,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 			mes "Buhbye for now, cutie~";
 			close;
 		case 2:
-			if (BaseClass != Job_Blacksmith) {
+			if (BaseJob != Job_Blacksmith) {
 				mes "[Uwe]";
 				mes "Oh, that is such";
 				mes "a good decision,";
@@ -668,7 +668,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 		mes "Never cut corners and always";
 		mes "dedicate yourself to make the";
 		mes "very best finished product~";
-		if (ein_cook == 7 && BaseClass == Job_Blacksmith)
+		if (ein_cook == 7 && BaseJob == Job_Blacksmith)
 			ein_cook += 10;
 		next;
 		mes "[Uwe]";
@@ -935,7 +935,7 @@ einbroch,215,180,6	script	Uwe Kleine#ein	4_M_03,{
 	}
 	
 	EinUwe = 0;
-	if (BaseClass == Job_Blacksmith) {
+	if (BaseJob == Job_Blacksmith) {
 		if (ein_cook > 999) {
 			if (ein_cook > 1199) {
 				mes "[Uwe]";

--- a/npc/quests/quests_morocc.txt
+++ b/npc/quests/quests_morocc.txt
@@ -1913,7 +1913,7 @@ moc_fild21,178,239,0	script	Group of Evil#edq	CLEAR_NPC,1,1,{
 		mes "You can feel the power of the darkness rise from the gap where light and darkness are mingled.";
 		close;
 	}
-	
+
 OnEnable:
 	enablenpc "Group of Evil#edq";
 	$@re_moc_time$ = "";

--- a/npc/quests/quests_morocc.txt
+++ b/npc/quests/quests_morocc.txt
@@ -161,7 +161,7 @@ moc_ruins,118,176,4	script	Alchemist	1_M_WIZARD,{
 //== Morroc Assassin Guild Bar [Disabled] ==================
 /*
 morocc,43,108,5	script	Sharp-Looking Kid#dan_07	4_KID01,{
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		mes "[Jack]";
 		mes "In spite of the chaotic mess in their town, ";
 		mes "there are still some of those who pay visits here.";
@@ -187,7 +187,7 @@ morocc,43,108,5	script	Sharp-Looking Kid#dan_07	4_KID01,{
 
 morocc,45,110,0	script	que_job01#01	WARPNPC,2,2,{
 OnTouch:
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		warp "que_job01",9,94;
 		end;
 	}
@@ -212,7 +212,7 @@ que_job01,68,96,0	warp	que_job01#03	2,2,que_job01,17,53
 
 que_job01,80,77,0	script	que_job01#04	WARPNPC,2,2,{
 OnTouch:
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		warp "que_job01",61,50;
 		end;
 	}
@@ -318,7 +318,7 @@ que_job01,81,79,5	script	Idle Knight#dan_08	4_M_JOB_KNIGHT1,{
 	mes "probably wondering why";
 	mes "a Knight like me is in a";
 	mes "secret Assassin's pub.";
-	if (BaseClass == Job_Knight) {
+	if (BaseJob == Job_Knight) {
 		mes "What about you, huh?";
 	}
 	next;
@@ -338,12 +338,12 @@ que_job01,82,95,3	script	Bar Master#moc_main01	1_ETC_01,{
 		mes "to store some of your items.^000000";
 		close;
 	}
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		mes "[Master]";
 		mes "Please, come in.";
 		mes "Care for a drink?";
 	}
-	else if ((BaseJob == Job_Thief) && (BaseClass != Job_Assassin)) {
+	else if ((BaseClass == Job_Thief) && (BaseJob != Job_Assassin)) {
 		mes "[Master]";
 		mes "......Huh. How did a ruffian like you get in here?";
 		mes "Well, I guess Jack's not doing his job.";
@@ -382,7 +382,7 @@ que_job01,82,95,3	script	Bar Master#moc_main01	1_ETC_01,{
 				close;
 			}
 			else {
-				if (BaseClass == Job_Assassin) {
+				if (BaseJob == Job_Assassin) {
 					if (Zeny < 800) {
 						mes "[Master]";
 						mes "You know...";
@@ -441,7 +441,7 @@ que_job01,82,95,3	script	Bar Master#moc_main01	1_ETC_01,{
 				close;
 			}
 			else {
-				if (BaseClass == Job_Assassin) {
+				if (BaseJob == Job_Assassin) {
 					if (Zeny < 800) {
 						mes "[Master]";
 						mes "You know...";
@@ -500,7 +500,7 @@ que_job01,82,95,3	script	Bar Master#moc_main01	1_ETC_01,{
 		}
 	case 2:
 		if (mao_request == 1) {
-			if (BaseClass == Job_Assassin) {
+			if (BaseJob == Job_Assassin) {
 				mes "[Master]";
 				mes "A mission...";
 				mes "Don't you think you're little too late?";
@@ -540,7 +540,7 @@ que_job01,82,95,3	script	Bar Master#moc_main01	1_ETC_01,{
 			}
 		}
 		else {
-			if (BaseClass == Job_Assassin) {
+			if (BaseJob == Job_Assassin) {
 				mes "[Master]";
 				mes "Let me take a guess. You haven't been assigned any missions from this joint, eh?";
 				mes "By the way, you like this place?";
@@ -577,7 +577,7 @@ que_job01,82,95,3	script	Bar Master#moc_main01	1_ETC_01,{
 }
 
 que_job01,49,49,5	script	Tao#dan_09	4_F_YUNYANG,{
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		mes "[Tao]";
 		mes "Welcome, meow~";
 		mes "How's out, meow?";
@@ -789,7 +789,7 @@ OnTouch:
 que_job01,80,27,0	warp	que_job01#room2_1_out	1,1,que_job01,52,50
 
 que_job01,16,21,5	script	Valdes#moc_master_1	1_M_JOBTESTER,{
-	if (BaseClass == Job_Assassin) {
+	if (BaseJob == Job_Assassin) {
 		mes "[Valdes]";
 		mes "What is it? I have nothing to ask you to do.";
 		mes "Could you please leave me alone? I have a bad headache.";

--- a/npc/quests/quests_nameless.txt
+++ b/npc/quests/quests_nameless.txt
@@ -4774,7 +4774,7 @@ moc_ruins,152,147,5	script	Ibrahim	4_M_JOB_HUNTER,3,3,{
 					mes "out with their problems.";
 					close;
 				}
-				else if (BaseClass == Job_Swordman) {
+				else if (BaseJob == Job_Swordman) {
 					mes "[Ibrahim]";
 					mes "I've got a few buddies";
 					mes "in the Swordman Association.";
@@ -4783,7 +4783,7 @@ moc_ruins,152,147,5	script	Ibrahim	4_M_JOB_HUNTER,3,3,{
 					mes "for someone smart and strong.";
 					close;
 				}
-				else if (BaseClass == Job_Crusader) {
+				else if (BaseJob == Job_Crusader) {
 					mes "[Ibrahim]";
 					mes "Heh, so you really";
 					mes "are one of those holy";
@@ -4799,7 +4799,7 @@ moc_ruins,152,147,5	script	Ibrahim	4_M_JOB_HUNTER,3,3,{
 					mes "reputation precedes you.";
 					close;
 				}
-				else if (BaseClass == Job_Merchant) {
+				else if (BaseJob == Job_Merchant) {
 					mes "[Ibrahim]";
 					mes "Hey, if I didn't know";
 					mes "your name, how could I call";
@@ -4807,14 +4807,14 @@ moc_ruins,152,147,5	script	Ibrahim	4_M_JOB_HUNTER,3,3,{
 					mes "an example for us all~";
 					close;
 				}
-				else if (BaseClass == Job_Blacksmith) {
+				else if (BaseJob == Job_Blacksmith) {
 					mes "[Ibrahim]";
 					mes "We have a mutual friend,";
 					mes "you know that? Aragham";
 					mes "really spoke highly of you.";
 					close;
 				}
-				else if (BaseClass == Job_Alchemist) {
+				else if (BaseJob == Job_Alchemist) {
 					mes "[Ibrahim]";
 					mes "I know a guy who knows";
 					mes "a guy in the Alchemist Guild.";
@@ -4841,7 +4841,7 @@ moc_ruins,152,147,5	script	Ibrahim	4_M_JOB_HUNTER,3,3,{
 					mes "acquaintance~";
 					close;
 				}
-				else if (BaseClass == Job_Archer) {
+				else if (BaseJob == Job_Archer || BaseJob == Job_Hunter) {
 					mes "[Ibrahim]";
 					mes "Anyone who's used";
 					mes "a bow seems to drop";
@@ -4851,14 +4851,14 @@ moc_ruins,152,147,5	script	Ibrahim	4_M_JOB_HUNTER,3,3,{
 					mes "actually talking to you~";
 					close;
 				}
-				else if (BaseClass == Job_Bard) {
+				else if (BaseJob == Job_Bard) {
 					mes "[Ibrahim]";
 					mes "Is it really true?";
 					mes "I hear you sing";
 					mes "like an angel...";
 					close;
 				}
-				else if (BaseClass == Job_Dancer) {
+				else if (BaseJob == Job_Dancer) {
 					mes "[Ibrahim]";
 					mes "Is it really true?";
 					mes "I hear you dance";


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

There are a few cases, especially in quests where thankfully mostly flavor texts were never able to trigger, because `BaseClass == Job_Assassin` for example was compared, while BaseClass will always return a 1-1 *normal* job or Job_Novice.
All these unsatisfiable conditions have been changed to what they were intended to be.
One of the Bar Keepers for example that sells Tropical Sograt for 800z to Assassins and everyone else 1000z was not offering that options to Assassins, that has been fixed.

Also in 2 files in a separate commit I removed some trailing whitespace.

**Issues addressed:** None?

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
