### PR TITLE
Fix some wrong return values in mob skill code

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -3370,9 +3370,9 @@ static int64 battle_calc_damage(struct block_list *src, struct block_list *bl, s
 	if( bl->type == BL_MOB && !status->isdead(bl) && src != bl) {
 		struct mob_data *md = BL_UCAST(BL_MOB, bl);
 		if (damage > 0)
-			mob->skill_event(md, src, timer->gettick(), flag);
+			mob->use_skill_event(md, src, timer->gettick(), flag);
 		if (skill_id)
-			mob->skill_event(md, src, timer->gettick(), MSC_SKILLUSED|(skill_id<<16));
+			mob->use_skill_event(md, src, timer->gettick(), MSC_SKILLUSED | (skill_id << 16));
 	}
 	if (t_sd && pc_ismadogear(t_sd) && rnd()%100 < 50) {
 		int element = -1;

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -3464,7 +3464,7 @@ static struct block_list *mob_getfriendstatus(struct mob_data *md, int cond1, in
 }
 
 /**
- * Checks if skill cast condition in fulfilled and executes the skill in case of success.
+ * Checks if skill cast condition is fulfilled and executes the skill in case of success.
  *
  * @param md The monster which tries to cast a skill.
  * @param tick The timestamp of skill execution.

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -3733,7 +3733,7 @@ static int mob_use_skill(struct mob_data *md, int64 tick, int event)
 /*==========================================
  * Skill use event processing
  *------------------------------------------*/
-static int mobskill_event(struct mob_data *md, struct block_list *src, int64 tick, int flag)
+static int mob_use_skill_event(struct mob_data *md, struct block_list *src, int64 tick, int flag)
 {
 	int target_id;
 
@@ -6162,7 +6162,7 @@ void mob_defaults(void)
 	mob->getfriendstatus_sub = mob_getfriendstatus_sub;
 	mob->getfriendstatus = mob_getfriendstatus;
 	mob->use_skill = mob_use_skill;
-	mob->skill_event = mobskill_event;
+	mob->use_skill_event = mob_use_skill_event;
 	mob->is_clone = mob_is_clone;
 	mob->clone_spawn = mob_clone_spawn;
 	mob->clone_delete = mob_clone_delete;

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -1703,7 +1703,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, int64 tick)
 			    || !mob->can_reach(md, tbl, md->min_chase, MSS_RUSH)
 			    )
 			 && md->state.attacked_count++ >= RUDE_ATTACKED_COUNT
-			 && mob->skill_use(md, tick, MSC_RUDEATTACKED) == 0 // If can't rude Attack
+			 && mob->skill_use(md, tick, MSC_RUDEATTACKED) != 0 // If can't rude Attack
 			 && can_move && unit->escape(&md->bl, tbl, rnd()%10 +1) // Attempt escape
 			) {
 				//Escaped
@@ -1731,7 +1731,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, int64 tick)
 			) {
 				// Rude attacked
 				if (md->state.attacked_count++ >= RUDE_ATTACKED_COUNT
-				 && mob->skill_use(md, tick, MSC_RUDEATTACKED) == 0 && can_move != 0
+				 && mob->skill_use(md, tick, MSC_RUDEATTACKED) != 0 && can_move != 0
 				 && !tbl && unit->escape(&md->bl, abl, rnd()%10 +1)
 				) {
 					//Escaped.

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -3474,11 +3474,11 @@ static struct block_list *mob_getfriendstatus(struct mob_data *md, int cond1, in
  **/
 static int mob_skill_use(struct mob_data *md, int64 tick, int event)
 {
-	nullpo_ret(md);
+	nullpo_retr(1, md);
 
 	struct mob_skill *ms = md->db->skill;
 
-	nullpo_ret(ms);
+	nullpo_retr(1, ms);
 
 	if (battle_config.mob_skill_rate == 0 || md->ud.skilltimer != INVALID_TIMER || md->db->maxskill == 0)
 		return 1;

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -3735,10 +3735,10 @@ static int mob_skill_use(struct mob_data *md, int64 tick, int event)
  *------------------------------------------*/
 static int mobskill_event(struct mob_data *md, struct block_list *src, int64 tick, int flag)
 {
-	int target_id, res = 0;
+	int target_id;
 
-	nullpo_ret(md);
-	nullpo_ret(src);
+	nullpo_retr(1, md);
+	nullpo_retr(1, src);
 	if(md->bl.prev == NULL || md->status.hp <= 0)
 		return 1;
 
@@ -3750,6 +3750,8 @@ static int mobskill_event(struct mob_data *md, struct block_list *src, int64 tic
 	target_id = md->target_id;
 	if (!target_id || battle_config.mob_changetarget_byskill)
 		md->target_id = src->id;
+
+	int res = 1;
 
 	if (flag == -1)
 		res = mob->skill_use(md, tick, MSC_CASTTARGETED);

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -1166,7 +1166,7 @@ static int mob_spawn(struct mob_data *md)
 	if( map->list[md->bl.m].users )
 		clif->spawn(&md->bl);
 	skill->unit_move(&md->bl,tick,1);
-	mob->skill_use(md, tick, MSC_SPAWN);
+	mob->use_skill(md, tick, MSC_SPAWN);
 	return 0;
 }
 
@@ -1523,7 +1523,7 @@ static int mob_unlocktarget(struct mob_data *md, int64 tick)
 		FALLTHROUGH
 	case MSS_IDLE:
 		// Idle skill.
-		if ((++md->ud.walk_count % IDLE_SKILL_INTERVAL) == 0 && mob->skill_use(md, tick, -1) == 0)
+		if ((++md->ud.walk_count % IDLE_SKILL_INTERVAL) == 0 && mob->use_skill(md, tick, -1) == 0)
 			break;
 		//Random walk.
 		if (!md->master_id &&
@@ -1703,7 +1703,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, int64 tick)
 			    || !mob->can_reach(md, tbl, md->min_chase, MSS_RUSH)
 			    )
 			 && md->state.attacked_count++ >= RUDE_ATTACKED_COUNT
-			 && mob->skill_use(md, tick, MSC_RUDEATTACKED) != 0 // If can't rude Attack
+			 && mob->use_skill(md, tick, MSC_RUDEATTACKED) != 0 // If can't rude Attack
 			 && can_move && unit->escape(&md->bl, tbl, rnd()%10 +1) // Attempt escape
 			) {
 				//Escaped
@@ -1731,7 +1731,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, int64 tick)
 			) {
 				// Rude attacked
 				if (md->state.attacked_count++ >= RUDE_ATTACKED_COUNT
-				 && mob->skill_use(md, tick, MSC_RUDEATTACKED) != 0 && can_move != 0
+				 && mob->use_skill(md, tick, MSC_RUDEATTACKED) != 0 && can_move != 0
 				 && !tbl && unit->escape(&md->bl, abl, rnd()%10 +1)
 				) {
 					//Escaped.
@@ -1876,7 +1876,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, int64 tick)
 	if(md->ud.walktimer == INVALID_TIMER && (md->state.skillstate == MSS_BERSERK || md->state.skillstate == MSS_ANGRY)) {
 		if (DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME && DIFF_TICK(md->ud.canact_tick, tick) < -MIN_MOBTHINKTIME*IDLE_SKILL_INTERVAL)
 		{ //Only use skill if able to walk on next tick and not used a skill the last second
-			mob->skill_use(md, tick, -1);
+			mob->use_skill(md, tick, -1);
 		}
 	}
 
@@ -2005,7 +2005,7 @@ static int mob_ai_sub_lazy(struct mob_data *md, va_list args)
 		//Because it is not unset when the mob finishes walking.
 		md->state.skillstate = MSS_IDLE;
 		if( rnd()%1000 < MOB_LAZYSKILLPERC(md) ) //Chance to do a mob's idle skill.
-			mob->skill_use(md, tick, -1);
+			mob->use_skill(md, tick, -1);
 	}
 
 	return 0;
@@ -2435,7 +2435,7 @@ static int mob_dead(struct mob_data *md, struct block_list *src, int type)
 	if( src )
 	{ // Use Dead skill only if not killed by Script or Command
 		md->state.skillstate = MSS_DEAD;
-		mob->skill_use(md,tick,-1);
+		mob->use_skill(md, tick, -1);
 	}
 
 	map->freeblock_lock();
@@ -2975,7 +2975,7 @@ static void mob_revive(struct mob_data *md, unsigned int hp)
 		map->addblock(&md->bl);
 	clif->spawn(&md->bl);
 	skill->unit_move(&md->bl,tick,1);
-	mob->skill_use(md, tick, MSC_SPAWN);
+	mob->use_skill(md, tick, MSC_SPAWN);
 	if (battle_config.show_mob_info&3)
 		clif->blname_ack(0, &md->bl);
 }
@@ -3472,7 +3472,7 @@ static struct block_list *mob_getfriendstatus(struct mob_data *md, int cond1, in
  * @return 0 on success, 1 on failure.
  *
  **/
-static int mob_skill_use(struct mob_data *md, int64 tick, int event)
+static int mob_use_skill(struct mob_data *md, int64 tick, int event)
 {
 	nullpo_retr(1, md);
 
@@ -3744,7 +3744,7 @@ static int mobskill_event(struct mob_data *md, struct block_list *src, int64 tic
 
 	if (md->special_state.ai == AI_SPHERE) {//LOne WOlf explained that ANYONE can trigger the marine countdown skill. [Skotlex]
 		md->state.alchemist = 1;
-		return mob->skill_use(md, timer->gettick(), MSC_ALCHEMIST);
+		return mob->use_skill(md, timer->gettick(), MSC_ALCHEMIST);
 	}
 
 	target_id = md->target_id;
@@ -3754,15 +3754,15 @@ static int mobskill_event(struct mob_data *md, struct block_list *src, int64 tic
 	int res = 1;
 
 	if (flag == -1)
-		res = mob->skill_use(md, tick, MSC_CASTTARGETED);
+		res = mob->use_skill(md, tick, MSC_CASTTARGETED);
 	else if ((flag&0xffff) == MSC_SKILLUSED)
-		res = mob->skill_use(md, tick, flag);
+		res = mob->use_skill(md, tick, flag);
 	else if (flag&BF_SHORT)
-		res = mob->skill_use(md, tick, MSC_CLOSEDATTACKED);
+		res = mob->use_skill(md, tick, MSC_CLOSEDATTACKED);
 	else if (flag&BF_LONG && !(flag&BF_MAGIC)) //Long-attacked should not include magic.
-		res = mob->skill_use(md, tick, MSC_LONGRANGEATTACKED);
+		res = mob->use_skill(md, tick, MSC_LONGRANGEATTACKED);
 	else if ((flag & BF_MAGIC) != 0)
-		res = mob->skill_use(md, tick, MSC_MAGICATTACKED);
+		res = mob->use_skill(md, tick, MSC_MAGICATTACKED);
 
 	if (res != 0)
 	//Restore previous target only if skill condition failed to trigger. [Skotlex]
@@ -6161,7 +6161,7 @@ void mob_defaults(void)
 	mob->getmasterhpltmaxrate = mob_getmasterhpltmaxrate;
 	mob->getfriendstatus_sub = mob_getfriendstatus_sub;
 	mob->getfriendstatus = mob_getfriendstatus;
-	mob->skill_use = mob_skill_use;
+	mob->use_skill = mob_use_skill;
 	mob->skill_event = mobskill_event;
 	mob->is_clone = mob_is_clone;
 	mob->clone_spawn = mob_clone_spawn;

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -575,7 +575,7 @@ struct mob_interface {
 	struct block_list* (*getmasterhpltmaxrate) (struct mob_data *md, int rate);
 	int (*getfriendstatus_sub) (struct block_list *bl, va_list ap);
 	struct block_list *(*getfriendstatus) (struct mob_data *md, int cond1, int cond2);
-	int (*skill_use) (struct mob_data *md, int64 tick, int event);
+	int (*use_skill) (struct mob_data *md, int64 tick, int event);
 	int (*skill_event) (struct mob_data *md, struct block_list *src, int64 tick, int flag);
 	int (*is_clone) (int class_);
 	int (*clone_spawn) (struct map_session_data *sd, int16 m, int16 x, int16 y, const char *event, int master_id, uint32 mode, int flag, unsigned int duration);

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -576,7 +576,7 @@ struct mob_interface {
 	int (*getfriendstatus_sub) (struct block_list *bl, va_list ap);
 	struct block_list *(*getfriendstatus) (struct mob_data *md, int cond1, int cond2);
 	int (*use_skill) (struct mob_data *md, int64 tick, int event);
-	int (*skill_event) (struct mob_data *md, struct block_list *src, int64 tick, int flag);
+	int (*use_skill_event) (struct mob_data *md, struct block_list *src, int64 tick, int flag);
 	int (*is_clone) (int class_);
 	int (*clone_spawn) (struct map_session_data *sd, int16 m, int16 x, int16 y, const char *event, int master_id, uint32 mode, int flag, unsigned int duration);
 	int (*clone_delete) (struct mob_data *md);

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -11038,7 +11038,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 
 	if (dstmd) { //Mob skill event for no damage skills (damage ones are handled in battle_calc_damage) [Skotlex]
 		mob->log_damage(dstmd, src, 0); //Log interaction (counts as 'attacker' for the exp bonus)
-		mob->skill_event(dstmd, src, tick, MSC_SKILLUSED|(skill_id<<16));
+		mob->use_skill_event(dstmd, src, tick, MSC_SKILLUSED | (skill_id << 16));
 	}
 
 	if( sd && !(flag&1) ) { // ensure that the skill last-cast tick is recorded
@@ -13998,7 +13998,7 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 	}
 
 	if (bl->type == BL_MOB && ss != bl)
-		mob->skill_event(BL_UCAST(BL_MOB, bl), ss, tick, MSC_SKILLUSED|(skill_id<<16));
+		mob->use_skill_event(BL_UCAST(BL_MOB, bl), ss, tick, MSC_SKILLUSED | (skill_id << 16));
 
 	return skill_id;
 }

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -381,10 +381,10 @@ static int unit_walk_toxy_timer(int tid, int64 tick, int id, intptr_t data)
 		clif->fixpos(bl);
 		// Monsters in this situation first use a chase skill, then unlock target and then use an idle skill
 		if ((++ud->walk_count % WALK_SKILL_INTERVAL) == 0)
-			mob->skill_use(md, tick, -1);
+			mob->use_skill(md, tick, -1);
 		mob->unlocktarget(md, tick);
 		if ((++ud->walk_count % WALK_SKILL_INTERVAL) != 0)
-			mob->skill_use(md, tick, -1);
+			mob->use_skill(md, tick, -1);
 		return 1;
 	}
 
@@ -435,7 +435,7 @@ static int unit_walk_toxy_timer(int tid, int64 tick, int id, intptr_t data)
 		// Walk skills are triggered regardless of target due to the idle-walk mob state.
 		// But avoid triggering on stop-walk calls.
 		if (tid != INVALID_TIMER && (ud->walk_count % WALK_SKILL_INTERVAL) == 0
-		    && map->list[bl->m].users > 0 && mob->skill_use(md, tick, -1) == 0) {
+		    && map->list[bl->m].users > 0 && mob->use_skill(md, tick, -1) == 0) {
 			// Walk skills are supposed to be used while walking
 			if (!(ud->skill_id == NPC_SELFDESTRUCTION && ud->skilltimer != INVALID_TIMER)
 			    && md->state.skillstate != MSS_WALK) {
@@ -2342,7 +2342,7 @@ static int unit_attack_timer_sub(struct block_list *src, int tid, int64 tick)
 		if(md) {
 			//First attack is always a normal attack
 			if(md->state.skillstate == MSS_ANGRY || md->state.skillstate == MSS_BERSERK) {
-				if (mob->skill_use(md, tick, -1) == 0) {
+				if (mob->use_skill(md, tick, -1) == 0) {
 					map->freeblock_unlock();
 					return 1;
 				}

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1725,7 +1725,7 @@ static int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill
 	{
 		if (sd != NULL && target->type == BL_MOB) {
 			struct mob_data *md = BL_UCAST(BL_MOB, target);
-			mob->skill_event(md, src, tick, -1); //Cast targeted skill event.
+			mob->use_skill_event(md, src, tick, -1); // Cast targeted skill event.
 			if (tstatus->mode&(MD_CASTSENSOR_IDLE|MD_CASTSENSOR_CHASE) &&
 				battle->check_target(target, src, BCT_ENEMY) > 0)
 			{

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -5488,8 +5488,8 @@ typedef struct block_list* (*HPMHOOK_pre_mob_getfriendstatus) (struct mob_data *
 typedef struct block_list* (*HPMHOOK_post_mob_getfriendstatus) (struct block_list* retVal___, struct mob_data *md, int cond1, int cond2);
 typedef int (*HPMHOOK_pre_mob_use_skill) (struct mob_data **md, int64 *tick, int *event);
 typedef int (*HPMHOOK_post_mob_use_skill) (int retVal___, struct mob_data *md, int64 tick, int event);
-typedef int (*HPMHOOK_pre_mob_skill_event) (struct mob_data **md, struct block_list **src, int64 *tick, int *flag);
-typedef int (*HPMHOOK_post_mob_skill_event) (int retVal___, struct mob_data *md, struct block_list *src, int64 tick, int flag);
+typedef int (*HPMHOOK_pre_mob_use_skill_event) (struct mob_data **md, struct block_list **src, int64 *tick, int *flag);
+typedef int (*HPMHOOK_post_mob_use_skill_event) (int retVal___, struct mob_data *md, struct block_list *src, int64 tick, int flag);
 typedef int (*HPMHOOK_pre_mob_is_clone) (int *class_);
 typedef int (*HPMHOOK_post_mob_is_clone) (int retVal___, int class_);
 typedef int (*HPMHOOK_pre_mob_clone_spawn) (struct map_session_data **sd, int16 *m, int16 *x, int16 *y, const char **event, int *master_id, uint32 *mode, int *flag, unsigned int *duration);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -5486,8 +5486,8 @@ typedef int (*HPMHOOK_pre_mob_getfriendstatus_sub) (struct block_list **bl, va_l
 typedef int (*HPMHOOK_post_mob_getfriendstatus_sub) (int retVal___, struct block_list *bl, va_list ap);
 typedef struct block_list* (*HPMHOOK_pre_mob_getfriendstatus) (struct mob_data **md, int *cond1, int *cond2);
 typedef struct block_list* (*HPMHOOK_post_mob_getfriendstatus) (struct block_list* retVal___, struct mob_data *md, int cond1, int cond2);
-typedef int (*HPMHOOK_pre_mob_skill_use) (struct mob_data **md, int64 *tick, int *event);
-typedef int (*HPMHOOK_post_mob_skill_use) (int retVal___, struct mob_data *md, int64 tick, int event);
+typedef int (*HPMHOOK_pre_mob_use_skill) (struct mob_data **md, int64 *tick, int *event);
+typedef int (*HPMHOOK_post_mob_use_skill) (int retVal___, struct mob_data *md, int64 tick, int event);
 typedef int (*HPMHOOK_pre_mob_skill_event) (struct mob_data **md, struct block_list **src, int64 *tick, int *flag);
 typedef int (*HPMHOOK_post_mob_skill_event) (int retVal___, struct mob_data *md, struct block_list *src, int64 tick, int flag);
 typedef int (*HPMHOOK_pre_mob_is_clone) (int *class_);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -4086,8 +4086,8 @@ struct {
 	struct HPMHookPoint *HP_mob_getfriendstatus_post;
 	struct HPMHookPoint *HP_mob_use_skill_pre;
 	struct HPMHookPoint *HP_mob_use_skill_post;
-	struct HPMHookPoint *HP_mob_skill_event_pre;
-	struct HPMHookPoint *HP_mob_skill_event_post;
+	struct HPMHookPoint *HP_mob_use_skill_event_pre;
+	struct HPMHookPoint *HP_mob_use_skill_event_post;
 	struct HPMHookPoint *HP_mob_is_clone_pre;
 	struct HPMHookPoint *HP_mob_is_clone_post;
 	struct HPMHookPoint *HP_mob_clone_spawn_pre;
@@ -11145,8 +11145,8 @@ struct {
 	int HP_mob_getfriendstatus_post;
 	int HP_mob_use_skill_pre;
 	int HP_mob_use_skill_post;
-	int HP_mob_skill_event_pre;
-	int HP_mob_skill_event_post;
+	int HP_mob_use_skill_event_pre;
+	int HP_mob_use_skill_event_post;
 	int HP_mob_is_clone_pre;
 	int HP_mob_is_clone_post;
 	int HP_mob_clone_spawn_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -4084,8 +4084,8 @@ struct {
 	struct HPMHookPoint *HP_mob_getfriendstatus_sub_post;
 	struct HPMHookPoint *HP_mob_getfriendstatus_pre;
 	struct HPMHookPoint *HP_mob_getfriendstatus_post;
-	struct HPMHookPoint *HP_mob_skill_use_pre;
-	struct HPMHookPoint *HP_mob_skill_use_post;
+	struct HPMHookPoint *HP_mob_use_skill_pre;
+	struct HPMHookPoint *HP_mob_use_skill_post;
 	struct HPMHookPoint *HP_mob_skill_event_pre;
 	struct HPMHookPoint *HP_mob_skill_event_post;
 	struct HPMHookPoint *HP_mob_is_clone_pre;
@@ -11143,8 +11143,8 @@ struct {
 	int HP_mob_getfriendstatus_sub_post;
 	int HP_mob_getfriendstatus_pre;
 	int HP_mob_getfriendstatus_post;
-	int HP_mob_skill_use_pre;
-	int HP_mob_skill_use_post;
+	int HP_mob_use_skill_pre;
+	int HP_mob_use_skill_post;
 	int HP_mob_skill_event_pre;
 	int HP_mob_skill_event_post;
 	int HP_mob_is_clone_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -2092,7 +2092,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(mob->getfriendstatus_sub, HP_mob_getfriendstatus_sub) },
 	{ HP_POP(mob->getfriendstatus, HP_mob_getfriendstatus) },
 	{ HP_POP(mob->use_skill, HP_mob_use_skill) },
-	{ HP_POP(mob->skill_event, HP_mob_skill_event) },
+	{ HP_POP(mob->use_skill_event, HP_mob_use_skill_event) },
 	{ HP_POP(mob->is_clone, HP_mob_is_clone) },
 	{ HP_POP(mob->clone_spawn, HP_mob_clone_spawn) },
 	{ HP_POP(mob->clone_delete, HP_mob_clone_delete) },

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -2091,7 +2091,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(mob->getmasterhpltmaxrate, HP_mob_getmasterhpltmaxrate) },
 	{ HP_POP(mob->getfriendstatus_sub, HP_mob_getfriendstatus_sub) },
 	{ HP_POP(mob->getfriendstatus, HP_mob_getfriendstatus) },
-	{ HP_POP(mob->skill_use, HP_mob_skill_use) },
+	{ HP_POP(mob->use_skill, HP_mob_use_skill) },
 	{ HP_POP(mob->skill_event, HP_mob_skill_event) },
 	{ HP_POP(mob->is_clone, HP_mob_is_clone) },
 	{ HP_POP(mob->clone_spawn, HP_mob_clone_spawn) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -54186,14 +54186,14 @@ int HP_mob_use_skill(struct mob_data *md, int64 tick, int event) {
 	}
 	return retVal___;
 }
-int HP_mob_skill_event(struct mob_data *md, struct block_list *src, int64 tick, int flag) {
+int HP_mob_use_skill_event(struct mob_data *md, struct block_list *src, int64 tick, int flag) {
 	int hIndex = 0;
 	int retVal___ = 0;
-	if (HPMHooks.count.HP_mob_skill_event_pre > 0) {
+	if (HPMHooks.count.HP_mob_use_skill_event_pre > 0) {
 		int (*preHookFunc) (struct mob_data **md, struct block_list **src, int64 *tick, int *flag);
 		*HPMforce_return = false;
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_mob_skill_event_pre; hIndex++) {
-			preHookFunc = HPMHooks.list.HP_mob_skill_event_pre[hIndex].func;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mob_use_skill_event_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_mob_use_skill_event_pre[hIndex].func;
 			retVal___ = preHookFunc(&md, &src, &tick, &flag);
 		}
 		if (*HPMforce_return) {
@@ -54202,12 +54202,12 @@ int HP_mob_skill_event(struct mob_data *md, struct block_list *src, int64 tick, 
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.mob.skill_event(md, src, tick, flag);
+		retVal___ = HPMHooks.source.mob.use_skill_event(md, src, tick, flag);
 	}
-	if (HPMHooks.count.HP_mob_skill_event_post > 0) {
+	if (HPMHooks.count.HP_mob_use_skill_event_post > 0) {
 		int (*postHookFunc) (int retVal___, struct mob_data *md, struct block_list *src, int64 tick, int flag);
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_mob_skill_event_post; hIndex++) {
-			postHookFunc = HPMHooks.list.HP_mob_skill_event_post[hIndex].func;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mob_use_skill_event_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_mob_use_skill_event_post[hIndex].func;
 			retVal___ = postHookFunc(retVal___, md, src, tick, flag);
 		}
 	}

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -54159,14 +54159,14 @@ struct block_list* HP_mob_getfriendstatus(struct mob_data *md, int cond1, int co
 	}
 	return retVal___;
 }
-int HP_mob_skill_use(struct mob_data *md, int64 tick, int event) {
+int HP_mob_use_skill(struct mob_data *md, int64 tick, int event) {
 	int hIndex = 0;
 	int retVal___ = 0;
-	if (HPMHooks.count.HP_mob_skill_use_pre > 0) {
+	if (HPMHooks.count.HP_mob_use_skill_pre > 0) {
 		int (*preHookFunc) (struct mob_data **md, int64 *tick, int *event);
 		*HPMforce_return = false;
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_mob_skill_use_pre; hIndex++) {
-			preHookFunc = HPMHooks.list.HP_mob_skill_use_pre[hIndex].func;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mob_use_skill_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_mob_use_skill_pre[hIndex].func;
 			retVal___ = preHookFunc(&md, &tick, &event);
 		}
 		if (*HPMforce_return) {
@@ -54175,12 +54175,12 @@ int HP_mob_skill_use(struct mob_data *md, int64 tick, int event) {
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.mob.skill_use(md, tick, event);
+		retVal___ = HPMHooks.source.mob.use_skill(md, tick, event);
 	}
-	if (HPMHooks.count.HP_mob_skill_use_post > 0) {
+	if (HPMHooks.count.HP_mob_use_skill_post > 0) {
 		int (*postHookFunc) (int retVal___, struct mob_data *md, int64 tick, int event);
-		for (hIndex = 0; hIndex < HPMHooks.count.HP_mob_skill_use_post; hIndex++) {
-			postHookFunc = HPMHooks.list.HP_mob_skill_use_post[hIndex].func;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_mob_use_skill_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_mob_use_skill_post[hIndex].func;
 			retVal___ = postHookFunc(retVal___, md, tick, event);
 		}
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Fix return value evaluation of `mob_skill_use()` in `mob_ai_sub_hard()`.
- Fix `nullpo`-check return values in `mob_skill_use()`.
- Fix `nullpo`-check return values and initial value of variable `ret` in `mobskill_event()`.
- Rename `mob->skill_use()` to `mob->use_skill()` due to changed return values.
- Rename `mob->skill_event()` to `mob->use_skill_event()` due to changed return values.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
