### PR TITLE
Update MVP DamageTakenRate

### DIFF
--- a/db/pre-re/mob_db.conf
+++ b/db/pre-re/mob_db.conf
@@ -151,7 +151,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 70
 		Scorpions_Tail: 5500
@@ -198,7 +197,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 		Knife_: 100
@@ -240,7 +238,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 512
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 {
 	Id: 1004
@@ -279,7 +276,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 216
-	MvpExp: 0
 	Drops: {
 		Wind_Of_Verdure: 80
 		Bee_Sting: 9000
@@ -328,7 +324,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Tooth_Of_Bat: 5500
 		Falchion_: 20
@@ -377,7 +372,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 {
 	Id: 1007
@@ -414,7 +408,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fluff: 6500
 		Feather: 500
@@ -459,7 +452,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 80
 		Chrysalis: 5500
@@ -507,7 +499,6 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Talon: 9000
 		Bow_: 150
@@ -553,7 +544,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Tree_Root: 9000
 		Wooden_Block: 100
@@ -600,7 +590,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Iron: 50
 		Shell: 6500
@@ -646,7 +635,6 @@ mob_db: (
 	AttackDelay: 2016
 	AttackMotion: 816
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Sticky_Webfoot: 9000
 		Spawn: 500
@@ -692,7 +680,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 504
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 20
 		Claw_Of_Wolves: 9000
@@ -738,7 +725,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mushroom_Spore: 9000
 		Red_Herb: 800
@@ -788,7 +774,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Decayed_Nail: 9000
 		Cardinal_Jewel_: 5
@@ -834,7 +819,6 @@ mob_db: (
 	AttackDelay: 2864
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 4500
 		Oridecon_Stone: 70
@@ -883,7 +867,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 3500
 		Garlet: 250
@@ -930,7 +913,6 @@ mob_db: (
 	AttackDelay: 1136
 	AttackMotion: 720
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Powder_Of_Butterfly: 9000
 		Silk_Robe_: 10
@@ -978,7 +960,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Bill_Of_Birds: 9000
 		Sandals_: 20
@@ -1023,7 +1004,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 50
 		Stem: 9000
@@ -1073,7 +1053,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 40
 		Insect_Feeler: 5500
@@ -1122,7 +1101,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 768
 	DamageMotion: 652
-	MvpExp: 0
 	Drops: {
 		Steel: 500
 		Cobold_Hair: 4000
@@ -1170,7 +1148,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Iron: 210
 		Orcish_Voucher: 9000
@@ -1217,7 +1194,6 @@ mob_db: (
 	AttackDelay: 1048
 	AttackMotion: 48
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 60
 		Emveretarcon: 25
@@ -1264,7 +1240,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scale_Of_Snakes: 9000
 		Katana_: 15
@@ -1314,7 +1289,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Danggie: 9000
 		Munak_Turban: 2
@@ -1362,7 +1336,6 @@ mob_db: (
 	AttackDelay: 2000
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 	}
@@ -1405,7 +1378,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 5500
 		Oridecon_Stone: 60
@@ -1456,7 +1428,6 @@ mob_db: (
 	AttackDelay: 1384
 	AttackMotion: 768
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Scales_Shell: 5335
 		Circlet_: 5
@@ -1503,7 +1474,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 50
 		Posionous_Canine: 9000
@@ -1550,7 +1520,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sticky_Mucus: 5500
 		Garlet: 1500
@@ -1597,7 +1566,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Immortal_Heart: 9000
 		Zargon: 700
@@ -1647,7 +1615,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 50
 		Resin: 9000
@@ -1693,7 +1660,6 @@ mob_db: (
 	AttackDelay: 2016
 	AttackMotion: 816
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 45
 		Spawn: 5500
@@ -1743,7 +1709,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rough_Wind: 30
 		Steel: 100
@@ -1793,7 +1758,6 @@ mob_db: (
 	AttackDelay: 2456
 	AttackMotion: 912
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Horrendous_Mouth: 6000
 		Oridecon_Stone: 110
@@ -1843,7 +1807,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Shining_Scales: 5335
 		Zargon: 1400
@@ -2008,7 +1971,6 @@ mob_db: (
 	AttackDelay: 1608
 	AttackMotion: 816
 	DamageMotion: 396
-	MvpExp: 0
 	Drops: {
 		Steel: 150
 		Stone_Heart: 9000
@@ -2058,7 +2020,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Rotten_Bandage: 9000
 		Oridecon_Stone: 100
@@ -2108,7 +2069,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Wind_Of_Verdure: 90
 		Steel: 30
@@ -2156,7 +2116,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 800
 	DamageMotion: 600
-	MvpExp: 0
 },*/
 {
 	Id: 1044
@@ -2196,7 +2155,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 13
 		Heart_Of_Mermaid: 9000
@@ -2246,7 +2204,6 @@ mob_db: (
 	AttackDelay: 1272
 	AttackMotion: 72
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 18
 		Gill: 9000
@@ -2346,7 +2303,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 250
 		Shell: 1500
@@ -2391,7 +2347,6 @@ mob_db: (
 	AttackDelay: 701
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 300
 		Chrysalis: 5000
@@ -2437,7 +2392,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 168
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Birds: 9000
 		Feather: 700
@@ -2482,7 +2436,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 168
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Birds: 9000
 		Feather: 700
@@ -2532,7 +2485,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 2500
 		Leather_Jacket_: 80
@@ -2578,7 +2530,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Grasshoppers_Leg: 9000
 		Guitar_Of_Vast_Land: 10
@@ -2629,7 +2580,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 3500
 		Garlet: 250
@@ -2681,7 +2631,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 40
 		Insect_Feeler: 5500
@@ -2727,7 +2676,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 70
 		Cactus_Needle: 9000
@@ -2774,7 +2722,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Raccoon_Leaf: 5500
 		Animals_Skin: 5500
@@ -2823,7 +2770,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 54
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yoyo_Tail: 9000
 		Banana: 1500
@@ -2873,7 +2819,6 @@ mob_db: (
 	AttackDelay: 1708
 	AttackMotion: 1008
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 60
 		Grasshoppers_Leg: 6500
@@ -2979,7 +2924,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Bears_Foot: 9000
 		Poo_Poo_Hat: 5
@@ -3031,7 +2975,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Horseshoe: 6000
 		Blue_Herb: 500
@@ -3077,7 +3020,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Candy: 2000
 		Candy_Striper: 1000
@@ -3122,7 +3064,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Clover: 6500
 		Feather: 1000
@@ -3168,7 +3109,6 @@ mob_db: (
 	AttackDelay: 2492
 	AttackMotion: 792
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Rotten_Scale: 5500
 		Skel_Bone: 1500
@@ -3218,7 +3158,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Fin: 5335
 		Oridecon_Stone: 115
@@ -3265,7 +3204,6 @@ mob_db: (
 	AttackDelay: 1632
 	AttackMotion: 432
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 40
 		Nipper: 9000
@@ -3312,7 +3250,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 48
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 45
 		Conch: 5500
@@ -3358,7 +3295,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 432
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 25
 		Tentacle: 5500
@@ -3407,7 +3343,6 @@ mob_db: (
 	AttackDelay: 1968
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 10
 		Sharp_Scale: 9000
@@ -3454,7 +3389,6 @@ mob_db: (
 	AttackDelay: 1776
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 30
 		Worm_Peelings: 5500
@@ -3504,7 +3438,6 @@ mob_db: (
 	AttackDelay: 1754
 	AttackMotion: 554
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 3000
 		Pirate_Bandana: 15
@@ -3555,7 +3488,6 @@ mob_db: (
 	AttackDelay: 1700
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 	Drops: {
 		Flame_Heart: 30
 		Coal: 150
@@ -3601,7 +3533,6 @@ mob_db: (
 	AttackDelay: 992
 	AttackMotion: 792
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Crap_Shell: 5500
 		Nipper: 1500
@@ -3646,7 +3577,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Clam_Shell: 5500
 		Flesh_Of_Clam: 1000
@@ -3691,7 +3621,6 @@ mob_db: (
 	AttackDelay: 500
 	AttackMotion: 500
 	DamageMotion: 500
-	MvpExp: 0
 },*/
 {
 	Id: 1076
@@ -3728,7 +3657,6 @@ mob_db: (
 	AttackDelay: 2228
 	AttackMotion: 528
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Phracon: 90
 		Skel_Bone: 800
@@ -3777,7 +3705,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Poison_Spore: 9000
 		Hat_: 20
@@ -3822,7 +3749,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Red_Herb: 5500
 		Flower: 1000
@@ -3867,7 +3793,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Blue_Herb: 5500
 		Flower: 1000
@@ -3912,7 +3837,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Green_Herb: 7000
 		Flower: 1000
@@ -3957,7 +3881,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Yellow_Herb: 5500
 		Flower: 1000
@@ -4002,7 +3925,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		White_Herb: 5500
 		Flower: 1000
@@ -4047,7 +3969,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Blue_Herb: 5500
 		Yellow_Herb: 1000
@@ -4092,7 +4013,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Alchol: 50
 		Detrimindexta: 50
@@ -4137,7 +4057,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Alchol: 50
 		Karvodailnirol: 50
@@ -4304,7 +4223,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Oldmans_Romance: 50
 		Grasshoppers_Leg: 8000
@@ -4358,7 +4276,6 @@ mob_db: (
 	AttackDelay: 1236
 	AttackMotion: 336
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Big_Sis_Ribbon: 50
 		Honey: 2000
@@ -4412,7 +4329,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Snowy_Horn: 200
 		Unripe_Apple: 50
@@ -4466,7 +4382,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sweet_Gents: 200
 		Red_Herb: 8000
@@ -4520,7 +4435,6 @@ mob_db: (
 	AttackDelay: 1048
 	AttackMotion: 648
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Western_Grace: 200
 		Claw_Of_Wolves: 8000
@@ -4574,7 +4488,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Fillet: 200
 		Red_Herb: 8000
@@ -4622,7 +4535,6 @@ mob_db: (
 	AttackDelay: 2048
 	AttackMotion: 648
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 50
 		Snails_Shell: 9000
@@ -4672,7 +4584,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 9000
 		Garlet: 1000
@@ -4726,7 +4637,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Angelic_Chain: 100
 		Scapulare_: 60
@@ -4768,7 +4678,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 320
 		Shell: 2000
@@ -4819,7 +4728,6 @@ mob_db: (
 	AttackDelay: 1250
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Rotten_Bandage: 3000
 		Healing_Staff: 10
@@ -4872,7 +4780,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Short_Leg: 5335
 		Zargon: 1200
@@ -4922,7 +4829,6 @@ mob_db: (
 	AttackDelay: 1468
 	AttackMotion: 468
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Spiderweb: 9000
 		Scell: 1200
@@ -4975,7 +4881,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 480
 	DamageMotion: 120
-	MvpExp: 0
 	Drops: {
 		Evil_Horn: 500
 		Oridecon: 63
@@ -5027,7 +4932,6 @@ mob_db: (
 	AttackDelay: 1504
 	AttackMotion: 840
 	DamageMotion: 900
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 200
 		Starsand_Of_Witch: 4850
@@ -5074,7 +4978,6 @@ mob_db: (
 	AttackDelay: 1604
 	AttackMotion: 840
 	DamageMotion: 756
-	MvpExp: 0
 	Drops: {
 		Porcupine_Spike: 9000
 		Coat_: 5
@@ -5120,7 +5023,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 1008
-	MvpExp: 0
 	Drops: {
 		Acorn: 9000
 		Hood_: 20
@@ -5170,7 +5072,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 9000
 		Garlet: 3000
@@ -5220,7 +5121,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 420
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Katar_: 5
 		Claw_Of_Desert_Wolf: 5500
@@ -5269,7 +5169,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 900
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Phracon: 85
 		Animals_Skin: 5500
@@ -5316,7 +5215,6 @@ mob_db: (
 	AttackDelay: 1680
 	AttackMotion: 480
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 25
 		Tooth_Of_Ancient_Fish: 9000
@@ -5369,7 +5267,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Horn: 5335
 		Petite_DiablOfs_Wing: 400
@@ -5417,7 +5314,6 @@ mob_db: (
 	AttackDelay: 1156
 	AttackMotion: 456
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dokkaebi_Horn: 9000
 		Elunium_Stone: 150
@@ -5467,7 +5363,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 60
 		Tooth_Of_Bat: 3000
@@ -5572,7 +5467,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7500
 		Rod_: 80
@@ -5620,7 +5514,6 @@ mob_db: (
 	AttackDelay: 1004
 	AttackMotion: 504
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Moth_Dust: 9000
 		Wing_Of_Moth: 500
@@ -5725,7 +5618,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 816
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Scell: 1000
 		Egg_Shell: 20
@@ -5777,7 +5669,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Biretta_: 10
 		Bone_Wand: 1
@@ -5823,7 +5714,6 @@ mob_db: (
 	AttackDelay: 1432
 	AttackMotion: 432
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Blossom_Of_Maneater: 9000
 		Sunflower: 3
@@ -5873,7 +5763,6 @@ mob_db: (
 	AttackDelay: 1540
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Lizard_Scruff: 5500
 		Elunium_Stone: 90
@@ -5927,7 +5816,6 @@ mob_db: (
 	AttackDelay: 1220
 	AttackMotion: 1080
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Transparent_Cloth: 5335
 		Ghost_Bandana: 100
@@ -5975,7 +5863,6 @@ mob_db: (
 	AttackDelay: 1848
 	AttackMotion: 1296
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Great_Nature: 30
 		Coal: 150
@@ -6026,7 +5913,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Iron: 270
 		Scell: 9000
@@ -6076,7 +5962,6 @@ mob_db: (
 	AttackDelay: 1320
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Iron: 250
 		Scell: 9000
@@ -6126,7 +6011,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Iron: 230
 		Scell: 9000
@@ -6176,7 +6060,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 100
 		Iron: 170
@@ -6226,7 +6109,6 @@ mob_db: (
 	AttackDelay: 3074
 	AttackMotion: 1874
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Iron: 150
 		Scell: 9000
@@ -6272,7 +6154,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 120
 		Earthworm_Peeling: 9000
@@ -6320,7 +6201,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 80
 		Emveretarcon: 35
@@ -6369,7 +6249,6 @@ mob_db: (
 	AttackDelay: 1888
 	AttackMotion: 1152
 	DamageMotion: 828
-	MvpExp: 0
 	Drops: {
 		Stone_Heart: 6500
 		Zargon: 500
@@ -6421,7 +6300,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Head: 9000
 		Zargon: 900
@@ -6472,7 +6350,6 @@ mob_db: (
 	AttackDelay: 1364
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Zargon: 2000
 		Old_Card_Album: 2
@@ -6524,7 +6401,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 1000
 	DamageMotion: 396
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 8000
 		Elunium: 191
@@ -6574,7 +6450,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 100
 		Cobold_Hair: 5335
@@ -6623,7 +6498,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 100
 		Cobold_Hair: 5335
@@ -6672,7 +6546,6 @@ mob_db: (
 	AttackDelay: 1228
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 35
 		Steel: 100
@@ -6724,7 +6597,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 50
 		Cobold_Hair: 5335
@@ -6776,7 +6648,6 @@ mob_db: (
 	AttackDelay: 1228
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 40
 		Cobold_Hair: 5335
@@ -6824,7 +6695,6 @@ mob_db: (
 	AttackDelay: 1560
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Old_Frying_Pan: 9000
 		Garlet: 800
@@ -6875,7 +6745,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 660
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 110
 		Limb_Of_Mantis: 9000
@@ -6925,7 +6794,6 @@ mob_db: (
 	AttackDelay: 1540
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Flame_Heart: 35
 		Sacred_Masque: 4365
@@ -6971,7 +6839,6 @@ mob_db: (
 	AttackDelay: 2280
 	AttackMotion: 1080
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 5000
 		Sticky_Mucus: 1500
@@ -7012,7 +6879,6 @@ mob_db: (
 	AttackDelay: 1201
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Tendon: 5000
 		Detonator: 2500
@@ -7062,7 +6928,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 1056
-	MvpExp: 0
 	Drops: {
 		Golden_Hair: 9000
 		Star_Dust: 5
@@ -7109,7 +6974,6 @@ mob_db: (
 	AttackDelay: 1956
 	AttackMotion: 756
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Chinese_Ink: 9000
 		Tentacle: 3000
@@ -7155,7 +7019,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moustache_Of_Mole: 9000
 		Nail_Of_Mole: 500
@@ -7205,7 +7068,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Matyrs_Flea_Guard: 10
 		Monsters_Feed: 5000
@@ -7316,7 +7178,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 1320
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Slender_Snake: 5335
 		Whip_Of_Red_Flame: 250
@@ -7366,7 +7227,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 5335
 		Oridecon_Stone: 196
@@ -7477,7 +7337,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Gas_Mask: 2
 		Wooden_Block: 800
@@ -7527,7 +7386,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Orcish_Cuspid: 5500
 		Skel_Bone: 3500
@@ -7576,7 +7434,6 @@ mob_db: (
 	AttackDelay: 2852
 	AttackMotion: 1152
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Nail_Of_Orc: 5500
 		Sticky_Mucus: 3000
@@ -7622,7 +7479,6 @@ mob_db: (
 	AttackDelay: 976
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Vroken_Sword: 4365
 		Honey_Jar: 2500
@@ -7671,7 +7527,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 620
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dragon_Canine: 5335
 		Dragon_Train: 300
@@ -7721,7 +7576,6 @@ mob_db: (
 	AttackDelay: 1420
 	AttackMotion: 1080
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Dragon_Scale: 5335
 		Dragon_Train: 300
@@ -7827,7 +7681,6 @@ mob_db: (
 	AttackDelay: 2544
 	AttackMotion: 1344
 	DamageMotion: 1152
-	MvpExp: 0
 	Drops: {
 		Fish_Tail: 5500
 		Sharp_Scale: 2000
@@ -7935,7 +7788,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 9000
 		Garlet: 1100
@@ -7981,7 +7833,6 @@ mob_db: (
 	AttackDelay: 2208
 	AttackMotion: 1008
 	DamageMotion: 324
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 9000
 		Garlet: 300
@@ -8031,7 +7882,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 528
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Root_Of_Maneater: 5500
 		Scell: 1600
@@ -8081,7 +7931,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 780
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Elunium: 106
 		Iron_Cane: 1
@@ -8131,7 +7980,6 @@ mob_db: (
 	AttackDelay: 1516
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Blue_Box: 35
 		Emperium: 1
@@ -8181,7 +8029,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 720
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Great_Nature: 35
 		Grit: 5335
@@ -8228,7 +8075,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wild_Boars_Mane: 9000
 		Grape: 300
@@ -8274,7 +8120,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Animals_Skin: 9000
 		Axe_: 100
@@ -8323,7 +8168,6 @@ mob_db: (
 	AttackDelay: 1700
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 	Drops: {
 		Flame_Heart: 45
 		Tweezer: 4850
@@ -8372,7 +8216,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Iron: 400
 		Lantern: 5500
@@ -8420,7 +8263,6 @@ mob_db: (
 	AttackDelay: 2112
 	AttackMotion: 912
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Long_Hair: 9000
 		Skirt_Of_Virgin: 50
@@ -8470,7 +8312,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Jaws_Of_Ant: 2700
 		Scell: 800
@@ -8519,7 +8360,6 @@ mob_db: (
 	AttackDelay: 2000
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 	Drops: {
 		Jaws_Of_Ant: 5500
 		Scell: 2000
@@ -8568,7 +8408,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Jaws_Of_Ant: 3100
 		Scell: 800
@@ -8615,7 +8454,6 @@ mob_db: (
 	AttackDelay: 1688
 	AttackMotion: 1188
 	DamageMotion: 612
-	MvpExp: 0
 	Drops: {
 		Wind_Of_Verdure: 70
 		Emveretarcon: 30
@@ -8662,7 +8500,6 @@ mob_db: (
 	AttackDelay: 1744
 	AttackMotion: 1044
 	DamageMotion: 684
-	MvpExp: 0
 	Drops: {
 		Rat_Tail: 9000
 		Animals_Skin: 3000
@@ -8708,7 +8545,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 90
 		Worm_Peelings: 5000
@@ -8755,7 +8591,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Tooth_Of_: 5500
 		Oridecon_Stone: 70
@@ -8804,7 +8639,6 @@ mob_db: (
 	AttackDelay: 1780
 	AttackMotion: 1080
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 55
 		Iron: 190
@@ -8855,7 +8689,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 150
 		Transparent_Cloth: 5335
@@ -8904,7 +8737,6 @@ mob_db: (
 	AttackDelay: 840
 	AttackMotion: 540
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fox_Tail: 4656
 		Glass_Bead: 200
@@ -8958,7 +8790,6 @@ mob_db: (
 	AttackDelay: 2700
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 },*/
 {
 	Id: 1182
@@ -8993,7 +8824,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Mushroom_Of_Thief_1: 1500
 		Mushroom_Of_Thief_2: 3000
@@ -9038,7 +8868,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Iron: 50
 		Shell: 5500
@@ -9088,7 +8917,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fluff: 2000
 		Feather: 250
@@ -9129,7 +8957,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 10
 		Transparent_Cloth: 100
@@ -9177,7 +9004,6 @@ mob_db: (
 	AttackDelay: 2536
 	AttackMotion: 1536
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 150
 		Transparent_Cloth: 5335
@@ -9216,7 +9042,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 },
 {
 	Id: 1188
@@ -9256,7 +9081,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 500
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Short_Daenggie: 5500
 		Old_Portrait: 40
@@ -9306,7 +9130,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 620
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sharpened_Cuspid: 4656
 		Steel_Arrow: 1000
@@ -9414,7 +9237,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 500
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 5
 		Old_Blue_Box: 45
@@ -9466,7 +9288,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 576
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Transparent_Cloth: 5820
 		Wedding_Veil: 10
@@ -9518,7 +9339,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 500
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Needle_Of_Alarm: 5335
 		Clip: 1
@@ -9570,7 +9390,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 500
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Round_Shell: 3500
 		Sticky_Mucus: 3000
@@ -9622,7 +9441,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Page: 4850
 		Book_Of_Billows: 4
@@ -9672,7 +9490,6 @@ mob_db: (
 	AttackDelay: 1848
 	AttackMotion: 500
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Manacles: 3500
 		Spoon_Stub: 100
@@ -9722,7 +9539,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Prison_Uniform: 3500
 		Spoon_Stub: 105
@@ -9774,7 +9590,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 1252
 	DamageMotion: 476
-	MvpExp: 0
 	Drops: {
 		Book_Of_The_Apocalypse: 5
 		Rosary: 30
@@ -9824,7 +9639,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Mould_Powder: 5335
 		Yellow_Gemstone: 800
@@ -9875,7 +9689,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 2112
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Executioners_Mitten: 5
 		White_Herb: 1800
@@ -9926,7 +9739,6 @@ mob_db: (
 	AttackDelay: 1790
 	AttackMotion: 1440
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Thin_N_Long_Tongue: 3880
 		Executioners_Mitten: 3
@@ -9976,7 +9788,6 @@ mob_db: (
 	AttackDelay: 1744
 	AttackMotion: 1344
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Thin_N_Long_Tongue: 3880
 		Executioners_Mitten: 4
@@ -10028,7 +9839,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Lokis_Whispers: 1
 		Biotite: 1500
@@ -10083,7 +9893,6 @@ mob_db: (
 	AttackDelay: 816
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Old_Hilt: 1
 		Silver_Knife_Of_Chaste: 50
@@ -10137,7 +9946,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 500
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Bloody_Edge: 5
 		Phlogopite: 1500
@@ -10189,7 +9997,6 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 500
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Anolian_Skin: 4850
 		Crystal_Arrow: 2000
@@ -10241,7 +10048,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Mud_Lump: 4850
 		Stone_Arrow: 1500
@@ -10295,7 +10101,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Skull: 4850
 		Old_Card_Album: 1
@@ -10345,7 +10150,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Claw_Of_Rat: 4656
 		Monsters_Feed: 1000
@@ -10395,7 +10199,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Stiff_Horn: 4850
 		Horn: 8000
@@ -10446,7 +10249,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Glitter_Shell: 5335
 		Wind_Of_Verdure: 200
@@ -10497,7 +10299,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Tail_Of_Steel_Scorpion: 5335
 		Elunium_Stone: 229
@@ -10548,7 +10349,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Ogre_Tooth: 2500
 		Orcish_Axe: 10
@@ -10598,7 +10398,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Claw_Of_Monkey: 5335
 		Yoyo_Tail: 7000
@@ -10648,7 +10447,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Tough_Scalelike_Stem: 5335
 		White_Herb: 1800
@@ -10700,7 +10498,6 @@ mob_db: (
 	AttackDelay: 832
 	AttackMotion: 500
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Coral_Reef: 4850
 		Tentacle: 8000
@@ -10753,7 +10550,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Reins: 5335
 		Blade_Lost_In_Darkness: 5
@@ -10805,7 +10601,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 420
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Katar_: 5
 		Claw_Of_Desert_Wolf: 5500
@@ -10856,7 +10651,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wild_Boars_Mane: 6000
 		Grape: 150
@@ -10907,7 +10701,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Ogre_Tooth: 2500
 		Orcish_Axe: 10
@@ -10959,7 +10752,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Iron: 210
 		Orcish_Voucher: 5500
@@ -11011,7 +10803,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mushroom_Spore: 8000
 		Hat_: 20
@@ -11061,7 +10852,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Claw_Of_Monkey: 5335
 		Yoyo_Tail: 7000
@@ -11113,7 +10903,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 90
 		Cobold_Hair: 5820
@@ -11164,7 +10953,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Iron: 270
 		Scell: 1200
@@ -11216,7 +11004,6 @@ mob_db: (
 	AttackDelay: 2544
 	AttackMotion: 1344
 	DamageMotion: 1152
-	MvpExp: 0
 	Drops: {
 		Fish_Tail: 6000
 		Sharp_Scale: 2300
@@ -11262,7 +11049,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fluff: 6500
 		Feather: 600
@@ -11307,7 +11093,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 300
 		Chrysalis: 6000
@@ -11354,7 +11139,6 @@ mob_db: (
 	AttackDelay: 1220
 	AttackMotion: 720
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Powder_Of_Butterfly: 6000
 		Silk_Robe_: 10
@@ -11395,7 +11179,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 120
 		Shell: 1500
@@ -11441,7 +11224,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Bill_Of_Birds: 6000
 		Sandals_: 20
@@ -11489,7 +11271,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 54
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yoyo_Tail: 6000
 		Cacao: 500
@@ -11539,7 +11320,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Iron: 210
 		Orcish_Voucher: 5500
@@ -11581,7 +11361,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 135
 		Shell: 2740
@@ -11630,7 +11409,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 6000
 		Garlet: 3000
@@ -11680,7 +11458,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 5700
 		Garlet: 1100
@@ -11730,7 +11507,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 6000
 		Garlet: 3000
@@ -11776,7 +11552,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 168
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Birds: 6500
 		Feather: 850
@@ -11821,7 +11596,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 168
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Birds: 6500
 		Feather: 850
@@ -11866,7 +11640,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Garlet: 3200
 		Sticky_Mucus: 1500
@@ -11918,7 +11691,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Zargon: 750
 		White_Herb: 800
@@ -11964,7 +11736,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Head: 5335
 		Zargon: 900
@@ -12010,7 +11781,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Packing_Ribbon: 550
 		Packing_Paper: 550
@@ -12057,7 +11827,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Well_Baked_Cookie: 1500
 		Scarlet_Jewel: 45
@@ -12104,7 +11873,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Red_Socks_With_Holes: 10000
 		Gift_Box: 200
@@ -12152,7 +11920,6 @@ mob_db: (
 	AttackDelay: 1296
 	AttackMotion: 1296
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Manacles: 900
 		Holy_Bonnet: 2
@@ -12199,7 +11966,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Candy_Striper: 90
 		Zargon: 1500
@@ -12251,7 +12017,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Matchstick: 2500
 		Zargon: 750
@@ -12419,7 +12184,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Zargon: 3880
 		Petite_DiablOfs_Wing: 500
@@ -12469,7 +12233,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 900
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Cyfar: 3000
 		Feather_Of_Birds: 5000
@@ -12522,7 +12285,6 @@ mob_db: (
 	AttackDelay: 776
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Earthworm_Peeling: 5100
 		Cyfar: 1000
@@ -12574,7 +12336,6 @@ mob_db: (
 	AttackDelay: 700
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Earthworm_Peeling: 5500
 		Brigan: 200
@@ -12625,7 +12386,6 @@ mob_db: (
 	AttackDelay: 770
 	AttackMotion: 720
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Steel: 300
 		Brigan: 5335
@@ -12673,7 +12433,6 @@ mob_db: (
 	AttackDelay: 1172
 	AttackMotion: 672
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Goblini_Mask: 3
 		Iron: 250
@@ -12727,7 +12486,6 @@ mob_db: (
 	AttackDelay: 704
 	AttackMotion: 504
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Talon_Of_Griffin: 2500
 		Brigan: 5335
@@ -12780,7 +12538,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 720
 	DamageMotion: 200
-	MvpExp: 0
 	Drops: {
 		Brigan: 4656
 		Red_Frame: 1000
@@ -12825,7 +12582,6 @@ mob_db: (
 	AttackDelay: 964
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Cyfar: 5335
 		Witherless_Rose: 50
@@ -12880,7 +12636,6 @@ mob_db: (
 	AttackDelay: 1280
 	AttackMotion: 1080
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Brigan: 4850
 		Dragon_Canine: 500
@@ -12933,7 +12688,6 @@ mob_db: (
 	AttackDelay: 1056
 	AttackMotion: 1056
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Zargon: 4559
 		Skel_Bone: 6000
@@ -12985,7 +12739,6 @@ mob_db: (
 	AttackDelay: 916
 	AttackMotion: 816
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Lip_Of_Ancient_Fish: 1300
 		Holy_Water: 300
@@ -13033,7 +12786,6 @@ mob_db: (
 	AttackDelay: 1036
 	AttackMotion: 936
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Well_Baked_Cookie: 1000
 		Candy_Striper: 150
@@ -13080,7 +12832,6 @@ mob_db: (
 	AttackDelay: 1264
 	AttackMotion: 864
 	DamageMotion: 216
-	MvpExp: 0
 	Drops: {
 		Sticky_Mucus: 500
 		Coral_Reef: 40
@@ -13132,7 +12883,6 @@ mob_db: (
 	AttackDelay: 1078
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Brigan: 3200
 		Ice_Cream: 1000
@@ -13182,7 +12932,6 @@ mob_db: (
 	AttackDelay: 828
 	AttackMotion: 528
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Brigan: 4850
 		Helm_: 45
@@ -13229,7 +12978,6 @@ mob_db: (
 	AttackDelay: 1092
 	AttackMotion: 792
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Needle_Of_Alarm: 5335
 		Wooden_Block: 800
@@ -13277,7 +13025,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Needle_Of_Alarm: 5335
 		Brigan: 5335
@@ -13324,7 +13071,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 900
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Zargon: 1000
 		Worn_Out_Prison_Uniform: 600
@@ -13433,7 +13179,6 @@ mob_db: (
 	AttackDelay: 1050
 	AttackMotion: 900
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4656
 		Iron: 300
@@ -13479,7 +13224,6 @@ mob_db: (
 	AttackDelay: 1332
 	AttackMotion: 1332
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Zargon: 100
 		Stone: 1000
@@ -13524,7 +13268,6 @@ mob_db: (
 	AttackDelay: 502
 	AttackMotion: 2304
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Alices_Apron: 2500
 		Old_Broom: 40
@@ -13573,7 +13316,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Brigan: 4656
 		Chain_Mail_: 2
@@ -13618,7 +13360,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Brigan: 2000
 		Wooden_Block: 2000
@@ -13665,7 +13406,6 @@ mob_db: (
 	AttackDelay: 1264
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mud_Lump: 2000
 		Brigan: 4850
@@ -13717,7 +13457,6 @@ mob_db: (
 	AttackDelay: 860
 	AttackMotion: 660
 	DamageMotion: 624
-	MvpExp: 0
 	Drops: {
 		Cyfar: 100
 		Solid_Shell: 380
@@ -13764,7 +13503,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1008
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Scell: 2500
 		Cyfar: 3880
@@ -13811,7 +13549,6 @@ mob_db: (
 	AttackDelay: 936
 	AttackMotion: 936
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Librarian_Glove: 5
 		Worn_Out_Page: 1000
@@ -13859,7 +13596,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1008
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Zargon: 250
 		Steel: 60
@@ -13913,7 +13649,6 @@ mob_db: (
 	AttackDelay: 772
 	AttackMotion: 672
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 5335
 		Slender_Snake: 2500
@@ -13960,7 +13695,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Apple: 100
 		Apple: 100
@@ -14013,7 +13747,6 @@ mob_db: (
 	AttackDelay: 1200
 	AttackMotion: 1200
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1286
@@ -14056,7 +13789,6 @@ mob_db: (
 	AttackDelay: 1200
 	AttackMotion: 1200
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1287
@@ -14096,7 +13828,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1288
@@ -14133,7 +13864,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1289
@@ -14177,7 +13907,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 1000
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4413
 		Elunium_Stone: 250
@@ -14229,7 +13958,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Burn_Tree: 2550
 		Oridecon_Stone: 160
@@ -14281,7 +14009,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 576
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Transparent_Cloth: 4413
 		Wedding_Veil: 10
@@ -14334,7 +14061,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Horn: 4413
 		Petite_DiablOfs_Wing: 450
@@ -14387,7 +14113,6 @@ mob_db: (
 	AttackDelay: 1136
 	AttackMotion: 720
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Powder_Of_Butterfly: 4550
 		Silver_Robe_: 10
@@ -14440,7 +14165,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 660
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Limb_Of_Mantis: 4550
 		Solid_Shell: 2500
@@ -14494,7 +14218,6 @@ mob_db: (
 	AttackDelay: 1345
 	AttackMotion: 824
 	DamageMotion: 440
-	MvpExp: 0
 	Drops: {
 		Tatters_Clothes: 3500
 		Soft_Feather: 2500
@@ -14546,7 +14269,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 450
 		Cobold_Hair: 6305
@@ -14598,7 +14320,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 120
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Rotten_Bandage: 4413
 		Mementos: 1800
@@ -14650,7 +14371,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Tatters_Clothes: 4413
 		Sticky_Mucus: 1500
@@ -14702,7 +14422,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Brigan: 1500
 		Steel: 800
@@ -14755,7 +14474,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Feather: 3000
 		Brigan: 5335
@@ -14808,7 +14526,6 @@ mob_db: (
 	AttackDelay: 1156
 	AttackMotion: 456
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dokkaebi_Horn: 4550
 		Elunium_Stone: 250
@@ -14862,7 +14579,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Bone_Wand: 3
 		Bone_Helm: 2
@@ -14915,7 +14631,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 340
-	MvpExp: 0
 	Drops: {
 		Royal_Jelly: 550
 		Honey: 1200
@@ -14968,7 +14683,6 @@ mob_db: (
 	AttackDelay: 1468
 	AttackMotion: 468
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Spiderweb: 4550
 		Short_Leg: 1200
@@ -15021,7 +14735,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Short_Leg: 4413
 		Zargon: 2500
@@ -15073,7 +14786,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 230
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Bears_Foot: 4550
 		Poo_Poo_Hat: 8
@@ -15127,7 +14839,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Puppy_Love: 1
 		Silver_Knife_Of_Chaste: 150
@@ -15179,7 +14890,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 1008
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4413
 		Brigan: 3500
@@ -15231,7 +14941,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 1152
 	DamageMotion: 828
-	MvpExp: 0
 	Drops: {
 		Stone_Heart: 6500
 		Zargon: 2300
@@ -15283,7 +14992,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 960
 	DamageMotion: 780
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 4413
 		Two_Handed_Axe_: 4
@@ -15335,7 +15043,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wild_Boars_Mane: 3500
 		Grape: 290
@@ -15446,7 +15153,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 560
 	DamageMotion: 580
-	MvpExp: 0
 	Drops: {
 		Poison_Knife: 3
 		Blue_Jewel: 4559
@@ -15493,7 +15199,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 45
@@ -15545,7 +15250,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 900
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Armor_Piece: 1200
@@ -15592,7 +15296,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 64
@@ -15643,7 +15346,6 @@ mob_db: (
 	AttackDelay: 1612
 	AttackMotion: 622
 	DamageMotion: 583
-	MvpExp: 0
 	Drops: {
 		Zargon: 4365
 		Blue_Herb: 250
@@ -15695,7 +15397,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 750
@@ -15747,7 +15448,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 850
@@ -15801,7 +15501,6 @@ mob_db: (
 	AttackDelay: 1345
 	AttackMotion: 824
 	DamageMotion: 440
-	MvpExp: 0
 	Drops: {
 		Tatters_Clothes: 4413
 		Soft_Feather: 1500
@@ -15854,7 +15553,6 @@ mob_db: (
 	AttackDelay: 862
 	AttackMotion: 534
 	DamageMotion: 312
-	MvpExp: 0
 	Drops: {
 		Dragon_Fly_Wing: 4413
 		Round_Shell: 400
@@ -15901,7 +15599,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 552
 	DamageMotion: 511
-	MvpExp: 0
 	Drops: {
 		Brigan: 3500
 		Cyfar: 2500
@@ -15951,7 +15648,6 @@ mob_db: (
 	AttackDelay: 1132
 	AttackMotion: 583
 	DamageMotion: 532
-	MvpExp: 0
 	Drops: {
 		Scarlet_Jewel: 150
 		Clam_Shell: 5500
@@ -15997,7 +15693,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16043,7 +15738,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Jewel_Of_Prayer: 80
 		Union_Of_Tribe: 500
@@ -16089,7 +15783,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16135,7 +15828,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Iron_Glove: 80
 		Union_Of_Tribe: 500
@@ -16181,7 +15873,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16227,7 +15918,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Iron_Maiden: 80
 		Union_Of_Tribe: 500
@@ -16273,7 +15963,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16319,7 +16008,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Mystery_Wheel: 80
 		Union_Of_Tribe: 500
@@ -16365,7 +16053,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16411,7 +16098,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Silver_Fancy: 80
 		Union_Of_Tribe: 500
@@ -16457,7 +16143,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16503,7 +16188,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Anger_Of_Valkurye: 80
 		Union_Of_Tribe: 500
@@ -16549,7 +16233,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16595,7 +16278,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Angel: 80
 		Union_Of_Tribe: 500
@@ -16641,7 +16323,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16687,7 +16368,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Foot_Step_Of_Cat: 80
 		Union_Of_Tribe: 500
@@ -16733,7 +16413,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16779,7 +16458,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Beard_Of_Women: 80
 		Union_Of_Tribe: 500
@@ -16825,7 +16503,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16871,7 +16548,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Root_Of_Stone: 80
 		Union_Of_Tribe: 500
@@ -16917,7 +16593,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16963,7 +16638,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Soul_Of_Fish: 80
 		Union_Of_Tribe: 500
@@ -17009,7 +16683,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17055,7 +16728,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Saliva_Of_Bird: 80
 		Union_Of_Tribe: 500
@@ -17101,7 +16773,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17147,7 +16818,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Tendon_Of_Bear: 80
 		Union_Of_Tribe: 500
@@ -17193,7 +16863,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17239,7 +16908,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Symbol_Of_Sun: 80
 		Union_Of_Tribe: 500
@@ -17285,7 +16953,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17331,7 +16998,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Breath_Of_Soul: 80
 		Union_Of_Tribe: 500
@@ -17377,7 +17043,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17423,7 +17088,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Of_Snow: 80
 		Union_Of_Tribe: 500
@@ -17469,7 +17133,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17515,7 +17178,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Indication_Of_Tempest: 80
 		Union_Of_Tribe: 500
@@ -17561,7 +17223,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17607,7 +17268,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Slilince_Wave: 80
 		Union_Of_Tribe: 500
@@ -17653,7 +17313,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17699,7 +17358,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Rough_Billows: 80
 		Union_Of_Tribe: 500
@@ -17745,7 +17403,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17791,7 +17448,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Air_Stream: 80
 		Union_Of_Tribe: 500
@@ -17844,7 +17500,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 900
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Wooden_Block: 9000
 	}
@@ -17884,7 +17539,6 @@ mob_db: (
 	AttackDelay: 1840
 	AttackMotion: 1440
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Broken_Steel_Piece: 5335
 		Mystery_Piece: 2400
@@ -17934,7 +17588,6 @@ mob_db: (
 	AttackDelay: 2190
 	AttackMotion: 2040
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Cold_Magma: 4559
 		Burning_Heart: 3686
@@ -17985,7 +17638,6 @@ mob_db: (
 	AttackDelay: 1732
 	AttackMotion: 1332
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 4850
 		Live_Coal: 3400
@@ -18027,7 +17679,6 @@ mob_db: (
 	AttackDelay: 1308
 	AttackMotion: 1008
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Blossom_Of_Maneater: 6200
 		Root_Of_Maneater: 5500
@@ -18073,7 +17724,6 @@ mob_db: (
 	AttackDelay: 1460
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Peco_Wing_Feather: 4850
 		Fruit_Of_Mastela: 300
@@ -18124,7 +17774,6 @@ mob_db: (
 	AttackDelay: 1306
 	AttackMotion: 1056
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Fruit_Of_Mastela: 1500
 		Chrystal_Pumps: 3
@@ -18175,7 +17824,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 720
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Blue_Gemstone: 1000
 		Yellow_Gemstone: 1000
@@ -18221,7 +17869,6 @@ mob_db: (
 	AttackDelay: 1380
 	AttackMotion: 1080
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Goats_Horn: 4559
 		Gaoats_Skin: 2500
@@ -18334,7 +17981,6 @@ mob_db: (
 	AttackDelay: 850
 	AttackMotion: 600
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Fruit_Of_Mastela: 1500
 		White_Herb: 5500
@@ -18384,7 +18030,6 @@ mob_db: (
 	AttackDelay: 1160
 	AttackMotion: 960
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Smooth_Paper: 4947
 		Fright_Paper_Blade: 3200
@@ -18433,7 +18078,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 672
 	DamageMotion: 470
-	MvpExp: 0
 	Drops: {
 		Harpys_Feather: 4850
 		Harpys_Claw: 2500
@@ -18482,7 +18126,6 @@ mob_db: (
 	AttackDelay: 1552
 	AttackMotion: 1152
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Old_Magic_Circle: 4000
 		Rent_Spell_Book: 1500
@@ -18533,7 +18176,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Spawns: 4074
 		Mould_Powder: 4559
@@ -18581,7 +18223,6 @@ mob_db: (
 	AttackDelay: 1216
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Burning_Horse_Shoe: 4947
 		Rosary_: 1
@@ -18631,7 +18272,6 @@ mob_db: (
 	AttackDelay: 1300
 	AttackMotion: 900
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Lizard_Scruff: 7500
 		Yellow_Gemstone: 3880
@@ -18677,7 +18317,6 @@ mob_db: (
 	AttackDelay: 1492
 	AttackMotion: 1092
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Bears_Foot: 5000
 		Animals_Skin: 5000
@@ -18724,7 +18363,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 780
 	DamageMotion: 180
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Horn: 5820
 		Petite_DiablOfs_Wing: 4850
@@ -18772,7 +18410,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Wing_Of_Red_Bat: 5500
 		Burning_Heart: 2200
@@ -18820,7 +18457,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dragons_Skin: 4074
 		Dragon_Canine: 5335
@@ -18867,7 +18503,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 624
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Dragons_Skin: 4074
 		Dragon_Canine: 5335
@@ -18914,7 +18549,6 @@ mob_db: (
 	AttackDelay: 1350
 	AttackMotion: 1200
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Sand_Lump: 4947
 		Grit: 5335
@@ -18964,7 +18598,6 @@ mob_db: (
 	AttackDelay: 1264
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scropions_Nipper: 4365
 		Scorpions_Tail: 5500
@@ -19017,7 +18650,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Satanic_Chain: 5
 		Leaf_Of_Yggdrasil: 1800
@@ -19123,7 +18755,6 @@ mob_db: (
 	AttackDelay: 1356
 	AttackMotion: 1056
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Golden_Hair: 6305
 		High_end_Cooking_Kits: 50
@@ -19172,7 +18803,6 @@ mob_db: (
 	AttackDelay: 1430
 	AttackMotion: 1080
 	DamageMotion: 1080
-	MvpExp: 0
 	Drops: {
 		Cyfar: 5335
 		Leaf_Of_Yggdrasil: 100
@@ -19220,7 +18850,6 @@ mob_db: (
 	AttackDelay: 2416
 	AttackMotion: 2016
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 500
 		Padded_Armor: 1
@@ -19270,7 +18899,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1394
@@ -19310,7 +18938,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1395
@@ -19348,7 +18975,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -19396,7 +19022,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -19444,7 +19069,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -19492,7 +19116,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -19597,7 +19220,6 @@ mob_db: (
 	AttackDelay: 1638
 	AttackMotion: 2016
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Oil_Paper: 5000
 		Bamboo_Cut: 4268
@@ -19649,7 +19271,6 @@ mob_db: (
 	AttackDelay: 1003
 	AttackMotion: 1152
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Broken_Shuriken: 5335
 		Ninja_Suit: 2
@@ -19696,7 +19317,6 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 1728
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Poison_Toads_Skin: 5500
 		Poison_Powder: 2400
@@ -19745,7 +19365,6 @@ mob_db: (
 	AttackDelay: 1084
 	AttackMotion: 2304
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Iron: 5500
 		Apple_Of_Archer: 1
@@ -19794,7 +19413,6 @@ mob_db: (
 	AttackDelay: 1938
 	AttackMotion: 2112
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Glossy_Hair: 5335
 		Old_Japaness_Clothes: 2500
@@ -19845,7 +19463,6 @@ mob_db: (
 	AttackDelay: 1439
 	AttackMotion: 1920
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Tengus_Nose: 3500
 		Broken_Wine_Vessel: 5500
@@ -19895,7 +19512,6 @@ mob_db: (
 	AttackDelay: 2012
 	AttackMotion: 1728
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Yellow_Plate: 6500
 		Cyfar: 3500
@@ -19937,7 +19553,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 {
 	Id: 1408
@@ -19978,7 +19593,6 @@ mob_db: (
 	AttackDelay: 472
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Sharp_Feeler: 4608
 		Great_Wing: 2500
@@ -20025,7 +19639,6 @@ mob_db: (
 	AttackDelay: 647
 	AttackMotion: 768
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Bamboo_Cut: 3200
 		Oil_Paper: 2500
@@ -20073,7 +19686,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Hard_Peach: 4365
 		Royal_Jelly: 1000
@@ -20113,7 +19725,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 {
 	Id: 1412
@@ -20152,7 +19763,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 840
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Cloud_Piece: 4656
 		Cheese: 5600
@@ -20200,7 +19810,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 756
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Leaflet_Of_Hinal: 3500
 		Leaflet_Of_Aloe: 3500
@@ -20242,7 +19851,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 {
 	Id: 1415
@@ -20282,7 +19890,6 @@ mob_db: (
 	AttackDelay: 318
 	AttackMotion: 528
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Leopard_Skin: 5200
 		Leopard_Talon: 3200
@@ -20335,7 +19942,6 @@ mob_db: (
 	AttackDelay: 637
 	AttackMotion: 1008
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Limpid_Celestial_Robe: 3977
 		Soft_Silk_Cloth: 1380
@@ -20382,7 +19988,6 @@ mob_db: (
 	AttackDelay: 780
 	AttackMotion: 1008
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Black_Bears_Skin: 4462
 		Mystery_Iron_Bit: 3500
@@ -20489,7 +20094,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1420
@@ -20529,7 +20133,6 @@ mob_db: (
 	AttackDelay: 2864
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1421
@@ -20570,7 +20173,6 @@ mob_db: (
 	AttackDelay: 1384
 	AttackMotion: 768
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1422
@@ -20611,7 +20213,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1423
@@ -20651,7 +20252,6 @@ mob_db: (
 	AttackDelay: 2456
 	AttackMotion: 912
 	DamageMotion: 504
-	MvpExp: 0
 },
 {
 	Id: 1424
@@ -20691,7 +20291,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1425
@@ -20731,7 +20330,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1426
@@ -20771,7 +20369,6 @@ mob_db: (
 	AttackDelay: 1272
 	AttackMotion: 72
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1427
@@ -20812,7 +20409,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1428
@@ -20852,7 +20448,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1429
@@ -20893,7 +20488,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1430
@@ -20934,7 +20528,6 @@ mob_db: (
 	AttackDelay: 1468
 	AttackMotion: 468
 	DamageMotion: 768
-	MvpExp: 0
 },
 {
 	Id: 1431
@@ -20975,7 +20568,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 480
 	DamageMotion: 120
-	MvpExp: 0
 },
 {
 	Id: 1432
@@ -21015,7 +20607,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 420
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1433
@@ -21056,7 +20647,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1434
@@ -21096,7 +20686,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1435
@@ -21136,7 +20725,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1436
@@ -21176,7 +20764,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1437
@@ -21216,7 +20803,6 @@ mob_db: (
 	AttackDelay: 1364
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1438
@@ -21256,7 +20842,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 1000
 	DamageMotion: 396
-	MvpExp: 0
 },
 {
 	Id: 1439
@@ -21296,7 +20881,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1440
@@ -21336,7 +20920,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1441
@@ -21376,7 +20959,6 @@ mob_db: (
 	AttackDelay: 832
 	AttackMotion: 500
 	DamageMotion: 600
-	MvpExp: 0
 },
 {
 	Id: 1442
@@ -21416,7 +20998,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1443
@@ -21456,7 +21037,6 @@ mob_db: (
 	AttackDelay: 1296
 	AttackMotion: 1296
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1444
@@ -21496,7 +21076,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1445
@@ -21536,7 +21115,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 900
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1446
@@ -21576,7 +21154,6 @@ mob_db: (
 	AttackDelay: 770
 	AttackMotion: 720
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1447
@@ -21618,7 +21195,6 @@ mob_db: (
 	AttackDelay: 704
 	AttackMotion: 504
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1448
@@ -21659,7 +21235,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 720
 	DamageMotion: 200
-	MvpExp: 0
 },
 {
 	Id: 1449
@@ -21702,7 +21277,6 @@ mob_db: (
 	AttackDelay: 1280
 	AttackMotion: 1080
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1450
@@ -21743,7 +21317,6 @@ mob_db: (
 	AttackDelay: 1056
 	AttackMotion: 1056
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1451
@@ -21783,7 +21356,6 @@ mob_db: (
 	AttackDelay: 916
 	AttackMotion: 816
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1452
@@ -21823,7 +21395,6 @@ mob_db: (
 	AttackDelay: 1050
 	AttackMotion: 900
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1453
@@ -21864,7 +21435,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1454
@@ -21905,7 +21475,6 @@ mob_db: (
 	AttackDelay: 860
 	AttackMotion: 660
 	DamageMotion: 624
-	MvpExp: 0
 },
 {
 	Id: 1455
@@ -21945,7 +21514,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1008
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1456
@@ -21987,7 +21555,6 @@ mob_db: (
 	AttackDelay: 772
 	AttackMotion: 672
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1457
@@ -22028,7 +21595,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 660
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1458
@@ -22068,7 +21634,6 @@ mob_db: (
 	AttackDelay: 1540
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 },
 {
 	Id: 1459
@@ -22109,7 +21674,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 1056
-	MvpExp: 0
 },
 {
 	Id: 1460
@@ -22149,7 +21713,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1461
@@ -22189,7 +21752,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1462
@@ -22229,7 +21791,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1463
@@ -22269,7 +21830,6 @@ mob_db: (
 	AttackDelay: 2852
 	AttackMotion: 1152
 	DamageMotion: 840
-	MvpExp: 0
 },
 {
 	Id: 1464
@@ -22309,7 +21869,6 @@ mob_db: (
 	AttackDelay: 976
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1465
@@ -22349,7 +21908,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 620
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1466
@@ -22389,7 +21947,6 @@ mob_db: (
 	AttackDelay: 1420
 	AttackMotion: 1080
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1467
@@ -22429,7 +21986,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 780
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1468
@@ -22470,7 +22026,6 @@ mob_db: (
 	AttackDelay: 1516
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1469
@@ -22510,7 +22065,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1470
@@ -22550,7 +22104,6 @@ mob_db: (
 	AttackDelay: 1780
 	AttackMotion: 1080
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1471
@@ -22590,7 +22143,6 @@ mob_db: (
 	AttackDelay: 840
 	AttackMotion: 540
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1472
@@ -22630,7 +22182,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 500
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1473
@@ -22670,7 +22221,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 620
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1474
@@ -22710,7 +22260,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 500
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1475
@@ -22750,7 +22299,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 576
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1476
@@ -22790,7 +22338,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 500
 	DamageMotion: 768
-	MvpExp: 0
 },
 {
 	Id: 1477
@@ -22832,7 +22379,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 500
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1478
@@ -22872,7 +22418,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1479
@@ -22912,7 +22457,6 @@ mob_db: (
 	AttackDelay: 1848
 	AttackMotion: 500
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1480
@@ -22952,7 +22496,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1481
@@ -22992,7 +22535,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1482
@@ -23033,7 +22575,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 792
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1483
@@ -23074,7 +22615,6 @@ mob_db: (
 	AttackDelay: 1790
 	AttackMotion: 1440
 	DamageMotion: 540
-	MvpExp: 0
 },
 {
 	Id: 1484
@@ -23114,7 +22654,6 @@ mob_db: (
 	AttackDelay: 1744
 	AttackMotion: 1344
 	DamageMotion: 600
-	MvpExp: 0
 },
 {
 	Id: 1485
@@ -23156,7 +22695,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1486
@@ -23199,7 +22737,6 @@ mob_db: (
 	AttackDelay: 816
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1487
@@ -23241,7 +22778,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 500
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1488
@@ -23281,7 +22817,6 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 500
 	DamageMotion: 864
-	MvpExp: 0
 },
 {
 	Id: 1489
@@ -23321,7 +22856,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1490
@@ -23363,7 +22897,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1491
@@ -23404,7 +22937,6 @@ mob_db: (
 	AttackDelay: 1156
 	AttackMotion: 456
 	DamageMotion: 384
-	MvpExp: 0
 },
 // Umbala
 {
@@ -23505,7 +23037,6 @@ mob_db: (
 	AttackDelay: 950
 	AttackMotion: 2520
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Tough_Vines: 5335
 		Great_Leaf: 1000
@@ -23554,7 +23085,6 @@ mob_db: (
 	AttackDelay: 1247
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Solid_Peeling: 6500
 		Beetle_Nipper: 4500
@@ -23602,7 +23132,6 @@ mob_db: (
 	AttackDelay: 2413
 	AttackMotion: 1248
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Solid_Twig: 5000
 		Log: 5000
@@ -23643,7 +23172,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 {
 	Id: 1497
@@ -23683,7 +23211,6 @@ mob_db: (
 	AttackDelay: 1543
 	AttackMotion: 1632
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Heart_Of_Tree: 4000
 		Browny_Root: 4000
@@ -23733,7 +23260,6 @@ mob_db: (
 	AttackDelay: 857
 	AttackMotion: 1056
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Air_Rifle: 4500
 		Flexible_String: 3500
@@ -23783,7 +23309,6 @@ mob_db: (
 	AttackDelay: 912
 	AttackMotion: 1344
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Meat: 4500
 		Shoulder_Protection: 4000
@@ -23829,7 +23354,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Germinating_Sprout: 5500
 		Soft_Leaf: 2000
@@ -23871,7 +23395,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 {
 	Id: 1502
@@ -23971,7 +23494,6 @@ mob_db: (
 	AttackDelay: 917
 	AttackMotion: 1584
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Hanging_Doll: 1800
 		Rotten_Rope: 5335
@@ -24020,7 +23542,6 @@ mob_db: (
 	AttackDelay: 847
 	AttackMotion: 1152
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Dullahans_Helm: 3200
 		Dullahan_Armor: 4850
@@ -24069,7 +23590,6 @@ mob_db: (
 	AttackDelay: 747
 	AttackMotion: 1632
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Black_Kitty_Doll: 800
 		Striped_Socks: 3000
@@ -24119,7 +23639,6 @@ mob_db: (
 	AttackDelay: 516
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Red_Scarf: 4850
 		Tangled_Chain: 3686
@@ -24169,7 +23688,6 @@ mob_db: (
 	AttackDelay: 914
 	AttackMotion: 1344
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Old_Manteau: 4171
 		Distorted_Portrait: 1000
@@ -24219,7 +23737,6 @@ mob_db: (
 	AttackDelay: 912
 	AttackMotion: 1248
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Black_Cloth: 3200
 		Ectoplasm: 5723
@@ -24267,7 +23784,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Bucket: 3200
 		Ectoplasm: 5723
@@ -24318,7 +23834,6 @@ mob_db: (
 	AttackDelay: 741
 	AttackMotion: 1536
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Broken_Needle: 4365
 		Spool: 5335
@@ -24423,7 +23938,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 1320
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Brigan: 3880
 		Amulet: 100
@@ -24472,7 +23986,6 @@ mob_db: (
 	AttackDelay: 1257
 	AttackMotion: 528
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Fan: 4171
 		Cat_Eyed_Stone: 2000
@@ -24518,7 +24031,6 @@ mob_db: (
 	AttackDelay: 600
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Dragon_Fang: 4365
 		Dragon_Horn: 3000
@@ -24567,7 +24079,6 @@ mob_db: (
 	AttackDelay: 879
 	AttackMotion: 672
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Milk_Bottle: 1500
 		Bib: 2500
@@ -24613,7 +24124,6 @@ mob_db: (
 	AttackDelay: 106
 	AttackMotion: 1056
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Dried_Sand: 4365
 		Mud_Lump: 2300
@@ -24662,7 +24172,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Tiger_Skin_Panties: 4500
 		Little_Blacky_Ghost: 400
@@ -24712,7 +24221,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Long_Hair: 5500
 		Old_Blue_Box: 2
@@ -24764,7 +24272,6 @@ mob_db: (
 	AttackDelay: 1728
 	AttackMotion: 816
 	DamageMotion: 1188
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4850
 		Stuffed_Doll: 100
@@ -24810,7 +24317,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 672
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Rice_Ball: 5500
 		Meat_Dumpling_Doll: 3000
@@ -24853,7 +24359,6 @@ mob_db: (
 	AttackDelay: 520
 	AttackMotion: 2304
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1522
@@ -24895,7 +24400,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 120
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1523
@@ -24934,7 +24438,6 @@ mob_db: (
 	AttackDelay: 1084
 	AttackMotion: 2304
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1524
@@ -24974,7 +24477,6 @@ mob_db: (
 	AttackDelay: 318
 	AttackMotion: 528
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1525
@@ -25016,7 +24518,6 @@ mob_db: (
 	AttackDelay: 1504
 	AttackMotion: 840
 	DamageMotion: 900
-	MvpExp: 0
 },
 {
 	Id: 1526
@@ -25057,7 +24558,6 @@ mob_db: (
 	AttackDelay: 472
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1527
@@ -25095,7 +24595,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1528
@@ -25132,7 +24631,6 @@ mob_db: (
 	AttackDelay: 1092
 	AttackMotion: 792
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1529
@@ -25177,7 +24675,6 @@ mob_db: (
 	AttackDelay: 588
 	AttackMotion: 816
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1530
@@ -25221,7 +24718,6 @@ mob_db: (
 	AttackDelay: 1290
 	AttackMotion: 1140
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1531
@@ -25260,7 +24756,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 840
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1532
@@ -25300,7 +24795,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1533
@@ -25341,7 +24835,6 @@ mob_db: (
 	AttackDelay: 1612
 	AttackMotion: 622
 	DamageMotion: 583
-	MvpExp: 0
 },
 {
 	Id: 1534
@@ -25383,7 +24876,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1535
@@ -25423,7 +24915,6 @@ mob_db: (
 	AttackDelay: 1320
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1536
@@ -25463,7 +24954,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1537
@@ -25503,7 +24993,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1538
@@ -25543,7 +25032,6 @@ mob_db: (
 	AttackDelay: 3074
 	AttackMotion: 1874
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1539
@@ -25585,7 +25073,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1540
@@ -25622,7 +25109,6 @@ mob_db: (
 	AttackDelay: 1608
 	AttackMotion: 816
 	DamageMotion: 396
-	MvpExp: 0
 },
 {
 	Id: 1541
@@ -25658,7 +25144,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1542
@@ -25702,7 +25187,6 @@ mob_db: (
 	AttackDelay: 874
 	AttackMotion: 1344
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1543
@@ -25742,7 +25226,6 @@ mob_db: (
 	AttackDelay: 2012
 	AttackMotion: 1728
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1544
@@ -25778,7 +25261,6 @@ mob_db: (
 	AttackDelay: 1638
 	AttackMotion: 2016
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1545
@@ -25818,7 +25300,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1546
@@ -25858,7 +25339,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1547
@@ -25898,7 +25378,6 @@ mob_db: (
 	AttackDelay: 1228
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1548
@@ -25940,7 +25419,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1549
@@ -25980,7 +25458,6 @@ mob_db: (
 	AttackDelay: 2190
 	AttackMotion: 2040
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1550
@@ -26019,7 +25496,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1551
@@ -26056,7 +25532,6 @@ mob_db: (
 	AttackDelay: 1956
 	AttackMotion: 756
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1552
@@ -26095,7 +25570,6 @@ mob_db: (
 	AttackDelay: 1938
 	AttackMotion: 2112
 	DamageMotion: 768
-	MvpExp: 0
 },
 {
 	Id: 1553
@@ -26137,7 +25611,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1554
@@ -26178,7 +25651,6 @@ mob_db: (
 	AttackDelay: 1216
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1555
@@ -26214,7 +25686,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1556
@@ -26251,7 +25722,6 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 1728
 	DamageMotion: 864
-	MvpExp: 0
 },
 {
 	Id: 1557
@@ -26289,7 +25759,6 @@ mob_db: (
 	AttackDelay: 2416
 	AttackMotion: 2016
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1558
@@ -26329,7 +25798,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 720
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1559
@@ -26370,7 +25838,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1560
@@ -26412,7 +25879,6 @@ mob_db: (
 	AttackDelay: 1003
 	AttackMotion: 1152
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1561
@@ -26449,7 +25915,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1562
@@ -26489,7 +25954,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1563
@@ -26530,7 +25994,6 @@ mob_db: (
 	AttackDelay: 1439
 	AttackMotion: 1920
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1564
@@ -26574,7 +26037,6 @@ mob_db: (
 	AttackDelay: 637
 	AttackMotion: 1008
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1565
@@ -26612,7 +26074,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 756
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1566
@@ -26654,7 +26115,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 576
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1567
@@ -26697,7 +26157,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1568
@@ -26741,7 +26200,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1569
@@ -26783,7 +26241,6 @@ mob_db: (
 	AttackDelay: 828
 	AttackMotion: 528
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1570
@@ -26823,7 +26280,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1571
@@ -26860,7 +26316,6 @@ mob_db: (
 	AttackDelay: 1680
 	AttackMotion: 480
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1572
@@ -26897,7 +26352,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1573
@@ -26937,7 +26391,6 @@ mob_db: (
 	AttackDelay: 1552
 	AttackMotion: 1152
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1574
@@ -26977,7 +26430,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1575
@@ -27013,7 +26465,6 @@ mob_db: (
 	AttackDelay: 1432
 	AttackMotion: 432
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1576
@@ -27057,7 +26508,6 @@ mob_db: (
 	AttackDelay: 1220
 	AttackMotion: 1080
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1577
@@ -27095,7 +26545,6 @@ mob_db: (
 	AttackDelay: 1172
 	AttackMotion: 672
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1578
@@ -27135,7 +26584,6 @@ mob_db: (
 	AttackDelay: 1888
 	AttackMotion: 1152
 	DamageMotion: 828
-	MvpExp: 0
 },
 {
 	Id: 1579
@@ -27171,7 +26619,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 432
 	DamageMotion: 600
-	MvpExp: 0
 },
 {
 	Id: 1580
@@ -27214,7 +26661,6 @@ mob_db: (
 	AttackDelay: 850
 	AttackMotion: 600
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1581
@@ -27257,7 +26703,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1582
@@ -27301,7 +26746,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 1056
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Wing: 3000
 		Zargon: 4850
@@ -27412,7 +26856,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 1152
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Sword_Accessory: 4850
 		Broken_Armor_Piece: 3000
@@ -27457,7 +26900,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 		Knife_: 100
@@ -27503,7 +26945,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 864
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Great_Leaf: 4365
 		Leaflet_Of_Hinal: 300
@@ -27553,7 +26994,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1536
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Zargon: 3500
 		Milk: 3000
@@ -27600,7 +27040,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Iron: 210
 		Orcish_Voucher: 5500
@@ -27646,7 +27085,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1590
@@ -27682,7 +27120,6 @@ mob_db: (
 	AttackDelay: 1308
 	AttackMotion: 1008
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1591
@@ -27719,7 +27156,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 	}
@@ -27762,7 +27198,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 560
 	DamageMotion: 580
-	MvpExp: 0
 	Drops: {
 		Stone: 10000
 		Wing_Of_Fly: 2000
@@ -27808,7 +27243,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 120
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 	}
@@ -27853,7 +27287,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1595
@@ -27889,7 +27322,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1596
@@ -27930,7 +27362,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 1152
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1597
@@ -27969,7 +27400,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1598
@@ -28011,7 +27441,6 @@ mob_db: (
 	AttackDelay: 1732
 	AttackMotion: 1332
 	DamageMotion: 540
-	MvpExp: 0
 },
 {
 	Id: 1599
@@ -28054,7 +27483,6 @@ mob_db: (
 	AttackDelay: 2536
 	AttackMotion: 1536
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1600
@@ -28096,7 +27524,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1601
@@ -28138,7 +27565,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1602
@@ -28180,7 +27606,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1603
@@ -28217,7 +27642,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1604
@@ -28260,7 +27684,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 340
-	MvpExp: 0
 },
 {
 	Id: 1605
@@ -28304,7 +27727,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1606
@@ -28345,7 +27767,6 @@ mob_db: (
 	AttackDelay: 879
 	AttackMotion: 672
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1607
@@ -28388,7 +27809,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1608
@@ -28430,7 +27850,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 },
 {
 	Id: 1609
@@ -28469,7 +27888,6 @@ mob_db: (
 	AttackDelay: 600
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Lucky_Candy: 500
 		Lucky_Candy_Cane: 50
@@ -28519,7 +27937,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 		Slow_Down_Potion: 100
@@ -28566,7 +27983,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 500
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 		Slow_Down_Potion: 100
@@ -28614,7 +28030,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 1320
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 		Slow_Down_Potion: 100
@@ -28657,7 +28072,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Tube: 4000
 		Iron_Ore: 1000
@@ -28704,7 +28118,6 @@ mob_db: (
 	AttackDelay: 648
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Fragment_Of_Crystal: 3000
 		Golden_Jewel: 500
@@ -28754,7 +28167,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 864
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Dark_Crystal_Fragment: 3000
 		Crystal_Jewel: 500
@@ -28800,7 +28212,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 336
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Old_Pick: 3000
 		Old_Steel_Plate: 500
@@ -28851,7 +28262,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Battered_Kettle: 1000
 		Burn_Tree: 1000
@@ -28904,7 +28314,6 @@ mob_db: (
 	AttackDelay: 420
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Long_Limb: 4500
 		Jaws_Of_Ant: 3500
@@ -28952,7 +28361,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Jubilee: 5000
 		Main_Gauche_: 25
@@ -29001,7 +28409,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1440
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Poisonous_Gas: 1000
 		Mould_Powder: 3000
@@ -29049,7 +28456,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1440
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Air_Pollutant: 5000
 		Spawns: 3000
@@ -29098,7 +28504,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 780
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Screw: 3800
 		Honey: 1000
@@ -29209,7 +28614,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1625
@@ -29250,7 +28654,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 },
 // Hellion Revenant
 {
@@ -29295,7 +28698,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 384
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Eye_Of_Hellion: 8000
 		Eye_Of_Hellion: 5000
@@ -29345,7 +28747,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 864
 	DamageMotion: 430
-	MvpExp: 0
 	Drops: {
 		Wing_Of_Fly: 1000
 		Spawns: 500
@@ -29389,7 +28790,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Moustache_Of_Mole: 5000
 		Nail_Of_Mole: 5000
@@ -29436,7 +28836,6 @@ mob_db: (
 	AttackDelay: 336
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Meat: 1000
 		Monsters_Feed: 1000
@@ -29540,7 +28939,6 @@ mob_db: (
 	AttackDelay: 1728
 	AttackMotion: 816
 	DamageMotion: 1188
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4200
 		Stuffed_Doll: 100
@@ -29587,7 +28985,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Will_Of_Darkness: 3000
 		Sticky_Mucus: 3000
@@ -29633,7 +29030,6 @@ mob_db: (
 	AttackDelay: 336
 	AttackMotion: 840
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Prickly_Fruit: 3000
 		Anodyne: 100
@@ -29684,7 +29080,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 3000
 		Dragon_Killer: 2
@@ -29736,7 +29131,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Lab_Staff_Record: 2000
 		Krishna: 1
@@ -29787,7 +29181,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 3000
 		Pauldron: 1
@@ -29839,7 +29232,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Lab_Staff_Record: 2000
 		Croce_Staff: 2
@@ -29890,7 +29282,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 3000
 		Imma_Arrow_Container: 110
@@ -29942,7 +29333,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 3000
 		Old_Blue_Box: 50
@@ -29997,7 +29387,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 10
 	}
@@ -30044,7 +29433,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 10
 	}
@@ -30092,7 +29480,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 10
 	}
@@ -30140,7 +29527,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 10
 	}
@@ -30188,7 +29574,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 10
 	}
@@ -30236,7 +29621,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 10
 	}
@@ -30640,7 +30024,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Lab_Staff_Record: 1000
 		Katzbalger: 1
@@ -30691,7 +30074,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 2000
 		Forturn_Sword: 1
@@ -30742,7 +30124,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 1000
 		Muffler_: 1
@@ -30793,7 +30174,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 500
 		Biretta_: 5
@@ -30844,7 +30224,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Lab_Staff_Record: 2000
 		Kakkung_: 1
@@ -30895,7 +30274,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mementos: 1000
 		Staff_Of_Wing: 1
@@ -31007,7 +30385,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31051,7 +30428,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31095,7 +30471,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31139,7 +30514,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31183,7 +30557,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31223,7 +30596,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 5000
 		Dark_Red_Jewel: 1000
@@ -31264,7 +30636,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 5000
 		Blue_Jewel: 1000
@@ -31306,7 +30677,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 5000
 		Azure_Jewel: 1000
@@ -31347,7 +30717,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 5000
 		Golden_Jewel: 1000
@@ -31394,7 +30763,6 @@ mob_db: (
 	AttackDelay: 580
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 5000
 		Steel: 500
@@ -31443,7 +30811,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Dimik_Card: 1
 	}
@@ -31486,7 +30853,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate01: 50
@@ -31536,7 +30902,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate02: 50
@@ -31586,7 +30951,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate03: 50
@@ -31636,7 +31000,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate04: 50
@@ -31684,7 +31047,6 @@ mob_db: (
 	AttackDelay: 1368
 	AttackMotion: 1344
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Stone: 2000
 		Stone_Heart: 1000
@@ -31728,7 +31090,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Venatu_Card: 1
 	}
@@ -31771,7 +31132,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 2000
 		Piece_Of_Crest1: 350
@@ -31821,7 +31181,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 2000
 		Piece_Of_Crest2: 500
@@ -31871,7 +31230,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 2000
 		Piece_Of_Crest3: 400
@@ -31921,7 +31279,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 2000
 		Piece_Of_Crest4: 300
@@ -31971,7 +31328,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Harpys_Feather: 4000
 		Harpys_Claw: 3000
@@ -32020,7 +31376,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 360
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Skull: 3000
 		Old_Blue_Box: 1000
@@ -32071,7 +31426,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 1056
 	DamageMotion: 1152
-	MvpExp: 0
 	Drops: {
 		Empty_Bottle: 5000
 		Old_Steel_Plate: 5000
@@ -32121,7 +31475,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1684
@@ -32161,7 +31514,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1685
@@ -32260,7 +31612,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 1000
 		Pacifier: 100
@@ -32307,7 +31658,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 528
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Leaflet_Of_Aloe: 1500
 		Reptile_Tongue: 1000
@@ -32415,7 +31765,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1690
@@ -32454,7 +31803,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 552
 	DamageMotion: 511
-	MvpExp: 0
 	Drops: {
 		Hometown_Gift: 100
 		Lucky_Cookie01: 300
@@ -32500,7 +31848,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1536
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Leaflet_Of_Aloe: 1
 		Leaflet_Of_Aloe: 1
@@ -32550,7 +31897,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Raccoon_Leaf: 500
 		Four_Leaf_Clover: 10
@@ -32600,7 +31946,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32648,7 +31993,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32696,7 +32040,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32744,7 +32087,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32792,7 +32134,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32843,7 +32184,6 @@ mob_db: (
 	AttackDelay: 176
 	AttackMotion: 912
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Page: 4000
 		Bookclip_In_Memory: 300
@@ -32893,7 +32233,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Old_Blue_Box: 30
 		Old_Violet_Box: 1
@@ -32947,7 +32286,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Feather: 500
 		Ring_: 1
@@ -33001,7 +32339,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 420
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Red_Feather: 200
 		Cursed_Seal: 1
@@ -33054,7 +32391,6 @@ mob_db: (
 	AttackDelay: 360
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Red_Feather: 400
 		Ring_: 1
@@ -33108,7 +32444,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 420
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Feather: 200
 		Ring_: 1
@@ -33163,7 +32498,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 288
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33217,7 +32551,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33271,7 +32604,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33325,7 +32657,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33438,7 +32769,6 @@ mob_db: (
 	AttackDelay: 115
 	AttackMotion: 288
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33487,7 +32817,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33536,7 +32865,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33585,7 +32913,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33630,7 +32957,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 1008
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Orange: 5100
 		Dragon_Canine: 4000
@@ -33680,7 +33006,6 @@ mob_db: (
 	AttackDelay: 108
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Strawberry: 2200
 		Dragon_Canine: 1000
@@ -33730,7 +33055,6 @@ mob_db: (
 	AttackDelay: 151
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Green_Herb: 3000
 		Cyfar: 1035
@@ -33776,7 +33100,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Potion: 150
 		Dragon_Canine: 4000
@@ -33826,7 +33149,6 @@ mob_db: (
 	AttackDelay: 108
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Delicious_Fish: 5100
 		Dragon_Canine: 1000
@@ -33875,7 +33197,6 @@ mob_db: (
 	AttackDelay: 252
 	AttackMotion: 816
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Yellow_Herb: 2000
 		Cyfar: 1035
@@ -33986,7 +33307,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Dragons_Skin: 4000
 		Dragon_Canine: 4000
@@ -34028,7 +33348,6 @@ mob_db: (
 	AttackDelay: 24
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Elunium: 5
 		Piece_Of_Egg_Shell: 100
@@ -34075,7 +33394,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Bucket: 1000
 		Pumpkin_Head: 1000
@@ -34124,7 +33442,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1724
@@ -34160,7 +33477,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1725
@@ -34197,7 +33513,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1726
@@ -34234,7 +33549,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1727
@@ -34271,7 +33585,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1728
@@ -34309,7 +33622,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 900
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1729
@@ -34347,7 +33659,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 480
 	DamageMotion: 120
-	MvpExp: 0
 },
 {
 	Id: 1730
@@ -34385,7 +33696,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1731
@@ -34430,7 +33740,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 480
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Warrior_Symbol: 10000
 	}
@@ -34470,7 +33779,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		3rd_Floor_Pass: 1000
 	}
@@ -34518,7 +33826,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1734
@@ -34618,7 +33925,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 480
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Burnt_Parts: 2000
 		Sturdy_Iron_Piece: 3000
@@ -34669,7 +33975,6 @@ mob_db: (
 	AttackDelay: 1296
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Burnt_Parts: 2000
 		Sturdy_Iron_Piece: 3000
@@ -34716,7 +34021,6 @@ mob_db: (
 	AttackDelay: 1440
 	AttackMotion: 576
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Brigan: 4000
 		Morpheuss_Shawl: 10
@@ -34766,7 +34070,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Burnt_Parts: 100
 		Sturdy_Iron_Piece: 1500
@@ -34814,7 +34117,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 480
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Sturdy_Iron_Piece: 500
 	}
@@ -34858,7 +34160,6 @@ mob_db: (
 	AttackDelay: 1296
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sturdy_Iron_Piece: 500
 	}
@@ -34901,7 +34202,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1742
@@ -34942,7 +34242,6 @@ mob_db: (
 	AttackDelay: 1078
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1743
@@ -34982,7 +34281,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1744
@@ -35022,7 +34320,6 @@ mob_db: (
 	AttackDelay: 964
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1745
@@ -35061,7 +34358,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sturdy_Iron_Piece: 500
 	}
@@ -35104,7 +34400,6 @@ mob_db: (
 	AttackDelay: 1440
 	AttackMotion: 576
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Sturdy_Iron_Piece: 500
 	}
@@ -35148,7 +34443,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1748
@@ -35188,7 +34482,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1749
@@ -35229,7 +34522,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 1320
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1750
@@ -35264,7 +34556,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 },
 // Odin monsters
 {
@@ -35365,7 +34656,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 384
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 3500
 		Brigan: 1000
@@ -35417,7 +34707,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 3500
 		Brigan: 1000
@@ -35470,7 +34759,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 780
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 6000
 		Angelic_Chain: 1
@@ -35524,7 +34812,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 780
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 6000
 		Angelic_Chain: 1
@@ -35577,7 +34864,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1757
@@ -35617,7 +34903,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 1008
 	DamageMotion: 300
-	MvpExp: 0
 },
 {
 	Id: 1758
@@ -35657,7 +34942,6 @@ mob_db: (
 	AttackDelay: 108
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1759
@@ -35697,7 +34981,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1760
@@ -35737,7 +35020,6 @@ mob_db: (
 	AttackDelay: 108
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1761
@@ -35778,7 +35060,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 384
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 500
 	}
@@ -35822,7 +35103,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 500
 	}
@@ -35867,7 +35147,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 780
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 500
 	}
@@ -35912,7 +35191,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 780
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 500
 	}
@@ -35959,7 +35237,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Valhalla_Flower: 500
 		Old_Violet_Box: 100
@@ -36004,7 +35281,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 	MvpDrops: {
 		Jellopy: 5000
 		Jellopy: 5000
@@ -36049,7 +35325,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 	MvpDrops: {
 		Jellopy: 5000
 		Jellopy: 5000
@@ -36154,7 +35429,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 2500
 		High_Fashion_Sandals: 2
@@ -36204,7 +35478,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 2500
 		Seed_Of_Yggdrasil: 10
@@ -36254,7 +35527,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		White_Mask: 2500
 		Royal_Jelly: 10
@@ -36303,7 +35575,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		White_Mask: 2500
 		High_Fashion_Sandals: 1
@@ -36353,7 +35624,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 528
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Prickly_Fruit_: 1000
 		Will_Of_Darkness: 1000
@@ -36404,7 +35674,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Prickly_Fruit_: 1000
 		Will_Of_Darkness: 1000
@@ -36453,7 +35722,6 @@ mob_db: (
 	AttackDelay: 936
 	AttackMotion: 1020
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 3000
 		Ice_Piece: 1000
@@ -36500,7 +35768,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 648
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 1000
 		Ice_Piece: 500
@@ -36547,7 +35814,6 @@ mob_db: (
 	AttackDelay: 861
 	AttackMotion: 660
 	DamageMotion: 144
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 5000
 		Ice_Piece: 3000
@@ -36598,7 +35864,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 370
 	DamageMotion: 270
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 3000
 		Ice_Piece: 3000
@@ -36699,7 +35964,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 648
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sticky_Poison: 3000
 		Blossom_Of_Maneater: 3000
@@ -36744,7 +36008,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 576
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Sticky_Poison: 3000
 		Sticky_Mucus: 3000
@@ -36792,7 +36055,6 @@ mob_db: (
 	AttackDelay: 412
 	AttackMotion: 840
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Rotten_Meat: 3000
 		Animals_Skin: 3000
@@ -36840,7 +36102,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Rotten_Meat: 3000
 		Animals_Skin: 3000
@@ -36884,7 +36145,6 @@ mob_db: (
 	AttackDelay: 936
 	AttackMotion: 792
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Jellopy: 1000
 		Jubilee: 1000
@@ -36993,7 +36253,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 1
 	}
@@ -37037,7 +36296,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 1
 	}
@@ -37081,7 +36339,6 @@ mob_db: (
 	AttackDelay: 861
 	AttackMotion: 660
 	DamageMotion: 144
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 1
 	}
@@ -37120,7 +36377,6 @@ mob_db: (
 	AttackDelay: 1344
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Ice_Piece: 1000
 		Ice_Piece: 1000
@@ -37170,7 +36426,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 528
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Golden_Jewel_: 3000
 		Red_Jewel_: 4000
@@ -37216,7 +36471,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1792
@@ -37251,7 +36505,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 96
 	DamageMotion: 96
-	MvpExp: 0
 },
 {
 	Id: 1793
@@ -37293,7 +36546,6 @@ mob_db: (
 	AttackDelay: 1332
 	AttackMotion: 1332
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1794
@@ -37334,7 +36586,6 @@ mob_db: (
 	AttackDelay: 412
 	AttackMotion: 840
 	DamageMotion: 300
-	MvpExp: 0
 },
 {
 	Id: 1795
@@ -37378,7 +36629,6 @@ mob_db: (
 	AttackDelay: 828
 	AttackMotion: 528
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Pole_Axe: 100
 		Grave_: 100
@@ -37429,7 +36679,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Memorize_Book: 1
 		Musika: 1
@@ -37478,7 +36727,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Memorize_Book: 1
 		Kandura: 1
@@ -37522,7 +36770,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Gem_Of_Ruin: 10000
 	}
@@ -37569,7 +36816,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 300
 	}
@@ -37616,7 +36862,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 300
 	}
@@ -37664,7 +36909,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 300
 	}
@@ -37759,7 +37003,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 300
 	}
@@ -37807,7 +37050,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 300
 	}
@@ -37854,7 +37096,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -37901,7 +37142,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -37949,7 +37189,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -37997,7 +37236,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -38045,7 +37283,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -38093,7 +37330,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -38134,7 +37370,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Sunglasses: 100
 		Tiger_Skin_Panties: 500
@@ -38177,7 +37412,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Bucket: 5000
 		Pumpkin_Head: 5000
@@ -38228,7 +37462,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Evil_Dragon_Head: 10000
 		Dragon_Killer: 500
@@ -38281,7 +37514,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1815
@@ -38317,7 +37549,6 @@ mob_db: (
 	AttackDelay: 1320
 	AttackMotion: 0
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Small_Rice_Dough: 10000
 		Small_Rice_Dough: 10000
@@ -38362,7 +37593,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 96
 	DamageMotion: 96
-	MvpExp: 0
 	Drops: {
 		Apple: 10000
 	}
@@ -38410,7 +37640,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 936
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Dragon_Spirit: 10000
 		Dragon_Wing: 500
@@ -38461,7 +37690,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 500
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cogwheel: 7000
 	}
@@ -38506,7 +37734,6 @@ mob_db: (
 	AttackDelay: 1504
 	AttackMotion: 840
 	DamageMotion: 900
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 2000
 	}
@@ -38546,7 +37773,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 2000
 	}
@@ -38589,7 +37815,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 420
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 2000
 	}
@@ -38635,7 +37860,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 3000
 	}
@@ -38680,7 +37904,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 3000
 	}
@@ -38724,7 +37947,6 @@ mob_db: (
 	AttackDelay: 879
 	AttackMotion: 672
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 5000
 	}
@@ -38770,7 +37992,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 5000
 	}
@@ -38815,7 +38036,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 3000
 	}
@@ -38860,7 +38080,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 3000
 	}
@@ -38906,7 +38125,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Bag_Of_Rice: 6000
 		Lucky_Candy: 9000
@@ -38956,7 +38174,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Broken_Armor_Piece: 3000
 		Doom_Slayer: 30
@@ -39010,7 +38227,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Broken_Armor_Piece: 3000
 		Luna_Bow: 30
@@ -39062,7 +38278,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Flame_Heart: 30
@@ -39175,7 +38390,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 600
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Hot_Hair: 2500
@@ -39229,7 +38443,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1835
@@ -39273,7 +38486,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 600
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1836
@@ -39310,7 +38522,6 @@ mob_db: (
 	AttackDelay: 1472
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Elunium_Stone: 34
@@ -39357,7 +38568,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Hot_Hair: 3000
 		Huuma_Blaze: 3
@@ -39404,7 +38614,6 @@ mob_db: (
 	AttackDelay: 1548
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Great_Nature: 30
 		Coal: 150
@@ -39459,7 +38668,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 600
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Drill_Katar: 50
 		Assassin_Mask_: 3
@@ -39508,7 +38716,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 480
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Leaf_Of_Yggdrasil: 3000
 		Treasure_Box: 100
@@ -39554,7 +38761,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Gold_Coin_US: 2000
 		Green_Ale_US: 200
@@ -39596,7 +38802,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Gold_Coin_US: 3500
 		Green_Ale_US: 400
@@ -39641,7 +38846,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Gold_Coin_US: 7000
 		Green_Ale_US: 600
@@ -39687,7 +38891,6 @@ mob_db: (
 	AttackDelay: 1384
 	AttackMotion: 768
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Gold_Coin_US: 8000
 		Green_Ale_US: 800
@@ -39729,7 +38932,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Gold_Coin_US: 10000
 		Gold_Coin_US: 10000
@@ -39775,7 +38977,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dragonball_Yellow_: 2000
 	}
@@ -39822,7 +39023,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1848
@@ -39866,7 +39066,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1849
@@ -39910,7 +39109,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1850
@@ -39954,7 +39152,6 @@ mob_db: (
 	AttackDelay: 1678
 	AttackMotion: 780
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1851
@@ -39996,7 +39193,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 560
 	DamageMotion: 580
-	MvpExp: 0
 },
 {
 	Id: 1852
@@ -40040,7 +39236,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1853
@@ -40084,7 +39279,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1854
@@ -40121,7 +39315,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 70
 		Cactus_Needle: 9000
@@ -40171,7 +39364,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Poison_Spore: 9000
 		Hat_: 20
@@ -40219,7 +39411,6 @@ mob_db: (
 	AttackDelay: 1560
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Old_Frying_Pan: 9000
 		Garlet: 800
@@ -40265,7 +39456,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Garlet: 3200
 		Sticky_Mucus: 1500
@@ -40311,7 +39501,6 @@ mob_db: (
 	AttackDelay: 2208
 	AttackMotion: 1008
 	DamageMotion: 324
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 9000
 		Sago: 300
@@ -40357,7 +39546,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 50
 		Stem: 9000
@@ -40404,7 +39592,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 1008
-	MvpExp: 0
 	Drops: {
 		Acorn: 9000
 		Hood_: 20
@@ -40454,7 +39641,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Claw_Of_Monkey: 5335
 		Yoyo_Tail: 7000
@@ -40500,7 +39686,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moustache_Of_Mole: 9000
 		Macapuno: 500
@@ -40547,7 +39732,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 552
 	DamageMotion: 511
-	MvpExp: 0
 	Drops: {
 		Peeps: 5000
 		Jelly_Bean: 5000
@@ -40595,7 +39779,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 648
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Clattering_Skull: 3000
 		Platinum_Shotel: 10
@@ -40645,7 +39828,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Clattering_Skull: 3000
 		Tidal_Shoes: 15
@@ -40698,7 +39880,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Monsters_Feed: 5000
 		Tooth_Blade: 10
@@ -40751,7 +39932,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 504
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Old_White_Cloth: 3000
 		Orleans_Gown: 10
@@ -40803,7 +39983,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 504
 	DamageMotion: 504
-	MvpExp: 0
 },
 {
 	Id: 1869
@@ -40844,7 +40023,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 648
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Skull: 5000
 		Black_Leather_Boots: 20
@@ -40895,7 +40073,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 1320
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Clattering_Skull: 3000
 		Lich_Bone_Wand: 20
@@ -41008,7 +40185,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1873
@@ -41052,7 +40228,6 @@ mob_db: (
 	AttackDelay: 100
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1874
@@ -41153,7 +40328,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 1152
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Broken_Crown: 9000
 		Sticky_Mucus: 9000
@@ -41201,7 +40375,6 @@ mob_db: (
 	AttackDelay: 1446
 	AttackMotion: 1296
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1877
@@ -41239,7 +40412,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		GOLD_ID4: 10
 		Gift_Box: 100
@@ -41279,7 +40451,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Love_Flower: 3000
 		Pointed_Scale: 1500
@@ -41331,7 +40502,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 },
 // Moscovia monsters
 {
@@ -41369,7 +40539,6 @@ mob_db: (
 	AttackDelay: 2304
 	AttackMotion: 840
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Iron_Wrist: 5
 		Solid_Twig: 4000
@@ -41417,7 +40586,6 @@ mob_db: (
 	AttackDelay: 1728
 	AttackMotion: 720
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Sharp_Leaf: 2000
 		Green_Herb: 1000
@@ -41467,7 +40635,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 600
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Old_Magic_Circle: 1000
 		Yaga_Pestle: 5000
@@ -41517,7 +40684,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Leaflet_Of_Hinal: 900
 		Ancient_Magic: 5
@@ -41566,7 +40732,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 504
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Principles_Of_Magic: 5
 		Singing_Flower: 300
@@ -41674,7 +40839,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 504
 	DamageMotion: 360
-	MvpExp: 0
 },
 // Additional Monsters
 {
@@ -41717,7 +40881,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Cyfar: 2000
 		Ice_Piece: 2000
@@ -41761,7 +40924,6 @@ mob_db: (
 	AttackDelay: 879
 	AttackMotion: 672
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Ice_Piece: 2000
 	}
@@ -41808,7 +40970,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 408
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Cyfar: 2000
 		Ice_Piece: 2000
@@ -41853,7 +41014,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1891
@@ -41897,7 +41057,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1892
@@ -41938,7 +41097,6 @@ mob_db: (
 	AttackDelay: 747
 	AttackMotion: 1632
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1893
@@ -41981,7 +41139,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1894
@@ -42022,7 +41179,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Cold_Medicine: 8335
 	}
@@ -42067,7 +41223,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1896
@@ -42109,7 +41264,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1897
@@ -42153,7 +41307,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1898
@@ -42193,7 +41346,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Jade_Plate: 10000
 	}
@@ -42235,7 +41387,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 /*{
 	Id: 1900
@@ -42274,7 +41425,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },*/
 {
 	Id: 1901
@@ -42312,7 +41462,6 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Heart_Box: 5000
 	}
@@ -42352,7 +41501,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Gold_Key77: 1000
 	}
@@ -42392,7 +41540,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Silver_Key77: 1000
 	}
@@ -42436,7 +41583,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 // WoE Second Edition; Battle Fields
 {
@@ -42473,7 +41619,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1906
@@ -42510,7 +41655,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1907
@@ -42546,7 +41690,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1908
@@ -42582,7 +41725,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1909
@@ -42619,7 +41761,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1910
@@ -42656,7 +41797,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1911
@@ -42693,7 +41833,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1912
@@ -42730,7 +41869,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1913
@@ -42767,7 +41905,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1914
@@ -42804,7 +41941,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1915
@@ -42841,7 +41977,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 // Satan Morroc
 {
@@ -42886,7 +42021,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1917
@@ -42987,7 +42121,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Herald_Of_GOD: 10
 		Dark_Crystal: 1000
@@ -43040,7 +42173,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Skin_Of_Ventus: 3
 		Dark_Crystal: 1000
@@ -43092,7 +42224,6 @@ mob_db: (
 	AttackDelay: 212
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Ragamuffin_Cape: 10
 		Dark_Crystal: 1000
@@ -43145,7 +42276,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Diabolus_Ring: 5
 		Dark_Crystal: 1000
@@ -43198,7 +42328,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1923
@@ -43243,7 +42372,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1924
@@ -43288,7 +42416,6 @@ mob_db: (
 	AttackDelay: 212
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1925
@@ -43333,7 +42460,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 },
 // God Item Creation (WoE SE); Catacombs
 {
@@ -43377,7 +42503,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Head: 3000
 		Pumpkin_Head: 3000
@@ -43425,7 +42550,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Transparent_Cloth: 5000
 		Transparent_Cloth: 5000
@@ -43472,7 +42596,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Horn: 3000
 		Petite_DiablOfs_Wing: 3000
@@ -43521,7 +42644,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Bapho_Doll: 500
 		Pauldron: 7000
@@ -43575,7 +42697,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1931
@@ -43619,7 +42740,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1932
@@ -43657,7 +42777,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Crystal_Key: 9000
 	}
@@ -43704,7 +42823,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1934
@@ -43740,7 +42858,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1935
@@ -43776,7 +42893,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1936
@@ -43812,7 +42928,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1937
@@ -43852,7 +42967,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1938
@@ -43888,7 +43002,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Goddess_Tear: 80
 		Union_Of_Tribe: 500
@@ -43934,7 +43047,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Valkyrie_Token: 80
 		Union_Of_Tribe: 500
@@ -43980,7 +43092,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Brynhild_Armor_Piece: 80
 		Union_Of_Tribe: 500
@@ -44026,7 +43137,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Hero_Remains: 80
 		Union_Of_Tribe: 500
@@ -44072,7 +43182,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Andvari_Ring: 80
 		Union_Of_Tribe: 500
@@ -44118,7 +43227,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Dusk_Glow: 80
 		Union_Of_Tribe: 500
@@ -44164,7 +43272,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Dawn_Essence: 80
 		Union_Of_Tribe: 500
@@ -44210,7 +43317,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Cold_Moonlight: 80
 		Union_Of_Tribe: 500
@@ -44256,7 +43362,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Hazy_Starlight: 80
 		Union_Of_Tribe: 500
@@ -44310,7 +43415,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1948
@@ -44350,7 +43454,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1949
@@ -44388,7 +43491,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1950
@@ -44426,7 +43528,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 // Ravies Sister's 'Valyrie's Gift' monsters.
 {
@@ -44465,7 +43566,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -44512,7 +43612,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -44559,7 +43658,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -44606,7 +43704,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -44653,7 +43750,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Tresure_Box_WoE: 3000
 		Soul_Crystal: 4000
@@ -44702,7 +43798,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 432
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Twin_Edge_B: 9000
 		Twin_Edge_R: 9000
@@ -44749,7 +43844,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 540
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Thorn_Staff: 9000
 		Holy_Stick: 9000
@@ -44797,7 +43891,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1959
@@ -44835,7 +43928,6 @@ mob_db: (
 	AttackDelay: 2864
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1960
@@ -44873,7 +43965,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1961
@@ -44911,7 +44002,6 @@ mob_db: (
 	AttackDelay: 2864
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 },
 // Additional Monsters
 {
@@ -44949,7 +44039,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1963
@@ -44991,7 +44080,6 @@ mob_db: (
 	AttackDelay: 1728
 	AttackMotion: 816
 	DamageMotion: 1188
-	MvpExp: 0
 },
 {
 	Id: 1964
@@ -45027,7 +44115,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Blue_Potion: 2000
 		Blue_Herb: 3000
@@ -45068,7 +44155,6 @@ mob_db: (
 	AttackDelay: 964
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1966
@@ -45104,7 +44190,6 @@ mob_db: (
 	AttackDelay: 300
 	AttackMotion: 480
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1967
@@ -45141,7 +44226,6 @@ mob_db: (
 	AttackDelay: 300
 	AttackMotion: 480
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1968
@@ -45177,7 +44261,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Fin: 5335
 		Oridecon_Stone: 230
@@ -45223,7 +44306,6 @@ mob_db: (
 	AttackDelay: 1272
 	AttackMotion: 72
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 36
 		Gill: 9000
@@ -45270,7 +44352,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 26
 		Heart_Of_Mermaid: 9000
@@ -45316,7 +44397,6 @@ mob_db: (
 	AttackDelay: 1632
 	AttackMotion: 432
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 40
 		Nipper: 9000
@@ -45362,7 +44442,6 @@ mob_db: (
 	AttackDelay: 2280
 	AttackMotion: 1080
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 5000
 		Sticky_Mucus: 1500
@@ -45407,7 +44486,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 		Sticky_Mucus: 400
@@ -45458,7 +44536,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 504
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Brigan: 5335
 		Old_White_Cloth: 3000
@@ -45508,7 +44585,6 @@ mob_db: (
 	AttackDelay: 336
 	AttackMotion: 840
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Prickly_Fruit: 3000
 		Anodyne: 100
@@ -45557,7 +44633,6 @@ mob_db: (
 	AttackDelay: 648
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Fragment_Of_Crystal: 3000
 		Golden_Jewel: 500
@@ -45607,7 +44682,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Tube: 4000
 		Iron_Ore: 1000
@@ -45657,7 +44731,6 @@ mob_db: (
 	AttackDelay: 1840
 	AttackMotion: 1440
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Broken_Steel_Piece: 5335
 		Steel: 2500
@@ -45708,7 +44781,6 @@ mob_db: (
 	AttackDelay: 580
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 5000
 		Steel: 500
@@ -45816,7 +44888,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1982
@@ -45857,7 +44928,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 620
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1983
@@ -45898,7 +44968,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1984
@@ -45941,7 +45010,6 @@ mob_db: (
 	AttackDelay: 1050
 	AttackMotion: 900
 	DamageMotion: 288
-	MvpExp: 0
 },
 // Another World (13.1)
 {
@@ -45984,7 +45052,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1986
@@ -46023,7 +45090,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Lunakaligo: 20
 		Cello: 10
@@ -46075,7 +45141,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Cold_Heart: 2
 		Black_Cat: 2
@@ -46121,7 +45186,6 @@ mob_db: (
 	AttackDelay: 500
 	AttackMotion: 576
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Mandragora_Cap: 1
 		Stem_Of_Nepenthes: 1
@@ -46170,7 +45234,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 780
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Sprint_Shoes: 10
 		Horn_Of_Hilthrion: 20
@@ -46224,7 +45287,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 660
 	DamageMotion: 588
-	MvpExp: 0
 	Drops: {
 		Bone_Head: 100
 		Tournament_Shield: 200
@@ -46277,7 +45339,6 @@ mob_db: (
 	AttackDelay: 500
 	AttackMotion: 960
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Leather_Of_Tendrilion: 500
 		Death_Guidance: 100
@@ -46324,7 +45385,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 624
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Sprint_Mail: 10
 		Angelic_Ring: 1
@@ -46376,7 +45436,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Armor_Of_Naga: 10
 		Shield_Of_Naga: 10
@@ -46429,7 +45488,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Sprint_Ring: 2
 		Worm_Peelings: 9000
@@ -46479,7 +45537,6 @@ mob_db: (
 	AttackDelay: 700
 	AttackMotion: 600
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Pinguicula_Corsage: 1
 		Whip_Of_Balance: 10
@@ -46532,7 +45589,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		White_Snake_Hat: 500
 		Exorcize_Sachet: 80
@@ -46576,7 +45632,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1998
@@ -46616,7 +45671,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 780
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1999
@@ -46659,7 +45713,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Boots_: 9
 		Crystal_Jewel__: 50
@@ -46704,7 +45757,6 @@ mob_db: (
 	AttackDelay: 300
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2001
@@ -46740,7 +45792,6 @@ mob_db: (
 	AttackDelay: 300
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2002
@@ -46776,7 +45827,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 552
 	DamageMotion: 511
-	MvpExp: 0
 	Drops: {
 		Moon_Cake: 1000
 		Plantain: 500
@@ -46823,7 +45873,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 1000
 		Moon_Cake2: 1000
@@ -46874,7 +45923,6 @@ mob_db: (
 	AttackDelay: 637
 	AttackMotion: 1008
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 800
 		Moon_Cake2: 800
@@ -46919,7 +45967,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 500
 		Moon_Cake2: 500
@@ -46962,7 +46009,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Moon_Cake15: 500
 		Moon_Cake16: 500
@@ -47005,7 +46051,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 500
 		Moon_Cake2: 500
@@ -47055,7 +46100,6 @@ mob_db: (
 	AttackDelay: 828
 	AttackMotion: 528
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 2009
@@ -47097,7 +46141,6 @@ mob_db: (
 	AttackDelay: 414
 	AttackMotion: 1080
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Cowkings_Nose_Ring: 10000
 	}
@@ -47136,7 +46179,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 960
 	DamageMotion: 780
-	MvpExp: 0
 },
 /*{
 	Id: 2011
@@ -47172,7 +46214,6 @@ mob_db: (
 	AttackDelay: 2456
 	AttackMotion: 912
 	DamageMotion: 504
-	MvpExp: 0
 },
 {
 	Id: 2012
@@ -47208,7 +46249,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 },*/
 // Another World (13.2)
 {
@@ -47247,7 +46287,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Dragons_Mane: 3000
 		Dragons_Skin: 100
@@ -47288,7 +46327,6 @@ mob_db: (
 	AttackDelay: 24
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Egg_Shell: 20
@@ -47332,7 +46370,6 @@ mob_db: (
 	AttackDelay: 1426
 	AttackMotion: 600
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sharp_Leaf: 5000
 		Great_Leaf: 2000
@@ -47379,7 +46416,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 960
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Crystalized_Teardrop: 1000
 		Fluorescent_Liquid: 5000
@@ -47426,7 +46462,6 @@ mob_db: (
 	AttackDelay: 792
 	AttackMotion: 540
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Unripe_Acorn: 5000
 		Acorn: 5000
@@ -47473,7 +46508,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 420
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Carrot: 5000
 		Fur: 4000
@@ -47521,7 +46555,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 960
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Tough_Vines: 1000
 		Great_Leaf: 1000
@@ -47568,7 +46601,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 660
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Fluorescent_Liquid: 5000
 		Karvodailnirol: 5
@@ -47611,7 +46643,6 @@ mob_db: (
 	AttackDelay: 360
 	AttackMotion: 780
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Fluorescent_Liquid: 5000
 		Detrimindexta: 5
@@ -47711,7 +46742,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1776
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Black_Cloth: 5000
 		Skul_Ring: 1000
@@ -47761,7 +46791,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1200
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Stone_Piece: 3000
 		Stone_Heart: 5000
@@ -47803,7 +46832,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Fire_Cracker_Xmas: 5000
 		Fire_Cracker_Love: 5000
@@ -47855,7 +46883,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Old_Frying_Pan: 5000
 		Delicious_Fish: 500
@@ -47908,7 +46935,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1776
 	DamageMotion: 648
-	MvpExp: 0
 },
 /*{
 	Id: 2028
@@ -47944,7 +46970,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Coin: 5000
 	}
@@ -47983,7 +47008,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 10
 		Fore_Flank_Sirloin: 2000
@@ -48038,7 +47062,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Popes_Cookie: 5000
 	}
@@ -48086,7 +47109,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Popes_Cookie: 5000
 	}
@@ -48125,7 +47147,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 480
 	DamageMotion: 120
-	MvpExp: 0
 },
 {
 	Id: 2033
@@ -48161,7 +47182,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Token_Bag: 10000
 	}
@@ -48200,7 +47220,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 900
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 2035
@@ -48237,7 +47256,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 },
 {
 	Id: 2036
@@ -48274,7 +47292,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Broken_Horn_Pipe: 10000
 	}
@@ -48313,7 +47330,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2038
@@ -48349,7 +47365,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2039
@@ -48385,7 +47400,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 500
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 2040
@@ -48422,7 +47436,6 @@ mob_db: (
 	AttackDelay: 816
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 2041
@@ -48458,7 +47471,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },*/
 // NC Mechanic Summons
 {
@@ -48495,7 +47507,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48534,7 +47545,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48573,7 +47583,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48612,7 +47621,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48651,7 +47659,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48696,7 +47703,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Scale_Of_Snakes: 5000
 	}
@@ -48735,7 +47741,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },*/
 {
 	Id: 2049
@@ -48776,7 +47781,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1200
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Purified_Bradium: 500
 	}
@@ -48815,7 +47819,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2051
@@ -48851,7 +47854,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Fools_Day_Box: 5000
 		Fools_Day_Box2: 5000
@@ -48891,7 +47893,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2053
@@ -48927,7 +47928,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2054
@@ -48963,7 +47963,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2055
@@ -48999,7 +47998,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2056
@@ -49035,7 +48033,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },*/
 {
 	Id: 2057
@@ -49072,7 +48069,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 /*{
 	Id: 2058
@@ -49108,7 +48104,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2059
@@ -49144,7 +48139,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2060
@@ -49180,7 +48174,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2061
@@ -49216,7 +48209,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2062
@@ -49252,7 +48244,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2063
@@ -49288,7 +48279,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2064
@@ -49324,7 +48314,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2065
@@ -49360,7 +48349,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2066
@@ -49396,7 +48384,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2067
@@ -49432,7 +48419,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },*/
 {
 	Id: 2068
@@ -49522,7 +48508,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 380
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Heart_Of_Mermaid: 9000
 		Fin: 500
@@ -49572,7 +48557,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Sharp_Scale: 9000
 		Gill: 600
@@ -49622,7 +48606,6 @@ mob_db: (
 	AttackDelay: 1216
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Burning_Horse_Shoe: 4000
 		Burning_Heart: 1000
@@ -49671,7 +48654,6 @@ mob_db: (
 	AttackDelay: 1250
 	AttackMotion: 580
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Leopard_Skin: 3000
 		Leopard_Talon: 2000
@@ -49718,7 +48700,6 @@ mob_db: (
 	AttackDelay: 1450
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Talon: 3000
 		Cyfar: 1000
@@ -49765,7 +48746,6 @@ mob_db: (
 	AttackDelay: 530
 	AttackMotion: 530
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Meat: 3000
 		Tiger_Skin_Panties: 500
@@ -49808,7 +48788,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },*/
 {
 	Id: 2076
@@ -49851,7 +48830,6 @@ mob_db: (
 	AttackDelay: 1056
 	AttackMotion: 1056
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 2077
@@ -49893,7 +48871,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 384
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2078
@@ -49936,7 +48913,6 @@ mob_db: (
 	AttackDelay: 1306
 	AttackMotion: 1056
 	DamageMotion: 288
-	MvpExp: 0
 },
 /*{
 	Id: 2079
@@ -49972,7 +48948,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2080
@@ -50008,7 +48983,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },*/
 {
 	Id: 2081
@@ -50041,7 +49015,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 432
 	DamageMotion: 600
-	MvpExp: 0
 },
 {
 	Id: 2082
@@ -50082,7 +49055,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 2210
@@ -50119,7 +49091,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 2308
@@ -50151,7 +49122,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2248
@@ -50187,7 +49157,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 //	Drops: {
 //		Blue_Card_C: 4000
 //		BlueCard_2: 4000

--- a/db/re/mob_db.conf
+++ b/db/re/mob_db.conf
@@ -150,7 +150,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 70
 		Scorpions_Tail: 5500
@@ -197,7 +196,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 		Knife_: 100
@@ -239,7 +237,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 512
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 {
 	Id: 1004
@@ -277,7 +274,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 216
-	MvpExp: 0
 	Drops: {
 		Wind_Of_Verdure: 80
 		Bee_Sting: 9000
@@ -325,7 +321,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Tooth_Of_Bat: 5500
 		Falchion_: 20
@@ -374,7 +369,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 {
 	Id: 1007
@@ -411,7 +405,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fluff: 6500
 		Feather: 500
@@ -456,7 +449,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 80
 		Chrysalis: 5500
@@ -503,7 +495,6 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Talon: 9000
 		Bow_: 150
@@ -549,7 +540,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Tree_Root: 9000
 		Wooden_Block: 100
@@ -596,7 +586,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Iron: 50
 		Shell: 6500
@@ -642,7 +631,6 @@ mob_db: (
 	AttackDelay: 2016
 	AttackMotion: 816
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Sticky_Webfoot: 9000
 		Spawn: 500
@@ -688,7 +676,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 504
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 20
 		Claw_Of_Wolves: 9000
@@ -734,7 +721,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mushroom_Spore: 9000
 		Red_Herb: 800
@@ -784,7 +770,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Decayed_Nail: 9000
 		Cardinal_Jewel_: 5
@@ -830,7 +815,6 @@ mob_db: (
 	AttackDelay: 2864
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 4500
 		Oridecon_Stone: 70
@@ -879,7 +863,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 3500
 		Garlet: 250
@@ -926,7 +909,6 @@ mob_db: (
 	AttackDelay: 1136
 	AttackMotion: 720
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Powder_Of_Butterfly: 9000
 		Silk_Robe_: 10
@@ -974,7 +956,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Bill_Of_Birds: 9000
 		Sandals_: 20
@@ -1019,7 +1000,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 50
 		Stem: 9000
@@ -1069,7 +1049,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 40
 		Insect_Feeler: 5500
@@ -1118,7 +1097,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 768
 	DamageMotion: 652
-	MvpExp: 0
 	Drops: {
 		Steel: 500
 		Cobold_Hair: 4000
@@ -1166,7 +1144,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Iron: 210
 		Orcish_Voucher: 9000
@@ -1213,7 +1190,6 @@ mob_db: (
 	AttackDelay: 1048
 	AttackMotion: 48
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 60
 		Emveretarcon: 25
@@ -1260,7 +1236,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scale_Of_Snakes: 9000
 		Katana_: 15
@@ -1310,7 +1285,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Danggie: 9000
 		Munak_Turban: 2
@@ -1358,7 +1332,6 @@ mob_db: (
 	AttackDelay: 2000
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 	}
@@ -1401,7 +1374,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 5500
 		Oridecon_Stone: 60
@@ -1452,7 +1424,6 @@ mob_db: (
 	AttackDelay: 1384
 	AttackMotion: 768
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Scales_Shell: 5335
 		Circlet_: 5
@@ -1499,7 +1470,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		White_Powder: 200
 		Posionous_Canine: 9000
@@ -1546,7 +1516,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sticky_Mucus: 5500
 		Garlet: 1500
@@ -1593,7 +1562,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Immortal_Heart: 9000
 		Zargon: 700
@@ -1643,7 +1611,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 50
 		Resin: 9000
@@ -1689,7 +1656,6 @@ mob_db: (
 	AttackDelay: 2016
 	AttackMotion: 816
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 45
 		Spawn: 5500
@@ -1739,7 +1705,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rough_Wind: 30
 		Steel: 100
@@ -1789,7 +1754,6 @@ mob_db: (
 	AttackDelay: 2456
 	AttackMotion: 912
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Horrendous_Mouth: 6000
 		Oridecon_Stone: 110
@@ -1839,7 +1803,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Shining_Scales: 5335
 		Zargon: 1400
@@ -2004,7 +1967,6 @@ mob_db: (
 	AttackDelay: 1608
 	AttackMotion: 816
 	DamageMotion: 396
-	MvpExp: 0
 	Drops: {
 		Steel: 150
 		Stone_Heart: 9000
@@ -2054,7 +2016,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Rotten_Bandage: 9000
 		Oridecon_Stone: 100
@@ -2104,7 +2065,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Wind_Of_Verdure: 90
 		Steel: 30
@@ -2152,7 +2112,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 800
 	DamageMotion: 600
-	MvpExp: 0
 },*/
 {
 	Id: 1044
@@ -2192,7 +2151,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 13
 		Heart_Of_Mermaid: 9000
@@ -2242,7 +2200,6 @@ mob_db: (
 	AttackDelay: 1272
 	AttackMotion: 72
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 18
 		Gill: 9000
@@ -2342,7 +2299,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 250
 		Shell: 1500
@@ -2387,7 +2343,6 @@ mob_db: (
 	AttackDelay: 701
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 300
 		Chrysalis: 5000
@@ -2433,7 +2388,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 168
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Birds: 9000
 		Feather: 700
@@ -2478,7 +2432,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 168
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Birds: 9000
 		Feather: 700
@@ -2527,7 +2480,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 2500
 		Leather_Jacket_: 80
@@ -2573,7 +2525,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Grasshoppers_Leg: 9000
 		Guitar_Of_Vast_Land: 10
@@ -2624,7 +2575,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 3500
 		Garlet: 250
@@ -2676,7 +2626,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 40
 		Insect_Feeler: 5500
@@ -2722,7 +2671,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 70
 		Cactus_Needle: 9000
@@ -2769,7 +2717,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Raccoon_Leaf: 5500
 		Animals_Skin: 5500
@@ -2818,7 +2765,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 54
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yoyo_Tail: 9000
 		Banana: 1500
@@ -2868,7 +2814,6 @@ mob_db: (
 	AttackDelay: 1708
 	AttackMotion: 1008
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 60
 		Grasshoppers_Leg: 6500
@@ -2974,7 +2919,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Bears_Foot: 9000
 		Poo_Poo_Hat: 5
@@ -3026,7 +2970,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Horseshoe: 6000
 		Blue_Herb: 500
@@ -3072,7 +3015,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Candy: 2000
 		Candy_Striper: 1000
@@ -3117,7 +3059,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Clover: 6500
 		Feather: 1000
@@ -3163,7 +3104,6 @@ mob_db: (
 	AttackDelay: 2492
 	AttackMotion: 792
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Rotten_Scale: 5500
 		Skel_Bone: 1500
@@ -3213,7 +3153,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Fin: 5335
 		Oridecon_Stone: 115
@@ -3260,7 +3199,6 @@ mob_db: (
 	AttackDelay: 1632
 	AttackMotion: 432
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 40
 		Nipper: 9000
@@ -3307,7 +3245,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 48
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 45
 		Conch: 5500
@@ -3353,7 +3290,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 432
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 25
 		Tentacle: 5500
@@ -3402,7 +3338,6 @@ mob_db: (
 	AttackDelay: 1968
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 10
 		Sharp_Scale: 9000
@@ -3449,7 +3384,6 @@ mob_db: (
 	AttackDelay: 1776
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 30
 		Worm_Peelings: 5500
@@ -3499,7 +3433,6 @@ mob_db: (
 	AttackDelay: 1754
 	AttackMotion: 554
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 3000
 		Pirate_Bandana: 15
@@ -3550,7 +3483,6 @@ mob_db: (
 	AttackDelay: 1700
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 	Drops: {
 		Flame_Heart: 30
 		Coal: 150
@@ -3596,7 +3528,6 @@ mob_db: (
 	AttackDelay: 992
 	AttackMotion: 792
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Crap_Shell: 5500
 		Nipper: 1500
@@ -3641,7 +3572,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Clam_Shell: 5500
 		Flesh_Of_Clam: 1000
@@ -3686,7 +3616,6 @@ mob_db: (
 	AttackDelay: 500
 	AttackMotion: 500
 	DamageMotion: 500
-	MvpExp: 0
 },*/
 {
 	Id: 1076
@@ -3723,7 +3652,6 @@ mob_db: (
 	AttackDelay: 2228
 	AttackMotion: 528
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Phracon: 90
 		Skel_Bone: 800
@@ -3772,7 +3700,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Poison_Spore: 9000
 		Hat_: 20
@@ -3817,7 +3744,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Red_Herb: 5500
 		Flower: 1000
@@ -3862,7 +3788,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Blue_Herb: 5500
 		Flower: 1000
@@ -3907,7 +3832,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Green_Herb: 7000
 		Poison_Herb_Makulata: 300
@@ -3952,7 +3876,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Yellow_Herb: 5500
 		Flower: 1000
@@ -3997,7 +3920,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		White_Herb: 5500
 		Flower: 1000
@@ -4042,7 +3964,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Blue_Herb: 5500
 		Yellow_Herb: 1000
@@ -4087,7 +4008,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Alchol: 50
 		Detrimindexta: 50
@@ -4132,7 +4052,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Alchol: 50
 		Karvodailnirol: 50
@@ -4299,7 +4218,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Oldmans_Romance: 50
 		Grasshoppers_Leg: 8000
@@ -4353,7 +4271,6 @@ mob_db: (
 	AttackDelay: 1236
 	AttackMotion: 336
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Big_Sis_Ribbon: 50
 		Honey: 2000
@@ -4407,7 +4324,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Snowy_Horn: 200
 		Unripe_Apple: 50
@@ -4461,7 +4377,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sweet_Gents: 200
 		Red_Herb: 8000
@@ -4515,7 +4430,6 @@ mob_db: (
 	AttackDelay: 1048
 	AttackMotion: 648
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Western_Grace: 200
 		Claw_Of_Wolves: 8000
@@ -4569,7 +4483,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Fillet: 200
 		Red_Herb: 8000
@@ -4617,7 +4530,6 @@ mob_db: (
 	AttackDelay: 2048
 	AttackMotion: 648
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 50
 		Snails_Shell: 9000
@@ -4665,7 +4577,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 9000
 		Garlet: 1000
@@ -4719,7 +4630,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Angelic_Chain: 100
 		Scapulare_: 60
@@ -4761,7 +4671,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 320
 		Shell: 2000
@@ -4812,7 +4721,6 @@ mob_db: (
 	AttackDelay: 1250
 	AttackMotion: 720
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Runstone_Ancient: 10
 		Healing_Staff: 10
@@ -4865,7 +4773,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Short_Leg: 5335
 		Zargon: 1200
@@ -4915,7 +4822,6 @@ mob_db: (
 	AttackDelay: 1468
 	AttackMotion: 468
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Spiderweb: 9000
 		Scell: 1200
@@ -4968,7 +4874,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 480
 	DamageMotion: 120
-	MvpExp: 0
 	Drops: {
 		Evil_Horn: 500
 		Oridecon: 63
@@ -5020,7 +4925,6 @@ mob_db: (
 	AttackDelay: 1504
 	AttackMotion: 840
 	DamageMotion: 900
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 200
 		Starsand_Of_Witch: 4850
@@ -5067,7 +4971,6 @@ mob_db: (
 	AttackDelay: 1604
 	AttackMotion: 840
 	DamageMotion: 756
-	MvpExp: 0
 	Drops: {
 		Porcupine_Spike: 9000
 		Coat_: 5
@@ -5113,7 +5016,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 1008
-	MvpExp: 0
 	Drops: {
 		Acorn: 9000
 		Hood_: 20
@@ -5161,7 +5063,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 9000
 		Garlet: 3000
@@ -5211,7 +5112,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 420
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Katar_: 1
 		Claw_Of_Desert_Wolf: 5500
@@ -5259,7 +5159,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 900
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Phracon: 85
 		Animals_Skin: 5500
@@ -5306,7 +5205,6 @@ mob_db: (
 	AttackDelay: 1680
 	AttackMotion: 480
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 25
 		Tooth_Of_Ancient_Fish: 9000
@@ -5359,7 +5257,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Horn: 5335
 		Petite_DiablOfs_Wing: 400
@@ -5407,7 +5304,6 @@ mob_db: (
 	AttackDelay: 1156
 	AttackMotion: 456
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dokkaebi_Horn: 9000
 		Elunium_Stone: 150
@@ -5457,7 +5353,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 60
 		Tooth_Of_Bat: 3000
@@ -5562,7 +5457,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7500
 		Rod_: 80
@@ -5610,7 +5504,6 @@ mob_db: (
 	AttackDelay: 1004
 	AttackMotion: 504
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Moth_Dust: 9000
 		Wing_Of_Moth: 500
@@ -5715,7 +5608,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 816
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Scell: 1000
 		Egg_Shell: 20
@@ -5767,7 +5659,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Biretta_: 10
 		Bone_Wand: 1
@@ -5813,7 +5704,6 @@ mob_db: (
 	AttackDelay: 1432
 	AttackMotion: 432
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Blossom_Of_Maneater: 9000
 		Sunflower: 3
@@ -5863,7 +5753,6 @@ mob_db: (
 	AttackDelay: 1540
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Lizard_Scruff: 5500
 		Elunium_Stone: 90
@@ -5917,7 +5806,6 @@ mob_db: (
 	AttackDelay: 1220
 	AttackMotion: 1080
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Transparent_Cloth: 5335
 		Ghost_Bandana: 100
@@ -5965,7 +5853,6 @@ mob_db: (
 	AttackDelay: 1848
 	AttackMotion: 1296
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Great_Nature: 30
 		Coal: 150
@@ -6016,7 +5903,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Iron: 270
 		Scell: 9000
@@ -6066,7 +5952,6 @@ mob_db: (
 	AttackDelay: 1320
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Iron: 250
 		Scell: 9000
@@ -6116,7 +6001,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Iron: 230
 		Scell: 9000
@@ -6166,7 +6050,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 100
 		Iron: 170
@@ -6216,7 +6099,6 @@ mob_db: (
 	AttackDelay: 3074
 	AttackMotion: 1874
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Iron: 150
 		Scell: 9000
@@ -6262,7 +6144,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 120
 		Earthworm_Peeling: 9000
@@ -6310,7 +6191,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 80
 		Emveretarcon: 35
@@ -6359,7 +6239,6 @@ mob_db: (
 	AttackDelay: 1888
 	AttackMotion: 1152
 	DamageMotion: 828
-	MvpExp: 0
 	Drops: {
 		Stone_Heart: 6500
 		Zargon: 500
@@ -6411,7 +6290,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Head: 9000
 		Zargon: 900
@@ -6463,7 +6341,6 @@ mob_db: (
 	AttackDelay: 1364
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Zargon: 2000
 		Old_Card_Album: 2
@@ -6515,7 +6392,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 1000
 	DamageMotion: 396
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 8000
 		Elunium: 191
@@ -6565,7 +6441,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 100
 		Cobold_Hair: 5335
@@ -6614,7 +6489,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 100
 		Cobold_Hair: 5335
@@ -6663,7 +6537,6 @@ mob_db: (
 	AttackDelay: 1228
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 35
 		Steel: 100
@@ -6713,7 +6586,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 50
 		Cobold_Hair: 5335
@@ -6763,7 +6635,6 @@ mob_db: (
 	AttackDelay: 1228
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 40
 		Cobold_Hair: 5335
@@ -6811,7 +6682,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 504
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Frying_Pan: 9000
 		Garlet: 800
@@ -6862,7 +6732,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 660
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 110
 		Limb_Of_Mantis: 9000
@@ -6912,7 +6781,6 @@ mob_db: (
 	AttackDelay: 1540
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Flame_Heart: 35
 		Sacred_Masque: 4365
@@ -6958,7 +6826,6 @@ mob_db: (
 	AttackDelay: 2280
 	AttackMotion: 1080
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 5000
 		Sticky_Mucus: 1500
@@ -6999,7 +6866,6 @@ mob_db: (
 	AttackDelay: 1201
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Tendon: 5000
 		Detonator: 2500
@@ -7049,7 +6915,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 1056
-	MvpExp: 0
 	Drops: {
 		Golden_Hair: 9000
 		Star_Dust: 5
@@ -7096,7 +6961,6 @@ mob_db: (
 	AttackDelay: 1956
 	AttackMotion: 756
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Chinese_Ink: 9000
 		Tentacle: 3000
@@ -7142,7 +7006,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moustache_Of_Mole: 9000
 		Nail_Of_Mole: 500
@@ -7192,7 +7055,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Matyrs_Flea_Guard: 10
 		Monsters_Feed: 5000
@@ -7303,7 +7165,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 1320
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Slender_Snake: 5335
 		Whip_Of_Red_Flame: 250
@@ -7353,7 +7214,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 5335
 		Oridecon_Stone: 196
@@ -7464,7 +7324,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Gas_Mask: 2
 		Wooden_Block: 800
@@ -7514,7 +7373,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Orcish_Cuspid: 5500
 		Skel_Bone: 3500
@@ -7563,7 +7421,6 @@ mob_db: (
 	AttackDelay: 2852
 	AttackMotion: 1152
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Nail_Of_Orc: 5500
 		Sticky_Mucus: 3000
@@ -7609,7 +7466,6 @@ mob_db: (
 	AttackDelay: 976
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Vroken_Sword: 4365
 		Honey_Jar: 2500
@@ -7658,7 +7514,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Dragon_Canine: 5335
 		Dragon_Train: 300
@@ -7708,7 +7563,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Dragon_Scale: 5335
 		Dragon_Train: 300
@@ -7814,7 +7668,6 @@ mob_db: (
 	AttackDelay: 2544
 	AttackMotion: 1344
 	DamageMotion: 1152
-	MvpExp: 0
 	Drops: {
 		Fish_Tail: 5500
 		Sharp_Scale: 2000
@@ -7920,7 +7773,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 9000
 		Garlet: 1100
@@ -7966,7 +7818,6 @@ mob_db: (
 	AttackDelay: 2208
 	AttackMotion: 1008
 	DamageMotion: 324
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 9000
 		Garlet: 300
@@ -8016,7 +7867,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 528
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Root_Of_Maneater: 5500
 		Scell: 1600
@@ -8066,7 +7916,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 780
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Elunium: 106
 		Iron_Cane: 1
@@ -8116,7 +7965,6 @@ mob_db: (
 	AttackDelay: 1516
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Blue_Box: 35
 		Emperium: 1
@@ -8166,7 +8014,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 720
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Great_Nature: 35
 		Grit: 5335
@@ -8213,7 +8060,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wild_Boars_Mane: 9000
 		Grape: 300
@@ -8259,7 +8105,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Animals_Skin: 9000
 		Axe_: 100
@@ -8308,7 +8153,6 @@ mob_db: (
 	AttackDelay: 1700
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 	Drops: {
 		Flame_Heart: 45
 		Tweezer: 4850
@@ -8357,7 +8201,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Iron: 400
 		Lantern: 5500
@@ -8405,7 +8248,6 @@ mob_db: (
 	AttackDelay: 2112
 	AttackMotion: 912
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Long_Hair: 9000
 		Skirt_Of_Virgin: 50
@@ -8455,7 +8297,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Jaws_Of_Ant: 2700
 		Scell: 800
@@ -8504,7 +8345,6 @@ mob_db: (
 	AttackDelay: 2000
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 	Drops: {
 		Jaws_Of_Ant: 5500
 		Scell: 2000
@@ -8553,7 +8393,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Jaws_Of_Ant: 3100
 		Scell: 800
@@ -8600,7 +8439,6 @@ mob_db: (
 	AttackDelay: 1688
 	AttackMotion: 1188
 	DamageMotion: 612
-	MvpExp: 0
 	Drops: {
 		Wind_Of_Verdure: 70
 		Emveretarcon: 30
@@ -8647,7 +8485,6 @@ mob_db: (
 	AttackDelay: 1744
 	AttackMotion: 1044
 	DamageMotion: 684
-	MvpExp: 0
 	Drops: {
 		Rat_Tail: 9000
 		Animals_Skin: 3000
@@ -8693,7 +8530,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 90
 		Worm_Peelings: 5000
@@ -8740,7 +8576,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Tooth_Of_: 5500
 		Oridecon_Stone: 70
@@ -8789,7 +8624,6 @@ mob_db: (
 	AttackDelay: 1780
 	AttackMotion: 1080
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 55
 		Iron: 190
@@ -8840,7 +8674,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 150
 		Transparent_Cloth: 5335
@@ -8889,7 +8722,6 @@ mob_db: (
 	AttackDelay: 840
 	AttackMotion: 540
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fox_Tail: 4656
 		Glass_Bead: 200
@@ -8943,7 +8775,6 @@ mob_db: (
 	AttackDelay: 2700
 	AttackMotion: 1000
 	DamageMotion: 500
-	MvpExp: 0
 },
 {
 	Id: 1182
@@ -8978,7 +8809,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Mushroom_Of_Thief_1: 3000
 		Mushroom_Of_Thief_2: 6000
@@ -9023,7 +8853,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Iron: 50
 		Shell: 5500
@@ -9073,7 +8902,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fluff: 2000
 		Feather: 250
@@ -9114,7 +8942,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 10
 		Transparent_Cloth: 100
@@ -9162,7 +8989,6 @@ mob_db: (
 	AttackDelay: 2536
 	AttackMotion: 1536
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 150
 		Transparent_Cloth: 5335
@@ -9209,7 +9035,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 500
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Short_Daenggie: 5500
 		Old_Portrait: 40
@@ -9259,7 +9084,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 620
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sharpened_Cuspid: 4656
 		Steel_Arrow: 1000
@@ -9367,7 +9191,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 500
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 5
 		Old_Blue_Box: 45
@@ -9419,7 +9242,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 576
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Transparent_Cloth: 5820
 		Wedding_Veil: 10
@@ -9471,7 +9293,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 500
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Needle_Of_Alarm: 5335
 		Clip: 1
@@ -9523,7 +9344,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 500
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Round_Shell: 3500
 		Sticky_Mucus: 3000
@@ -9575,7 +9395,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Page: 4850
 		Book_Of_Billows: 4
@@ -9625,7 +9444,6 @@ mob_db: (
 	AttackDelay: 1848
 	AttackMotion: 500
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Manacles: 3500
 		Spoon_Stub: 100
@@ -9675,7 +9493,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Prison_Uniform: 3500
 		Spoon_Stub: 105
@@ -9727,7 +9544,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 1252
 	DamageMotion: 476
-	MvpExp: 0
 	Drops: {
 		Book_Of_The_Apocalypse: 5
 		Rosary: 30
@@ -9777,7 +9593,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Mould_Powder: 5335
 		Yellow_Gemstone: 800
@@ -9828,7 +9643,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 2112
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Executioners_Mitten: 5
 		Black_Butterfly_Mask: 10
@@ -9879,7 +9693,6 @@ mob_db: (
 	AttackDelay: 1790
 	AttackMotion: 1440
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Thin_N_Long_Tongue: 3880
 		Executioners_Mitten: 3
@@ -9929,7 +9742,6 @@ mob_db: (
 	AttackDelay: 1744
 	AttackMotion: 1344
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Thin_N_Long_Tongue: 3880
 		Executioners_Mitten: 4
@@ -9982,7 +9794,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Lokis_Whispers: 1
 		Biotite: 1500
@@ -10037,7 +9848,6 @@ mob_db: (
 	AttackDelay: 816
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Old_Hilt: 1
 		Silver_Knife_Of_Chaste: 50
@@ -10091,7 +9901,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 500
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Bloody_Edge: 5
 		Phlogopite: 1500
@@ -10143,7 +9952,6 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 500
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Anolian_Skin: 4850
 		Crystal_Arrow: 2000
@@ -10195,7 +10003,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Mud_Lump: 4850
 		Stone_Arrow: 1500
@@ -10249,7 +10056,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Skull: 4850
 		Old_Card_Album: 1
@@ -10299,7 +10105,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Claw_Of_Rat: 4656
 		Monsters_Feed: 1000
@@ -10349,7 +10154,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Stiff_Horn: 4850
 		Horn: 8000
@@ -10400,7 +10204,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Glitter_Shell: 5335
 		Wind_Of_Verdure: 200
@@ -10451,7 +10254,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Tail_Of_Steel_Scorpion: 5335
 		Elunium_Stone: 229
@@ -10502,7 +10304,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Ogre_Tooth: 2500
 		Orcish_Axe: 10
@@ -10552,7 +10353,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Claw_Of_Monkey: 5335
 		Yoyo_Tail: 7000
@@ -10602,7 +10402,6 @@ mob_db: (
 	AttackDelay: 1956
 	AttackMotion: 756
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Tough_Scalelike_Stem: 5335
 		White_Herb: 1800
@@ -10654,7 +10453,6 @@ mob_db: (
 	AttackDelay: 832
 	AttackMotion: 500
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Coral_Reef: 4850
 		Tentacle: 8000
@@ -10707,7 +10505,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Reins: 5335
 		Blade_Lost_In_Darkness: 5
@@ -10759,7 +10556,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 420
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Katar_: 5
 		Claw_Of_Desert_Wolf: 5500
@@ -10810,7 +10606,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wild_Boars_Mane: 6000
 		Grape: 150
@@ -10861,7 +10656,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Ogre_Tooth: 2500
 		Orcish_Axe: 10
@@ -10913,7 +10707,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Iron: 210
 		Orcish_Voucher: 5500
@@ -10965,7 +10758,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mushroom_Spore: 8000
 		Hat_: 20
@@ -11015,7 +10807,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Claw_Of_Monkey: 5335
 		Yoyo_Tail: 7000
@@ -11067,7 +10858,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 90
 		Cobold_Hair: 5820
@@ -11118,7 +10908,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Iron: 270
 		Scell: 1200
@@ -11170,7 +10959,6 @@ mob_db: (
 	AttackDelay: 2544
 	AttackMotion: 1344
 	DamageMotion: 1152
-	MvpExp: 0
 	Drops: {
 		Fish_Tail: 6000
 		Sharp_Scale: 2300
@@ -11216,7 +11004,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fluff: 6500
 		Feather: 600
@@ -11261,7 +11048,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 300
 		Chrysalis: 6000
@@ -11308,7 +11094,6 @@ mob_db: (
 	AttackDelay: 1220
 	AttackMotion: 720
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Powder_Of_Butterfly: 6000
 		Silk_Robe_: 10
@@ -11349,7 +11134,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 120
 		Shell: 1500
@@ -11395,7 +11179,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Bill_Of_Birds: 6000
 		Sandals_: 20
@@ -11443,7 +11226,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 54
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yoyo_Tail: 6000
 		Cacao: 500
@@ -11493,7 +11275,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Iron: 210
 		Orcish_Voucher: 5500
@@ -11535,7 +11316,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Phracon: 135
 		Shell: 2740
@@ -11582,7 +11362,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 6000
 		Garlet: 3000
@@ -11630,7 +11409,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 5700
 		Garlet: 1100
@@ -11678,7 +11456,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 6000
 		Garlet: 3000
@@ -11724,7 +11501,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 168
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Birds: 6500
 		Feather: 850
@@ -11769,7 +11545,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 168
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Birds: 6500
 		Feather: 850
@@ -11816,7 +11591,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Garlet: 3200
 		Sticky_Mucus: 1500
@@ -11868,7 +11642,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Zargon: 750
 		White_Herb: 800
@@ -11914,7 +11687,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Head: 5335
 		Zargon: 900
@@ -11960,7 +11732,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Packing_Ribbon: 550
 		Packing_Paper: 550
@@ -12007,7 +11778,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Well_Baked_Cookie: 1500
 		Scarlet_Jewel: 45
@@ -12054,7 +11824,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Red_Socks_With_Holes: 10000
 		Gift_Box: 2000
@@ -12102,7 +11871,6 @@ mob_db: (
 	AttackDelay: 1296
 	AttackMotion: 1296
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Manacles: 900
 		Holy_Bonnet: 2
@@ -12149,7 +11917,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Candy_Striper: 90
 		Light_Granule: 10
@@ -12201,7 +11968,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Matchstick: 2500
 		Zargon: 750
@@ -12370,7 +12136,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Zargon: 3880
 		Petite_DiablOfs_Wing: 500
@@ -12421,7 +12186,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 900
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Cyfar: 3000
 		Feather_Of_Birds: 5000
@@ -12474,7 +12238,6 @@ mob_db: (
 	AttackDelay: 776
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Earthworm_Peeling: 5100
 		Cyfar: 1000
@@ -12526,7 +12289,6 @@ mob_db: (
 	AttackDelay: 700
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Earthworm_Peeling: 5500
 		Brigan: 200
@@ -12577,7 +12339,6 @@ mob_db: (
 	AttackDelay: 770
 	AttackMotion: 720
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Steel: 300
 		Brigan: 5335
@@ -12625,7 +12386,6 @@ mob_db: (
 	AttackDelay: 1172
 	AttackMotion: 672
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Goblini_Mask: 3
 		Iron: 250
@@ -12679,7 +12439,6 @@ mob_db: (
 	AttackDelay: 704
 	AttackMotion: 504
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Talon_Of_Griffin: 2500
 		Brigan: 5335
@@ -12732,7 +12491,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 720
 	DamageMotion: 200
-	MvpExp: 0
 	Drops: {
 		Brigan: 4656
 		Red_Frame: 1000
@@ -12777,7 +12535,6 @@ mob_db: (
 	AttackDelay: 964
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Cyfar: 5335
 		Witherless_Rose: 50
@@ -12832,7 +12589,6 @@ mob_db: (
 	AttackDelay: 1280
 	AttackMotion: 1080
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Brigan: 4850
 		Dragon_Canine: 500
@@ -12885,7 +12641,6 @@ mob_db: (
 	AttackDelay: 1056
 	AttackMotion: 1056
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Zargon: 4559
 		Skel_Bone: 6000
@@ -12937,7 +12692,6 @@ mob_db: (
 	AttackDelay: 916
 	AttackMotion: 816
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Lip_Of_Ancient_Fish: 1300
 		Plate_Armor_: 2
@@ -12985,7 +12739,6 @@ mob_db: (
 	AttackDelay: 1036
 	AttackMotion: 936
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Well_Baked_Cookie: 1000
 		Candy_Striper: 150
@@ -13032,7 +12785,6 @@ mob_db: (
 	AttackDelay: 1264
 	AttackMotion: 864
 	DamageMotion: 216
-	MvpExp: 0
 	Drops: {
 		Sticky_Mucus: 500
 		Coral_Reef: 40
@@ -13084,7 +12836,6 @@ mob_db: (
 	AttackDelay: 1078
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Brigan: 3200
 		Ice_Cream: 1000
@@ -13134,7 +12885,6 @@ mob_db: (
 	AttackDelay: 828
 	AttackMotion: 528
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Brigan: 4850
 		Helm_: 45
@@ -13181,7 +12931,6 @@ mob_db: (
 	AttackDelay: 1092
 	AttackMotion: 792
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Needle_Of_Alarm: 5335
 		Wooden_Block: 800
@@ -13229,7 +12978,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Needle_Of_Alarm: 5335
 		Brigan: 5335
@@ -13276,7 +13024,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 900
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Zargon: 1000
 		Worn_Out_Prison_Uniform: 600
@@ -13385,7 +13132,6 @@ mob_db: (
 	AttackDelay: 1050
 	AttackMotion: 900
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4656
 		Puente_Robe: 3
@@ -13431,7 +13177,6 @@ mob_db: (
 	AttackDelay: 1332
 	AttackMotion: 1332
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Zargon: 100
 		Stone: 1000
@@ -13476,7 +13221,6 @@ mob_db: (
 	AttackDelay: 502
 	AttackMotion: 1999
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Alices_Apron: 2500
 		Old_Broom: 40
@@ -13525,7 +13269,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Brigan: 4656
 		Chain_Mail_: 2
@@ -13570,7 +13313,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Brigan: 2000
 		Wooden_Block: 2000
@@ -13617,7 +13359,6 @@ mob_db: (
 	AttackDelay: 1264
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mud_Lump: 2000
 		Brigan: 4850
@@ -13670,7 +13411,6 @@ mob_db: (
 	AttackDelay: 860
 	AttackMotion: 660
 	DamageMotion: 624
-	MvpExp: 0
 	Drops: {
 		Cyfar: 100
 		Solid_Shell: 380
@@ -13717,7 +13457,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1008
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Scell: 2500
 		Cyfar: 3880
@@ -13764,7 +13503,6 @@ mob_db: (
 	AttackDelay: 936
 	AttackMotion: 936
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Librarian_Glove: 5
 		Worn_Out_Page: 1000
@@ -13812,7 +13550,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1008
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Zargon: 250
 		Steel: 60
@@ -13866,7 +13603,6 @@ mob_db: (
 	AttackDelay: 772
 	AttackMotion: 672
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 5335
 		Slender_Snake: 2500
@@ -13913,7 +13649,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Apple: 100
 		Apple: 100
@@ -13967,7 +13702,6 @@ mob_db: (
 	AttackDelay: 1200
 	AttackMotion: 1200
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1286
@@ -14010,7 +13744,6 @@ mob_db: (
 	AttackDelay: 1200
 	AttackMotion: 1200
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1287
@@ -14050,7 +13783,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1288
@@ -14088,7 +13820,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1289
@@ -14132,7 +13863,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 1000
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4413
 		Elunium_Stone: 250
@@ -14184,7 +13914,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Burn_Tree: 2550
 		Oridecon_Stone: 160
@@ -14236,7 +13965,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 576
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Transparent_Cloth: 4413
 		Wedding_Veil: 10
@@ -14289,7 +14017,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Horn: 4413
 		Petite_DiablOfs_Wing: 450
@@ -14342,7 +14069,6 @@ mob_db: (
 	AttackDelay: 1136
 	AttackMotion: 720
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Powder_Of_Butterfly: 4550
 		Silver_Robe_: 10
@@ -14395,7 +14121,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 660
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Limb_Of_Mantis: 4550
 		Solid_Shell: 2500
@@ -14449,7 +14174,6 @@ mob_db: (
 	AttackDelay: 1345
 	AttackMotion: 824
 	DamageMotion: 440
-	MvpExp: 0
 	Drops: {
 		Tatters_Clothes: 3500
 		Soft_Feather: 2500
@@ -14501,7 +14225,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 450
 		Cobold_Hair: 6305
@@ -14553,7 +14276,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 120
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Rotten_Bandage: 4413
 		Mementos: 1800
@@ -14605,7 +14327,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Tatters_Clothes: 4413
 		Sticky_Mucus: 1500
@@ -14657,7 +14378,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Brigan: 1500
 		Steel: 800
@@ -14710,7 +14430,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Feather: 3000
 		Brigan: 5335
@@ -14763,7 +14482,6 @@ mob_db: (
 	AttackDelay: 1156
 	AttackMotion: 456
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dokkaebi_Horn: 4550
 		Elunium_Stone: 250
@@ -14817,7 +14535,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Bone_Wand: 3
 		Bone_Helm: 2
@@ -14870,7 +14587,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 340
-	MvpExp: 0
 	Drops: {
 		Royal_Jelly: 550
 		Honey: 1200
@@ -14923,7 +14639,6 @@ mob_db: (
 	AttackDelay: 1468
 	AttackMotion: 468
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Spiderweb: 4550
 		Short_Leg: 1200
@@ -14976,7 +14691,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Short_Leg: 4413
 		Zargon: 2500
@@ -15028,7 +14742,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 230
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Bears_Foot: 4550
 		Poo_Poo_Hat: 8
@@ -15082,7 +14795,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Puppy_Love: 1
 		Silver_Knife_Of_Chaste: 150
@@ -15134,7 +14846,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 1008
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4413
 		Brigan: 3500
@@ -15186,7 +14897,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 1152
 	DamageMotion: 828
-	MvpExp: 0
 	Drops: {
 		Stone_Heart: 6500
 		Zargon: 2300
@@ -15238,7 +14948,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 960
 	DamageMotion: 780
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 4413
 		Two_Handed_Axe_: 4
@@ -15290,7 +14999,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wild_Boars_Mane: 3500
 		Grape: 290
@@ -15402,7 +15110,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 560
 	DamageMotion: 580
-	MvpExp: 0
 	Drops: {
 		Poison_Knife: 3
 		Blue_Jewel: 4559
@@ -15449,7 +15156,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Coconut_Fruit: 200
@@ -15501,7 +15207,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 780
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Armor_Piece: 1200
@@ -15548,7 +15253,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 64
@@ -15599,7 +15303,6 @@ mob_db: (
 	AttackDelay: 1612
 	AttackMotion: 622
 	DamageMotion: 583
-	MvpExp: 0
 	Drops: {
 		Zargon: 4365
 		Blue_Herb: 250
@@ -15651,7 +15354,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 750
@@ -15703,7 +15405,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 850
@@ -15757,7 +15458,6 @@ mob_db: (
 	AttackDelay: 1345
 	AttackMotion: 824
 	DamageMotion: 440
-	MvpExp: 0
 	Drops: {
 		Tatters_Clothes: 4413
 		Soft_Feather: 1500
@@ -15810,7 +15510,6 @@ mob_db: (
 	AttackDelay: 862
 	AttackMotion: 534
 	DamageMotion: 312
-	MvpExp: 0
 	Drops: {
 		Dragon_Fly_Wing: 4413
 		Round_Shell: 400
@@ -15857,7 +15556,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 552
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Brigan: 3500
 		Cyfar: 2500
@@ -15907,7 +15605,6 @@ mob_db: (
 	AttackDelay: 1132
 	AttackMotion: 583
 	DamageMotion: 532
-	MvpExp: 0
 	Drops: {
 		Scarlet_Jewel: 150
 		Clam_Shell: 5500
@@ -15954,7 +15651,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16000,7 +15696,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16046,7 +15741,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16092,7 +15786,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16138,7 +15831,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16184,7 +15876,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16230,7 +15921,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16276,7 +15966,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16322,7 +16011,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16368,7 +16056,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16414,7 +16101,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16460,7 +16146,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16506,7 +16191,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16552,7 +16236,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16598,7 +16281,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16644,7 +16326,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16690,7 +16371,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16736,7 +16416,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16782,7 +16461,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16828,7 +16506,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16874,7 +16551,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -16920,7 +16596,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -16966,7 +16641,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17012,7 +16686,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -17058,7 +16731,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17104,7 +16776,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -17150,7 +16821,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17196,7 +16866,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -17242,7 +16911,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17288,7 +16956,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -17334,7 +17001,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17380,7 +17046,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -17426,7 +17091,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17472,7 +17136,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -17518,7 +17181,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17564,7 +17226,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -17610,7 +17271,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17656,7 +17316,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -17702,7 +17361,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Crystal_Jewel__: 7760
 		Seed_Of_Yggdrasil: 3000
@@ -17748,7 +17406,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		God_Material_Box: 10
 		Union_Of_Tribe: 500
@@ -17802,7 +17459,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 900
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Wooden_Block: 9000
 	}
@@ -17842,7 +17498,6 @@ mob_db: (
 	AttackDelay: 1840
 	AttackMotion: 1440
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Broken_Steel_Piece: 5335
 		Mystery_Piece: 2400
@@ -17892,7 +17547,6 @@ mob_db: (
 	AttackDelay: 2190
 	AttackMotion: 2040
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Cold_Magma: 4559
 		Burning_Heart: 3686
@@ -17944,7 +17598,6 @@ mob_db: (
 	AttackDelay: 1732
 	AttackMotion: 1332
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 4850
 		Live_Coal: 3400
@@ -17986,7 +17639,6 @@ mob_db: (
 	AttackDelay: 1308
 	AttackMotion: 1008
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Blossom_Of_Maneater: 6200
 		Root_Of_Maneater: 5500
@@ -18032,7 +17684,6 @@ mob_db: (
 	AttackDelay: 1460
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Peco_Wing_Feather: 4850
 		Fruit_Of_Mastela: 300
@@ -18083,7 +17734,6 @@ mob_db: (
 	AttackDelay: 1306
 	AttackMotion: 1056
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Fruit_Of_Mastela: 1500
 		Chrystal_Pumps: 3
@@ -18134,7 +17784,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 720
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Blue_Gemstone: 1000
 		Yellow_Gemstone: 1000
@@ -18180,7 +17829,6 @@ mob_db: (
 	AttackDelay: 1380
 	AttackMotion: 1080
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Goats_Horn: 4559
 		Gaoats_Skin: 2500
@@ -18293,7 +17941,6 @@ mob_db: (
 	AttackDelay: 850
 	AttackMotion: 600
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Fruit_Of_Mastela: 1500
 		White_Herb: 5500
@@ -18343,7 +17990,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 864
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Smooth_Paper: 4947
 		Fright_Paper_Blade: 3200
@@ -18392,7 +18038,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 672
 	DamageMotion: 470
-	MvpExp: 0
 	Drops: {
 		Harpys_Feather: 4850
 		Harpys_Claw: 2500
@@ -18441,7 +18086,6 @@ mob_db: (
 	AttackDelay: 1552
 	AttackMotion: 1152
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Old_Magic_Circle: 4000
 		Rent_Spell_Book: 1500
@@ -18492,7 +18136,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Spawns: 4074
 		Mould_Powder: 4559
@@ -18540,7 +18183,6 @@ mob_db: (
 	AttackDelay: 1216
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Burning_Horse_Shoe: 4947
 		Rosary_: 1
@@ -18590,7 +18232,6 @@ mob_db: (
 	AttackDelay: 1300
 	AttackMotion: 900
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Lizard_Scruff: 7500
 		Yellow_Gemstone: 3880
@@ -18636,7 +18277,6 @@ mob_db: (
 	AttackDelay: 1492
 	AttackMotion: 1092
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Bears_Foot: 5000
 		Animals_Skin: 5000
@@ -18684,7 +18324,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 780
 	DamageMotion: 180
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Horn: 5820
 		Petite_DiablOfs_Wing: 4850
@@ -18732,7 +18371,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Wing_Of_Red_Bat: 5500
 		Burning_Heart: 2200
@@ -18780,7 +18418,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dragons_Skin: 4074
 		Dragon_Canine: 5335
@@ -18827,7 +18464,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 624
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Dragons_Skin: 4074
 		Dragon_Canine: 5335
@@ -18875,7 +18511,6 @@ mob_db: (
 	AttackDelay: 1350
 	AttackMotion: 1200
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Sand_Lump: 4947
 		Grit: 5335
@@ -18925,7 +18560,6 @@ mob_db: (
 	AttackDelay: 1264
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scropions_Nipper: 4365
 		Scorpions_Tail: 5500
@@ -18978,7 +18612,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Satanic_Chain: 5
 		Leaf_Of_Yggdrasil: 1800
@@ -19084,7 +18717,6 @@ mob_db: (
 	AttackDelay: 1356
 	AttackMotion: 1056
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Golden_Hair: 6305
 		High_end_Cooking_Kits: 50
@@ -19133,7 +18765,6 @@ mob_db: (
 	AttackDelay: 1430
 	AttackMotion: 1080
 	DamageMotion: 1080
-	MvpExp: 0
 	Drops: {
 		Cyfar: 5335
 		Coconut_Fruit: 300
@@ -19181,7 +18812,6 @@ mob_db: (
 	AttackDelay: 2416
 	AttackMotion: 2016
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 500
 		Padded_Armor: 1
@@ -19231,7 +18861,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1394
@@ -19271,7 +18900,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1395
@@ -19309,7 +18937,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -19357,7 +18984,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -19404,7 +19030,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -19451,7 +19076,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -19557,7 +19181,6 @@ mob_db: (
 	AttackDelay: 1638
 	AttackMotion: 2016
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Oil_Paper: 5000
 		Bamboo_Cut: 4268
@@ -19609,7 +19232,6 @@ mob_db: (
 	AttackDelay: 1003
 	AttackMotion: 1152
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Broken_Shuriken: 5335
 		Ninja_Suit: 2
@@ -19656,7 +19278,6 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 1728
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Poison_Toads_Skin: 5500
 		Poison_Powder: 2400
@@ -19705,7 +19326,6 @@ mob_db: (
 	AttackDelay: 1084
 	AttackMotion: 2304
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Iron: 5500
 		Apple_Of_Archer: 1
@@ -19754,7 +19374,6 @@ mob_db: (
 	AttackDelay: 1938
 	AttackMotion: 2112
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Glossy_Hair: 5335
 		Old_Japaness_Clothes: 2500
@@ -19805,7 +19424,6 @@ mob_db: (
 	AttackDelay: 1439
 	AttackMotion: 1920
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Tengus_Nose: 3500
 		Broken_Wine_Vessel: 5500
@@ -19855,7 +19473,6 @@ mob_db: (
 	AttackDelay: 2012
 	AttackMotion: 1728
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Yellow_Plate: 6500
 		Cyfar: 3500
@@ -19897,7 +19514,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },*/
 // Gonryun (6.1)
 {
@@ -19939,7 +19555,6 @@ mob_db: (
 	AttackDelay: 472
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Sharp_Feeler: 4608
 		Great_Wing: 2500
@@ -19986,7 +19601,6 @@ mob_db: (
 	AttackDelay: 1247
 	AttackMotion: 768
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Bamboo_Cut: 3200
 		Oil_Paper: 2500
@@ -20034,7 +19648,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Hard_Peach: 4365
 		Elder_Branch: 100
@@ -20075,7 +19688,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 1412
@@ -20114,7 +19726,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 840
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Cloud_Piece: 4656
 		Cheese: 5600
@@ -20162,7 +19773,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 756
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Leaflet_Of_Hinal: 3500
 		Leaflet_Of_Aloe: 3500
@@ -20204,7 +19814,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 1415
@@ -20244,7 +19853,6 @@ mob_db: (
 	AttackDelay: 318
 	AttackMotion: 528
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Leopard_Skin: 5200
 		Leopard_Talon: 3200
@@ -20297,7 +19905,6 @@ mob_db: (
 	AttackDelay: 637
 	AttackMotion: 1008
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Limpid_Celestial_Robe: 3977
 		Soft_Silk_Cloth: 1380
@@ -20344,7 +19951,6 @@ mob_db: (
 	AttackDelay: 780
 	AttackMotion: 1008
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Black_Bears_Skin: 4462
 		Mystery_Iron_Bit: 3500
@@ -20451,7 +20057,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1420
@@ -20491,7 +20096,6 @@ mob_db: (
 	AttackDelay: 2864
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1421
@@ -20532,7 +20136,6 @@ mob_db: (
 	AttackDelay: 1384
 	AttackMotion: 768
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1422
@@ -20573,7 +20176,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1423
@@ -20613,7 +20215,6 @@ mob_db: (
 	AttackDelay: 2456
 	AttackMotion: 912
 	DamageMotion: 504
-	MvpExp: 0
 },
 {
 	Id: 1424
@@ -20653,7 +20254,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1425
@@ -20693,7 +20293,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1426
@@ -20733,7 +20332,6 @@ mob_db: (
 	AttackDelay: 1272
 	AttackMotion: 72
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1427
@@ -20774,7 +20372,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1428
@@ -20814,7 +20411,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1429
@@ -20855,7 +20451,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1430
@@ -20896,7 +20491,6 @@ mob_db: (
 	AttackDelay: 1468
 	AttackMotion: 468
 	DamageMotion: 768
-	MvpExp: 0
 },
 {
 	Id: 1431
@@ -20937,7 +20531,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 480
 	DamageMotion: 120
-	MvpExp: 0
 },
 {
 	Id: 1432
@@ -20977,7 +20570,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 420
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1433
@@ -21018,7 +20610,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1434
@@ -21058,7 +20649,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1435
@@ -21098,7 +20688,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1436
@@ -21138,7 +20727,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1437
@@ -21178,7 +20766,6 @@ mob_db: (
 	AttackDelay: 1364
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1438
@@ -21218,7 +20805,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 1000
 	DamageMotion: 396
-	MvpExp: 0
 },
 {
 	Id: 1439
@@ -21258,7 +20844,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1440
@@ -21298,7 +20883,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1441
@@ -21338,7 +20922,6 @@ mob_db: (
 	AttackDelay: 832
 	AttackMotion: 500
 	DamageMotion: 600
-	MvpExp: 0
 },
 {
 	Id: 1442
@@ -21378,7 +20961,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1443
@@ -21418,7 +21000,6 @@ mob_db: (
 	AttackDelay: 1296
 	AttackMotion: 1296
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Undelivered_Gift: 10000
 	}
@@ -21461,7 +21042,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1445
@@ -21501,7 +21081,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 900
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1446
@@ -21541,7 +21120,6 @@ mob_db: (
 	AttackDelay: 770
 	AttackMotion: 720
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1447
@@ -21583,7 +21161,6 @@ mob_db: (
 	AttackDelay: 704
 	AttackMotion: 504
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1448
@@ -21624,7 +21201,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 720
 	DamageMotion: 200
-	MvpExp: 0
 },
 {
 	Id: 1449
@@ -21667,7 +21243,6 @@ mob_db: (
 	AttackDelay: 1280
 	AttackMotion: 1080
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1450
@@ -21708,7 +21283,6 @@ mob_db: (
 	AttackDelay: 1056
 	AttackMotion: 1056
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1451
@@ -21748,7 +21322,6 @@ mob_db: (
 	AttackDelay: 916
 	AttackMotion: 816
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1452
@@ -21788,7 +21361,6 @@ mob_db: (
 	AttackDelay: 1050
 	AttackMotion: 900
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1453
@@ -21829,7 +21401,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1454
@@ -21870,7 +21441,6 @@ mob_db: (
 	AttackDelay: 860
 	AttackMotion: 660
 	DamageMotion: 624
-	MvpExp: 0
 },
 {
 	Id: 1455
@@ -21910,7 +21480,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1008
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1456
@@ -21952,7 +21521,6 @@ mob_db: (
 	AttackDelay: 772
 	AttackMotion: 672
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1457
@@ -21993,7 +21561,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 660
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1458
@@ -22033,7 +21600,6 @@ mob_db: (
 	AttackDelay: 1540
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 },
 {
 	Id: 1459
@@ -22074,7 +21640,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 1056
-	MvpExp: 0
 },
 {
 	Id: 1460
@@ -22114,7 +21679,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1461
@@ -22154,7 +21718,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1462
@@ -22194,7 +21757,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1463
@@ -22234,7 +21796,6 @@ mob_db: (
 	AttackDelay: 2852
 	AttackMotion: 1152
 	DamageMotion: 840
-	MvpExp: 0
 },
 {
 	Id: 1464
@@ -22274,7 +21835,6 @@ mob_db: (
 	AttackDelay: 976
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1465
@@ -22314,7 +21874,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 620
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1466
@@ -22354,7 +21913,6 @@ mob_db: (
 	AttackDelay: 1420
 	AttackMotion: 1080
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1467
@@ -22394,7 +21952,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 780
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1468
@@ -22435,7 +21992,6 @@ mob_db: (
 	AttackDelay: 1516
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1469
@@ -22475,7 +22031,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1470
@@ -22515,7 +22070,6 @@ mob_db: (
 	AttackDelay: 1780
 	AttackMotion: 1080
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1471
@@ -22555,7 +22109,6 @@ mob_db: (
 	AttackDelay: 840
 	AttackMotion: 540
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1472
@@ -22595,7 +22148,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 500
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1473
@@ -22635,7 +22187,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 620
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1474
@@ -22675,7 +22226,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 500
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1475
@@ -22715,7 +22265,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 576
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1476
@@ -22755,7 +22304,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 500
 	DamageMotion: 768
-	MvpExp: 0
 },
 {
 	Id: 1477
@@ -22797,7 +22345,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 500
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1478
@@ -22837,7 +22384,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1479
@@ -22877,7 +22423,6 @@ mob_db: (
 	AttackDelay: 1848
 	AttackMotion: 500
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1480
@@ -22917,7 +22462,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1481
@@ -22957,7 +22501,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1482
@@ -22998,7 +22541,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 792
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1483
@@ -23039,7 +22581,6 @@ mob_db: (
 	AttackDelay: 1790
 	AttackMotion: 1440
 	DamageMotion: 540
-	MvpExp: 0
 },
 {
 	Id: 1484
@@ -23079,7 +22620,6 @@ mob_db: (
 	AttackDelay: 1744
 	AttackMotion: 1344
 	DamageMotion: 600
-	MvpExp: 0
 },
 {
 	Id: 1485
@@ -23121,7 +22661,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1486
@@ -23164,7 +22703,6 @@ mob_db: (
 	AttackDelay: 816
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1487
@@ -23206,7 +22744,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 500
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1488
@@ -23246,7 +22783,6 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 500
 	DamageMotion: 864
-	MvpExp: 0
 },
 {
 	Id: 1489
@@ -23286,7 +22822,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1490
@@ -23328,7 +22863,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1491
@@ -23369,7 +22903,6 @@ mob_db: (
 	AttackDelay: 1156
 	AttackMotion: 456
 	DamageMotion: 384
-	MvpExp: 0
 },
 // Umbala (6.2)
 {
@@ -23470,7 +23003,6 @@ mob_db: (
 	AttackDelay: 950
 	AttackMotion: 2520
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Tough_Vines: 5335
 		Great_Leaf: 1000
@@ -23519,7 +23051,6 @@ mob_db: (
 	AttackDelay: 1247
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Solid_Peeling: 6500
 		Beetle_Nipper: 4500
@@ -23567,7 +23098,6 @@ mob_db: (
 	AttackDelay: 2413
 	AttackMotion: 1248
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Solid_Twig: 5000
 		Log: 5000
@@ -23608,7 +23138,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 1497
@@ -23648,7 +23177,6 @@ mob_db: (
 	AttackDelay: 1543
 	AttackMotion: 1632
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Heart_Of_Tree: 4000
 		Browny_Root: 4000
@@ -23698,7 +23226,6 @@ mob_db: (
 	AttackDelay: 857
 	AttackMotion: 1056
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Air_Rifle: 4500
 		Flexible_String: 3500
@@ -23748,7 +23275,6 @@ mob_db: (
 	AttackDelay: 912
 	AttackMotion: 1344
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Meat: 4500
 		Shoulder_Protection: 4000
@@ -23794,7 +23320,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Germinating_Sprout: 5500
 		Soft_Leaf: 2000
@@ -23836,7 +23361,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 // Event MVP
 {
@@ -23937,7 +23461,6 @@ mob_db: (
 	AttackDelay: 917
 	AttackMotion: 1584
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Hanging_Doll: 1800
 		Rotten_Rope: 5335
@@ -23987,7 +23510,6 @@ mob_db: (
 	AttackDelay: 847
 	AttackMotion: 1152
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Dullahans_Helm: 3200
 		Dullahan_Armor: 4850
@@ -24037,7 +23559,6 @@ mob_db: (
 	AttackDelay: 747
 	AttackMotion: 1632
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Black_Kitty_Doll: 800
 		Striped_Socks: 3000
@@ -24088,7 +23609,6 @@ mob_db: (
 	AttackDelay: 516
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Red_Scarf: 4850
 		Tangled_Chain: 3686
@@ -24138,7 +23658,6 @@ mob_db: (
 	AttackDelay: 914
 	AttackMotion: 1344
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Old_Manteau: 4171
 		Distorted_Portrait: 1000
@@ -24188,7 +23707,6 @@ mob_db: (
 	AttackDelay: 912
 	AttackMotion: 1248
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Black_Cloth: 3200
 		Ectoplasm: 5723
@@ -24237,7 +23755,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Bucket: 3200
 		Ectoplasm: 5723
@@ -24289,7 +23806,6 @@ mob_db: (
 	AttackDelay: 741
 	AttackMotion: 1536
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Broken_Needle: 4365
 		Spool: 5335
@@ -24395,7 +23911,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 1320
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Brigan: 3880
 		Amulet: 100
@@ -24445,7 +23960,6 @@ mob_db: (
 	AttackDelay: 1257
 	AttackMotion: 528
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Fan: 4171
 		Cat_Eyed_Stone: 2000
@@ -24491,7 +24005,6 @@ mob_db: (
 	AttackDelay: 600
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Dragon_Fang: 4365
 		Dragon_Horn: 3000
@@ -24540,7 +24053,6 @@ mob_db: (
 	AttackDelay: 879
 	AttackMotion: 672
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Milk_Bottle: 1500
 		Bib: 2500
@@ -24586,7 +24098,6 @@ mob_db: (
 	AttackDelay: 106
 	AttackMotion: 1056
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Dried_Sand: 4365
 		Mud_Lump: 2300
@@ -24635,7 +24146,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Tiger_Skin_Panties: 4500
 		Little_Blacky_Ghost: 400
@@ -24685,7 +24195,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Long_Hair: 5500
 		Old_Blue_Box: 2
@@ -24738,7 +24247,6 @@ mob_db: (
 	AttackDelay: 1728
 	AttackMotion: 816
 	DamageMotion: 1188
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4850
 		Stuffed_Doll: 100
@@ -24783,7 +24291,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 672
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Exorcize_Herb: 3000
 		Iris: 1000
@@ -24829,7 +24336,6 @@ mob_db: (
 	AttackDelay: 520
 	AttackMotion: 2304
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1522
@@ -24871,7 +24377,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 120
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1523
@@ -24910,7 +24415,6 @@ mob_db: (
 	AttackDelay: 1084
 	AttackMotion: 2304
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1524
@@ -24950,7 +24454,6 @@ mob_db: (
 	AttackDelay: 318
 	AttackMotion: 528
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1525
@@ -24992,7 +24495,6 @@ mob_db: (
 	AttackDelay: 1504
 	AttackMotion: 840
 	DamageMotion: 900
-	MvpExp: 0
 },
 {
 	Id: 1526
@@ -25033,7 +24535,6 @@ mob_db: (
 	AttackDelay: 472
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1527
@@ -25071,7 +24572,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1528
@@ -25108,7 +24608,6 @@ mob_db: (
 	AttackDelay: 1092
 	AttackMotion: 792
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1529
@@ -25153,7 +24652,6 @@ mob_db: (
 	AttackDelay: 588
 	AttackMotion: 816
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1530
@@ -25197,7 +24695,6 @@ mob_db: (
 	AttackDelay: 1290
 	AttackMotion: 1140
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1531
@@ -25236,7 +24733,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 840
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1532
@@ -25276,7 +24772,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1533
@@ -25317,7 +24812,6 @@ mob_db: (
 	AttackDelay: 1612
 	AttackMotion: 622
 	DamageMotion: 583
-	MvpExp: 0
 },
 {
 	Id: 1534
@@ -25359,7 +24853,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1535
@@ -25399,7 +24892,6 @@ mob_db: (
 	AttackDelay: 1320
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1536
@@ -25439,7 +24931,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1537
@@ -25479,7 +24970,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1538
@@ -25519,7 +25009,6 @@ mob_db: (
 	AttackDelay: 3074
 	AttackMotion: 1874
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1539
@@ -25561,7 +25050,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1540
@@ -25598,7 +25086,6 @@ mob_db: (
 	AttackDelay: 1608
 	AttackMotion: 816
 	DamageMotion: 396
-	MvpExp: 0
 },
 {
 	Id: 1541
@@ -25634,7 +25121,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 384
-	MvpExp: 0
 },
 /*{
 	Id: 1542
@@ -25678,7 +25164,6 @@ mob_db: (
 	AttackDelay: 874
 	AttackMotion: 1344
 	DamageMotion: 576
-	MvpExp: 0
 },*/
 {
 	Id: 1543
@@ -25718,7 +25203,6 @@ mob_db: (
 	AttackDelay: 2012
 	AttackMotion: 1728
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1544
@@ -25754,7 +25238,6 @@ mob_db: (
 	AttackDelay: 1638
 	AttackMotion: 2016
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1545
@@ -25794,7 +25277,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1546
@@ -25834,7 +25316,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1547
@@ -25874,7 +25355,6 @@ mob_db: (
 	AttackDelay: 1228
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1548
@@ -25916,7 +25396,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1549
@@ -25956,7 +25435,6 @@ mob_db: (
 	AttackDelay: 2190
 	AttackMotion: 2040
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1550
@@ -25995,7 +25473,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1551
@@ -26032,7 +25509,6 @@ mob_db: (
 	AttackDelay: 1956
 	AttackMotion: 756
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1552
@@ -26071,7 +25547,6 @@ mob_db: (
 	AttackDelay: 1938
 	AttackMotion: 2112
 	DamageMotion: 768
-	MvpExp: 0
 },
 {
 	Id: 1553
@@ -26113,7 +25588,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1554
@@ -26154,7 +25628,6 @@ mob_db: (
 	AttackDelay: 1216
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1555
@@ -26190,7 +25663,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1556
@@ -26227,7 +25699,6 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 1728
 	DamageMotion: 864
-	MvpExp: 0
 },
 {
 	Id: 1557
@@ -26265,7 +25736,6 @@ mob_db: (
 	AttackDelay: 2416
 	AttackMotion: 2016
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1558
@@ -26305,7 +25775,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 720
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1559
@@ -26345,7 +25814,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1560
@@ -26387,7 +25855,6 @@ mob_db: (
 	AttackDelay: 1003
 	AttackMotion: 1152
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1561
@@ -26424,7 +25891,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1562
@@ -26464,7 +25930,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1563
@@ -26505,7 +25970,6 @@ mob_db: (
 	AttackDelay: 1439
 	AttackMotion: 1920
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1564
@@ -26549,7 +26013,6 @@ mob_db: (
 	AttackDelay: 637
 	AttackMotion: 1008
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1565
@@ -26587,7 +26050,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 756
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1566
@@ -26629,7 +26091,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 576
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1567
@@ -26672,7 +26133,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1568
@@ -26716,7 +26176,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1569
@@ -26758,7 +26217,6 @@ mob_db: (
 	AttackDelay: 828
 	AttackMotion: 528
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1570
@@ -26798,7 +26256,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1571
@@ -26835,7 +26292,6 @@ mob_db: (
 	AttackDelay: 1680
 	AttackMotion: 480
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1572
@@ -26872,7 +26328,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1573
@@ -26912,7 +26367,6 @@ mob_db: (
 	AttackDelay: 1552
 	AttackMotion: 1152
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1574
@@ -26952,7 +26406,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1575
@@ -26988,7 +26441,6 @@ mob_db: (
 	AttackDelay: 1432
 	AttackMotion: 432
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1576
@@ -27032,7 +26484,6 @@ mob_db: (
 	AttackDelay: 1220
 	AttackMotion: 1080
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1577
@@ -27070,7 +26521,6 @@ mob_db: (
 	AttackDelay: 1172
 	AttackMotion: 672
 	DamageMotion: 420
-	MvpExp: 0
 },
 {
 	Id: 1578
@@ -27110,7 +26560,6 @@ mob_db: (
 	AttackDelay: 1888
 	AttackMotion: 1152
 	DamageMotion: 828
-	MvpExp: 0
 },
 {
 	Id: 1579
@@ -27146,7 +26595,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 432
 	DamageMotion: 600
-	MvpExp: 0
 },
 {
 	Id: 1580
@@ -27189,7 +26637,6 @@ mob_db: (
 	AttackDelay: 850
 	AttackMotion: 600
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1581
@@ -27232,7 +26679,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1582
@@ -27276,7 +26722,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 1056
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Wing: 3000
 		Zargon: 4850
@@ -27387,7 +26832,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 1152
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Sword_Accessory: 4850
 		Broken_Armor_Piece: 3000
@@ -27433,7 +26877,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 		Knife_: 100
@@ -27479,7 +26922,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 864
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Great_Leaf: 4365
 		Leaflet_Of_Hinal: 300
@@ -27529,7 +26971,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1536
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Zargon: 3500
 		Milk: 3000
@@ -27576,7 +27017,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Iron: 210
 		Orcish_Voucher: 5500
@@ -27622,7 +27062,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1590
@@ -27658,7 +27097,6 @@ mob_db: (
 	AttackDelay: 1308
 	AttackMotion: 1008
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1591
@@ -27695,7 +27133,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 	}
@@ -27738,7 +27175,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 560
 	DamageMotion: 580
-	MvpExp: 0
 	Drops: {
 		Stone: 10000
 		Wing_Of_Fly: 2000
@@ -27784,7 +27220,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 120
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 	}
@@ -27829,7 +27264,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1595
@@ -27866,7 +27300,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1596
@@ -27907,7 +27340,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 1152
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1597
@@ -27946,7 +27378,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1598
@@ -27988,7 +27419,6 @@ mob_db: (
 	AttackDelay: 1732
 	AttackMotion: 1332
 	DamageMotion: 540
-	MvpExp: 0
 },
 {
 	Id: 1599
@@ -28031,7 +27461,6 @@ mob_db: (
 	AttackDelay: 2536
 	AttackMotion: 1536
 	DamageMotion: 672
-	MvpExp: 0
 },
 {
 	Id: 1600
@@ -28073,7 +27502,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1601
@@ -28115,7 +27543,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1602
@@ -28157,7 +27584,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 },
 {
 	Id: 1603
@@ -28194,7 +27620,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 1604
@@ -28237,7 +27662,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 340
-	MvpExp: 0
 },
 {
 	Id: 1605
@@ -28281,7 +27705,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1606
@@ -28322,7 +27745,6 @@ mob_db: (
 	AttackDelay: 879
 	AttackMotion: 672
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1607
@@ -28365,7 +27787,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1608
@@ -28407,7 +27828,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 },
 {
 	Id: 1609
@@ -28446,7 +27866,6 @@ mob_db: (
 	AttackDelay: 600
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Lucky_Candy: 500
 		Lucky_Candy_Cane: 50
@@ -28496,7 +27915,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 		Slow_Down_Potion: 100
@@ -28543,7 +27961,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 500
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 		Slow_Down_Potion: 100
@@ -28591,7 +28008,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 1320
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Orange_Potion: 2000
 		Slow_Down_Potion: 100
@@ -28634,7 +28050,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Tube: 4000
 		Iron_Ore: 1000
@@ -28681,7 +28096,6 @@ mob_db: (
 	AttackDelay: 648
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Fragment_Of_Crystal: 3000
 		Golden_Jewel: 500
@@ -28731,7 +28145,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 864
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Dark_Crystal_Fragment: 3000
 		Crystal_Jewel: 500
@@ -28777,7 +28190,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 336
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Old_Pick: 3000
 		Old_Steel_Plate: 500
@@ -28828,7 +28240,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Battered_Kettle: 1000
 		Burn_Tree: 1000
@@ -28881,7 +28292,6 @@ mob_db: (
 	AttackDelay: 420
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Long_Limb: 4500
 		Jaws_Of_Ant: 3500
@@ -28929,7 +28339,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Jubilee: 5000
 		Main_Gauche_: 25
@@ -28978,7 +28387,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1440
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Poisonous_Gas: 1000
 		Mould_Powder: 3000
@@ -29028,7 +28436,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1440
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Air_Pollutant: 5000
 		Spawns: 3000
@@ -29079,7 +28486,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 780
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Screw: 3800
 		Honey: 1000
@@ -29190,7 +28596,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1625
@@ -29231,7 +28636,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 },
 // Hellion Revenant
 {
@@ -29276,7 +28680,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 384
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Eye_Of_Hellion: 8000
 		Eye_Of_Hellion: 5000
@@ -29326,7 +28729,6 @@ mob_db: (
 	AttackDelay: 1084
 	AttackMotion: 2304
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Wing_Of_Fly: 1000
 		Spawns: 500
@@ -29370,7 +28772,6 @@ mob_db: (
 	AttackDelay: 1400
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Moustache_Of_Mole: 5000
 		Nail_Of_Mole: 5000
@@ -29417,7 +28818,6 @@ mob_db: (
 	AttackDelay: 336
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Meat: 1000
 		Monsters_Feed: 1000
@@ -29521,7 +28921,6 @@ mob_db: (
 	AttackDelay: 1728
 	AttackMotion: 816
 	DamageMotion: 1188
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4200
 		Stuffed_Doll: 100
@@ -29568,7 +28967,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 540
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Will_Of_Darkness: 3000
 		Sticky_Mucus: 3000
@@ -29614,7 +29012,6 @@ mob_db: (
 	AttackDelay: 336
 	AttackMotion: 840
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Prickly_Fruit: 3000
 		Anodyne: 100
@@ -29665,7 +29062,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 3000
 		Dragon_Killer: 2
@@ -29717,7 +29113,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Lab_Staff_Record: 2000
 		Carnium: 1
@@ -29768,7 +29163,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 3000
 		Goast_Chill: 1
@@ -29820,7 +29214,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Lab_Staff_Record: 2000
 		Croce_Staff: 100
@@ -29871,7 +29264,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 3000
 		Imma_Arrow_Container: 110
@@ -29923,7 +29315,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 3000
 		Carnium: 1
@@ -29978,7 +29369,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Carnium: 100
 		Old_Violet_Box: 10
@@ -30026,7 +29416,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Carnium: 100
 		Old_Violet_Box: 10
@@ -30075,7 +29464,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Carnium: 100
 		Old_Violet_Box: 10
@@ -30124,7 +29512,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Carnium: 100
 		Old_Violet_Box: 10
@@ -30173,7 +29560,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Carnium: 100
 		Old_Violet_Box: 10
@@ -30222,7 +29608,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Carnium: 100
 		Old_Violet_Box: 10
@@ -30627,7 +30012,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Lab_Staff_Record: 1000
 		Katzbalger: 1
@@ -30678,7 +30062,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 2000
 		Forturn_Sword: 1
@@ -30729,7 +30112,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 1000
 		Muffler_: 1
@@ -30780,7 +30162,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 500
 		Biretta_: 5
@@ -30831,7 +30212,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Lab_Staff_Record: 2000
 		Kakkung_: 1
@@ -30882,7 +30262,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mementos: 1000
 		Staff_Of_Wing: 1
@@ -30994,7 +30373,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31038,7 +30416,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31082,7 +30459,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31126,7 +30502,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31170,7 +30545,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10
 	}
@@ -31210,7 +30584,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 5000
 		Dark_Red_Jewel: 1000
@@ -31251,7 +30624,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 5000
 		Blue_Jewel: 1000
@@ -31293,7 +30665,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 5000
 		Azure_Jewel: 1000
@@ -31334,7 +30705,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 5000
 		Golden_Jewel: 1000
@@ -31381,7 +30751,6 @@ mob_db: (
 	AttackDelay: 580
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 5000
 		Steel: 500
@@ -31430,7 +30799,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Dimik_Card: 1
 	}
@@ -31473,7 +30841,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate01: 50
@@ -31523,7 +30890,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate02: 50
@@ -31573,7 +30939,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate03: 50
@@ -31623,7 +30988,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate04: 50
@@ -31671,7 +31035,6 @@ mob_db: (
 	AttackDelay: 1368
 	AttackMotion: 1344
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Stone: 2000
 		Stone_Heart: 1000
@@ -31715,7 +31078,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Venatu_Card: 1
 	}
@@ -31758,7 +31120,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 2000
 		Piece_Of_Crest1: 350
@@ -31808,7 +31169,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 2000
 		Piece_Of_Crest2: 500
@@ -31858,7 +31218,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 2000
 		Piece_Of_Crest3: 400
@@ -31908,7 +31267,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 2000
 		Piece_Of_Crest4: 300
@@ -31958,7 +31316,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Harpys_Feather: 4000
 		Harpys_Claw: 3000
@@ -32007,7 +31364,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 360
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Skull: 3000
 		Old_Blue_Box: 1000
@@ -32058,7 +31414,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 1056
 	DamageMotion: 1152
-	MvpExp: 0
 	Drops: {
 		Empty_Bottle: 5000
 		Old_Steel_Plate: 5000
@@ -32108,7 +31463,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1684
@@ -32148,7 +31502,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1685
@@ -32247,7 +31600,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Large_Jellopy: 1000
 		Pacifier: 100
@@ -32294,7 +31646,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Leaflet_Of_Aloe: 1500
 		Reptile_Tongue: 1000
@@ -32402,7 +31753,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1690
@@ -32441,7 +31791,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 552
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		New_Year_Rice_Cake: 5000
 	}
@@ -32484,7 +31833,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1536
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Leaflet_Of_Aloe: 1
 		Leaflet_Of_Aloe: 1
@@ -32534,7 +31882,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Raccoon_Leaf: 500
 		Four_Leaf_Clover: 10
@@ -32584,7 +31931,6 @@ mob_db: (
 	AttackDelay: 1056
 	AttackMotion: 1056
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32633,7 +31979,6 @@ mob_db: (
 	AttackDelay: 912
 	AttackMotion: 1248
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32681,7 +32026,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32729,7 +32073,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1440
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32777,7 +32120,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -32828,7 +32170,6 @@ mob_db: (
 	AttackDelay: 176
 	AttackMotion: 912
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Page: 4000
 		Bookclip_In_Memory: 300
@@ -32878,7 +32219,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Old_Blue_Box: 30
 		Old_Violet_Box: 1
@@ -32932,7 +32272,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Feather: 500
 		Ring_: 1
@@ -32986,7 +32325,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 420
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Red_Feather: 200
 		Cursed_Seal: 1
@@ -33039,7 +32377,6 @@ mob_db: (
 	AttackDelay: 360
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Red_Feather: 400
 		Ring_: 1
@@ -33093,7 +32430,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 420
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Feather: 200
 		Ring_: 1
@@ -33148,7 +32484,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 288
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33202,7 +32537,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33256,7 +32590,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33310,7 +32643,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33423,7 +32755,6 @@ mob_db: (
 	AttackDelay: 115
 	AttackMotion: 288
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33472,7 +32803,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33521,7 +32851,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33570,7 +32899,6 @@ mob_db: (
 	AttackDelay: 160
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Crystal_Jewel_: 500
@@ -33616,7 +32944,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 1008
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Light_Granule: 500
 		Dragon_Canine: 4000
@@ -33666,7 +32993,6 @@ mob_db: (
 	AttackDelay: 108
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Black_wing_Brooch: 10
 		Dragon_Canine: 1000
@@ -33716,7 +33042,6 @@ mob_db: (
 	AttackDelay: 151
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Green_Herb: 3000
 		Cyfar: 1035
@@ -33762,7 +33087,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Potion: 150
 		Dragon_Canine: 4000
@@ -33812,7 +33136,6 @@ mob_db: (
 	AttackDelay: 108
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Delicious_Fish: 5100
 		Dragon_Canine: 1000
@@ -33862,7 +33185,6 @@ mob_db: (
 	AttackDelay: 252
 	AttackMotion: 816
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Yellow_Herb: 2000
 		Cyfar: 1035
@@ -33973,7 +33295,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Dragons_Skin: 4000
 		Dragon_Canine: 4000
@@ -34015,7 +33336,6 @@ mob_db: (
 	AttackDelay: 24
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Elunium: 5
 		Piece_Of_Egg_Shell: 100
@@ -34062,7 +33382,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Bucket: 1000
 		Pumpkin_Head: 1000
@@ -34111,7 +33430,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1724
@@ -34147,7 +33465,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1725
@@ -34184,7 +33501,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Stone: 10000
 	}
@@ -34224,7 +33540,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 1727
@@ -34261,7 +33576,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1728
@@ -34299,7 +33613,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 900
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 1729
@@ -34337,7 +33650,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 480
 	DamageMotion: 120
-	MvpExp: 0
 },
 {
 	Id: 1730
@@ -34375,7 +33687,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1731
@@ -34420,7 +33731,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 480
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Warrior_Symbol: 10000
 	}
@@ -34460,7 +33770,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		3rd_Floor_Pass: 1000
 	}
@@ -34508,7 +33817,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 	}
 },
@@ -34610,7 +33918,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 480
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Burnt_Parts: 2000
 		Sturdy_Iron_Piece: 3000
@@ -34661,7 +33968,6 @@ mob_db: (
 	AttackDelay: 1296
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Burnt_Parts: 2000
 		Sturdy_Iron_Piece: 3000
@@ -34708,7 +34014,6 @@ mob_db: (
 	AttackDelay: 1440
 	AttackMotion: 576
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Brigan: 4000
 		Morpheuss_Shawl: 10
@@ -34758,7 +34063,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Burnt_Parts: 100
 		Sturdy_Iron_Piece: 1500
@@ -34806,7 +34110,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 480
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Sturdy_Iron_Piece: 500
 	}
@@ -34850,7 +34153,6 @@ mob_db: (
 	AttackDelay: 1296
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sturdy_Iron_Piece: 500
 	}
@@ -34893,7 +34195,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Undelivered_Gift: 10000
 	}
@@ -34937,7 +34238,6 @@ mob_db: (
 	AttackDelay: 1078
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1743
@@ -34977,7 +34277,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Undelivered_Gift: 10000
 	}
@@ -35020,7 +34319,6 @@ mob_db: (
 	AttackDelay: 964
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1745
@@ -35059,7 +34357,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sturdy_Iron_Piece: 500
 	}
@@ -35102,7 +34399,6 @@ mob_db: (
 	AttackDelay: 1440
 	AttackMotion: 576
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Sturdy_Iron_Piece: 500
 	}
@@ -35146,7 +34442,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1748
@@ -35186,7 +34481,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1749
@@ -35227,7 +34521,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 1320
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1750
@@ -35262,7 +34555,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 },
 // Odin's Temple
 {
@@ -35363,7 +34655,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 384
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 3500
 		Peuz_Seal: 10
@@ -35415,7 +34706,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 3500
 		Peuz_Seal: 10
@@ -35468,7 +34758,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 780
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 6000
 		Angelic_Chain: 1
@@ -35522,7 +34811,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 780
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 6000
 		Angelic_Chain: 1
@@ -35575,7 +34863,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1757
@@ -35615,7 +34902,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 1008
 	DamageMotion: 300
-	MvpExp: 0
 },
 {
 	Id: 1758
@@ -35655,7 +34941,6 @@ mob_db: (
 	AttackDelay: 108
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1759
@@ -35695,7 +34980,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1760
@@ -35735,7 +35019,6 @@ mob_db: (
 	AttackDelay: 108
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1761
@@ -35776,7 +35059,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 384
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 500
 	}
@@ -35820,7 +35102,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 500
 	}
@@ -35865,7 +35146,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 780
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 500
 	}
@@ -35910,7 +35190,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 780
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 500
 	}
@@ -35957,7 +35236,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Valhalla_Flower: 160
 		Old_Violet_Box: 40
@@ -36002,7 +35280,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 	MvpDrops: {
 		Jellopy: 5000
 		Jellopy: 5000
@@ -36047,7 +35324,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 	MvpDrops: {
 		Jellopy: 5000
 		Jellopy: 5000
@@ -36152,7 +35428,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 2500
 		High_Fashion_Sandals: 2
@@ -36203,7 +35478,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 2500
 		Seed_Of_Yggdrasil: 10
@@ -36253,7 +35527,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		White_Mask: 2500
 		Royal_Jelly: 10
@@ -36303,7 +35576,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		White_Mask: 2500
 		High_Fashion_Sandals: 1
@@ -36354,7 +35626,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 528
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Prickly_Fruit_: 1000
 		Will_Of_Darkness: 1000
@@ -36405,7 +35676,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Prickly_Fruit_: 1000
 		Will_Of_Darkness: 1000
@@ -36454,7 +35724,6 @@ mob_db: (
 	AttackDelay: 936
 	AttackMotion: 1020
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 3000
 		Ice_Piece: 1000
@@ -36501,7 +35770,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 648
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 500
 		Ice_Piece: 1500
@@ -36548,7 +35816,6 @@ mob_db: (
 	AttackDelay: 861
 	AttackMotion: 660
 	DamageMotion: 144
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 5000
 		Ice_Piece: 3000
@@ -36600,7 +35867,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 370
 	DamageMotion: 270
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 3000
 		Ice_Piece: 3000
@@ -36703,7 +35969,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 648
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sticky_Poison: 3000
 		Blossom_Of_Maneater: 3000
@@ -36749,7 +36014,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 576
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Sticky_Poison: 3000
 		Drocera_Tentacle: 100
@@ -36798,7 +36062,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Rotten_Meat: 3000
 		Animals_Skin: 3000
@@ -36846,7 +36109,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Rotten_Meat: 3000
 		Animals_Skin: 3000
@@ -36890,7 +36152,6 @@ mob_db: (
 	AttackDelay: 936
 	AttackMotion: 792
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Jellopy: 1000
 		Jubilee: 1000
@@ -36999,7 +36260,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 1
 	}
@@ -37043,7 +36303,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 1
 	}
@@ -37087,7 +36346,6 @@ mob_db: (
 	AttackDelay: 861
 	AttackMotion: 660
 	DamageMotion: 144
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 1
 	}
@@ -37126,7 +36384,6 @@ mob_db: (
 	AttackDelay: 1344
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Ice_Piece: 1000
 		Ice_Piece: 1000
@@ -37176,7 +36433,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 528
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Golden_Jewel_: 3000
 		Red_Jewel_: 4000
@@ -37222,7 +36478,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1792
@@ -37257,7 +36512,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 96
 	DamageMotion: 96
-	MvpExp: 0
 	Drops: {
 		Small_Horn_Of_Devil: 5000
 		Small_Horn_Of_Devil: 3000
@@ -37306,7 +36560,6 @@ mob_db: (
 	AttackDelay: 1332
 	AttackMotion: 1332
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 	}
 },
@@ -37349,7 +36602,6 @@ mob_db: (
 	AttackDelay: 412
 	AttackMotion: 840
 	DamageMotion: 300
-	MvpExp: 0
 },
 {
 	Id: 1795
@@ -37393,7 +36645,6 @@ mob_db: (
 	AttackDelay: 828
 	AttackMotion: 528
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Pole_Axe: 100
 		Grave_: 100
@@ -37445,7 +36696,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		White_Mask: 2500
 		High_Fashion_Sandals: 2
@@ -37495,7 +36745,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Kandura: 10
 		High_Fashion_Sandals: 2
@@ -37540,7 +36789,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Gem_Of_Ruin: 10000
 	}
@@ -37587,7 +36835,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -37634,7 +36881,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -37682,7 +36928,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -37777,7 +37022,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -37825,7 +37069,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Evil_Mind: 10000
 	}
@@ -37872,7 +37115,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		3D_Glasses_Box: 5000
 	}
@@ -37919,7 +37161,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		3D_Glasses_Box: 5000
 	}
@@ -37967,7 +37208,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		3D_Glasses_Box: 5000
 	}
@@ -38015,7 +37255,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		3D_Glasses_Box: 5000
 	}
@@ -38063,7 +37302,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		3D_Glasses_Box: 5000
 	}
@@ -38111,7 +37349,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		3D_Glasses_Box: 5000
 	}
@@ -38152,7 +37389,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Sunglasses: 100
 		Tiger_Skin_Panties: 500
@@ -38195,7 +37431,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Chocolate: 10000
 		White_Chocolate: 6000
@@ -38246,7 +37481,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	MvpDrops: {
 		Old_Violet_Box: 5500
 		Old_Blue_Box: 5000
@@ -38304,7 +37538,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1815
@@ -38340,7 +37573,6 @@ mob_db: (
 	AttackDelay: 1320
 	AttackMotion: 0
 	DamageMotion: 300
-	MvpExp: 0
 },
 {
 	Id: 1816
@@ -38375,7 +37607,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 96
 	DamageMotion: 96
-	MvpExp: 0
 	MvpDrops: {
 		Fatty_Chubby_Earthworm: 5000
 		Fatty_Chubby_Earthworm: 5000
@@ -38428,7 +37659,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 936
 	DamageMotion: 360
-	MvpExp: 0
 	MvpDrops: {
 		Bloody_Dead_Branch: 5500
 		Old_Violet_Box: 5000
@@ -38484,7 +37714,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 500
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cogwheel: 7000
 	}
@@ -38529,7 +37758,6 @@ mob_db: (
 	AttackDelay: 1504
 	AttackMotion: 840
 	DamageMotion: 900
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 2000
 	}
@@ -38569,7 +37797,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 2000
 	}
@@ -38612,7 +37839,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 420
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 2000
 	}
@@ -38658,7 +37884,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 3000
 	}
@@ -38703,7 +37928,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 3000
 	}
@@ -38747,7 +37971,6 @@ mob_db: (
 	AttackDelay: 879
 	AttackMotion: 672
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 5000
 	}
@@ -38793,7 +38016,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 5000
 	}
@@ -38838,7 +38060,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 3000
 	}
@@ -38883,7 +38104,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Wooden_Block_: 3000
 	}
@@ -38929,7 +38149,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Bag_Of_Rice: 6000
 		Lucky_Candy: 9000
@@ -38980,7 +38199,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Broken_Armor_Piece: 3000
 		Doom_Slayer: 30
@@ -39035,7 +38253,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Broken_Armor_Piece: 3000
 		Luna_Bow: 30
@@ -39088,7 +38305,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Flame_Heart: 30
@@ -39201,7 +38417,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 600
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Hot_Hair: 2500
@@ -39255,7 +38470,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1835
@@ -39299,7 +38513,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 600
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1836
@@ -39336,7 +38549,6 @@ mob_db: (
 	AttackDelay: 1472
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Elunium_Stone: 34
@@ -39383,7 +38595,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Hot_Hair: 3000
 		Huuma_Blaze: 100
@@ -39431,7 +38642,6 @@ mob_db: (
 	AttackDelay: 1548
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Great_Nature: 30
 		Coal: 150
@@ -39486,7 +38696,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 600
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Drill_Katar: 50
 		Assassin_Mask_: 3
@@ -39536,7 +38745,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 480
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Leaf_Of_Yggdrasil: 3000
 		Treasure_Box: 100
@@ -39582,7 +38790,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Copper_Coin_: 1000
 		Black_Treasure_Box: 500
@@ -39623,7 +38830,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Copper_Coin_: 1000
 		Copper_Coin_: 1000
@@ -39668,7 +38874,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Copper_Coin_: 1000
 		Silver_Coin_: 1000
@@ -39714,7 +38919,6 @@ mob_db: (
 	AttackDelay: 1384
 	AttackMotion: 768
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Copper_Coin_: 1000
 		Silver_Coin_: 1000
@@ -39758,7 +38962,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Gold_Coin_US: 10000
 		Gold_Coin_US: 10000
@@ -39804,7 +39007,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dragonball_Yellow_: 2000
 	}
@@ -39851,7 +39053,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1849
@@ -39895,7 +39096,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1850
@@ -39939,7 +39139,6 @@ mob_db: (
 	AttackDelay: 1678
 	AttackMotion: 780
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1851
@@ -39981,7 +39180,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 560
 	DamageMotion: 580
-	MvpExp: 0
 },
 {
 	Id: 1852
@@ -40025,7 +39223,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1853
@@ -40069,7 +39266,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1854
@@ -40106,7 +39302,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 70
 		Cactus_Needle: 9000
@@ -40156,7 +39351,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Poison_Spore: 9000
 		Hat_: 20
@@ -40204,7 +39398,6 @@ mob_db: (
 	AttackDelay: 1560
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Old_Frying_Pan: 9000
 		Garlet: 800
@@ -40251,7 +39444,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Garlet: 3200
 		Sticky_Mucus: 1500
@@ -40297,7 +39489,6 @@ mob_db: (
 	AttackDelay: 2208
 	AttackMotion: 1008
 	DamageMotion: 324
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 9000
 		Sago: 300
@@ -40343,7 +39534,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 50
 		Stem: 9000
@@ -40390,7 +39580,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 1008
-	MvpExp: 0
 	Drops: {
 		Acorn: 9000
 		Hood_: 20
@@ -40440,7 +39629,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Claw_Of_Monkey: 5335
 		Yoyo_Tail: 7000
@@ -40486,7 +39674,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moustache_Of_Mole: 9000
 		Macapuno: 500
@@ -40533,7 +39720,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 552
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Peeps: 5000
 		Jelly_Bean: 5000
@@ -40581,7 +39767,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 648
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Clattering_Skull: 3000
 		Platinum_Shotel: 10
@@ -40633,7 +39818,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Clattering_Skull: 3000
 		Tidal_Shoes: 15
@@ -40687,7 +39871,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Monsters_Feed: 5000
 		Tooth_Blade: 10
@@ -40740,7 +39923,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 504
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Old_White_Cloth: 3000
 		Orleans_Gown: 10
@@ -40792,7 +39974,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 504
 	DamageMotion: 504
-	MvpExp: 0
 },
 {
 	Id: 1869
@@ -40833,7 +40014,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 648
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Skull: 5000
 		Black_Leather_Boots: 20
@@ -40884,7 +40064,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 1320
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Clattering_Skull: 3000
 		Lich_Bone_Wand: 20
@@ -40998,7 +40177,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1873
@@ -41042,7 +40220,6 @@ mob_db: (
 	AttackDelay: 100
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1874
@@ -41143,7 +40320,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 1152
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Broken_Crown: 9000
 		Sticky_Mucus: 9000
@@ -41232,7 +40408,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		GOLD_ID4: 10
 		Gift_Box: 100
@@ -41272,7 +40447,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Love_Flower: 3000
 		Pointed_Scale: 1500
@@ -41324,7 +40498,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 },
 // Moscovia
 {
@@ -41362,7 +40535,6 @@ mob_db: (
 	AttackDelay: 2304
 	AttackMotion: 840
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Iron_Wrist: 5
 		Solid_Twig: 4000
@@ -41410,7 +40582,6 @@ mob_db: (
 	AttackDelay: 1728
 	AttackMotion: 720
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Sharp_Leaf: 2000
 		Green_Herb: 1000
@@ -41460,7 +40631,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 600
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Old_Magic_Circle: 1000
 		Yaga_Pestle: 5000
@@ -41510,7 +40680,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Leaflet_Of_Hinal: 900
 		Ancient_Magic: 5
@@ -41559,7 +40728,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 504
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Principles_Of_Magic: 5
 		Singing_Flower: 300
@@ -41667,7 +40835,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 504
 	DamageMotion: 360
-	MvpExp: 0
 },
 // Additional Monsters
 {
@@ -41710,7 +40877,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Cyfar: 2000
 		Ice_Piece: 2000
@@ -41754,7 +40920,6 @@ mob_db: (
 	AttackDelay: 879
 	AttackMotion: 672
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Ice_Piece: 2000
 	}
@@ -41801,7 +40966,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 408
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Cyfar: 2000
 		Ice_Piece: 2000
@@ -41846,7 +41010,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1891
@@ -41890,7 +41053,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 	}
 },
@@ -41933,7 +41095,6 @@ mob_db: (
 	AttackDelay: 747
 	AttackMotion: 1632
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1893
@@ -41976,7 +41137,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1894
@@ -42017,7 +41177,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Unknown_Fish: 10000
 		Unknown_Fish: 10000
@@ -42069,7 +41228,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1896
@@ -42111,7 +41269,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1897
@@ -42155,7 +41312,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1898
@@ -42195,7 +41351,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Jade_Plate: 10000
 	}
@@ -42238,7 +41393,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1900
@@ -42277,7 +41431,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1901
@@ -42314,7 +41467,6 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 648
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Immortality_Egg: 1000
 	}
@@ -42354,7 +41506,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Gold_Key77: 1000
 	}
@@ -42394,7 +41545,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Silver_Key77: 1000
 	}
@@ -42438,7 +41588,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1905
@@ -42474,7 +41623,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1906
@@ -42511,7 +41659,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1907
@@ -42547,7 +41694,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1908
@@ -42583,7 +41729,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1909
@@ -42620,7 +41765,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1910
@@ -42657,7 +41801,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1911
@@ -42694,7 +41837,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1912
@@ -42731,7 +41873,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1913
@@ -42768,7 +41909,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1914
@@ -42805,7 +41945,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1915
@@ -42842,7 +41981,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 },
 // Dimentional Gorge (12.1)
 {
@@ -42887,7 +42025,6 @@ mob_db: (
 	AttackDelay: 312
 	AttackMotion: 624
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Diabolus_Helmet: 1500
 		Diabolus_Robe: 7000
@@ -42996,7 +42133,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 480
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Herald_Of_GOD: 10
 		Dark_Crystal: 1000
@@ -43049,7 +42185,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 648
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Skin_Of_Ventus: 3
 		Dark_Crystal: 1000
@@ -43101,7 +42236,6 @@ mob_db: (
 	AttackDelay: 212
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Ragamuffin_Cape: 10
 		Dark_Crystal: 1000
@@ -43154,7 +42288,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 648
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Diabolus_Ring: 5
 		Dark_Crystal: 1000
@@ -43207,7 +42340,6 @@ mob_db: (
 	AttackDelay: 312
 	AttackMotion: 480
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1923
@@ -43252,7 +42384,6 @@ mob_db: (
 	AttackDelay: 312
 	AttackMotion: 648
 	DamageMotion: 300
-	MvpExp: 0
 },
 {
 	Id: 1924
@@ -43297,7 +42428,6 @@ mob_db: (
 	AttackDelay: 212
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1925
@@ -43342,7 +42472,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 648
 	DamageMotion: 300
-	MvpExp: 0
 },
 // God Item Creation (WoE SE); Catacombs
 {
@@ -43386,7 +42515,6 @@ mob_db: (
 	AttackDelay: 1180
 	AttackMotion: 480
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Pie: 2000
 		Pumpkin: 10000
@@ -43436,7 +42564,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Pie: 2000
 		Worn_Cloth_Piece: 5000
@@ -43486,7 +42613,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Horn: 3000
 		Petite_DiablOfs_Wing: 3000
@@ -43535,7 +42661,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Bapho_Doll: 500
 		Pauldron: 7000
@@ -43589,7 +42714,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1931
@@ -43633,7 +42757,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1932
@@ -43671,7 +42794,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Crystal_Key: 9000
 	}
@@ -43718,7 +42840,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1934
@@ -43754,7 +42875,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1935
@@ -43790,7 +42910,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1936
@@ -43826,7 +42945,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1937
@@ -43866,7 +42984,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1938
@@ -43902,7 +43019,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Goddess_Tear: 10
 		Union_Of_Tribe: 500
@@ -43948,7 +43064,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Valkyrie_Token: 10
 		Union_Of_Tribe: 500
@@ -43994,7 +43109,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Brynhild_Armor_Piece: 10
 		Union_Of_Tribe: 500
@@ -44040,7 +43154,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Hero_Remains: 10
 		Union_Of_Tribe: 500
@@ -44086,7 +43199,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Andvari_Ring: 10
 		Union_Of_Tribe: 500
@@ -44132,7 +43244,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Dusk_Glow: 10
 		Union_Of_Tribe: 500
@@ -44178,7 +43289,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Dawn_Essence: 10
 		Union_Of_Tribe: 500
@@ -44224,7 +43334,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Cold_Moonlight: 10
 		Union_Of_Tribe: 500
@@ -44270,7 +43379,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Hazy_Starlight: 10
 		Union_Of_Tribe: 500
@@ -44324,7 +43432,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1948
@@ -44364,7 +43471,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 },
 // Battlegrounds Guardians
 {
@@ -44403,7 +43509,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1950
@@ -44441,7 +43546,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 // Ravies Sister's 'Valyrie's Gift' monsters.
 {
@@ -44480,7 +43584,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -44527,7 +43630,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -44574,7 +43676,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -44621,7 +43722,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Cake: 3800
 		Candy_Striper: 4500
@@ -44668,7 +43768,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Fools_Day_Box: 1000
 		Fools_Day_Box2: 1000
@@ -44721,7 +43820,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 432
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Twin_Edge_B: 9000
 		Twin_Edge_R: 9000
@@ -44769,7 +43867,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 540
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Thorn_Staff: 9000
 		Holy_Stick: 9000
@@ -44817,7 +43914,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1959
@@ -44855,7 +43951,6 @@ mob_db: (
 	AttackDelay: 2864
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1960
@@ -44893,7 +43988,6 @@ mob_db: (
 	AttackDelay: 1024
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1961
@@ -44931,7 +44025,6 @@ mob_db: (
 	AttackDelay: 2864
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 },
 // Additional Monsters
 {
@@ -44969,7 +44062,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 1963
@@ -45011,7 +44103,6 @@ mob_db: (
 	AttackDelay: 1728
 	AttackMotion: 816
 	DamageMotion: 1188
-	MvpExp: 0
 },
 {
 	Id: 1964
@@ -45047,7 +44138,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Blue_Potion: 2000
 		Blue_Herb: 3000
@@ -45088,7 +44178,6 @@ mob_db: (
 	AttackDelay: 964
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1966
@@ -45124,7 +44213,6 @@ mob_db: (
 	AttackDelay: 300
 	AttackMotion: 480
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1967
@@ -45161,7 +44249,6 @@ mob_db: (
 	AttackDelay: 300
 	AttackMotion: 480
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 1968
@@ -45197,7 +44284,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Fin: 5335
 		Oridecon_Stone: 230
@@ -45243,7 +44329,6 @@ mob_db: (
 	AttackDelay: 1272
 	AttackMotion: 72
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 36
 		Gill: 9000
@@ -45290,7 +44375,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 26
 		Heart_Of_Mermaid: 9000
@@ -45336,7 +44420,6 @@ mob_db: (
 	AttackDelay: 1632
 	AttackMotion: 432
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 40
 		Nipper: 9000
@@ -45382,7 +44465,6 @@ mob_db: (
 	AttackDelay: 2280
 	AttackMotion: 1080
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 5000
 		Sticky_Mucus: 1500
@@ -45427,7 +44509,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Gift_Box: 10000
 		Old_Blue_Box: 10000
@@ -45478,7 +44559,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 504
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Old_White_Cloth: 3000
 		Orleans_Gown: 10
@@ -45528,7 +44608,6 @@ mob_db: (
 	AttackDelay: 336
 	AttackMotion: 840
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Prickly_Fruit: 3000
 		Anodyne: 100
@@ -45578,7 +44657,6 @@ mob_db: (
 	AttackDelay: 648
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Fragment_Of_Crystal: 3000
 		Golden_Jewel: 500
@@ -45628,7 +44706,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Tube: 4000
 		Iron_Ore: 1000
@@ -45679,7 +44756,6 @@ mob_db: (
 	AttackDelay: 1840
 	AttackMotion: 1440
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Broken_Steel_Piece: 5335
 		Mystery_Piece: 2400
@@ -45730,7 +44806,6 @@ mob_db: (
 	AttackDelay: 580
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 5000
 		Steel: 500
@@ -45840,7 +44915,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 1982
@@ -45881,7 +44955,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 620
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 1983
@@ -45922,7 +44995,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 648
-	MvpExp: 0
 },
 {
 	Id: 1984
@@ -45965,7 +45037,6 @@ mob_db: (
 	AttackDelay: 1050
 	AttackMotion: 900
 	DamageMotion: 288
-	MvpExp: 0
 },
 // Another World (13.1)
 {
@@ -46008,7 +45079,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 1986
@@ -46047,7 +45117,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Lunakaligo: 20
 		Cello: 10
@@ -46100,7 +45169,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Cold_Heart: 2
 		Black_Cat: 2
@@ -46146,7 +45214,6 @@ mob_db: (
 	AttackDelay: 500
 	AttackMotion: 576
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Mandragora_Cap: 1
 		Stem_Of_Nepenthes: 1
@@ -46196,7 +45263,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 780
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Sprint_Shoes: 10
 		Horn_Of_Hilthrion: 20
@@ -46250,7 +45316,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 660
 	DamageMotion: 588
-	MvpExp: 0
 	Drops: {
 		Bone_Head: 100
 		Tournament_Shield: 200
@@ -46304,7 +45369,6 @@ mob_db: (
 	AttackDelay: 500
 	AttackMotion: 960
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Leather_Of_Tendrilion: 500
 		Death_Guidance: 100
@@ -46352,7 +45416,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 624
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Sprint_Mail: 10
 		Angelic_Ring: 1
@@ -46404,7 +45467,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Armor_Of_Naga: 10
 		Shield_Of_Naga: 10
@@ -46458,7 +45520,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Sprint_Ring: 2
 		Bradium: 1
@@ -46508,7 +45569,6 @@ mob_db: (
 	AttackDelay: 700
 	AttackMotion: 600
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Pinguicula_Corsage: 1
 		Whip_Of_Balance: 10
@@ -46562,7 +45622,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		White_Snake_Hat: 3
 		Exorcize_Sachet: 80
@@ -46606,7 +45665,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 1998
@@ -46646,7 +45704,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 780
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 1999
@@ -46689,7 +45746,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Boots_: 9
 		Crystal_Jewel__: 50
@@ -46735,7 +45791,6 @@ mob_db: (
 	AttackDelay: 300
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2001
@@ -46771,7 +45826,6 @@ mob_db: (
 	AttackDelay: 300
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2002
@@ -46808,7 +45862,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 552
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Magical_Moon_Cake: 1000
 		Plantain: 500
@@ -46855,7 +45908,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 1000
 		Moon_Cake2: 1000
@@ -46906,7 +45958,6 @@ mob_db: (
 	AttackDelay: 637
 	AttackMotion: 1008
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 800
 		Moon_Cake2: 800
@@ -46955,7 +46006,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 500
 		Moon_Cake2: 500
@@ -47002,7 +46052,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Moon_Cake15: 500
 		Moon_Cake16: 500
@@ -47049,7 +46098,6 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 1440
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 500
 		Moon_Cake2: 500
@@ -47099,7 +46147,6 @@ mob_db: (
 	AttackDelay: 828
 	AttackMotion: 528
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 2009
@@ -47141,7 +46188,6 @@ mob_db: (
 	AttackDelay: 414
 	AttackMotion: 1080
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Cowkings_Nose_Ring: 10000
 	}
@@ -47184,7 +46230,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 960
 	DamageMotion: 780
-	MvpExp: 0
 },
 {
 	Id: 2011
@@ -47224,7 +46269,6 @@ mob_db: (
 	AttackDelay: 2456
 	AttackMotion: 912
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Horrendous_Mouth: 6000
 		Oridecon_Stone: 110
@@ -47272,7 +46316,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Decayed_Nail: 9000
 		Cardinal_Jewel_: 6
@@ -47319,7 +46362,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Dragons_Mane: 3000
 		Dragons_Skin: 100
@@ -47361,7 +46403,6 @@ mob_db: (
 	AttackDelay: 24
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Egg_Shell: 20
@@ -47406,7 +46447,6 @@ mob_db: (
 	AttackDelay: 1426
 	AttackMotion: 600
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sharp_Leaf: 5000
 		Great_Leaf: 2000
@@ -47456,7 +46496,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 960
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Crystalized_Teardrop: 1000
 		Fluorescent_Liquid: 5000
@@ -47505,7 +46544,6 @@ mob_db: (
 	AttackDelay: 792
 	AttackMotion: 540
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Unripe_Acorn: 5000
 		Acorn: 5000
@@ -47554,7 +46592,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 420
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Carrot: 5000
 		Fur: 4000
@@ -47604,7 +46641,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 960
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Tough_Vines: 1000
 		Great_Leaf: 1000
@@ -47653,7 +46689,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 660
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Fluorescent_Liquid: 5000
 		Karvodailnirol: 5
@@ -47697,7 +46732,6 @@ mob_db: (
 	AttackDelay: 360
 	AttackMotion: 780
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Fluorescent_Liquid: 5000
 		Detrimindexta: 5
@@ -47804,7 +46838,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1776
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Black_Cloth: 5000
 		Skul_Ring: 1000
@@ -47855,7 +46888,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1200
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Stone_Piece: 3000
 		Stone_Heart: 5000
@@ -47900,7 +46932,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Chocolate: 5000
 		Chocolate: 5000
@@ -47952,7 +46983,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Old_Frying_Pan: 5000
 		Delicious_Fish: 500
@@ -48005,7 +47035,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1776
 	DamageMotion: 648
-	MvpExp: 0
 },
 // Additional Monsters
 /*{
@@ -48042,7 +47071,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Coin: 5000
 	}
@@ -48081,7 +47109,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 10
 		Natural_Leather: 2000
@@ -48136,7 +47163,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Popes_Cookie: 5000
 	}
@@ -48184,7 +47210,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Popes_Cookie: 5000
 	}
@@ -48227,7 +47252,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 480
 	DamageMotion: 120
-	MvpExp: 0
 },
 {
 	Id: 2033
@@ -48259,7 +47283,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 	Drops: {
 		Gold_Tulip: 10000
 	}
@@ -48298,7 +47321,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 900
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 2035
@@ -48334,7 +47356,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 },
 {
 	Id: 2036
@@ -48375,7 +47396,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Broken_Horn_Pipe: 9000
 		Broken_Horn_Pipe: 5000
@@ -48416,7 +47436,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2038
@@ -48452,7 +47471,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2039
@@ -48496,7 +47514,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 500
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 2040
@@ -48541,7 +47558,6 @@ mob_db: (
 	AttackDelay: 816
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 2041
@@ -48585,7 +47601,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 },
 // Mechanic Fixed Autonomous Weapon Platforms
 {
@@ -48622,7 +47637,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48661,7 +47675,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48700,7 +47713,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48739,7 +47751,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48778,7 +47789,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 1000
 	}
@@ -48824,7 +47834,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Scale_Of_Snakes: 5000
 	}
@@ -48867,7 +47876,6 @@ mob_db: (
 	AttackDelay: 1426
 	AttackMotion: 600
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Withered_Flower: 1000
 	}
@@ -48911,7 +47919,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1200
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Purified_Bradium: 500
 	}
@@ -48954,7 +47961,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 960
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Tiny_Waterbottle: 100
 	}
@@ -49001,7 +48007,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Fools_Day_Box: 5000
 		Fools_Day_Box2: 5000
@@ -49093,7 +48098,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate01: 50
@@ -49145,7 +48149,6 @@ mob_db: (
 	AttackDelay: 1504
 	AttackMotion: 840
 	DamageMotion: 900
-	MvpExp: 0
 },
 {
 	Id: 2055
@@ -49188,7 +48191,6 @@ mob_db: (
 	AttackDelay: 850
 	AttackMotion: 600
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 2056
@@ -49228,7 +48230,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 2112
 	DamageMotion: 768
-	MvpExp: 0
 },*/
 {
 	Id: 2057
@@ -49269,7 +48270,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 },
 {
 	Id: 2058
@@ -49309,7 +48309,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 500
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2059
@@ -49349,7 +48348,6 @@ mob_db: (
 	AttackDelay: 516
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 2060
@@ -49386,7 +48384,6 @@ mob_db: (
 	AttackDelay: 502
 	AttackMotion: 1999
 	DamageMotion: 480
-	MvpExp: 0
 },
 /*{
 	Id: 2061
@@ -49423,7 +48420,6 @@ mob_db: (
 	AttackDelay: 936
 	AttackMotion: 792
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Jellopy: 1000
 		Jubilee: 1000
@@ -49470,7 +48466,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sticky_Mucus: 5500
 		Garlet: 1500
@@ -49517,7 +48512,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7500
 		Rod_: 80
@@ -49564,7 +48558,6 @@ mob_db: (
 	AttackDelay: 1472
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Elunium_Stone: 34
@@ -49610,7 +48603,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Tube: 4000
 		Lost_Card4: 4000
@@ -49664,7 +48656,6 @@ mob_db: (
 	AttackDelay: 1084
 	AttackMotion: 2304
 	DamageMotion: 576
-	MvpExp: 0
 	MvpDrops: {
 		Mosquito_Coil: 10000
 	}
@@ -49707,7 +48698,6 @@ mob_db: (
 	AttackDelay: 1084
 	AttackMotion: 2304
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Wing_Of_Fly: 1000
 		Animal_Blood: 10
@@ -49808,7 +48798,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 5
 		Heart_Of_Mermaid: 9000
@@ -49857,7 +48846,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 480
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Gill: 600
 		Mistic_Frozen: 5
@@ -49907,7 +48895,6 @@ mob_db: (
 	AttackDelay: 1216
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Burning_Horse_Shoe: 4000
 		Plate_Armor_: 5
@@ -49953,7 +48940,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 1248
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Leopard_Skin: 3000
 		Leopard_Talon: 2000
@@ -49998,7 +48984,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 1440
 	DamageMotion: 960
-	MvpExp: 0
 	Drops: {
 		Talon: 3000
 		Cyfar: 1000
@@ -50045,7 +49030,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 480
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Meat: 3000
 		Elunium_Stone: 250
@@ -50089,7 +49073,6 @@ mob_db: (
 	AttackDelay: 1632
 	AttackMotion: 432
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Nipper: 5000
 		Broken_Steel_Piece: 3000
@@ -50143,7 +49126,6 @@ mob_db: (
 	AttackDelay: 1056
 	AttackMotion: 1056
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 2077
@@ -50185,7 +49167,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 384
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2078
@@ -50228,7 +49209,6 @@ mob_db: (
 	AttackDelay: 1306
 	AttackMotion: 1056
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2079
@@ -50270,7 +49250,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2080
@@ -50312,7 +49291,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2081
@@ -50345,7 +49323,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 432
 	DamageMotion: 600
-	MvpExp: 0
 },
 {
 	Id: 2082
@@ -50386,7 +49363,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 480
 	DamageMotion: 864
-	MvpExp: 0
 },
 // El Dicastes (13.3)
 {
@@ -50427,7 +49403,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Singlehorn_Helm: 6500
 		Imperial_Spear: 10
@@ -50475,7 +49450,6 @@ mob_db: (
 	AttackDelay: 336
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Twinhorn_Helm: 6500
 		Black_Wing: 10
@@ -50524,7 +49498,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Antler_Helm: 6500
 		Green_Whistle: 10
@@ -50573,7 +49546,6 @@ mob_db: (
 	AttackDelay: 588
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rakehorn_Helm: 6500
 		Red_Ether_Bag: 10
@@ -50674,7 +49646,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 1
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Honey: 100
@@ -50715,7 +49686,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 1
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Honey: 100
@@ -50755,7 +49725,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 1
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Honey: 100
@@ -50795,7 +49764,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 1
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Honey: 100
@@ -50842,7 +49810,6 @@ mob_db: (
 	AttackDelay: 360
 	AttackMotion: 360
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Small_Bradium: 3000
 		White_Spider_Limb: 5000
@@ -50888,7 +49855,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Crumpled_Paper: 7000
 		Crumpled_Paper: 3500
@@ -51414,7 +50380,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	MvpDrops: {
 		Skull: 6000
 		Blue_Coif_: 2000
@@ -52116,7 +51081,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2115
@@ -52152,7 +51116,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2116
@@ -52188,7 +51151,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2117
@@ -52224,7 +51186,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2118
@@ -52260,7 +51221,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2119
@@ -52296,7 +51256,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2120
@@ -52332,7 +51291,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2121
@@ -52368,7 +51326,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2122
@@ -52404,7 +51361,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2123
@@ -52440,7 +51396,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2124
@@ -52476,7 +51431,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2125
@@ -52512,7 +51466,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2126
@@ -52553,7 +51506,6 @@ mob_db: (
 	AttackDelay: 1084
 	AttackMotion: 2304
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 2127
@@ -52591,7 +51543,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 216
-	MvpExp: 0
 },
 {
 	Id: 2128
@@ -52629,7 +51580,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 216
-	MvpExp: 0
 },
 {
 	Id: 2129
@@ -52673,7 +51623,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 2130
@@ -52717,7 +51666,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 },*/
 // Bifrost (14.1)
 {
@@ -52760,7 +51708,6 @@ mob_db: (
 	AttackDelay: 840
 	AttackMotion: 648
 	DamageMotion: 576
-	MvpExp: 0
 	MvpDrops: {
 		Old_Card_Album: 500
 		Old_Violet_Box: 5000
@@ -52814,7 +51761,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 1056
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Fruit_Basket: 500
 		Mora_Mandarin: 1000
@@ -52863,7 +51809,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 480
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Withered_Flower: 3000
 		Soft_Leaf: 1000
@@ -52909,7 +51854,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 792
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Round_Feather: 3000
 		Soft_Feather: 1000
@@ -52953,7 +51897,6 @@ mob_db: (
 	AttackDelay: 192
 	AttackMotion: 192
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 2136
@@ -52993,7 +51936,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 300
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Angel_Magic_Power: 3000
 		Light_Granule: 100
@@ -53040,7 +51982,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 1140
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Golden_Feather: 3000
 		Light_Granule: 100
@@ -53086,7 +52027,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 576
 	DamageMotion: 1248
-	MvpExp: 0
 },
 {
 	Id: 2139
@@ -53125,7 +52065,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 576
 	DamageMotion: 1248
-	MvpExp: 0
 },
 {
 	Id: 2140
@@ -53164,7 +52103,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 576
 	DamageMotion: 1248
-	MvpExp: 0
 },
 {
 	Id: 2141
@@ -53203,7 +52141,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 576
 	DamageMotion: 1248
-	MvpExp: 0
 },
 {
 	Id: 2142
@@ -53242,7 +52179,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 576
 	DamageMotion: 1248
-	MvpExp: 0
 },
 {
 	Id: 2143
@@ -53281,7 +52217,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 576
 	DamageMotion: 1248
-	MvpExp: 0
 },
 {
 	Id: 2144
@@ -53322,7 +52257,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2145
@@ -53363,7 +52297,6 @@ mob_db: (
 	AttackDelay: 588
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2146
@@ -53408,7 +52341,6 @@ mob_db: (
 	AttackDelay: 1596
 	AttackMotion: 1620
 	DamageMotion: 864
-	MvpExp: 0
 },
 {
 	Id: 2147
@@ -53445,7 +52377,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2148
@@ -53482,7 +52413,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2149
@@ -53519,7 +52449,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2150
@@ -53555,7 +52484,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 96
 	DamageMotion: 96
-	MvpExp: 0
 	Drops: {
 		Stem: 3000
 		Thin_Stem: 2000
@@ -53604,7 +52532,6 @@ mob_db: (
 	AttackDelay: 500
 	AttackMotion: 576
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Clover: 250
 		Leaflet_Of_Hinal: 426
@@ -53653,7 +52580,6 @@ mob_db: (
 	AttackDelay: 500
 	AttackMotion: 576
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Comodo_L: 5000
 		Meat: 9000
@@ -53700,7 +52626,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Cendrawasih_F: 9000
 		Soft_Feather: 8000
@@ -53746,7 +52671,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 2304
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Coal: 1000
 		Zargon: 2000
@@ -53794,7 +52718,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 768
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Sticky_Mucus: 2750
 		Meat: 500
@@ -53844,7 +52767,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 360
-	MvpExp: 0
 	MvpDrops: {
 		Old_Violet_Box: 5000
 		Old_Violet_Box: 5000
@@ -53897,7 +52819,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 // Homunculus S Summons
 {
@@ -53935,7 +52856,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 216
-	MvpExp: 0
 },
 {
 	Id: 2159
@@ -53972,7 +52892,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 340
-	MvpExp: 0
 },
 {
 	Id: 2160
@@ -54009,7 +52928,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 },
 // Nightmare Scaraba Hole
 {
@@ -54053,7 +52971,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Singlehorn_Helm: 6500
 		Imperial_Spear: 10
@@ -54106,7 +53023,6 @@ mob_db: (
 	AttackDelay: 336
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Twinhorn_Helm: 6500
 		Black_Wing: 10
@@ -54158,7 +53074,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Antler_Helm: 6500
 		Green_Whistle: 10
@@ -54210,7 +53125,6 @@ mob_db: (
 	AttackDelay: 588
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rakehorn_Helm: 6500
 		Red_Ether_Bag: 10
@@ -54264,7 +53178,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 1000
 	DamageMotion: 360
-	MvpExp: 0
 	MvpDrops: {
 		Old_Card_Album: 5000
 		Old_Card_Album: 5000
@@ -54313,7 +53226,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 1
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Honey: 100
@@ -54352,7 +53264,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 1
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Honey: 100
@@ -54390,7 +53301,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 1
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Honey: 100
@@ -54428,7 +53338,6 @@ mob_db: (
 	AttackDelay: 96
 	AttackMotion: 1
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
 		Honey: 100
@@ -54477,7 +53386,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2171
@@ -54519,7 +53427,6 @@ mob_db: (
 	AttackDelay: 588
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2172
@@ -54562,7 +53469,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2173
@@ -54605,7 +53511,6 @@ mob_db: (
 	AttackDelay: 336
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 },
 // Malangdo Island
 {
@@ -54650,7 +53555,6 @@ mob_db: (
 	AttackDelay: 1632
 	AttackMotion: 432
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 40
 		Nipper: 9000
@@ -54702,7 +53606,6 @@ mob_db: (
 	AttackDelay: 1956
 	AttackMotion: 756
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Chinese_Ink: 9000
 		Tentacle: 3000
@@ -54754,7 +53657,6 @@ mob_db: (
 	AttackDelay: 992
 	AttackMotion: 792
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Crap_Shell: 5500
 		Nipper: 1500
@@ -54805,7 +53707,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 48
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 46
 		Conch: 5500
@@ -54857,7 +53758,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Clam_Shell: 5500
 		Flesh_Of_Clam: 1000
@@ -54909,7 +53809,6 @@ mob_db: (
 	AttackDelay: 1776
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 30
 		Worm_Peelings: 5500
@@ -54961,7 +53860,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Fin: 5336
 		Oridecon_Stone: 116
@@ -55013,7 +53911,6 @@ mob_db: (
 	AttackDelay: 1968
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 10
 		Sharp_Scale: 9000
@@ -55065,7 +53962,6 @@ mob_db: (
 	AttackDelay: 1272
 	AttackMotion: 72
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 18
 		Gill: 9000
@@ -55117,7 +54013,6 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 500
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Anolian_Skin: 4850
 		Crystal_Arrow: 2000
@@ -55169,7 +54064,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 14
 		Heart_Of_Mermaid: 9000
@@ -55221,7 +54115,6 @@ mob_db: (
 	AttackDelay: 2012
 	AttackMotion: 1728
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Yellow_Plate: 6500
 		Cyfar: 3500
@@ -55274,7 +54167,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Agrade_Pocket: 10000
 		Mid_Coin_Pocket: 4000
@@ -55328,7 +54220,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Agrade_Pocket: 10000
 		Mid_Coin_Pocket: 10000
@@ -55382,7 +54273,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Agrade_Pocket: 10000
 		Mid_Coin_Pocket: 10000
@@ -55436,7 +54326,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Agrade_Pocket: 14000
 		Anger_Seagod: 14000
@@ -55490,7 +54379,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Agrade_Pocket: 14000
 		Anger_Seagod: 10000
@@ -55539,7 +54427,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 720
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2192
@@ -55582,7 +54469,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 2160
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Chinese_Ink: 5000
 		Tentacle: 5000
@@ -55626,7 +54512,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 720
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Chinese_Ink: 9000
 		Tentacle: 5000
@@ -55676,7 +54561,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 1584
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Bgrade_Pocket: 3000
 		Mid_Coin_Pocket: 1000
@@ -55727,7 +54611,6 @@ mob_db: (
 	AttackDelay: 1776
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2196
@@ -55770,7 +54653,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 2197
@@ -55808,7 +54690,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1224
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Clam_Shell: 5000
 		Flesh_Of_Clam: 2000
@@ -55862,7 +54743,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Ice_Fragment: 100
 		Nipper: 5000
@@ -55909,7 +54789,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 1296
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Delicious_Jelly: 1400
 		Skull: 1000
@@ -55957,7 +54836,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2201
@@ -56001,7 +54879,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 792
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Fin: 5000
 		Electric_Eel: 4
@@ -56109,7 +54986,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 936
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Ice_Crystal: 10
 		Coral_Reef: 1000
@@ -56163,7 +55039,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 792
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Tentacle: 5000
 		Tidal_Shoes: 6
@@ -56210,7 +55085,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },*/
 {
 	Id: 2206
@@ -56255,7 +55129,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 864
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Sticky_Poison: 2
 		Cold_Ice: 2
@@ -56296,7 +55169,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },*/
 {
 	Id: 2208
@@ -56340,7 +55212,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 792
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Delicious_Jelly: 5000
 		Gill: 5000
@@ -56388,7 +55259,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 },
 {
 	Id: 2210
@@ -56426,7 +55296,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 },
 {
 	Id: 2211
@@ -56464,7 +55333,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 780
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Old_Blue_Box: 1000
 		Gift_Box: 3000
@@ -56511,7 +55379,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2213
@@ -56549,7 +55416,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 2214
@@ -56587,7 +55453,6 @@ mob_db: (
 	AttackDelay: 637
 	AttackMotion: 1008
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2215
@@ -56624,7 +55489,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 600
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2216
@@ -56661,7 +55525,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2217
@@ -56698,7 +55561,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 780
 	DamageMotion: 504
-	MvpExp: 0
 },
 {
 	Id: 2218
@@ -56736,7 +55598,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2219
@@ -56773,7 +55634,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2220
@@ -56811,7 +55671,6 @@ mob_db: (
 	AttackDelay: 912
 	AttackMotion: 1248
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Chocolate: 10000
 		White_Chocolate: 6000
@@ -56859,7 +55718,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 4000
 		Goast_Chill: 2
@@ -56909,7 +55767,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 4000
 		Goast_Chill: 2
@@ -56959,7 +55816,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 4000
 		Goast_Chill: 2
@@ -57010,7 +55866,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 768
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Goast_Chill: 2
 		Lab_Staff_Record: 4000
@@ -57061,7 +55916,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Goast_Chill: 2
 		Lab_Staff_Record: 4000
@@ -57111,7 +55965,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Goast_Chill: 2
 		Lab_Staff_Record: 4000
@@ -57161,7 +56014,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Goast_Chill: 2
 		Lab_Staff_Record: 4000
@@ -57216,7 +56068,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2229
@@ -57261,7 +56112,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2230
@@ -57306,7 +56156,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2231
@@ -57351,7 +56200,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 768
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2232
@@ -57396,7 +56244,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2233
@@ -57441,7 +56288,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2234
@@ -57486,7 +56332,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2235
@@ -57531,7 +56376,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	MvpDrops: {
 		Magic_Card_Album: 5000
 		Old_Violet_Box: 5000
@@ -57590,7 +56434,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	MvpDrops: {
 		Magic_Card_Album: 5000
 		Old_Violet_Box: 5000
@@ -57650,7 +56493,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	MvpDrops: {
 		Magic_Card_Album: 5000
 		Old_Violet_Box: 5000
@@ -57708,7 +56550,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 768
 	DamageMotion: 288
-	MvpExp: 0
 	MvpDrops: {
 		Magic_Card_Album: 5000
 		Old_Violet_Box: 5000
@@ -57767,7 +56608,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	MvpDrops: {
 		Magic_Card_Album: 5000
 		Old_Violet_Box: 5000
@@ -57826,7 +56666,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	MvpDrops: {
 		Magic_Card_Album: 5000
 		Old_Violet_Box: 5000
@@ -57884,7 +56723,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	MvpDrops: {
 		Magic_Card_Album: 5000
 		Old_Violet_Box: 5000
@@ -57935,7 +56773,6 @@ mob_db: (
 	AttackDelay: 200
 	AttackMotion: 420
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2243
@@ -57972,7 +56809,6 @@ mob_db: (
 	AttackDelay: 200
 	AttackMotion: 900
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 2244
@@ -58010,7 +56846,6 @@ mob_db: (
 	AttackDelay: 200
 	AttackMotion: 768
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2245
@@ -58043,7 +56878,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 480
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2246
@@ -58076,7 +56910,6 @@ mob_db: (
 	AttackDelay: 912
 	AttackMotion: 1344
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2247
@@ -58109,7 +56942,6 @@ mob_db: (
 	AttackDelay: 106
 	AttackMotion: 1056
 	DamageMotion: 576
-	MvpExp: 0
 },
 {
 	Id: 2248
@@ -58145,7 +56977,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Blue_Card_C: 4000
 		BlueCard_2: 4000
@@ -58259,7 +57090,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		High_Weapon_Box: 10
 		Old_Violet_Box: 6000
@@ -58369,7 +57199,6 @@ mob_db: (
 	AttackDelay: 880
 	AttackMotion: 1224
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		High_Weapon_Box: 10
 		Old_Violet_Box: 6000
@@ -58481,7 +57310,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 1008
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		High_Weapon_Box: 10
 		Old_Violet_Box: 6000
@@ -58592,7 +57420,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 504
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		High_Weapon_Box: 10
 		Old_Violet_Box: 6000
@@ -58638,7 +57465,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2258
@@ -58675,7 +57501,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2259
@@ -58712,7 +57537,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2260
@@ -58749,7 +57573,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2261
@@ -58786,7 +57609,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2262
@@ -58823,7 +57645,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2263
@@ -58860,7 +57681,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2264
@@ -58898,7 +57718,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2265
@@ -58936,7 +57755,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2266
@@ -58974,7 +57792,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2267
@@ -59012,7 +57829,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2268
@@ -59050,7 +57866,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2269
@@ -59088,7 +57903,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2270
@@ -59126,7 +57940,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2271
@@ -59164,7 +57977,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2272
@@ -59202,7 +58014,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2273
@@ -59240,7 +58051,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2274
@@ -59278,7 +58088,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2275
@@ -59316,7 +58125,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2276
@@ -59353,7 +58161,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2277
@@ -59397,7 +58204,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2278
@@ -59440,7 +58246,6 @@ mob_db: (
 	AttackDelay: 880
 	AttackMotion: 1224
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2279
@@ -59483,7 +58288,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 1008
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 2280
@@ -59526,7 +58330,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 504
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2281
@@ -59570,7 +58373,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1776
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Black_Cloth: 5000
 		Skul_Ring: 1000
@@ -59623,7 +58425,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 720
 	DamageMotion: 200
-	MvpExp: 0
 	Drops: {
 		Brigan: 4656
 		Red_Frame: 1000
@@ -59676,7 +58477,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 1252
 	DamageMotion: 476
-	MvpExp: 0
 	Drops: {
 		Velum_Bible: 2
 		Black_Rosary: 2
@@ -59729,7 +58529,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 100
 		Cobold_Hair: 5336
@@ -59781,7 +58580,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 100
 		Cobold_Hair: 5336
@@ -59833,7 +58631,6 @@ mob_db: (
 	AttackDelay: 1228
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 100
 		Cobold_Hair: 5336
@@ -59885,7 +58682,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1008
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Zargon: 250
 		Steel: 60
@@ -59930,7 +58726,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Woe_Violet_Potion: 4000
 		Woe_White_Potion: 2000
@@ -59978,7 +58773,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2290
@@ -60015,7 +58809,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2291
@@ -60052,7 +58845,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2292
@@ -60089,7 +58881,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2293
@@ -60126,7 +58917,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2294
@@ -60163,7 +58953,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2295
@@ -60200,7 +58989,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2296
@@ -60237,7 +59025,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2297
@@ -60274,7 +59061,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2298
@@ -60311,7 +59097,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2299
@@ -60348,7 +59133,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2300
@@ -60385,7 +59169,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2301
@@ -60422,7 +59205,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2302
@@ -60459,7 +59241,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2303
@@ -60496,7 +59277,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2304
@@ -60533,7 +59313,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2305
@@ -60570,7 +59349,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2306
@@ -60607,7 +59385,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2307
@@ -60644,7 +59421,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2308
@@ -60676,7 +59452,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 // Malaya Port
 {
@@ -60720,7 +59495,6 @@ mob_db: (
 	AttackDelay: 1568
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 2000
 		Beautiful_Flower: 2000
@@ -60770,7 +59544,6 @@ mob_db: (
 	AttackDelay: 1424
 	AttackMotion: 576
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 2000
 		Beautiful_Flower: 2000
@@ -60820,7 +59593,6 @@ mob_db: (
 	AttackDelay: 280
 	AttackMotion: 720
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Silver_Bracelet: 4000
 		Elegant_Flower: 2000
@@ -60873,7 +59645,6 @@ mob_db: (
 	AttackDelay: 1664
 	AttackMotion: 336
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Brigan: 2000
 		Elegant_Flower: 2000
@@ -60925,7 +59696,6 @@ mob_db: (
 	AttackDelay: 1064
 	AttackMotion: 936
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Tikbalang_Thick_Spine: 1000
 		Oridecon: 20
@@ -60974,7 +59744,6 @@ mob_db: (
 	AttackDelay: 496
 	AttackMotion: 504
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Silver_Bracelet: 3000
 		Mysterious_Flower: 2000
@@ -61023,7 +59792,6 @@ mob_db: (
 	AttackDelay: 424
 	AttackMotion: 576
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Silver_Bracelet: 3000
 		Mysterious_Flower: 2000
@@ -61065,7 +59833,6 @@ mob_db: (
 	AttackDelay: 1328
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jejellopy: 4000
 		Jellopy: 2000
@@ -61118,7 +59885,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 1080
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Bangungot_Card: 1
 	}
@@ -61157,7 +59923,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 1080
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2319
@@ -61248,7 +60013,6 @@ mob_db: (
 	AttackDelay: 440
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Bakonawa_Card: 1
 	}
@@ -61289,7 +60053,6 @@ mob_db: (
 	AttackDelay: 440
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 2322
@@ -61327,7 +60090,6 @@ mob_db: (
 	AttackDelay: 440
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 },
 {
 	Id: 2323
@@ -61367,7 +60129,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Gift_Box_1: 1000
 		Gift_Box_2: 1000
@@ -61415,7 +60176,6 @@ mob_db: (
 	AttackDelay: 832
 	AttackMotion: 500
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Gift_Box_1: 1000
 		Gift_Box_2: 1000
@@ -61466,7 +60226,6 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 480
 	DamageMotion: 120
-	MvpExp: 0
 },
 {
 	Id: 2326
@@ -61510,7 +60269,6 @@ mob_db: (
 	AttackDelay: 1430
 	AttackMotion: 1080
 	DamageMotion: 1080
-	MvpExp: 0
 },
 {
 	Id: 2327
@@ -61553,7 +60311,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Bangungot_Doll: 4000
 		Bangungot_Spirit_Piece: 100
@@ -61597,7 +60354,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 },
 {
 	Id: 2329
@@ -61629,7 +60385,6 @@ mob_db: (
 	AttackDelay: 1001
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 },
 {
 	Id: 2330
@@ -61673,7 +60428,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 },
 {
 	Id: 2331
@@ -61711,7 +60465,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 720
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2332
@@ -61756,7 +60509,6 @@ mob_db: (
 	AttackDelay: 1424
 	AttackMotion: 576
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2333
@@ -61793,7 +60545,6 @@ mob_db: (
 	AttackDelay: 1
 	AttackMotion: 1
 	DamageMotion: 1
-	MvpExp: 0
 },
 {
 	Id: 2334
@@ -61830,7 +60581,6 @@ mob_db: (
 	AttackDelay: 424
 	AttackMotion: 576
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2335
@@ -61867,7 +60617,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		Bakonawa_Doll: 4000
 		Bakonawa_Spirit_Piece: 100
@@ -61913,7 +60662,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 1200
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2337
@@ -61952,7 +60700,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 1000
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2338
@@ -61996,7 +60743,6 @@ mob_db: (
 	AttackDelay: 280
 	AttackMotion: 720
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2339
@@ -62040,7 +60786,6 @@ mob_db: (
 	AttackDelay: 1664
 	AttackMotion: 336
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2340
@@ -62083,7 +60828,6 @@ mob_db: (
 	AttackDelay: 496
 	AttackMotion: 504
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2341
@@ -62188,7 +60932,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 780
 	DamageMotion: 180
-	MvpExp: 0
 },
 {
 	Id: 2343
@@ -62227,7 +60970,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 2000
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2344
@@ -62264,7 +61006,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2345
@@ -62309,7 +61050,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 780
 	DamageMotion: 180
-	MvpExp: 0
 },
 {
 	Id: 2346
@@ -62346,7 +61086,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2347
@@ -62390,7 +61129,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 780
 	DamageMotion: 180
-	MvpExp: 0
 },
 {
 	Id: 2348
@@ -62435,7 +61173,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 780
 	DamageMotion: 180
-	MvpExp: 0
 },
 {
 	Id: 2349
@@ -62479,7 +61216,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 780
 	DamageMotion: 180
-	MvpExp: 0
 },
 {
 	Id: 2350
@@ -62524,7 +61260,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 780
 	DamageMotion: 180
-	MvpExp: 0
 },
 {
 	Id: 2351
@@ -62568,7 +61303,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 780
 	DamageMotion: 180
-	MvpExp: 0
 },
 // Nightmare Pyramids
 {
@@ -62606,7 +61340,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2353
@@ -62650,7 +61383,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 10000
 		Oridecon_Stone: 400
@@ -62704,7 +61436,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Rotten_Bandage: 18000
 		Oridecon_Stone: 200
@@ -62758,7 +61489,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Immortal_Heart: 18000
 		Zargon: 1400
@@ -62812,7 +61542,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 500
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 12
 		Old_Blue_Box: 100
@@ -62865,7 +61594,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 500
 	DamageMotion: 288
-	MvpExp: 0
 },
 {
 	Id: 2358
@@ -62909,7 +61637,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 500
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Round_Shell: 7000
 		Sticky_Mucus: 6000
@@ -62963,7 +61690,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 500
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2360
@@ -63007,7 +61733,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 120
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Rotten_Bandage: 9000
 		Mementos: 3600
@@ -63061,7 +61786,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 120
 	DamageMotion: 384
-	MvpExp: 0
 },
 {
 	Id: 2362
@@ -63159,7 +61883,6 @@ mob_db: (
 	AttackDelay: 472
 	AttackMotion: 1056
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fancy_Fairy_Wing: 3000
 		Great_Wing: 1000
@@ -63209,7 +61932,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Pile_Of_Acorn: 3000
 		Unripe_Acorn: 1000
@@ -63260,7 +61982,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 720
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Dustball: 5000
 		Poisonous_Gas: 500
@@ -63311,7 +62032,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Leaf_Bookmark: 3000
 		Bookclip_In_Memory: 1000
@@ -63362,7 +62082,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 1728
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Star_Crumb: 1000
 		Sparkling_Dust: 1000
@@ -63413,7 +62132,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 2304
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Star_Crumb: 1000
 		Sparkling_Dust: 1000
@@ -63464,7 +62182,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 4032
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Star_Crumb: 1000
 		Sparkling_Dust: 1000
@@ -63515,7 +62232,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 3456
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Star_Crumb: 1000
 		Sparkling_Dust: 1000
@@ -63565,7 +62281,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 1536
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Eye_Drops: 3000
 		Tiny_Waterbottle: 1000
@@ -63611,7 +62326,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2373
@@ -63648,7 +62362,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2374
@@ -63685,7 +62398,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2375
@@ -63722,7 +62434,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2376
@@ -63759,7 +62470,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2377
@@ -63796,7 +62506,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2378
@@ -63840,7 +62549,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 },
 {
 	Id: 2379
@@ -63878,7 +62586,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Red_Cloth: 6000
 		Red_Cloth: 6000
@@ -63920,7 +62627,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Stolen_Cookie: 6000
 		Stolen_Candy: 6000
@@ -63983,7 +62689,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 9000
 		Knife_: 100
@@ -64028,7 +62733,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2402
@@ -64061,7 +62765,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2403
@@ -64094,7 +62797,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 2404
@@ -64126,7 +62828,6 @@ mob_db: (
 	AttackDelay: 2208
 	AttackMotion: 1008
 	DamageMotion: 324
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 2000
 		Garlet: 70
@@ -64166,7 +62867,6 @@ mob_db: (
 	AttackDelay: 2228
 	AttackMotion: 528
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Phracon: 45
 		Skel_Bone: 800
@@ -64206,7 +62906,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 1300
 		Oridecon_Stone: 15
@@ -64247,7 +62946,6 @@ mob_db: (
 	AttackDelay: 2228
 	AttackMotion: 528
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 700
 		Pirate_Bandana: 4
@@ -64292,7 +62990,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2409
@@ -64328,7 +63025,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2410
@@ -64364,7 +63060,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2411
@@ -64400,7 +63095,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 //2412,E_VALKIWI
 {
@@ -64436,7 +63130,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 },
 {
 	Id: 2414
@@ -66189,7 +64882,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66234,7 +64926,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66279,7 +64970,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66324,7 +65014,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66369,7 +65058,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66414,7 +65102,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66459,7 +65146,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66504,7 +65190,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66549,7 +65234,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66594,7 +65278,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66639,7 +65322,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66684,7 +65366,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66729,7 +65410,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66774,7 +65454,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66819,7 +65498,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66864,7 +65542,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66909,7 +65586,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -66955,7 +65631,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -67000,7 +65675,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -67045,7 +65719,6 @@ mob_db: (
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
-	MvpExp: 0
 	Drops: {
 		/* Needs more information */
 	}
@@ -67126,7 +65799,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 648
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Clattering_Skull: 3000
 		Platinum_Shotel: 10
@@ -67176,7 +65848,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Prison_Uniform: 3500
 		Spoon_Stub: 105
@@ -67228,7 +65899,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Tatters_Clothes: 4413
 		Sticky_Mucus: 1500
@@ -67278,7 +65948,6 @@ mob_db: (
 	AttackDelay: 2612
 	AttackMotion: 912
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Decayed_Nail: 9000
 		Cardinal_Jewel_: 5
@@ -67326,7 +65995,6 @@ mob_db: (
 	AttackDelay: 580
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 5000
 		Steel: 500
@@ -67375,7 +66043,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 54
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yoyo_Tail: 9000
 		Banana: 1500
@@ -67424,7 +66091,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 54
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yoyo_Tail: 9000
 		Banana: 1500
@@ -67471,7 +66137,6 @@ mob_db: (
 	AttackDelay: 1048
 	AttackMotion: 48
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 60
 		Emveretarcon: 25
@@ -67521,7 +66186,6 @@ mob_db: (
 	AttackDelay: 912
 	AttackMotion: 1344
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Meat: 4500
 		Shoulder_Protection: 4000
@@ -67567,7 +66231,6 @@ mob_db: (
 	AttackDelay: 2304
 	AttackMotion: 840
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Iron_Wrist: 5
 		Solid_Twig: 4000
@@ -67614,7 +66277,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 504
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 20
 		Claw_Of_Wolves: 9000
@@ -67667,7 +66329,6 @@ mob_db: (
 	AttackDelay: 1056
 	AttackMotion: 1056
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Zargon: 4559
 		Skel_Bone: 6000
@@ -67713,7 +66374,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Tree_Root: 9000
 		Wooden_Block: 100
@@ -67760,7 +66420,6 @@ mob_db: (
 	AttackDelay: 964
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Cyfar: 5335
 		Witherless_Rose: 50
@@ -67813,7 +66472,6 @@ mob_db: (
 	AttackDelay: 637
 	AttackMotion: 1008
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Limpid_Celestial_Robe: 3977
 		Soft_Silk_Cloth: 1380
@@ -67864,7 +66522,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 150
 		Transparent_Cloth: 5335
@@ -67908,7 +66565,6 @@ mob_db: (
 	AttackDelay: 2228
 	AttackMotion: 576
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Phracon: 45
 		Skel_Bone: 800
@@ -67959,7 +66615,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Skull: 4850
 		Old_Card_Album: 1
@@ -68007,7 +66662,6 @@ mob_db: (
 	AttackDelay: 1356
 	AttackMotion: 1056
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Golden_Hair: 6305
 		High_end_Cooking_Kits: 50
@@ -68055,7 +66709,6 @@ mob_db: (
 	AttackDelay: 1356
 	AttackMotion: 1056
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Golden_Hair: 6305
 		High_end_Cooking_Kits: 50
@@ -68103,7 +66756,6 @@ mob_db: (
 	AttackDelay: 1356
 	AttackMotion: 1056
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Golden_Hair: 6305
 		High_end_Cooking_Kits: 50
@@ -68153,7 +66805,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1440
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Air_Pollutant: 5000
 		Spawns: 3000
@@ -68203,7 +66854,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 1020
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Screw: 2000
 		Piece_Of_Crest1: 350
@@ -68253,7 +66903,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 600
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Old_Magic_Circle: 1000
 		Yaga_Pestle: 5000
@@ -68302,7 +66951,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		White_Mask: 2500
 		Royal_Jelly: 10
@@ -68349,7 +66997,6 @@ mob_db: (
 	AttackDelay: 1632
 	AttackMotion: 432
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Nipper: 10000
 		Garlet: 10000
@@ -68402,7 +67049,6 @@ mob_db: (
 	AttackDelay: 420
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Long_Limb: 4500
 		Jaws_Of_Ant: 3500
@@ -68450,7 +67096,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 1440
 	DamageMotion: 960
-	MvpExp: 0
 	Drops: {
 		Talon: 3000
 		Cyfar: 1000
@@ -68500,7 +67145,6 @@ mob_db: (
 	AttackDelay: 496
 	AttackMotion: 504
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Silver_Bracelet: 1500
 		Mysterious_Flower: 1000
@@ -68545,7 +67189,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 2500
 		Leather_Jacket_: 80
@@ -68593,7 +67236,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 2500
 		Leather_Jacket_: 80
@@ -68641,7 +67283,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 2500
 		Leather_Jacket_: 80
@@ -68686,7 +67327,6 @@ mob_db: (
 	AttackDelay: 2016
 	AttackMotion: 816
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 45
 		Spawn: 5500
@@ -68736,7 +67376,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 780
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Screw: 3800
 		Honey: 1000
@@ -68785,7 +67424,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Lunakaligo: 20
 		Cello: 10
@@ -68832,7 +67470,6 @@ mob_db: (
 	AttackDelay: 1744
 	AttackMotion: 1044
 	DamageMotion: 684
-	MvpExp: 0
 	Drops: {
 		Rat_Tail: 9000
 		Animals_Skin: 3000
@@ -68881,7 +67518,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 1152
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Sword_Accessory: 4850
 		Broken_Armor_Piece: 3000
@@ -68932,7 +67568,6 @@ mob_db: (
 	AttackDelay: 528
 	AttackMotion: 500
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Mud_Lump: 4850
 		Stone_Arrow: 1500
@@ -68982,7 +67617,6 @@ mob_db: (
 	AttackDelay: 1956
 	AttackMotion: 756
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Tough_Scalelike_Stem: 5335
 		White_Herb: 1800
@@ -69032,7 +67666,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Wind_Of_Verdure: 90
 		Steel: 30
@@ -69079,7 +67712,6 @@ mob_db: (
 	AttackDelay: 936
 	AttackMotion: 792
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Jellopy: 1000
 		Jubilee: 1000
@@ -69125,7 +67757,6 @@ mob_db: (
 	AttackDelay: 1264
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mud_Lump: 2000
 		Brigan: 4850
@@ -69173,7 +67804,6 @@ mob_db: (
 	AttackDelay: 1688
 	AttackMotion: 1188
 	DamageMotion: 612
-	MvpExp: 0
 	Drops: {
 		Wind_Of_Verdure: 70
 		Emveretarcon: 30
@@ -69219,7 +67849,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mushroom_Spore: 9000
 		Red_Herb: 800
@@ -69266,7 +67895,6 @@ mob_db: (
 	AttackDelay: 1452
 	AttackMotion: 483
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 64
@@ -69316,7 +67944,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 5500
 		Oridecon_Stone: 60
@@ -69366,7 +67993,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 5500
 		Oridecon_Stone: 60
@@ -69419,7 +68045,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 420
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Feather: 200
 		Ring_: 1
@@ -69467,7 +68092,6 @@ mob_db: (
 	AttackDelay: 2112
 	AttackMotion: 912
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Long_Hair: 9000
 		Skirt_Of_Virgin: 50
@@ -69517,7 +68141,6 @@ mob_db: (
 	AttackDelay: 936
 	AttackMotion: 1020
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 3000
 		Ice_Piece: 1000
@@ -69563,7 +68186,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Scale_Of_Snakes: 9000
 		Katana_: 15
@@ -69610,7 +68232,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Raccoon_Leaf: 5500
 		Animals_Skin: 5500
@@ -69660,7 +68281,6 @@ mob_db: (
 	AttackDelay: 1350
 	AttackMotion: 1200
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Sand_Lump: 4947
 		Grit: 5335
@@ -69710,7 +68330,6 @@ mob_db: (
 	AttackDelay: 1350
 	AttackMotion: 1200
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Sand_Lump: 4947
 		Grit: 5335
@@ -69762,7 +68381,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 384
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rune_Of_Darkness: 3500
 		Peuz_Seal: 10
@@ -69814,7 +68432,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Burn_Tree: 2550
 		Oridecon_Stone: 160
@@ -69866,7 +68483,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Burn_Tree: 2550
 		Oridecon_Stone: 160
@@ -69916,7 +68532,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Iron: 400
 		Lantern: 5500
@@ -69963,7 +68578,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 648
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 1000
 		Ice_Piece: 500
@@ -70010,7 +68624,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Shining_Scales: 5335
 		Zargon: 1400
@@ -70060,7 +68673,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Shining_Scales: 5335
 		Zargon: 1400
@@ -70112,7 +68724,6 @@ mob_db: (
 	AttackDelay: 1003
 	AttackMotion: 1152
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Broken_Shuriken: 5335
 		Ninja_Suit: 2
@@ -70165,7 +68776,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 420
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Red_Feather: 200
 		Cursed_Seal: 1
@@ -70211,7 +68821,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Clam_Shell: 5500
 		Flesh_Of_Clam: 1000
@@ -70260,7 +68869,6 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 1500
 		Imma_Arrow_Container: 55
@@ -70310,7 +68918,6 @@ mob_db: (
 	AttackDelay: 1132
 	AttackMotion: 583
 	DamageMotion: 532
-	MvpExp: 0
 	Drops: {
 		Scarlet_Jewel: 150
 		Clam_Shell: 5500
@@ -70363,7 +68970,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 960
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Tentacle: 2500
 		Tidal_Shoes: 3
@@ -70413,7 +69019,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 70
 		Scorpions_Tail: 5500
@@ -70459,7 +69064,6 @@ mob_db: (
 	AttackDelay: 1624
 	AttackMotion: 624
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Animals_Skin: 9000
 		Axe_: 100
@@ -70506,7 +69110,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wild_Boars_Mane: 9000
 		Grape: 300
@@ -70553,7 +69156,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Wild_Boars_Mane: 9000
 		Grape: 300
@@ -70603,7 +69205,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 720
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Great_Nature: 35
 		Grit: 5335
@@ -70657,7 +69258,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Flame_Heart: 30
@@ -70707,7 +69307,6 @@ mob_db: (
 	AttackDelay: 2228
 	AttackMotion: 576
 	DamageMotion: 528
-	MvpExp: 0
 	Drops: {
 		Skel_Bone: 700
 		Pirate_Bandana: 4
@@ -70755,7 +69354,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Rotten_Meat: 3000
 		Animals_Skin: 3000
@@ -70798,7 +69396,6 @@ mob_db: (
 	AttackDelay: 2016
 	AttackMotion: 816
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Sticky_Webfoot: 9000
 		Spawn: 500
@@ -70842,7 +69439,6 @@ mob_db: (
 	AttackDelay: 2016
 	AttackMotion: 816
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Sticky_Webfoot: 9000
 		Spawn: 500
@@ -70887,7 +69483,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Grasshoppers_Leg: 9000
 		Wing_Of_Fly: 10000
@@ -70939,7 +69534,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Page: 4850
 		Book_Of_Billows: 4
@@ -70991,7 +69585,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Page: 4850
 		Book_Of_Billows: 4
@@ -71038,7 +69631,6 @@ mob_db: (
 	AttackDelay: 1247
 	AttackMotion: 768
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Bamboo_Cut: 3200
 		Oil_Paper: 2500
@@ -71090,7 +69682,6 @@ mob_db: (
 	AttackDelay: 360
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Red_Feather: 400
 		Ring_: 1
@@ -71143,7 +69734,6 @@ mob_db: (
 	AttackDelay: 360
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Red_Feather: 400
 		Ring_: 1
@@ -71196,7 +69786,6 @@ mob_db: (
 	AttackDelay: 360
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Red_Feather: 400
 		Ring_: 1
@@ -71246,7 +69835,6 @@ mob_db: (
 	AttackDelay: 1516
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Blue_Box: 35
 		Emperium: 1
@@ -71296,7 +69884,6 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 1056
 	DamageMotion: 1152
-	MvpExp: 0
 	Drops: {
 		Empty_Bottle: 5000
 		Old_Steel_Plate: 5000
@@ -71344,7 +69931,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1224
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Clam_Shell: 2500
 		Flesh_Of_Clam: 1000
@@ -71394,7 +69980,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 780
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Elunium: 106
 		Iron_Cane: 1
@@ -71444,7 +70029,6 @@ mob_db: (
 	AttackDelay: 824
 	AttackMotion: 780
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Elunium: 106
 		Iron_Cane: 1
@@ -71494,7 +70078,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Goast_Chill: 1000
 		Staff_Of_Wing: 1
@@ -71545,7 +70128,6 @@ mob_db: (
 	AttackDelay: 588
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rakehorn_Helm: 6500
 		Red_Ether_Bag: 1
@@ -71595,7 +70177,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 900
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Cyfar: 3000
 		Feather_Of_Birds: 5000
@@ -71645,7 +70226,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 528
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Root_Of_Maneater: 5500
 		Scell: 1600
@@ -71692,7 +70272,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 		Knife_: 100
@@ -71739,7 +70318,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 		Knife_: 100
@@ -71786,7 +70364,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 		Knife_: 100
@@ -71833,7 +70410,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7000
 		Sticky_Mucus: 10000
@@ -71881,7 +70457,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Jubilee: 5000
 		Main_Gauche_: 25
@@ -71927,7 +70502,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sticky_Mucus: 5500
 		Garlet: 1500
@@ -71974,7 +70548,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sticky_Mucus: 5500
 		Garlet: 1500
@@ -72021,7 +70594,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Sticky_Mucus: 5500
 		Garlet: 1500
@@ -72067,7 +70639,6 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 1728
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Poison_Toads_Skin: 5500
 		Poison_Powder: 2400
@@ -72117,7 +70688,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Poison_Spore: 9000
 		Hat_: 20
@@ -72167,7 +70737,6 @@ mob_db: (
 	AttackDelay: 1056
 	AttackMotion: 1056
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Scell: 100
 		Gift_Box: 10
@@ -72212,7 +70781,6 @@ mob_db: (
 	AttackDelay: 2208
 	AttackMotion: 1008
 	DamageMotion: 324
-	MvpExp: 0
 	Drops: {
 		Single_Cell: 9000
 		Garlet: 300
@@ -72259,7 +70827,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 336
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Old_Pick: 3000
 		Old_Steel_Plate: 500
@@ -72309,7 +70876,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 480
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Gill: 600
 		Mistic_Frozen: 5
@@ -72358,7 +70924,6 @@ mob_db: (
 	AttackDelay: 1426
 	AttackMotion: 600
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sharp_Leaf: 5000
 		Great_Leaf: 2000
@@ -72408,7 +70973,6 @@ mob_db: (
 	AttackDelay: 700
 	AttackMotion: 600
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Pinguicula_Corsage: 1
 		Whip_Of_Balance: 10
@@ -72454,7 +71018,6 @@ mob_db: (
 	AttackDelay: 988
 	AttackMotion: 288
 	DamageMotion: 168
-	MvpExp: 0
 	Drops: {
 		Feather_Of_Birds: 9000
 		Feather: 700
@@ -72501,7 +71064,6 @@ mob_db: (
 	AttackDelay: 2544
 	AttackMotion: 1344
 	DamageMotion: 1152
-	MvpExp: 0
 	Drops: {
 		Fish_Tail: 5500
 		Sharp_Scale: 2000
@@ -72550,7 +71112,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Dragon_Canine: 5335
 		Dragon_Train: 300
@@ -72600,7 +71161,6 @@ mob_db: (
 	AttackDelay: 2468
 	AttackMotion: 768
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Dragon_Canine: 5335
 		Dragon_Train: 300
@@ -72652,7 +71212,6 @@ mob_db: (
 	AttackDelay: 832
 	AttackMotion: 500
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Coral_Reef: 4850
 		Tentacle: 8000
@@ -72704,7 +71263,6 @@ mob_db: (
 	AttackDelay: 832
 	AttackMotion: 500
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Coral_Reef: 4850
 		Tentacle: 8000
@@ -72752,7 +71310,6 @@ mob_db: (
 	AttackDelay: 1564
 	AttackMotion: 864
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Bill_Of_Birds: 9000
 		Sandals_: 20
@@ -72801,7 +71358,6 @@ mob_db: (
 	AttackDelay: 976
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Vroken_Sword: 4365
 		Honey_Jar: 2500
@@ -72846,7 +71402,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 864
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Germinating_Sprout: 5500
 		Soft_Leaf: 2000
@@ -72900,7 +71455,6 @@ mob_db: (
 	AttackDelay: 1345
 	AttackMotion: 824
 	DamageMotion: 440
-	MvpExp: 0
 	Drops: {
 		Tatters_Clothes: 4413
 		Soft_Feather: 1500
@@ -72950,7 +71504,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Wing_Of_Fly: 210
 		Orcish_Voucher: 9000
@@ -73000,7 +71553,6 @@ mob_db: (
 	AttackDelay: 2852
 	AttackMotion: 1152
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Nail_Of_Orc: 5500
 		Sticky_Mucus: 3000
@@ -73046,7 +71598,6 @@ mob_db: (
 	AttackDelay: 2420
 	AttackMotion: 720
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Orcish_Cuspid: 5500
 		Skel_Bone: 3500
@@ -73097,7 +71648,6 @@ mob_db: (
 	AttackDelay: 1050
 	AttackMotion: 900
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Cyfar: 4656
 		Puente_Robe: 3
@@ -73150,7 +71700,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Feather: 500
 		Ring_: 1
@@ -73200,7 +71749,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1440
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Poisonous_Gas: 1000
 		Mould_Powder: 3000
@@ -73250,7 +71798,6 @@ mob_db: (
 	AttackDelay: 151
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Green_Herb: 3000
 		Cyfar: 135
@@ -73296,7 +71843,6 @@ mob_db: (
 	AttackDelay: 151
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Green_Herb: 3000
 		Cyfar: 135
@@ -73342,7 +71888,6 @@ mob_db: (
 	AttackDelay: 151
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Green_Herb: 3000
 		Cyfar: 135
@@ -73388,7 +71933,6 @@ mob_db: (
 	AttackDelay: 151
 	AttackMotion: 288
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Green_Herb: 3000
 		Cyfar: 135
@@ -73435,7 +71979,6 @@ mob_db: (
 	AttackDelay: 1216
 	AttackMotion: 816
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Burning_Horse_Shoe: 4947
 		Rosary_: 1
@@ -73487,7 +72030,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 576
 	DamageMotion: 240
-	MvpExp: 0
 },
 {
 	Id: 2734
@@ -73528,7 +72070,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 500
 	DamageMotion: 192
-	MvpExp: 0
 },
 {
 	Id: 2735
@@ -73564,7 +72105,6 @@ mob_db: (
 	AttackDelay: 500
 	AttackMotion: 576
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Mandragora_Cap: 1
 		Stem_Of_Nepenthes: 1
@@ -73618,7 +72158,6 @@ mob_db: (
 	AttackDelay: 1816
 	AttackMotion: 1320
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Clattering_Skull: 3000
 		Lich_Bone_Wand: 20
@@ -73665,7 +72204,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 1248
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Candy_Striper: 90
 		Wing_Of_Fly: 10
@@ -73711,7 +72249,6 @@ mob_db: (
 	AttackDelay: 672
 	AttackMotion: 648
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Sticky_Poison: 3000
 		Blossom_Of_Maneater: 3000
@@ -73761,7 +72298,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Rotten_Bandage: 9000
 		Oridecon_Stone: 100
@@ -73811,7 +72347,6 @@ mob_db: (
 	AttackDelay: 1772
 	AttackMotion: 72
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Rotten_Bandage: 9000
 		Oridecon_Stone: 100
@@ -73857,7 +72392,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 70
 		Cactus_Needle: 9000
@@ -73911,7 +72445,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 480
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Herald_Of_GOD: 10
 		Dark_Crystal: 1000
@@ -73964,7 +72497,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 480
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Herald_Of_GOD: 10
 		Dark_Crystal: 1000
@@ -74017,7 +72549,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 480
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Herald_Of_GOD: 10
 		Dark_Crystal: 1000
@@ -74064,7 +72595,6 @@ mob_db: (
 	AttackDelay: 1400
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Moustache_Of_Mole: 5000
 		Nail_Of_Mole: 5000
@@ -74109,7 +72639,6 @@ mob_db: (
 	AttackDelay: 1938
 	AttackMotion: 2112
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Glossy_Hair: 5335
 		Old_Japaness_Clothes: 2500
@@ -74159,7 +72688,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 5335
 		Oridecon_Stone: 196
@@ -74209,7 +72737,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 5335
 		Oridecon_Stone: 196
@@ -74259,7 +72786,6 @@ mob_db: (
 	AttackDelay: 1360
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 5335
 		Oridecon_Stone: 196
@@ -74306,7 +72832,6 @@ mob_db: (
 	AttackDelay: 648
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Fragment_Of_Crystal: 3000
 		Golden_Jewel: 500
@@ -74356,7 +72881,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 1140
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Golden_Feather: 5000
 		Light_Granule: 100
@@ -74403,7 +72927,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 500
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 5
 		Old_Blue_Box: 45
@@ -74453,7 +72976,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 500
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Old_Violet_Box: 5
 		Old_Blue_Box: 45
@@ -74503,7 +73025,6 @@ mob_db: (
 	AttackDelay: 1708
 	AttackMotion: 1008
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Boody_Red: 60
 		Grasshoppers_Leg: 6500
@@ -74550,7 +73071,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Tube: 4000
 		Iron_Ore: 1000
@@ -74597,7 +73117,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Tube: 4000
 		Iron_Ore: 1000
@@ -74649,7 +73168,6 @@ mob_db: (
 	AttackDelay: 916
 	AttackMotion: 816
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Lip_Of_Ancient_Fish: 1300
 		Plate_Armor_: 2
@@ -74702,7 +73220,6 @@ mob_db: (
 	AttackDelay: 472
 	AttackMotion: 1056
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fancy_Fairy_Wing: 2000
 		Great_Wing: 1000
@@ -74751,7 +73268,6 @@ mob_db: (
 	AttackDelay: 1720
 	AttackMotion: 1320
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Slender_Snake: 5335
 		Whip_Of_Red_Flame: 250
@@ -74797,7 +73313,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moustache_Of_Mole: 9000
 		Nail_Of_Mole: 500
@@ -74848,7 +73363,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 1056
-	MvpExp: 0
 	Drops: {
 		Golden_Hair: 9000
 		Star_Dust: 5
@@ -74895,7 +73409,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Garlet: 3200
 		Sticky_Mucus: 1500
@@ -74945,7 +73458,6 @@ mob_db: (
 	AttackDelay: 1540
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Flame_Heart: 35
 		Sacred_Masque: 4365
@@ -74996,7 +73508,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 660
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 110
 		Limb_Of_Mantis: 9000
@@ -75042,7 +73553,6 @@ mob_db: (
 	AttackDelay: 1768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 50
 		Stem: 9000
@@ -75095,7 +73605,6 @@ mob_db: (
 	AttackDelay: 280
 	AttackMotion: 720
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Silver_Bracelet: 2000
 		Elegant_Flower: 1000
@@ -75147,7 +73656,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 960
 	DamageMotion: 780
-	MvpExp: 0
 	Drops: {
 		Nose_Ring: 4413
 		Two_Handed_Axe_: 4
@@ -75195,7 +73703,6 @@ mob_db: (
 	AttackDelay: 1054
 	AttackMotion: 504
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Frying_Pan: 9000
 		Garlet: 800
@@ -75242,7 +73749,6 @@ mob_db: (
 	AttackDelay: 1472
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Elunium_Stone: 34
@@ -75283,7 +73789,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Clover: 6500
 		Feather: 1000
@@ -75329,7 +73834,6 @@ mob_db: (
 	AttackDelay: 1456
 	AttackMotion: 456
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Clover: 6500
 		Feather: 1000
@@ -75379,7 +73883,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Bucket: 3200
 		Ectoplasm: 5723
@@ -75433,7 +73936,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 864
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Sprint_Ring: 2
 		Bradium: 1
@@ -75484,7 +73986,6 @@ mob_db: (
 	AttackDelay: 747
 	AttackMotion: 1632
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Black_Kitty_Doll: 800
 		Striped_Socks: 3000
@@ -75532,7 +74033,6 @@ mob_db: (
 	AttackDelay: 400
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Hard_Peach: 4365
 		Elder_Branch: 100
@@ -75578,7 +74078,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 9000
 		Knife_: 100
@@ -75628,7 +74127,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 300
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Angel_Magic_Power: 5000
 		Light_Granule: 100
@@ -75676,7 +74174,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 576
 	DamageMotion: 420
-	MvpExp: 0
 	Drops: {
 		Tiger_Skin_Panties: 4500
 		Little_Blacky_Ghost: 400
@@ -75721,7 +74218,6 @@ mob_db: (
 	AttackDelay: 1728
 	AttackMotion: 720
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Sharp_Leaf: 2000
 		Green_Herb: 1000
@@ -75772,7 +74268,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 230
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Bears_Foot: 4550
 		Poo_Poo_Hat: 8
@@ -75819,7 +74314,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 864
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Great_Leaf: 4365
 		Leaflet_Of_Hinal: 300
@@ -75867,7 +74361,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1008
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Zargon: 250
 		Steel: 60
@@ -75917,7 +74410,6 @@ mob_db: (
 	AttackDelay: 1028
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 100
 		Cobold_Hair: 5335
@@ -75964,7 +74456,6 @@ mob_db: (
 	AttackDelay: 1548
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Great_Nature: 30
 		Coal: 150
@@ -76013,7 +74504,6 @@ mob_db: (
 	AttackDelay: 1247
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Solid_Peeling: 6500
 		Beetle_Nipper: 4500
@@ -76065,7 +74555,6 @@ mob_db: (
 	AttackDelay: 800
 	AttackMotion: 600
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Burning_Heart: 3000
 		Hot_Hair: 2500
@@ -76111,7 +74600,6 @@ mob_db: (
 	AttackDelay: 1638
 	AttackMotion: 2016
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Oil_Paper: 5000
 		Bamboo_Cut: 4268
@@ -76162,7 +74650,6 @@ mob_db: (
 	AttackDelay: 1384
 	AttackMotion: 768
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Scales_Shell: 5335
 		Circlet_: 5
@@ -76212,7 +74699,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		White_Mask: 2500
 		High_Fashion_Sandals: 1
@@ -76264,7 +74750,6 @@ mob_db: (
 	AttackDelay: 770
 	AttackMotion: 720
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Steel: 300
 		Brigan: 5335
@@ -76311,7 +74796,6 @@ mob_db: (
 	AttackDelay: 106
 	AttackMotion: 1056
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Dried_Sand: 4365
 		Mud_Lump: 2300
@@ -76358,7 +74842,6 @@ mob_db: (
 	AttackDelay: 861
 	AttackMotion: 660
 	DamageMotion: 144
-	MvpExp: 0
 	Drops: {
 		Ice_Heart: 5000
 		Ice_Piece: 3000
@@ -76405,7 +74888,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Mistic_Frozen: 5
 		Heart_Of_Mermaid: 9000
@@ -76454,7 +74936,6 @@ mob_db: (
 	AttackDelay: 890
 	AttackMotion: 1320
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Brigan: 3880
 		Amulet: 100
@@ -76504,7 +74985,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Rough_Wind: 30
 		Steel: 100
@@ -76552,7 +75032,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 216
-	MvpExp: 0
 	Drops: {
 		Wind_Of_Verdure: 80
 		Bee_Sting: 9000
@@ -76600,7 +75079,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Singlehorn_Helm: 6500
 		Imperial_Spear: 1
@@ -76646,7 +75124,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 80
 		Emveretarcon: 35
@@ -76696,7 +75173,6 @@ mob_db: (
 	AttackDelay: 960
 	AttackMotion: 528
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Prickly_Fruit_: 1000
 		Will_Of_Darkness: 1000
@@ -76742,7 +75218,6 @@ mob_db: (
 	AttackDelay: 1480
 	AttackMotion: 480
 	DamageMotion: 720
-	MvpExp: 0
 	Drops: {
 		Yellow_Live: 120
 		Earthworm_Peeling: 9000
@@ -76792,7 +75267,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Harpys_Feather: 4000
 		Harpys_Claw: 3000
@@ -76839,7 +75313,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Harpys_Feather: 4000
 		Harpys_Claw: 3000
@@ -76888,7 +75361,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Ogre_Tooth: 2500
 		Orcish_Axe: 10
@@ -76939,7 +75411,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 672
 	DamageMotion: 470
-	MvpExp: 0
 	Drops: {
 		Harpys_Feather: 4850
 		Harpys_Claw: 2500
@@ -76989,7 +75460,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 672
 	DamageMotion: 470
-	MvpExp: 0
 	Drops: {
 		Harpys_Feather: 4850
 		Harpys_Claw: 2500
@@ -77035,7 +75505,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Leaflet_Of_Aloe: 1500
 		Reptile_Tongue: 1000
@@ -77081,7 +75550,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Brigan: 2000
 		Wooden_Block: 2000
@@ -77129,7 +75597,6 @@ mob_db: (
 	AttackDelay: 1460
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Peco_Wing_Feather: 4850
 		Fruit_Of_Mastela: 300
@@ -77175,7 +75642,6 @@ mob_db: (
 	AttackDelay: 1460
 	AttackMotion: 960
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Peco_Wing_Feather: 4850
 		Fruit_Of_Mastela: 300
@@ -77220,7 +75686,6 @@ mob_db: (
 	AttackDelay: 1608
 	AttackMotion: 816
 	DamageMotion: 396
-	MvpExp: 0
 	Drops: {
 		Steel: 150
 		Stone_Heart: 9000
@@ -77272,7 +75737,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Wing_Of_Fly: 270
 		Scell: 9000
@@ -77324,7 +75788,6 @@ mob_db: (
 	AttackDelay: 1120
 	AttackMotion: 620
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Wing_Of_Fly: 270
 		Scell: 9000
@@ -77372,7 +75835,6 @@ mob_db: (
 	AttackDelay: 1380
 	AttackMotion: 1080
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Goats_Horn: 4559
 		Gaoats_Skin: 2500
@@ -77420,7 +75882,6 @@ mob_db: (
 	AttackDelay: 1380
 	AttackMotion: 1080
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Goats_Horn: 4559
 		Gaoats_Skin: 2500
@@ -77473,7 +75934,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 50
 		Cobold_Hair: 2668
@@ -77524,7 +75984,6 @@ mob_db: (
 	AttackDelay: 1528
 	AttackMotion: 528
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Steel: 50
 		Cobold_Hair: 2668
@@ -77575,7 +76034,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1776
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Black_Cloth: 2500
 		Skul_Ring: 500
@@ -77627,7 +76085,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 1776
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Piece_Of_Black_Cloth: 2500
 		Skul_Ring: 500
@@ -77679,7 +76136,6 @@ mob_db: (
 	AttackDelay: 1292
 	AttackMotion: 792
 	DamageMotion: 340
-	MvpExp: 0
 	Drops: {
 		Royal_Jelly: 550
 		Honey: 1200
@@ -77729,7 +76185,6 @@ mob_db: (
 	AttackDelay: 2456
 	AttackMotion: 912
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Horrendous_Mouth: 6000
 		Oridecon_Stone: 110
@@ -77779,7 +76234,6 @@ mob_db: (
 	AttackDelay: 2456
 	AttackMotion: 912
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Horrendous_Mouth: 6000
 		Oridecon_Stone: 110
@@ -77825,7 +76279,6 @@ mob_db: (
 	AttackDelay: 1308
 	AttackMotion: 1008
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Blossom_Of_Maneater: 6200
 		Root_Of_Maneater: 5500
@@ -77869,7 +76322,6 @@ mob_db: (
 	AttackDelay: 1308
 	AttackMotion: 1008
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Blossom_Of_Maneater: 6200
 		Root_Of_Maneater: 5500
@@ -77916,7 +76368,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Zargon: 3880
 		Petite_DiablOfs_Wing: 500
@@ -77965,7 +76416,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 720
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Zargon: 3880
 		Petite_DiablOfs_Wing: 500
@@ -78016,7 +76466,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Rotten_Meat: 3000
 		Animals_Skin: 3000
@@ -78063,7 +76512,6 @@ mob_db: (
 	AttackDelay: 1612
 	AttackMotion: 622
 	DamageMotion: 583
-	MvpExp: 0
 	Drops: {
 		Zargon: 4365
 		Wing_Of_Fly: 250
@@ -78115,7 +76563,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 850
@@ -78167,7 +76614,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 672
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Shell: 850
@@ -78217,7 +76663,6 @@ mob_db: (
 	AttackDelay: 108
 	AttackMotion: 576
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Delicious_Fish: 5100
 		Dragon_Canine: 1000
@@ -78265,7 +76710,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Tooth_Of_Bat: 5500
 		Falchion_: 20
@@ -78315,7 +76759,6 @@ mob_db: (
 	AttackDelay: 920
 	AttackMotion: 720
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Blue_Gemstone: 1000
 		Yellow_Gemstone: 1000
@@ -78360,7 +76803,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fluff: 6500
 		Feather: 500
@@ -78407,7 +76849,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Fluff: 6500
 		Feather: 500
@@ -78457,7 +76898,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 960
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Wing_Of_Red_Bat: 5500
 		Burning_Heart: 2200
@@ -78507,7 +76947,6 @@ mob_db: (
 	AttackDelay: 2276
 	AttackMotion: 576
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Biretta_: 10
 		Bone_Wand: 1
@@ -78557,7 +76996,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Resin: 5000
 		Wing_Of_Fly: 10000
@@ -78607,7 +77045,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Resin: 5000
 		Wing_Of_Fly: 5000
@@ -78658,7 +77095,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 2500
 		Seed_Of_Yggdrasil: 10
@@ -78706,7 +77142,6 @@ mob_db: (
 	AttackDelay: 1004
 	AttackMotion: 504
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Moth_Dust: 9000
 		Wing_Of_Moth: 500
@@ -78755,7 +77190,6 @@ mob_db: (
 	AttackDelay: 950
 	AttackMotion: 2520
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Tough_Vines: 5335
 		Great_Leaf: 1000
@@ -78801,7 +77235,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 576
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Sticky_Poison: 3000
 		Drocera_Tentacle: 200
@@ -78848,7 +77281,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 7500
 		Rod_: 80
@@ -78898,7 +77330,6 @@ mob_db: (
 	AttackDelay: 1300
 	AttackMotion: 900
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Lizard_Scruff: 7500
 		Yellow_Gemstone: 3880
@@ -78944,7 +77375,6 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Emveretarcon: 60
 		Tooth_Of_Bat: 3000
@@ -78997,7 +77427,6 @@ mob_db: (
 	AttackDelay: 862
 	AttackMotion: 534
 	DamageMotion: 312
-	MvpExp: 0
 	Drops: {
 		Dragon_Fly_Wing: 4413
 		Round_Shell: 400
@@ -79045,7 +77474,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Dragons_Mane: 3000
 		Dragons_Skin: 100
@@ -79096,7 +77524,6 @@ mob_db: (
 	AttackDelay: 360
 	AttackMotion: 360
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Small_Bradium: 3000
 		White_Spider_Limb: 5000
@@ -79144,7 +77571,6 @@ mob_db: (
 	AttackDelay: 1156
 	AttackMotion: 456
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Dokkaebi_Horn: 9000
 		Elunium_Stone: 150
@@ -79195,7 +77621,6 @@ mob_db: (
 	AttackDelay: 516
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Red_Scarf: 4850
 		Tangled_Chain: 3686
@@ -79245,7 +77670,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 720
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Old_Steel_Plate: 2000
 		Transparent_Plate01: 50
@@ -79298,7 +77722,6 @@ mob_db: (
 	AttackDelay: 980
 	AttackMotion: 600
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Petite_DiablOfs_Horn: 5335
 		Petite_DiablOfs_Wing: 400
@@ -79345,7 +77768,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 900
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Phracon: 85
 		Animals_Skin: 5500
@@ -79392,7 +77814,6 @@ mob_db: (
 	AttackDelay: 1600
 	AttackMotion: 900
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Phracon: 85
 		Animals_Skin: 5500
@@ -79440,7 +77861,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 9000
 		Garlet: 3000
@@ -79492,7 +77912,6 @@ mob_db: (
 	AttackDelay: 176
 	AttackMotion: 912
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Page: 4000
 		Bookclip_In_Memory: 300
@@ -79544,7 +77963,6 @@ mob_db: (
 	AttackDelay: 176
 	AttackMotion: 912
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Page: 4000
 		Bookclip_In_Memory: 300
@@ -79596,7 +78014,6 @@ mob_db: (
 	AttackDelay: 176
 	AttackMotion: 912
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Worn_Out_Page: 4000
 		Bookclip_In_Memory: 300
@@ -79648,7 +78065,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 1252
 	DamageMotion: 476
-	MvpExp: 0
 	Drops: {
 		Book_Of_The_Apocalypse: 5
 		Rosary: 30
@@ -79695,7 +78111,6 @@ mob_db: (
 	AttackDelay: 600
 	AttackMotion: 840
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Dragon_Fang: 4365
 		Dragon_Horn: 3000
@@ -79740,7 +78155,6 @@ mob_db: (
 	AttackDelay: 1136
 	AttackMotion: 720
 	DamageMotion: 840
-	MvpExp: 0
 	Drops: {
 		Powder_Of_Butterfly: 9000
 		Silk_Robe_: 10
@@ -79787,7 +78201,6 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 48
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 45
 		Conch: 5500
@@ -79835,7 +78248,6 @@ mob_db: (
 	AttackDelay: 1036
 	AttackMotion: 936
 	DamageMotion: 240
-	MvpExp: 0
 	Drops: {
 		Well_Baked_Cookie: 1000
 		Candy_Striper: 150
@@ -79885,7 +78297,6 @@ mob_db: (
 	AttackDelay: 720
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Burnt_Parts: 100
 		Sturdy_Iron_Piece: 1500
@@ -79933,7 +78344,6 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Comodo_L: 2500
 		Meat: 4500
@@ -79977,7 +78387,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 1008
-	MvpExp: 0
 	Drops: {
 		Acorn: 9000
 		Fluff: 10000
@@ -80024,7 +78433,6 @@ mob_db: (
 	AttackDelay: 1864
 	AttackMotion: 864
 	DamageMotion: 1008
-	MvpExp: 0
 	Drops: {
 		Fluff: 3333
 		Animals_Skin: 3333
@@ -80071,7 +78479,6 @@ mob_db: (
 	AttackDelay: 1092
 	AttackMotion: 792
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Needle_Of_Alarm: 5335
 		Wooden_Block: 800
@@ -80118,7 +78525,6 @@ mob_db: (
 	AttackDelay: 1092
 	AttackMotion: 792
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Needle_Of_Alarm: 5335
 		Wooden_Block: 800
@@ -80165,7 +78571,6 @@ mob_db: (
 	AttackDelay: 1076
 	AttackMotion: 576
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Jellopy: 10000
 		Wing_Of_Fly: 10000
@@ -80218,7 +78623,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Cold_Heart: 2
 		Black_Cat: 2
@@ -80271,7 +78675,6 @@ mob_db: (
 	AttackDelay: 1500
 	AttackMotion: 720
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Dustball: 2000
 		Poisonous_Gas: 500
@@ -80319,7 +78722,6 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 384
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Armlet_Of_Prisoner: 2000
 		Goast_Chill: 1
@@ -80372,7 +78774,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Feather: 3000
 		Brigan: 5335
@@ -80425,7 +78826,6 @@ mob_db: (
 	AttackDelay: 1078
 	AttackMotion: 768
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Brigan: 3200
 		Ice_Cream: 1000
@@ -80470,7 +78870,6 @@ mob_db: (
 	AttackDelay: 1604
 	AttackMotion: 840
 	DamageMotion: 756
-	MvpExp: 0
 	Drops: {
 		Porcupine_Spike: 9000
 		Coat_: 5
@@ -80522,7 +78921,6 @@ mob_db: (
 	AttackDelay: 1568
 	AttackMotion: 432
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Brigan: 1000
 		Beautiful_Flower: 1000
@@ -80569,7 +78967,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Raccoon_Leaf: 500
 		Four_Leaf_Clover: 10
@@ -80619,7 +79016,6 @@ mob_db: (
 	AttackDelay: 140
 	AttackMotion: 384
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Raccoon_Leaf: 500
 		Four_Leaf_Clover: 10
@@ -80670,7 +79066,6 @@ mob_db: (
 	AttackDelay: 1008
 	AttackMotion: 1200
 	DamageMotion: 540
-	MvpExp: 0
 	Drops: {
 		Stone_Piece: 3000
 		Stone_Heart: 5000
@@ -80720,7 +79115,6 @@ mob_db: (
 	AttackDelay: 472
 	AttackMotion: 576
 	DamageMotion: 288
-	MvpExp: 0
 	Drops: {
 		Sharp_Feeler: 4608
 		Great_Wing: 2500
@@ -80766,7 +79160,6 @@ mob_db: (
 	AttackDelay: 1260
 	AttackMotion: 192
 	DamageMotion: 192
-	MvpExp: 0
 	Drops: {
 		Bears_Foot: 9000
 		Poo_Poo_Hat: 5
@@ -80818,7 +79211,6 @@ mob_db: (
 	AttackDelay: 1504
 	AttackMotion: 840
 	DamageMotion: 900
-	MvpExp: 0
 	Drops: {
 		Sparkling_Dust: 200
 		Starsand_Of_Witch: 4850
@@ -80871,7 +79263,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 504
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Old_White_Cloth: 3000
 		Orleans_Gown: 10
@@ -80923,7 +79314,6 @@ mob_db: (
 	AttackDelay: 676
 	AttackMotion: 504
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Old_White_Cloth: 3000
 		Orleans_Gown: 10
@@ -80974,7 +79364,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Coal: 500
 		Zargon: 1000
@@ -81024,7 +79413,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 780
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Turtle_Shell: 4413
 		Broken_Armor_Piece: 1200
@@ -81076,7 +79464,6 @@ mob_db: (
 	AttackDelay: 512
 	AttackMotion: 780
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Spiderweb: 9000
 		Scell: 1200
@@ -81129,7 +79516,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Short_Leg: 5335
 		Zargon: 1200
@@ -81181,7 +79567,6 @@ mob_db: (
 	AttackDelay: 1792
 	AttackMotion: 792
 	DamageMotion: 336
-	MvpExp: 0
 	Drops: {
 		Short_Leg: 5335
 		Zargon: 1200
@@ -81227,7 +79612,6 @@ mob_db: (
 	AttackDelay: 1840
 	AttackMotion: 1440
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Round_Shell: 3500
 		Sticky_Mucus: 3000
@@ -81274,7 +79658,6 @@ mob_db: (
 	AttackDelay: 1840
 	AttackMotion: 1440
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Round_Shell: 3500
 		Sticky_Mucus: 3000
@@ -81321,7 +79704,6 @@ mob_db: (
 	AttackDelay: 1840
 	AttackMotion: 1440
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Broken_Steel_Piece: 5335
 		Mystery_Piece: 2400
@@ -81372,7 +79754,6 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 624
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Antler_Helm: 6500
 		Green_Whistle: 1
@@ -81423,7 +79804,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Leaf_Bookmark: 2000
 		Bookclip_In_Memory: 1000
@@ -81472,7 +79852,6 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 960
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Leaf_Bookmark: 2000
 		Bookclip_In_Memory: 1000
@@ -81520,7 +79899,6 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 500
 	DamageMotion: 864
-	MvpExp: 0
 	Drops: {
 		Anolian_Skin: 4850
 		Crystal_Arrow: 2000
@@ -81571,7 +79949,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 480
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Withered_Flower: 5000
 		Soft_Leaf: 1000
@@ -81619,7 +79996,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 480
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Withered_Flower: 5000
 		Soft_Leaf: 1000
@@ -81664,7 +80040,6 @@ mob_db: (
 	AttackDelay: 1288
 	AttackMotion: 288
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Worm_Peelings: 9000
 		Garlet: 1000
@@ -81714,7 +80089,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Old_Blue_Box: 30
 		Old_Violet_Box: 1
@@ -81761,7 +80135,6 @@ mob_db: (
 	AttackDelay: 1576
 	AttackMotion: 576
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		White_Powder: 200
 		Posionous_Canine: 9000
@@ -81809,7 +80182,6 @@ mob_db: (
 	AttackDelay: 2048
 	AttackMotion: 648
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Crystal_Blue: 50
 		Snails_Shell: 9000
@@ -81860,7 +80232,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Clover: 125
 		Leaflet_Of_Hinal: 213
@@ -81906,7 +80277,6 @@ mob_db: (
 	AttackDelay: 1100
 	AttackMotion: 900
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Zargon: 1000
 		Worn_Out_Prison_Uniform: 600
@@ -81951,7 +80321,6 @@ mob_db: (
 	AttackDelay: 1440
 	AttackMotion: 576
 	DamageMotion: 600
-	MvpExp: 0
 	Drops: {
 		Brigan: 4000
 		Morpheuss_Shawl: 10
@@ -82002,7 +80371,6 @@ mob_db: (
 	AttackDelay: 1080
 	AttackMotion: 480
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Burnt_Parts: 2000
 		Sturdy_Iron_Piece: 3000
@@ -82054,7 +80422,6 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 500
 	DamageMotion: 768
-	MvpExp: 0
 	Drops: {
 		Needle_Of_Alarm: 5335
 		Clip: 1
@@ -82105,7 +80472,6 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 360
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Suspicious_Hat: 2500
 		High_Fashion_Sandals: 2
@@ -82155,7 +80521,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Potion: 150
 		Dragon_Canine: 4000
@@ -82205,7 +80570,6 @@ mob_db: (
 	AttackDelay: 168
 	AttackMotion: 768
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Blue_Potion: 150
 		Dragon_Canine: 4000
@@ -82604,7 +80968,6 @@ mob_db: (
 	AttackDelay: 1372
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Moon_Cake20: 500
 		Moon_Cake1: 500
@@ -82645,7 +81008,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Moon_Cake18: 500
 		Moon_Cake19: 500
@@ -82690,7 +81052,6 @@ mob_db: (
 	AttackDelay: 972
 	AttackMotion: 672
 	DamageMotion: 470
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 500
 		Moon_Cake2: 500
@@ -82731,7 +81092,6 @@ mob_db: (
 	AttackDelay: 648
 	AttackMotion: 480
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 500
 		Moon_Cake2: 500
@@ -82775,7 +81135,6 @@ mob_db: (
 	AttackDelay: 917
 	AttackMotion: 1584
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Moon_Cake1: 500
 		Moon_Cake2: 500
@@ -82819,7 +81178,6 @@ mob_db: (
 	AttackDelay: 1000
 	AttackMotion: 500
 	DamageMotion: 1000
-	MvpExp: 0
 	Drops: {
 		Moon_Cake18: 500
 		Moon_Cake19: 500
@@ -82864,7 +81222,6 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 420
 	DamageMotion: 360
-	MvpExp: 0
 	Drops: {
 		Moon_Cake20: 500
 	}
@@ -82904,7 +81261,6 @@ mob_db: (
 	AttackDelay: 384
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moon_Cake20: 500
 	}
@@ -82944,7 +81300,6 @@ mob_db: (
 	AttackDelay: 1672
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moon_Cake20: 500
 	}
@@ -82989,7 +81344,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 1056
 	DamageMotion: 384
-	MvpExp: 0
 	Drops: {
 		Moon_Cake5: 500
 		Moon_Cake6: 500
@@ -83035,7 +81389,6 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Moon_Cake5: 500
 		Moon_Cake6: 500
@@ -83077,7 +81430,6 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 840
 	DamageMotion: 432
-	MvpExp: 0
 	Drops: {
 		Moon_Cake20: 500
 	}
@@ -83112,7 +81464,6 @@ mob_db: (
 	AttackDelay: 1220
 	AttackMotion: 1080
 	DamageMotion: 648
-	MvpExp: 0
 	Drops: {
 		Pumpkin: 2000
 		Pumpkin_Pie: 2000
@@ -83942,7 +82293,6 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 864
 	DamageMotion: 480
-	MvpExp: 0
 	Drops: {
 		Yggdrasilberry: 500
 		Old_Blue_Box: 200
@@ -84278,7 +82628,6 @@ mob_db: (
 	AttackDelay: 1018
 	AttackMotion: 1008
 	DamageMotion: 300
-	MvpExp: 0
 	Drops: {
 		Felock_Armor: 100
 		Felock_Cape: 100
@@ -84364,7 +82713,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },*/
 {
 	Id: 3202
@@ -84401,7 +82749,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		ORGANIC_PUMPKIN: 5000
 		ORGANIC_PUMPKIN: 5000
@@ -84448,7 +82795,6 @@ mob_db: (
 	AttackDelay: 0
 	AttackMotion: 0
 	DamageMotion: 0
-	MvpExp: 0
 	Drops: {
 		INORGANIC_PUMPKIN: 5000
 		INORGANIC_PUMPKIN: 5000
@@ -84495,7 +82841,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 3205
@@ -84532,7 +82877,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 3206
@@ -84569,7 +82913,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },
 {
 	Id: 3207
@@ -84606,7 +82949,6 @@ mob_db: (
 	AttackDelay: 1872
 	AttackMotion: 672
 	DamageMotion: 480
-	MvpExp: 0
 },*/
 {
 	Id: 3261
@@ -84764,7 +83106,6 @@ mob_db: (
 	AttackDelay: 1960
 	AttackMotion: 960
 	DamageMotion: 504
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Pie: 2000
 		Black_Soul: 4000
@@ -84804,7 +83145,6 @@ mob_db: (
 	AttackDelay: 912
 	AttackMotion: 1248
 	DamageMotion: 576
-	MvpExp: 0
 	Drops: {
 		Pumpkin_Pie: 2000
 		Captured_Soul: 4000

--- a/db/re/mob_db.conf
+++ b/db/re/mob_db.conf
@@ -1856,6 +1856,7 @@ mob_db: (
 	AttackDelay: 1072
 	AttackMotion: 672
 	DamageMotion: 384
+	DamageTakenRate: 10
 	MvpExp: 122760
 	MvpDrops: {
 		Old_Blue_Box: 4000
@@ -1915,6 +1916,7 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 576
+	DamageTakenRate: 10
 	MvpExp: 198262
 	MvpDrops: {
 		Yggdrasilberry: 2000
@@ -2253,6 +2255,7 @@ mob_db: (
 	AttackDelay: 480
 	AttackMotion: 480
 	DamageMotion: 288
+	DamageTakenRate: 10
 	MvpExp: 156600
 	MvpDrops: {
 		Cardinal_Jewel_: 1500
@@ -2867,6 +2870,7 @@ mob_db: (
 	AttackDelay: 1148
 	AttackMotion: 648
 	DamageMotion: 300
+	DamageTakenRate: 10
 	MvpExp: 184140
 	MvpDrops: {
 		Rough_Wind: 1500
@@ -4102,6 +4106,7 @@ mob_db: (
 	AttackDelay: 768
 	AttackMotion: 768
 	DamageMotion: 480
+	DamageTakenRate: 10
 	MvpExp: 97200
 	MvpDrops: {
 		Gold_Ring: 2000
@@ -4160,6 +4165,7 @@ mob_db: (
 	AttackDelay: 1678
 	AttackMotion: 780
 	DamageMotion: 648
+	DamageTakenRate: 10
 	MvpExp: 53460
 	MvpDrops: {
 		Red_Jewel: 2000
@@ -5406,6 +5412,7 @@ mob_db: (
 	AttackDelay: 620
 	AttackMotion: 420
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 257580
 	MvpDrops: {
 		White_Potion: 5000
@@ -5556,6 +5563,7 @@ mob_db: (
 	AttackDelay: 872
 	AttackMotion: 1344
 	DamageMotion: 432
+	DamageTakenRate: 10
 	MvpExp: 99000
 	MvpDrops: {
 		Tigers_Skin: 5000
@@ -7107,6 +7115,7 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 1000
 	DamageMotion: 480
+	DamageTakenRate: 10
 	MvpExp: 89280
 	MvpDrops: {
 		Crystal_Jewel: 2000
@@ -7267,6 +7276,7 @@ mob_db: (
 	AttackDelay: 1276
 	AttackMotion: 576
 	DamageMotion: 288
+	DamageTakenRate: 10
 	MvpExp: 167040
 	MvpDrops: {
 		Fox_Tail: 5000
@@ -7616,6 +7626,7 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 768
 	DamageMotion: 288
+	DamageTakenRate: 10
 	MvpExp: 208800
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -7720,6 +7731,7 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 1020
 	DamageMotion: 288
+	DamageTakenRate: 10
 	MvpExp: 58000
 	MvpDrops: {
 		Frozen_Heart: 500
@@ -9137,6 +9149,7 @@ mob_db: (
 	AttackDelay: 1248
 	AttackMotion: 500
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 31102
 	MvpDrops: {
 		Voucher_Of_Orcish_Hero: 5500
@@ -12022,6 +12035,7 @@ mob_db: (
 	AttackDelay: 468
 	AttackMotion: 468
 	DamageMotion: 288
+	DamageTakenRate: 10
 	MvpExp: 206900
 	MvpDrops: {
 		Skyblue_Jewel: 4500
@@ -12082,6 +12096,7 @@ mob_db: (
 	AttackDelay: 608
 	AttackMotion: 408
 	DamageMotion: 336
+	DamageTakenRate: 10
 	MvpExp: 379440
 	MvpDrops: {
 		Fang_Of_Garm: 1000
@@ -13075,6 +13090,7 @@ mob_db: (
 	AttackDelay: 868
 	AttackMotion: 768
 	DamageMotion: 480
+	DamageTakenRate: 10
 	MvpExp: 357120
 	MvpDrops: {
 		Skull: 6000
@@ -15053,6 +15069,7 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 1000
 	DamageMotion: 500
+	DamageTakenRate: 10
 	MvpExp: 466560
 	MvpDrops: {
 		Turtle_Shell: 5500
@@ -17883,6 +17900,7 @@ mob_db: (
 	AttackDelay: 1446
 	AttackMotion: 1296
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 218560
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -18665,6 +18683,7 @@ mob_db: (
 	AttackDelay: 1290
 	AttackMotion: 1140
 	DamageMotion: 576
+	DamageTakenRate: 10
 	MvpExp: 156240
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -20002,6 +20021,7 @@ mob_db: (
 	AttackDelay: 588
 	AttackMotion: 816
 	DamageMotion: 420
+	DamageTakenRate: 10
 	MvpExp: 78120
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -22948,6 +22968,7 @@ mob_db: (
 	AttackDelay: 874
 	AttackMotion: 1344
 	DamageMotion: 576
+	DamageTakenRate: 10
 	MvpExp: 375840
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -23854,6 +23875,7 @@ mob_db: (
 	AttackDelay: 854
 	AttackMotion: 2016
 	DamageMotion: 480
+	DamageTakenRate: 10
 	MvpExp: 120060
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -26775,6 +26797,7 @@ mob_db: (
 	AttackDelay: 1020
 	AttackMotion: 288
 	DamageMotion: 144
+	DamageTakenRate: 10
 	MvpExp: 450000
 	MvpDrops: {
 		Oridecon: 6000
@@ -28540,6 +28563,7 @@ mob_db: (
 	AttackDelay: 128
 	AttackMotion: 1104
 	DamageMotion: 240
+	DamageTakenRate: 10
 	MvpExp: 360000
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -28865,6 +28889,7 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 960
 	DamageMotion: 480
+	DamageTakenRate: 10
 	MvpExp: 334080
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -31693,6 +31718,7 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 432
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 167040
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -32696,6 +32722,7 @@ mob_db: (
 	AttackDelay: 115
 	AttackMotion: 816
 	DamageMotion: 504
+	DamageTakenRate: 10
 	MvpExp: 649700
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -33235,6 +33262,7 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 936
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 2160000
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -33862,6 +33890,7 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 576
 	DamageMotion: 432
+	DamageTakenRate: 10
 	MvpExp: 900000
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -34599,6 +34628,7 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 480
+	DamageTakenRate: 10
 	MvpExp: 1000000
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -35373,6 +35403,7 @@ mob_db: (
 	AttackDelay: 1344
 	AttackMotion: 2880
 	DamageMotion: 576
+	DamageTakenRate: 10
 	MvpExp: 1080000
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -35919,6 +35950,7 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 840
 	DamageMotion: 216
+	DamageTakenRate: 10
 	MvpExp: 517788
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -36204,6 +36236,7 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 600
 	DamageMotion: 240
+	DamageTakenRate: 10
 	MvpExp: 540000
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -38358,6 +38391,7 @@ mob_db: (
 	AttackDelay: 212
 	AttackMotion: 384
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 3348000
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -40118,6 +40152,7 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 432
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 1350000
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -40263,6 +40298,7 @@ mob_db: (
 	AttackDelay: 212
 	AttackMotion: 504
 	DamageMotion: 432
+	DamageTakenRate: 10
 	MvpExp: 3525000
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -40781,6 +40817,7 @@ mob_db: (
 	AttackDelay: 1536
 	AttackMotion: 864
 	DamageMotion: 432
+	DamageTakenRate: 10
 	MvpExp: 357120
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -42076,6 +42113,7 @@ mob_db: (
 	AttackDelay: 312
 	AttackMotion: 624
 	DamageMotion: 432
+	DamageTakenRate: 10
 	MvpExp: 2025000
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -48747,6 +48785,7 @@ mob_db: (
 	AttackDelay: 1152
 	AttackMotion: 1152
 	DamageMotion: 576
+	DamageTakenRate: 10
 	MvpExp: 37144
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -49597,6 +49636,7 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 1000
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 205110
 	MvpDrops: {
 		Old_Card_Album: 5500
@@ -50616,6 +50656,7 @@ mob_db: (
 	AttackDelay: 504
 	AttackMotion: 912
 	DamageMotion: 432
+	DamageTakenRate: 10
 	MvpExp: 1005
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -52767,6 +52808,7 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 576
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpDrops: {
 		Old_Violet_Box: 5000
 		Old_Violet_Box: 5000
@@ -53178,6 +53220,7 @@ mob_db: (
 	AttackDelay: 864
 	AttackMotion: 1000
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpDrops: {
 		Old_Card_Album: 5000
 		Old_Card_Album: 5000
@@ -54932,6 +54975,7 @@ mob_db: (
 	AttackDelay: 432
 	AttackMotion: 864
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 491666
 	MvpDrops: {
 		Old_Violet_Box: 5000
@@ -57032,6 +57076,7 @@ mob_db: (
 	AttackDelay: 576
 	AttackMotion: 1380
 	DamageMotion: 360
+	DamageTakenRate: 10
 	MvpExp: 750061
 	MvpDrops: {
 		Old_Card_Album: 5000
@@ -57142,6 +57187,7 @@ mob_db: (
 	AttackDelay: 1344
 	AttackMotion: 2592
 	DamageMotion: 432
+	DamageTakenRate: 10
 	MvpExp: 751725
 	MvpDrops: {
 		Old_Card_Album: 5000
@@ -57252,6 +57298,7 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 792
 	DamageMotion: 432
+	DamageTakenRate: 10
 	MvpExp: 750780
 	MvpDrops: {
 		Old_Card_Album: 5000
@@ -57363,6 +57410,7 @@ mob_db: (
 	AttackDelay: 900
 	AttackMotion: 648
 	DamageMotion: 480
+	DamageTakenRate: 10
 	MvpExp: 802000
 	MvpDrops: {
 		Old_Card_Album: 5000
@@ -61824,6 +61872,7 @@ mob_db: (
 	AttackDelay: 854
 	AttackMotion: 2016
 	DamageMotion: 480
+	DamageTakenRate: 10
 	MvpExp: 813243
 	MvpDrops: {
 		Yggdrasilberry: 5500
@@ -82387,6 +82436,7 @@ mob_db: (
 	AttackDelay: 76
 	AttackMotion: 384
 	DamageMotion: 288
+	DamageTakenRate: 10
 	MvpExp: 2291250
 	Drops: {
 		Needle_Of_Alarm: 3000


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
- They will take only `10%` of damage dealt.
- This will applies to bosses in Endless Tower and Central Laboratory as well.

However, the following MVP aren't in the database yet, so they aren't included for now.
```
Gold Queen Scaraba / Spider Chariot / R48-85-BESTIA / Rigid Muspellskoll / 
Corrupted Dark Lord / Corrupted Spider Queen / Jewgoliant / Bone Datardeurus / 
Reginleif / Ingrid / Chimera The One / R001-BESTIA / Death Witch
```

**Issues addressed:** <!-- Write here the issue number, if any. -->
https://www.divine-pride.net/forum/index.php?/topic/3318-kro-mvp-bosses-adjustment/

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
