### PR TITLE
Changed the default value of max_body_style

### DIFF
--- a/conf/map/battle/client.conf
+++ b/conf/map/battle/client.conf
@@ -44,13 +44,13 @@ min_chat_delay: 0
 
 // Valid range of dyes and styles on the client.
 min_hair_style: 0
-max_hair_style: 29
+max_hair_style: 31
 min_hair_color: 0
 max_hair_color: 8
 min_cloth_color: 0
 max_cloth_color: 4
 min_body_style: 0
-max_body_style: 4
+max_body_style: 1
 
 // When set to true, the damage field in packets sent from woe maps will be set
 // to -1, making it impossible for GMs, Bots and Hexed clients to know the

--- a/conf/map/battle/client.conf
+++ b/conf/map/battle/client.conf
@@ -44,7 +44,7 @@ min_chat_delay: 0
 
 // Valid range of dyes and styles on the client.
 min_hair_style: 0
-max_hair_style: 31
+max_hair_style: 29
 min_hair_color: 0
 max_hair_color: 8
 min_cloth_color: 0


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Changed the default value of max_body_style to 1 since there is only one body style AFAIK, otherwise it will cause a gravity error if someone set a value higher than 1 without having the proper sprites

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
