### PR TITLE
Fixed convex mirror effect

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -18151,54 +18151,49 @@ static void clif_parse_Adopt_reply(int fd, struct map_session_data *sd)
 /// Convex Mirror (ZC_BOSS_INFO).
 /// 0293 <infoType>.B <x>.L <y>.L <minHours>.W <minMinutes>.W <maxHours>.W <maxMinutes>.W <monster name>.51B
 /// infoType:
-///     0 = No boss on this map (BOSS_INFO_NOT).
-///     1 = Boss is alive (position update) (BOSS_INFO_ALIVE).
-///     2 = Boss is alive (initial announce) (BOSS_INFO_ALIVE_WITHMSG).
-///     3 = Boss is dead (BOSS_INFO_DEAD).
-static void clif_bossmapinfo(struct map_session_data *sd, struct mob_data *md, short flag)
+///     BOSS_INFO_NONE  = No boss on the map
+///     BOSS_INFO_ALIVE = Boss is alive (Update monster position)
+///     BOSS_INFO_ALIVE_WITHMSG = Boss is alive (Initial announce)
+///     BOSS_INFO_DEAD = Boss on the map is dead (Display respawn time)
+static void clif_bossmapinfo(int fd, struct mob_data *md, enum bossmap_info_type flag)
 {
-	int fd = sd->fd;
-
-	WFIFOHEAD(fd,70);
-	memset(WFIFOP(fd,0),0,70);
-	WFIFOW(fd,0) = 0x293;
+	WFIFOHEAD(fd, 70);
+	memset(WFIFOP(fd, 0), 0, 70);
+	WFIFOW(fd, 0) = 0x293;
+	WFIFOB(fd, 2) = flag;
 
 	switch (flag) {
-		case 0:
-			WFIFOB(fd,2) = 0;
-			break; 
-		case 1:
-			WFIFOB(fd,2) = 1;
-			WFIFOL(fd,3) = md->bl.x;
-			WFIFOL(fd,7) = md->bl.y;
-			break;
-		case 2:
-			WFIFOB(fd,2) = 2;
-			WFIFOL(fd,3) = md->bl.x;
-			WFIFOL(fd,7) = md->bl.y;
-			break;
-		case 3:
-		{
-			const struct TimerData * timer_data = timer->get(md->spawn_timer);
+	case BOSS_INFO_NONE:
+		break; 
+	case BOSS_INFO_ALIVE:
+	case BOSS_INFO_ALIVE_WITHMSG:
+		if (md != NULL) {
+			WFIFOL(fd, 3) = md->bl.x;
+			WFIFOL(fd, 7) = md->bl.y;
+		}
+		break;
+	case BOSS_INFO_DEAD:
+		if (md != NULL) {
+			const struct TimerData *timer_data = timer->get(md->spawn_timer);
 			unsigned int seconds;
-			int hours, minutes;
+			int hours;
+			int minutes;
 
 			seconds = (unsigned int)(DIFF_TICK(timer_data->tick, timer->gettick()) / 1000 + 60);
 			hours = seconds / (60 * 60);
 			seconds = seconds - (60 * 60 * hours);
 			minutes = seconds / 60;
 
-			WFIFOB(fd,2) = 3;
-			WFIFOW(fd,11) = hours; // Hours
-			WFIFOW(fd,13) = minutes; // Minutes
+			WFIFOW(fd, 11) = hours;
+			WFIFOW(fd, 13) = minutes;
 		}
 		break;
 	}
 
 	if (md != NULL)
-		safestrncpy(WFIFOP(fd,19), md->db->jname, NAME_LENGTH);
+		safestrncpy(WFIFOP(fd, 19), md->db->jname, NAME_LENGTH);
 
-	WFIFOSET(fd,70);
+	WFIFOSET(fd, 70);
 }
 
 static void clif_parse_ViewPlayerEquip(int fd, struct map_session_data *sd) __attribute__((nonnull (2)));

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -874,7 +874,7 @@ struct clif_interface {
 	void (*map_property) (struct map_session_data* sd, enum map_property property);
 	void (*pvpset) (struct map_session_data *sd, int pvprank, int pvpnum,int type);
 	void (*map_property_mapall) (int mapid, enum map_property property);
-	void (*bossmapinfo) (int fd, struct mob_data *md, short flag);
+	void (*bossmapinfo) (struct map_session_data *sd, struct mob_data *md, short flag);
 	void (*map_type) (struct map_session_data* sd, enum map_type type);
 	void (*maptypeproperty2) (struct block_list *bl,enum send_target t);
 	/* multi-map-server */

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -753,9 +753,19 @@ enum removeGear_flag {
 /** Info types for PACKET_ZC_PERSONAL_INFOMATION (0x097b). **/
 enum detail_exp_info_type {
 	PC_EXP_INFO = 0x0,	//!< PCBang internet cafe modifiers. (http://pcbang.gnjoy.com/) (Unused.)
-	PREMIUM_EXP_INFO = 0x1,	//!< Premium user modifiers. Values aren't displayed in 20161207+ clients.
+	PREMIUM_EXP_INFO = 0x1, //!< Premium user modifiers. Values aren't displayed in 20161207+ clients.
 	SERVER_EXP_INFO = 0x2,	//!< Server rates.
 	TPLUS_EXP_INFO = 0x3,	//!< Unknown. Values are displayed as "TPLUS" in kRO. (Unused.)
+};
+
+/**
+ * Convex Mirror (ZC_BOSS_INFO)
+ **/
+enum bossmap_info_type {
+	BOSS_INFO_NONE = 0,      // No Boss within the map
+	BOSS_INFO_ALIVE,         // Boss is still alive
+	BOSS_INFO_ALIVE_WITHMSG, // Boss is alive (on item use)
+	BOSS_INFO_DEAD,          // Boss is dead
 };
 
 /**
@@ -874,7 +884,7 @@ struct clif_interface {
 	void (*map_property) (struct map_session_data* sd, enum map_property property);
 	void (*pvpset) (struct map_session_data *sd, int pvprank, int pvpnum,int type);
 	void (*map_property_mapall) (int mapid, enum map_property property);
-	void (*bossmapinfo) (struct map_session_data *sd, struct mob_data *md, short flag);
+	void (*bossmapinfo) (int fd, struct mob_data *md, enum bossmap_info_type flag);
 	void (*map_type) (struct map_session_data* sd, enum map_type type);
 	void (*maptypeproperty2) (struct block_list *bl,enum send_target t);
 	/* multi-map-server */

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -8282,12 +8282,11 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 				tick_time = val2 * 1000; // [GodLesZ] tick time
 				break;
 			case SC_CASH_BOSS_ALARM:
-				if( sd != NULL ) {
+				if (sd != NULL) {
 					struct mob_data *boss_md = map->getmob_boss(bl->m); // Search for Boss on this Map
-					if( boss_md == NULL || boss_md->bl.prev == NULL ) {
-						// No MVP on this map - MVP is dead
-						clif->bossmapinfo(sd->fd, boss_md, 1);
-						return 0; // No need to start SC
+					if (boss_md == NULL) {
+						clif->bossmapinfo(sd, NULL, 0); // No MVP in the Map
+						return 0;
 					}
 					val1 = boss_md->bl.id;
 					if( (val4 = total_tick/1000) < 1 )
@@ -9941,8 +9940,8 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 			}
 			break;
 		case SC_CASH_BOSS_ALARM:
-			if( sd )
-				clif->bossmapinfo(sd->fd, map->id2boss(sce->val1), 0); // First Message
+			if (sd)
+				clif->bossmapinfo(sd, map->id2boss(sce->val1), 2); // First Message
 			break;
 		case SC_MER_HP:
 			status_percent_heal(bl, 100, 0); // Recover Full HP
@@ -12089,15 +12088,22 @@ static int status_change_timer(int tid, int64 tick, int id, intptr_t data)
 			break;
 
 		case SC_CASH_BOSS_ALARM:
-			if( sd && --(sce->val4) >= 0 ) {
+			if (sd && --(sce->val4) >= 0) {
 				struct mob_data *boss_md = map->id2boss(sce->val1);
-				if( boss_md && sd->bl.m == boss_md->bl.m ) {
-					clif->bossmapinfo(sd->fd, boss_md, 1); // Update X - Y on minimap
-					if (boss_md->bl.prev != NULL) {
-						sc_timer_next(5000 + tick, status->change_timer, bl->id, data);
+				if (boss_md) {
+					if (sd->bl.m != boss_md->bl.m) // Changed map
+ 						return 0;
+					else if (boss_md->bl.prev != NULL) { // Boss monster still alive, update x and y position on map
+						sce->val2 = 0;
+						clif->bossmapinfo(sd, boss_md, 1);
+					} else if (boss_md->spawn_timer != INVALID_TIMER && !sce->val2) { // Boss monster is dead
+						sce->val2 = 1;
+						clif->bossmapinfo(sd, boss_md, 3);
 						return 0;
 					}
 				}
+				sc_timer_next(1000 + tick, status->change_timer, bl->id, data);
+				return 0;
 			}
 			break;
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes convex mirror, where it should display monster location on the mini-map constantly until the status isn't yet `INVALID_TIMER` as long as the there is a boss on the certain map(alive or dead?) where you used the convex mirror itself and will display respawn time after you used the convex mirror or while the effect is still up.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
