### PR TITLE
Allow override libconfig command @include

### DIFF
--- a/3rdparty/libconfig/scanctx.c
+++ b/3rdparty/libconfig/scanctx.c
@@ -114,7 +114,17 @@ FILE *scanctx_push_include(struct scan_context *ctx, void *buffer,
     strcat(full_file, file);
   }
 
-  fp = fopen(full_file ? full_file : file, "rt");
+  if(full_file)
+  {
+    fp = fopen(full_file, "rt");
+    if(fp == NULL)
+      fp = fopen(file, "rt");
+  }
+  else
+  {
+    fp = fopen(file, "rt");
+  }
+
   free(full_file);
 
   if(fp)

--- a/src/common/conf.c
+++ b/src/common/conf.c
@@ -22,6 +22,7 @@
 
 #include "conf.h"
 
+#include "common/core.h"
 #include "common/nullpo.h" // nullpo_retv
 #include "common/showmsg.h" // ShowError
 #include "common/strlib.h" // safestrncpy
@@ -73,6 +74,14 @@ static void config_format_db_path(const char *filename, char *path_buf, int buff
 static int config_load_file(struct config_t *config, const char *config_filename)
 {
 	libconfig->init(config);
+
+	if (config_filename != NULL && strlen(config_filename) < 300) {
+		char include_path[350];
+		strcpy(include_path, "conf/import/include/");
+		strcat(include_path, SERVER_NAME);
+		libconfig->set_include_dir(config, include_path);
+	}
+
 	if (!exists(config_filename)) {
 		ShowError("Unable to load '%s' - File not found\n", config_filename);
 		return CONFIG_FALSE;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Override code try to open first conf/import/include/SERVERNAME/FILEPATH file,
if it failed fallback to normal FILEPATH path.

This feature need for example for override sql_connection.conf
without changing any other configs.



[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
