### PR TITLE
Refactor map->random_dir and implement aegis behavior of some skills which used it

### DIFF
--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -7040,7 +7040,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SplashRange: 1
+	SplashRange: 2
 	NumberOfHits: 0
 	CastTime: 2000
 	CoolDown: 0
@@ -9936,7 +9936,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SplashRange: 3
+	SplashRange: 2
 	InterruptCast: true
 	SkillInstances: 1
 	SkillData1: 20000
@@ -12159,7 +12159,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SplashRange: 3
+	SplashRange: 2
 	InterruptCast: true
 	SkillInstances: 1
 	SkillData1: 20000
@@ -12192,7 +12192,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SplashRange: 3
+	SplashRange: 2
 	InterruptCast: true
 	SkillInstances: 1
 	SkillData1: 20000

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -7366,7 +7366,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SplashRange: 1
+	SplashRange: 2
 	NumberOfHits: 0
 	CastTime: 2000
 	FixedCastTime: 1000
@@ -10267,7 +10267,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SplashRange: 3
+	SplashRange: 2
 	InterruptCast: true
 	SkillInstances: 1
 	SkillData1: 20000
@@ -12492,7 +12492,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SplashRange: 3
+	SplashRange: 2
 	InterruptCast: true
 	SkillInstances: 1
 	SkillData1: 20000
