### PR TITLE
Fixes Abracadabra and Improvised Skill

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1155,7 +1155,7 @@ static int unit_skilluse_id(struct block_list *src, int target_id, uint16 skill_
 	int ret = unit->skilluse_id2(src, target_id, skill_id, skill_lv, casttime, castcancel);
 	struct map_session_data *sd = BL_CAST(BL_PC, src);
 
-	if (sd != NULL)
+	if (sd != NULL && ret == 0)
 		pc->autocast_remove(sd, sd->auto_cast_current.type, sd->auto_cast_current.skill_id,
 				    sd->auto_cast_current.skill_lv);
 
@@ -1793,7 +1793,7 @@ static int unit_skilluse_pos(struct block_list *src, short skill_x, short skill_
 	int ret = unit->skilluse_pos2(src, skill_x, skill_y, skill_id, skill_lv, casttime, castcancel);
 	struct map_session_data *sd = BL_CAST(BL_PC, src);
 
-	if (sd != NULL)
+	if (sd != NULL && ret == 0)
 		pc->autocast_remove(sd, sd->auto_cast_current.type, sd->auto_cast_current.skill_id,
 				    sd->auto_cast_current.skill_lv);
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
The Autocast by abra was cleared before the actual casting, which resulted in failure of skill if not learned.

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Adding ret = 0 check while casting skill, to clear the autocast data

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
* [x] #2823
* [x] #2824

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
