### PR TITLE
Allow constants on QuestDB

### DIFF
--- a/db/pre-re/item_db.conf
+++ b/db/pre-re/item_db.conf
@@ -55875,6 +55875,34 @@ item_db: (
 	Weight: 1
 },
 {
+	Id: 6498
+	AegisName: "Jejellopy"
+	Name: "Jejellopy"
+	Buy: 200
+	Weight: 10
+},
+{
+	Id: 6507
+	AegisName: "Evil_Bone"
+	Name: "Evil Spirit Bone"
+	Trade: {
+		nodrop: true
+		notrade: true
+		nocart: true
+		nostorage: true
+		nogstorage: true
+		nomail: true
+		noauction: true
+	}
+},
+{
+	Id: 6510
+	AegisName: "Elegant_Flower"
+	Name: "Elegant Flower"
+	Buy: 300
+	Weight: 10
+},
+{
 	Id: 6512
 	AegisName: "Charm_Fire"
 	Name: "Charm Fire"
@@ -55901,6 +55929,34 @@ item_db: (
 	Name: "Charm Earth"
 	Buy: 100
 	Weight: 1
+},
+{
+	Id: 6520
+	AegisName: "Lost_Belongings"
+	Name: "Lost Belongings"
+	Trade: {
+		nodrop: true
+		notrade: true
+		nocart: true
+		nogstorage: true
+		nomail: true
+		noauction: true
+	}
+},
+{
+	Id: 6542
+	AegisName: "Star_Shape_Mushroom"
+	Name: "Star Shape Mushroom"
+	Buy: 20
+	Weight: 100
+	Trade: {
+		nodrop: true
+		notrade: true
+		nocart: true
+		nogstorage: true
+		nomail: true
+		noauction: true
+	}
 },
 {
 	Id: 6707

--- a/db/quest_db.conf
+++ b/db/quest_db.conf
@@ -40,7 +40,7 @@ quest_db: (
 		// ================ Mandatory fields ==============================
 		Count: number           (int)
 		// ================ Optional fields ===============================
-		MobId: Mob_ID           (int, defaults to 0 = Any Monster)
+		MobId: Mob_ID           (int/constant, defaults to 0 = Any Monster)
 		Level: [min, max]       (int, defaults to 0)
 		MapName: name           (string, defaults to All maps)
 		MobType: {
@@ -53,9 +53,9 @@ quest_db: (
 	)
 	Drops: (                        (list, optional)
 	{
-		ItemId: item_to_drop    (int)
+		ItemId: item_to_drop    (int/constant)
 		Rate: Drop_Rate         (int)
-		MobId: Mob_ID_to_match  (int, optional)
+		MobId: Mob_ID_to_match  (int/constant, optional)
 	},
 	// ... (can be repeated)
 	)

--- a/src/map/quest.h
+++ b/src/map/quest.h
@@ -164,6 +164,7 @@ struct quest_interface {
 	void (*clear) (void);
 	int (*read_db) (void);
 	struct quest_db *(*read_db_sub) (struct config_setting_t *cs, int n, const char *source);
+	int (*setting_lookup_const) (struct config_setting_t *tt, const char *name, int *value, int quest_id, int idx, const char *kind, const char *source);
 
 	int (*questinfo_validate_icon) (int icon);
 	void (*questinfo_refresh) (struct map_session_data *sd);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -6704,6 +6704,8 @@ typedef int (*HPMHOOK_pre_quest_read_db) (void);
 typedef int (*HPMHOOK_post_quest_read_db) (int retVal___);
 typedef struct quest_db* (*HPMHOOK_pre_quest_read_db_sub) (struct config_setting_t **cs, int *n, const char **source);
 typedef struct quest_db* (*HPMHOOK_post_quest_read_db_sub) (struct quest_db* retVal___, struct config_setting_t *cs, int n, const char *source);
+typedef int (*HPMHOOK_pre_quest_setting_lookup_const) (struct config_setting_t **tt, const char **name, int **value, int *quest_id, int *idx, const char **kind, const char **source);
+typedef int (*HPMHOOK_post_quest_setting_lookup_const) (int retVal___, struct config_setting_t *tt, const char *name, int *value, int quest_id, int idx, const char *kind, const char *source);
 typedef int (*HPMHOOK_pre_quest_questinfo_validate_icon) (int *icon);
 typedef int (*HPMHOOK_post_quest_questinfo_validate_icon) (int retVal___, int icon);
 typedef void (*HPMHOOK_pre_quest_questinfo_refresh) (struct map_session_data **sd);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -5244,6 +5244,8 @@ struct {
 	struct HPMHookPoint *HP_quest_read_db_post;
 	struct HPMHookPoint *HP_quest_read_db_sub_pre;
 	struct HPMHookPoint *HP_quest_read_db_sub_post;
+	struct HPMHookPoint *HP_quest_setting_lookup_const_pre;
+	struct HPMHookPoint *HP_quest_setting_lookup_const_post;
 	struct HPMHookPoint *HP_quest_questinfo_validate_icon_pre;
 	struct HPMHookPoint *HP_quest_questinfo_validate_icon_post;
 	struct HPMHookPoint *HP_quest_questinfo_refresh_pre;
@@ -12317,6 +12319,8 @@ struct {
 	int HP_quest_read_db_post;
 	int HP_quest_read_db_sub_pre;
 	int HP_quest_read_db_sub_post;
+	int HP_quest_setting_lookup_const_pre;
+	int HP_quest_setting_lookup_const_post;
 	int HP_quest_questinfo_validate_icon_pre;
 	int HP_quest_questinfo_validate_icon_post;
 	int HP_quest_questinfo_refresh_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -2683,6 +2683,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(quest->clear, HP_quest_clear) },
 	{ HP_POP(quest->read_db, HP_quest_read_db) },
 	{ HP_POP(quest->read_db_sub, HP_quest_read_db_sub) },
+	{ HP_POP(quest->setting_lookup_const, HP_quest_setting_lookup_const) },
 	{ HP_POP(quest->questinfo_validate_icon, HP_quest_questinfo_validate_icon) },
 	{ HP_POP(quest->questinfo_refresh, HP_quest_questinfo_refresh) },
 	{ HP_POP(quest->questinfo_validate, HP_quest_questinfo_validate) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -69834,6 +69834,33 @@ struct quest_db* HP_quest_read_db_sub(struct config_setting_t *cs, int n, const 
 	}
 	return retVal___;
 }
+int HP_quest_setting_lookup_const(struct config_setting_t *tt, const char *name, int *value, int quest_id, int idx, const char *kind, const char *source) {
+	int hIndex = 0;
+	int retVal___ = 0;
+	if (HPMHooks.count.HP_quest_setting_lookup_const_pre > 0) {
+		int (*preHookFunc) (struct config_setting_t **tt, const char **name, int **value, int *quest_id, int *idx, const char **kind, const char **source);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_quest_setting_lookup_const_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_quest_setting_lookup_const_pre[hIndex].func;
+			retVal___ = preHookFunc(&tt, &name, &value, &quest_id, &idx, &kind, &source);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.quest.setting_lookup_const(tt, name, value, quest_id, idx, kind, source);
+	}
+	if (HPMHooks.count.HP_quest_setting_lookup_const_post > 0) {
+		int (*postHookFunc) (int retVal___, struct config_setting_t *tt, const char *name, int *value, int quest_id, int idx, const char *kind, const char *source);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_quest_setting_lookup_const_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_quest_setting_lookup_const_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, tt, name, value, quest_id, idx, kind, source);
+		}
+	}
+	return retVal___;
+}
 int HP_quest_questinfo_validate_icon(int icon) {
 	int hIndex = 0;
 	int retVal___ = 0;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### IMPORTANT
These changes were made using Asheraf's #2874 as base, so it must wait for it before being merged.

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This change allows the use of constants for monster IDs and Item Ids. Also it adds some error messages when ignoring entries, so the user knows what happened.

After doing the change, some quests were giving errors on pre-re, because they have special RE drops, so I copied those items to pre-re db, as you shouldn't get the quest.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None, I think.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