@@ -12525,7 +12525,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SplashRange: 3
+	SplashRange: 2
 	InterruptCast: true
 	SkillInstances: 1
 	SkillData1: 20000

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2946,6 +2946,49 @@ static enum unit_dir map_calc_dir(const struct block_list *src, int16 x, int16 y
 }
 
 /**
+ * Randomizes (x, y) to a walkable cell on a rectangle with (x, y) being the center cell.
+ *
+ * __Only__ tries each quarter of the rectangle once, doesn't try all possibilities. (Aegis behavior)
+ * The rectangle has a width of 2 * x_range - 1 and a height of 2 * y_range - 1 .
+ *
+ * @remark e.g. (x + x_range, y + y_range) is not part of the rectangle and won't be randomized.
+ * @param[in] bl optional object to base walkable checks on.
+ * @param[in] m map ID for the walkable cell checks
+ * @param[in,out] x pointer which contains the x-axis center value of the rectangle
+ * @param[in,out] y pointer which contains the y-axis center value of the rectangle
+ * @param[in] x_range horizontal distance from center to border
+ * @param[in] y_range vertical distance from center to border
+ * @retval 0 success, random walkable cell found
+ * @retval 1 failure, no cell found, x and y remain unchanged
+ * @retval 2 failure, x or y nullpointer.
+ */
+static int map_get_random_cell_in_range(struct block_list *bl, int16 m, int16 *x, int16 *y, int16 x_range, int16 y_range)
+{
+	nullpo_retr(2, x);
+	nullpo_retr(2, y);
+	enum unit_dir dir = unit_get_rnd_diagonal_dir();
+
+	for (int i = 0; i < 4; i++, dir = unit_get_ccw90_dir(dir)) {
+		int16 x_rnd_range = rnd() % max(1, x_range);
+		int16 y_rnd_range = rnd() % max(1, y_range);
+		int16 x_rnd = *x + dirx[dir] * x_rnd_range;
+		int16 y_rnd = *y + diry[dir] * y_rnd_range;
+
+		// cell walkable?
+		if (map->getcell(m, bl, x_rnd, y_rnd, CELL_CHKNOPASS) != 0)
+			continue;
+		if (!path->search(NULL, bl, m, *x, *y, x_rnd, y_rnd, 1, CELL_CHKNOREACH))
+			continue;
+
+		*x = x_rnd;
+		*y = y_rnd;
+		return 0;
+	}
+
+	return 1;
+}
+
+/**
  * Randomizes target cell x, y to a random walkable cell that
  * has the same distance from bl on a circle as given coordinates do.
  *
@@ -7132,6 +7175,7 @@ PRAGMA_GCC9(GCC diagnostic pop)
 
 	map->check_dir = map_check_dir;
 	map->calc_dir = map_calc_dir;
+	map->get_random_cell_in_range = map_get_random_cell_in_range;
 	map->random_dir = map_random_dir; // [Skotlex]
 
 	map->cleanup_sub = cleanup_sub;

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2961,22 +2961,22 @@ static int map_random_dir(struct block_list *bl, int16 *x, int16 *y)
 	nullpo_ret(bl);
 	nullpo_ret(x);
 	nullpo_ret(y);
-	short xi = *x - bl->x;
-	short yi = *y - bl->y;
+	int16 xi = *x - bl->x;
+	int16 yi = *y - bl->y;
 	if (xi == 0 && yi == 0) {
 		// No distance between points, go with distance 1 instead to prevent NaN in second sqrt
 		xi = 1;
 		yi = 1;
 	}
 	int dist2 = xi * xi + yi * yi;
-	short dist = (short)sqrt(dist2);
+	int16 dist = (int16)sqrt(dist2);
 
-	short i = 0;
+	int16 i = 0;
 	do {
 		enum unit_dir dir = unit_get_rnd_diagonal_dir();
-		short segment = 1 + (rnd() % dist); // Pick a random interval from the whole vector in that direction
+		int16 segment = 1 + (rnd() % dist); // Pick a random interval from the whole vector in that direction
 		xi = bl->x + segment * dirx[dir];
-		segment = (short)sqrt(dist2 - segment * segment); // The complement of the previously picked segment
+		segment = (int16)sqrt(dist2 - segment * segment); // The complement of the previously picked segment
 		yi = bl->y + segment * diry[dir];
 	} while ((map->getcell(bl->m, bl, xi, yi, CELL_CHKNOPASS) || !path->search(NULL, bl, bl->m, bl->x, bl->y, xi, yi, 1, CELL_CHKNOREACH))
 	         && (++i) < 100);

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2968,14 +2968,14 @@ static int map_random_dir(struct block_list *bl, int16 *x, int16 *y)
 		yi = 1;
 	}
 	int dist2 = xi * xi + yi * yi;
-	short dist = (short)sqrt((float)dist2);
+	short dist = (short)sqrt(dist2);
 
 	short i = 0;
 	do {
 		enum unit_dir dir = unit_get_rnd_diagonal_dir();
 		short segment = 1+(rnd()%dist); //Pick a random interval from the whole vector in that direction
 		xi = bl->x + segment * dirx[dir];
-		segment = (short)sqrt((float)(dist2 - segment*segment)); //The complement of the previously picked segment
+		segment = (short)sqrt(dist2 - segment * segment); // The complement of the previously picked segment
 		yi = bl->y + segment * diry[dir];
 	} while ((map->getcell(bl->m, bl, xi, yi, CELL_CHKNOPASS) || !path->search(NULL, bl, bl->m, bl->x, bl->y, xi, yi, 1, CELL_CHKNOREACH))
 	       && (++i)<100);

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2947,7 +2947,7 @@ static enum unit_dir map_calc_dir(const struct block_list *src, int16 x, int16 y
 
 /**
  * Randomizes target cell x, y to a random walkable cell that
- * has the same distance from bl as given coordinates do.
+ * has the same distance from bl on a circle as given coordinates do.
  *
  * @warning this function has gaps, especially on the west and east side in relation to @p bl
  * @param bl object to which we keep the same distance after randomizing the giving cells

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2949,6 +2949,7 @@ static enum unit_dir map_calc_dir(const struct block_list *src, int16 x, int16 y
  * Randomizes target cell x, y to a random walkable cell that
  * has the same distance from bl as given coordinates do.
  *
+ * @warning this function has gaps, especially on the west and east side in relation to @p bl
  * @param bl object to which we keep the same distance after randomizing the giving cells
  * @param[in,out] x x-axis pointer of cell for distance to @p bl
  * @param[in,out] y y-axis pointer of cell for distance to @p bl

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2973,12 +2973,12 @@ static int map_random_dir(struct block_list *bl, int16 *x, int16 *y)
 	short i = 0;
 	do {
 		enum unit_dir dir = unit_get_rnd_diagonal_dir();
-		short segment = 1+(rnd()%dist); //Pick a random interval from the whole vector in that direction
+		short segment = 1 + (rnd() % dist); // Pick a random interval from the whole vector in that direction
 		xi = bl->x + segment * dirx[dir];
 		segment = (short)sqrt(dist2 - segment * segment); // The complement of the previously picked segment
 		yi = bl->y + segment * diry[dir];
 	} while ((map->getcell(bl->m, bl, xi, yi, CELL_CHKNOPASS) || !path->search(NULL, bl, bl->m, bl->x, bl->y, xi, yi, 1, CELL_CHKNOREACH))
-	       && (++i)<100);
+	         && (++i) < 100);
 
 	if (i < 100) {
 		*x = xi;

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2951,22 +2951,17 @@ static enum unit_dir map_calc_dir(const struct block_list *src, int16 x, int16 y
  *------------------------------------------*/
 static int map_random_dir(struct block_list *bl, int16 *x, int16 *y)
 {
-	short xi;
-	short yi;
-	short i=0;
-	int dist2;
-	short dist;
-
 	nullpo_ret(bl);
 	nullpo_ret(x);
 	nullpo_ret(y);
-	xi = *x-bl->x;
-	yi = *y-bl->y;
-	dist2 = xi*xi + yi*yi;
-	dist = (short)sqrt((float)dist2);
+	short xi = *x - bl->x;
+	short yi = *y - bl->y;
+	int dist2 = xi * xi + yi * yi;
+	short dist = (short)sqrt((float)dist2);
 
 	if (dist < 1) dist =1;
 
+	short i = 0;
 	do {
 		enum unit_dir dir = unit_get_rnd_diagonal_dir();
 		short segment = 1+(rnd()%dist); //Pick a random interval from the whole vector in that direction

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2962,10 +2962,13 @@ static int map_random_dir(struct block_list *bl, int16 *x, int16 *y)
 	nullpo_ret(y);
 	short xi = *x - bl->x;
 	short yi = *y - bl->y;
+	if (xi == 0 && yi == 0) {
+		// No distance between points, go with distance 1 instead to prevent NaN in second sqrt
+		xi = 1;
+		yi = 1;
+	}
 	int dist2 = xi * xi + yi * yi;
 	short dist = (short)sqrt((float)dist2);
-
-	if (dist < 1) dist =1;
 
 	short i = 0;
 	do {

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2945,10 +2945,16 @@ static enum unit_dir map_calc_dir(const struct block_list *src, int16 x, int16 y
 	return dir;
 }
 
-/*==========================================
- * Randomizes target cell x,y to a random walkable cell that
- * has the same distance from object as given coordinates do. [Skotlex]
- *------------------------------------------*/
+/**
+ * Randomizes target cell x, y to a random walkable cell that
+ * has the same distance from bl as given coordinates do.
+ *
+ * @param bl object to which we keep the same distance after randomizing the giving cells
+ * @param[in,out] x x-axis pointer of cell for distance to @p bl
+ * @param[in,out] y y-axis pointer of cell for distance to @p bl
+ * @retval 0 failure to randomize coordinates, x and y won't be changed
+ * @retval 1 success
+ */
 static int map_random_dir(struct block_list *bl, int16 *x, int16 *y)
 {
 	nullpo_ret(bl);

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -1232,6 +1232,7 @@ END_ZEROED_BLOCK;
 
 	int (*check_dir) (enum unit_dir s_dir, enum unit_dir t_dir);
 	enum unit_dir (*calc_dir) (const struct block_list *src, int16 x, int16 y);
+	int (*get_random_cell) (struct block_list *bl, int16 m, int16 *x, int16 *y, int16 min_dist, int16 max_dist);
 	int (*get_random_cell_in_range) (struct block_list *bl, int16 m, int16 *x, int16 *y, int16 x_range, int16 y_range);
 	int (*random_dir) (struct block_list *bl, short *x, short *y); // [Skotlex]
 

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -1232,6 +1232,7 @@ END_ZEROED_BLOCK;
 
 	int (*check_dir) (enum unit_dir s_dir, enum unit_dir t_dir);
 	enum unit_dir (*calc_dir) (const struct block_list *src, int16 x, int16 y);
+	int (*get_random_cell_in_range) (struct block_list *bl, int16 m, int16 *x, int16 *y, int16 x_range, int16 y_range);
 	int (*random_dir) (struct block_list *bl, short *x, short *y); // [Skotlex]
 
 	int (*cleanup_sub) (struct block_list *bl, va_list ap);

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -6008,7 +6008,6 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 			case WE_CALLPARENT:
 			case WE_CALLBABY:
 			case AM_RESURRECTHOMUN:
-			case PF_SPIDERWEB:
 				//Find a random spot to place the skill. [Skotlex]
 				inf2 = skill->get_splash(ud->skill_id, ud->skill_lv);
 				ud->skillx = target->x + inf2;
@@ -6019,6 +6018,7 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 				}
 				ud->skilltimer=tid;
 				return skill->castend_pos(tid,tick,id,data);
+			case PF_SPIDERWEB:
 			case GN_WALLOFTHORN:
 			case SU_CN_POWDERING:
 			case SU_SV_ROOTTWIST:

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -859,7 +859,7 @@ static int skill_get_type(int skill_id, int skill_lv)
  *
  * @param skill_id The skill's ID.
  * @param skill_lv The skill's level.
- * @param flag 
+ * @param flag
  * @return The skill's unit ID corresponding to the passed level. Defaults to 0 in case of error.
  *
  **/
@@ -11237,7 +11237,7 @@ static int skill_castend_pos(int tid, int64 tick, int id, intptr_t data)
 
 	if (sd == NULL || sd->auto_cast_current.skill_id != ud->skill_id || skill->get_delay(ud->skill_id, ud->skill_lv) != 0)
 		ud->canact_tick = tick;
-	
+
 	if (sd != NULL && ud->skill_id == sd->auto_cast_current.skill_id)
 		pc->autocast_remove(sd, sd->auto_cast_current.type, ud->skill_id, ud->skill_lv);
 	else if(md)

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -6010,12 +6010,9 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 			case AM_RESURRECTHOMUN:
 				//Find a random spot to place the skill. [Skotlex]
 				inf2 = skill->get_splash(ud->skill_id, ud->skill_lv);
-				ud->skillx = target->x + inf2;
-				ud->skilly = target->y + inf2;
-				if (inf2 && !map->random_dir(target, &ud->skillx, &ud->skilly)) {
-					ud->skillx = target->x;
-					ud->skilly = target->y;
-				}
+				ud->skillx = target->x;
+				ud->skilly = target->y;
+				map->get_random_cell(target, target->m, &ud->skillx, &ud->skilly, 1, inf2);
 				ud->skilltimer=tid;
 				return skill->castend_pos(tid,tick,id,data);
 			case PF_SPIDERWEB:

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -622,8 +622,12 @@ static int unit_walk_toxy(struct block_list *bl, short x, short y, int flag)
 
 	sc = status->get_sc(bl);
 	if (sc != NULL) {
-		if (sc->data[SC_CONFUSION] != NULL || sc->data[SC__CHAOS] != NULL) // Randomize the target position
-			map->random_dir(bl, &ud->to_x, &ud->to_y);
+		if (sc->data[SC_CONFUSION] != NULL || sc->data[SC__CHAOS] != NULL) { // Randomize the target position
+			// Aegis behavior, yes if it doesn't find a random walkable cell it will not move at all.
+			ud->to_x = bl->x;
+			ud->to_y = bl->y;
+			map->get_random_cell_in_range(bl, bl->m, &ud->to_x, &ud->to_y, AREA_SIZE / 2, AREA_SIZE / 2);
+		}
 		if (sc->data[SC_COMBOATTACK] != NULL)
 			status_change_end(bl, SC_COMBOATTACK, INVALID_TIMER);
 	}
@@ -716,8 +720,12 @@ static int unit_walktobl(struct block_list *bl, struct block_list *tbl, int rang
 	unit->stop_attack(bl); //Sets target to 0
 
 	sc = status->get_sc(bl);
-	if (sc && (sc->data[SC_CONFUSION] || sc->data[SC__CHAOS])) //Randomize the target position
-		map->random_dir(bl, &ud->to_x, &ud->to_y);
+	if (sc != NULL && (sc->data[SC_CONFUSION] != NULL || sc->data[SC__CHAOS] != NULL)) { // Randomize the target position
+		// Aegis behavior, yes if it doesn't find a random walkable cell it will not move at all.
+		ud->to_x = bl->x;
+		ud->to_y = bl->y;
+		map->get_random_cell_in_range(bl, bl->m, &ud->to_x, &ud->to_y, AREA_SIZE / 2, AREA_SIZE / 2);
+	}
 
 	if(ud->walktimer != INVALID_TIMER) {
 		ud->state.change_walk_target = 1;

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -4754,6 +4754,8 @@ typedef int (*HPMHOOK_pre_map_check_dir) (enum unit_dir *s_dir, enum unit_dir *t
 typedef int (*HPMHOOK_post_map_check_dir) (int retVal___, enum unit_dir s_dir, enum unit_dir t_dir);
 typedef enum unit_dir (*HPMHOOK_pre_map_calc_dir) (const struct block_list **src, int16 *x, int16 *y);
 typedef enum unit_dir (*HPMHOOK_post_map_calc_dir) (enum unit_dir retVal___, const struct block_list *src, int16 x, int16 y);
+typedef int (*HPMHOOK_pre_map_get_random_cell) (struct block_list **bl, int16 *m, int16 **x, int16 **y, int16 *min_dist, int16 *max_dist);
+typedef int (*HPMHOOK_post_map_get_random_cell) (int retVal___, struct block_list *bl, int16 m, int16 *x, int16 *y, int16 min_dist, int16 max_dist);
 typedef int (*HPMHOOK_pre_map_get_random_cell_in_range) (struct block_list **bl, int16 *m, int16 **x, int16 **y, int16 *x_range, int16 *y_range);
 typedef int (*HPMHOOK_post_map_get_random_cell_in_range) (int retVal___, struct block_list *bl, int16 m, int16 *x, int16 *y, int16 x_range, int16 y_range);
 typedef int (*HPMHOOK_pre_map_random_dir) (struct block_list **bl, short **x, short **y);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -4754,6 +4754,8 @@ typedef int (*HPMHOOK_pre_map_check_dir) (enum unit_dir *s_dir, enum unit_dir *t
 typedef int (*HPMHOOK_post_map_check_dir) (int retVal___, enum unit_dir s_dir, enum unit_dir t_dir);
 typedef enum unit_dir (*HPMHOOK_pre_map_calc_dir) (const struct block_list **src, int16 *x, int16 *y);
 typedef enum unit_dir (*HPMHOOK_post_map_calc_dir) (enum unit_dir retVal___, const struct block_list *src, int16 x, int16 y);
+typedef int (*HPMHOOK_pre_map_get_random_cell_in_range) (struct block_list **bl, int16 *m, int16 **x, int16 **y, int16 *x_range, int16 *y_range);
+typedef int (*HPMHOOK_post_map_get_random_cell_in_range) (int retVal___, struct block_list *bl, int16 m, int16 *x, int16 *y, int16 x_range, int16 y_range);
 typedef int (*HPMHOOK_pre_map_random_dir) (struct block_list **bl, short **x, short **y);
 typedef int (*HPMHOOK_post_map_random_dir) (int retVal___, struct block_list *bl, short *x, short *y);
 typedef int (*HPMHOOK_pre_map_cleanup_sub) (struct block_list **bl, va_list ap);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -3678,6 +3678,8 @@ struct {
 	struct HPMHookPoint *HP_map_check_dir_post;
 	struct HPMHookPoint *HP_map_calc_dir_pre;
 	struct HPMHookPoint *HP_map_calc_dir_post;
+	struct HPMHookPoint *HP_map_get_random_cell_in_range_pre;
+	struct HPMHookPoint *HP_map_get_random_cell_in_range_post;
 	struct HPMHookPoint *HP_map_random_dir_pre;
 	struct HPMHookPoint *HP_map_random_dir_post;
 	struct HPMHookPoint *HP_map_cleanup_sub_pre;
@@ -10737,6 +10739,8 @@ struct {
 	int HP_map_check_dir_post;
 	int HP_map_calc_dir_pre;
 	int HP_map_calc_dir_post;
+	int HP_map_get_random_cell_in_range_pre;
+	int HP_map_get_random_cell_in_range_post;
 	int HP_map_random_dir_pre;
 	int HP_map_random_dir_post;
 	int HP_map_cleanup_sub_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -3678,6 +3678,8 @@ struct {
 	struct HPMHookPoint *HP_map_check_dir_post;
 	struct HPMHookPoint *HP_map_calc_dir_pre;
 	struct HPMHookPoint *HP_map_calc_dir_post;
+	struct HPMHookPoint *HP_map_get_random_cell_pre;
+	struct HPMHookPoint *HP_map_get_random_cell_post;
 	struct HPMHookPoint *HP_map_get_random_cell_in_range_pre;
 	struct HPMHookPoint *HP_map_get_random_cell_in_range_post;
 	struct HPMHookPoint *HP_map_random_dir_pre;
@@ -10739,6 +10741,8 @@ struct {
 	int HP_map_check_dir_post;
 	int HP_map_calc_dir_pre;
 	int HP_map_calc_dir_post;
+	int HP_map_get_random_cell_pre;
+	int HP_map_get_random_cell_post;
 	int HP_map_get_random_cell_in_range_pre;
 	int HP_map_get_random_cell_in_range_post;
 	int HP_map_random_dir_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -1882,6 +1882,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(map->reloadnpc, HP_map_reloadnpc) },
 	{ HP_POP(map->check_dir, HP_map_check_dir) },
 	{ HP_POP(map->calc_dir, HP_map_calc_dir) },
+	{ HP_POP(map->get_random_cell_in_range, HP_map_get_random_cell_in_range) },
 	{ HP_POP(map->random_dir, HP_map_random_dir) },
 	{ HP_POP(map->cleanup_sub, HP_map_cleanup_sub) },
 	{ HP_POP(map->delmap, HP_map_delmap) },

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -1882,6 +1882,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(map->reloadnpc, HP_map_reloadnpc) },
 	{ HP_POP(map->check_dir, HP_map_check_dir) },
 	{ HP_POP(map->calc_dir, HP_map_calc_dir) },
+	{ HP_POP(map->get_random_cell, HP_map_get_random_cell) },
 	{ HP_POP(map->get_random_cell_in_range, HP_map_get_random_cell_in_range) },
 	{ HP_POP(map->random_dir, HP_map_random_dir) },
 	{ HP_POP(map->cleanup_sub, HP_map_cleanup_sub) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -48555,6 +48555,33 @@ enum unit_dir HP_map_calc_dir(const struct block_list *src, int16 x, int16 y) {
 	}
 	return retVal___;
 }
+int HP_map_get_random_cell(struct block_list *bl, int16 m, int16 *x, int16 *y, int16 min_dist, int16 max_dist) {
+	int hIndex = 0;
+	int retVal___ = 0;
+	if (HPMHooks.count.HP_map_get_random_cell_pre > 0) {
+		int (*preHookFunc) (struct block_list **bl, int16 *m, int16 **x, int16 **y, int16 *min_dist, int16 *max_dist);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_map_get_random_cell_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_map_get_random_cell_pre[hIndex].func;
+			retVal___ = preHookFunc(&bl, &m, &x, &y, &min_dist, &max_dist);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.map.get_random_cell(bl, m, x, y, min_dist, max_dist);
+	}
+	if (HPMHooks.count.HP_map_get_random_cell_post > 0) {
+		int (*postHookFunc) (int retVal___, struct block_list *bl, int16 m, int16 *x, int16 *y, int16 min_dist, int16 max_dist);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_map_get_random_cell_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_map_get_random_cell_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, bl, m, x, y, min_dist, max_dist);
+		}
+	}
+	return retVal___;
+}
 int HP_map_get_random_cell_in_range(struct block_list *bl, int16 m, int16 *x, int16 *y, int16 x_range, int16 y_range) {
 	int hIndex = 0;
 	int retVal___ = 0;

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -48555,6 +48555,33 @@ enum unit_dir HP_map_calc_dir(const struct block_list *src, int16 x, int16 y) {
 	}
 	return retVal___;
 }
+int HP_map_get_random_cell_in_range(struct block_list *bl, int16 m, int16 *x, int16 *y, int16 x_range, int16 y_range) {
+	int hIndex = 0;
+	int retVal___ = 0;
+	if (HPMHooks.count.HP_map_get_random_cell_in_range_pre > 0) {
+		int (*preHookFunc) (struct block_list **bl, int16 *m, int16 **x, int16 **y, int16 *x_range, int16 *y_range);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_map_get_random_cell_in_range_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_map_get_random_cell_in_range_pre[hIndex].func;
+			retVal___ = preHookFunc(&bl, &m, &x, &y, &x_range, &y_range);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.map.get_random_cell_in_range(bl, m, x, y, x_range, y_range);
+	}
+	if (HPMHooks.count.HP_map_get_random_cell_in_range_post > 0) {
+		int (*postHookFunc) (int retVal___, struct block_list *bl, int16 m, int16 *x, int16 *y, int16 x_range, int16 y_range);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_map_get_random_cell_in_range_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_map_get_random_cell_in_range_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, bl, m, x, y, x_range, y_range);
+		}
+	}
+	return retVal___;
+}
 int HP_map_random_dir(struct block_list *bl, short *x, short *y) {
 	int hIndex = 0;
 	int retVal___ = 0;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Refactors map->random_dir. Adds map->get_random_cell and map->get_random_cell_in_range.  
Implements correct behavior of Confusion / Chaos movement, WE_CALLPARTNER, WE_CALLPARENT, WE_CALLBABY and AM_RESURRECTHOMUN.

Visualized gaps of map->random_dir 's distribution mentioned in a commit and documentation now:
![Image of random cells produced by map->random_dir](http://skyleo.de/herc/gaps_map_random_dir.png)

**Issues addressed:** none?

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
