### PR TITLE
Prevent using unit->set_dir needlessly in unit_attack_timer_sub

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -2382,7 +2382,9 @@ static int unit_attack_timer_sub(struct block_list *src, int tid, int64 tick)
 	}
 
 	if(ud->state.attack_continue) {
-		unit->set_dir(src, map->calc_dir(src, target->x, target->y));
+		enum unit_dir dir = map->calc_dir(src, target->x, target->y);
+		if (dir != ud->dir)
+			unit->set_dir(src, dir);
 		if( src->type == BL_PC )
 			pc->update_idle_time(sd, BCIDLE_ATTACK);
 		ud->attacktimer = timer->add(ud->attackabletime,unit->attack_timer,src->id,0);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Prevent using unit->set_dir needlessly in unit_attack_timer_sub
Also prevents broadcasting it needlessly with clif_changed_dir

Credits to Heka from Origins Online Staff

**Issues addressed:** none


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
