### PR TITLE
update F_InsertComma to allow numbers bigger than INT_MAX

### DIFF
--- a/npc/other/Global_Functions.txt
+++ b/npc/other/Global_Functions.txt
@@ -44,23 +44,17 @@
 // separator.
 // callfunc "F_InsertComma",<number>{,<precision>,<separator>}
 // Examples:
-//    callfunc("F_InsertComma",7777777)           // returns "7,777,777"
-//    callfunc("F_InsertComma",1000000000,3,",") // returns "1,000,000,000"
-//    callfunc("F_InsertComma",1000000000,3,"_") // returns "1_000_000_000"
-//    callfunc("F_InsertComma",1000000000,4)      // returns "10,0000,0000"
+//    callfunc("F_InsertComma", 7777777)            // returns "7,777,777"
+//    callfunc("F_InsertComma", 1000000000, 3, ",") // returns "1,000,000,000"
+//    callfunc("F_InsertComma", 1000000000, 3, "_") // returns "1_000_000_000"
+//    callfunc("F_InsertComma", 1000000000, 4)      // returns "10,0000,0000"
 function	script	F_InsertComma	{
-	.@value = getarg(0);
-	.@precision = getarg(1,3);
-	.@separator$ = getarg( 2,"," );
-
-	.@str$ = ""+.@value;
-	.@is_negative = ( .@value < 0 );
-
-	.@length = getstrlen( .@str$ ) - .@precision - .@is_negative;
-	while ( .@length > 0 ) {
-		.@str$ = insertchar( .@str$, .@separator$ , ( .@length + .@is_negative ) );
-		.@length -= .@precision;
-	}
+	.@str$ = getarg(0);
+	.@precision = getarg(1, 3);
+	.@separator$ = getarg(2, ",");
+	.@is_negative = (charat(.@str$, 0) == "-");
+	for (.@i = getstrlen(.@str$) - .@precision; .@i > .@is_negative; .@i -= .@precision)
+		.@str$ = insertchar(.@str$, .@separator$, .@i);
 	return .@str$;
 }
 


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
Currently dealing with a paid service script, that needs to display integer higher than 2.1b
--> please remember SQL can calculate value above INT_MAX
I have my own int__ function .... but I try to use the one in Github
nope doesn't work, it doesn't allow to display value higher than INT_MAX

the tested script below, will show you 2.1b if input over that value, along with this error on console
```
[Error]: script:conv_num: overflow detected, capping to 2147483647
[Debug]: Data: string value="1321321321321"
[Debug]: Source (NPC): dsfsdflkjsdf at prontera (158,185)
```

### Changes Proposed
`.@value` variable removed, and change `.@is_negative` to check condition with strings

### Tested With
```
//	~~~~~ Please use this latest int__ function that support negative numbers ~~~~~
function	script	int__	{
	.@str$ = getarg(0);
	.@is_negative = (charat(.@str$, 0) == "-");
	for (.@i = getstrlen(.@str$) -3; .@i > .@is_negative; .@i -= 3)
		.@str$ = insertchar(.@str$, ",", .@i);
	return .@str$;
}

prontera,158,185,5	script	dsfsdflkjsdf	1_F_MARIA,{
	input .@a$;
	dispbottom F_InsertComma(.@a$);
	dispbottom int__(.@a$);
}

prontera,155,185,5	script	sfdsdf	1_F_MARIA,{
	input .@a;
	dispbottom F_InsertComma(.@a);
	dispbottom int__(.@a);
}
```

### Affected Branches
* Master

### Known Issues and TODO List
