### PR TITLE
Fix nullpo error in searchstore

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -19750,6 +19750,9 @@ static void clif_parse_SearchStoreInfo(int fd, struct map_session_data *sd)
 		return;
 	}
 
+	if (p->itemsCount < 1)
+		return; // Should never happen
+
 	type       = p->searchType;
 	max_price  = p->maxPrice;
 	min_price  = p->minPrice;

--- a/src/map/searchstore.c
+++ b/src/map/searchstore.c
@@ -135,8 +135,14 @@ static void searchstore_query(struct map_session_data *sd,
 		return;
 	}
 
+	if (item_count < 1) {
+		clif->search_store_info_failed(sd, SSI_FAILED_NOTHING_SEARCH_ITEM);
+		return;
+	}
+
 	nullpo_retv(itemlist);
-	nullpo_retv(cardlist);
+	if (card_count > 0)
+		nullpo_retv(cardlist);
 
 	// validate lists
 	for( i = 0; i < item_count; i++ ) {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes 2 checks in search store function:
1. it prevents trying to search with an empty item list, this is not even allowed by the client, and makes no sense in the process, as it always start the search by an item. (that's why I put the check on clif)

2. When searching for an item without asking for cards, it was giving us a nullpo because card_list would be NULL (as it becomes a "0-length array"), but it is a totally valid search (e.g. Searching for an ETC item would never have cards to check for). So I disabled the null pointer check when the card count is zero, from my tests and checking the code, every code called from this would check card count before trying to access the array, so it looks safe.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None, i think

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
