### PR TITLE
Fix a failed assertion in the char server when trying to save a plagiarized skill

### DIFF
--- a/src/char/char.c
+++ b/src/char/char.c
@@ -629,6 +629,8 @@ static int char_mmo_char_tosql(int char_id, struct mmo_charstatus *p)
 				continue;
 			if (p->skill[i].flag == SKILL_FLAG_TEMPORARY)
 				continue;
+			if (p->skill[i].flag == SKILL_FLAG_PLAGIARIZED)
+				continue;
 			if (p->skill[i].lv == 0 && (p->skill[i].flag == SKILL_FLAG_PERM_GRANTED || p->skill[i].flag == SKILL_FLAG_PERMANENT))
 				continue;
 			if (p->skill[i].flag == SKILL_FLAG_REPLACED_LV_0)


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR adds an explicit check to skip skills with the `SKILL_FLAG_PLAGIARIZED` flag when saving them. It introduces no functional changes, since the issue was already caught by the subsequent Assert_chk.

Skills learned through Plagiarism should be treated like temporary skills and skipped when saving the character's skills, since they're already saved through char regs.

**Issues addressed:** https://herc.ws/board/topic/18999-plagiarism-server-error/

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
