### PR TITLE
Add static assertion checks to prevent MAX_STORAGE and MAX_GUILD_STORAGE from causing oversized inter-server packets

### DIFF
--- a/src/char/mapif.c
+++ b/src/char/mapif.c
@@ -1866,10 +1866,22 @@ static int mapif_parse_AccountStorageLoad(int fd)
 
 /**
  * Parses an account storage save request from the map server.
- * @packet 0x3011 [in] <packet_len>.W <account_id>.L <struct item[]>.P
- * @param  fd     [in] file/socket descriptor.
- * @return 1 on success, 0 on failure.
- */
+ *
+ * @code{.unparsed}
+ *	@packet 0x3011 [in] <packet_len>.W <account_id>.L <struct item[]>.P
+ * @endcode
+ *
+ * @attention If the size of packet 0x3011 changes,
+ *            @ref MAX_STORAGE_ASSERT "the related static assertion check"
+ *            in mmo.h needs to be adjusted, too.
+ *
+ * @see intif_send_account_storage()
+ *
+ * @param[in] fd The file/socket descriptor.
+ * @retval 1 Success.
+ * @retval 0 Failure.
+ *
+ **/
 static int mapif_parse_AccountStorageSave(int fd)
 {
 	int payload_size = RFIFOW(fd, 2) - 8, account_id = RFIFOL(fd, 4);

--- a/src/char/mapif.c
+++ b/src/char/mapif.c
@@ -1942,6 +1942,23 @@ static int mapif_parse_LoadGuildStorage(int fd)
 	return 0;
 }
 
+/**
+ * Parses a guild storage save request from the map server.
+ *
+ * @code{.unparsed}
+ *	@packet 0x3019 [in] <packet_len>.W <account_id>.L <guild_id>.L <struct guild_storage>.P
+ * @endcode
+ *
+ * @attention If the size of packet 0x3019 changes,
+ *            @ref MAX_GUILD_STORAGE_ASSERT "the related static assertion check"
+ *            in mmo.h needs to be adjusted, too.
+ *
+ * @see intif_send_guild_storage()
+ *
+ * @param[in] fd The file/socket descriptor.
+ * @return Always 0.
+ *
+ **/
 static int mapif_parse_SaveGuildStorage(int fd)
 {
 	int guild_id;

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -469,6 +469,19 @@ struct item {
 	struct item_option option[MAX_ITEM_OPTIONS];
 };
 
+/**
+ * Prevents @ref MAX_STORAGE from causing oversized 0x3011 inter-server packets.
+ *
+ * @attention If the size of packet 0x3011 changes, this assertion check needs to be adjusted, too.
+ *
+ * @see intif_send_account_storage() @n
+ *      mapif_parse_AccountStorageSave()
+ *
+ * @anchor MAX_STORAGE_ASSERT
+ *
+ **/
+STATIC_ASSERT(MAX_STORAGE * sizeof(struct item) + 8 <= 0xFFFF, "The maximum amount of item slots per account storage is limited by the inter-server communication layout. Use a smaller value!");
+
 //Equip position constants
 enum equip_pos {
 	EQP_NONE               = 0x000000,

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -631,6 +631,19 @@ struct guild_storage {
 	unsigned short lock;
 };
 
+/**
+ * Prevents @ref MAX_GUILD_STORAGE from causing oversized 0x3019 inter-server packets.
+ *
+ * @attention If the size of packet 0x3019 changes, this assertion check needs to be adjusted, too.
+ *
+ * @see intif_send_guild_storage() @n
+ *      mapif_parse_SaveGuildStorage()
+ *
+ * @anchor MAX_GUILD_STORAGE_ASSERT
+ *
+ **/
+STATIC_ASSERT(sizeof(struct guild_storage) + 12 <= 0xFFFF, "The maximum amount of item slots per guild storage is limited by the inter-server communication layout. Use a smaller value!");
+
 struct s_pet {
 	int account_id;
 	int char_id;

--- a/src/map/intif.c
+++ b/src/map/intif.c
@@ -357,10 +357,21 @@ static void intif_parse_account_storage(int fd)
 }
 
 /**
- * Send account storage information for saving.
- * @packet 0x3011 [out] <packet_len>.W <account_id>.L <struct item[]>.P
- * @param  sd     [in]  pointer to session data.
- */
+ * Sends account storage information for saving to the character server.
+ *
+ * @code{.unparsed}
+ *	@packet 0x3011 [out] <packet_len>.W <account_id>.L <struct item[]>.P
+ * @endcode
+ *
+ * @attention If the size of packet 0x3011 changes,
+ *            @ref MAX_STORAGE_ASSERT "the related static assertion check"
+ *            in mmo.h needs to be adjusted, too.
+ *
+ * @see mapif_parse_AccountStorageSave()
+ *
+ * @param[in] sd Pointer to the session data containing the account storage information to save.
+ *
+ **/
 static void intif_send_account_storage(struct map_session_data *sd)
 {
 	int len = 0, i = 0, c = 0;

--- a/src/map/intif.c
+++ b/src/map/intif.c
@@ -443,6 +443,25 @@ static int intif_request_guild_storage(int account_id, int guild_id)
 	WFIFOSET(inter_fd,10);
 	return 0;
 }
+
+/**
+ * Sends guild storage information for saving to the character server.
+ *
+ * @code{.unparsed}
+ *	@packet 0x3019 [out] <packet_len>.W <account_id>.L <guild_id>.L <struct guild_storage>.P
+ * @endcode
+ *
+ * @attention If the size of packet 0x3019 changes,
+ *            @ref MAX_GUILD_STORAGE_ASSERT "the related static assertion check"
+ *            in mmo.h needs to be adjusted, too.
+ *
+ * @see mapif_parse_SaveGuildStorage()
+ *
+ * @param[in] account_id The account ID of the character who initiated saving the guild storage information.
+ * @param[in] gstor Pointer to the guild storage data containing the information to save.
+ * @return Always 0. 
+ *
+ **/
 static int intif_send_guild_storage(int account_id, struct guild_storage *gstor)
 {
 	if (intif->CheckForCharServer())


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Using too large values for `MAX_STORAGE` or `MAX_GUILD_STORAGE` can cause oversized inter-server packets which leads to a server shutdown.
To prevent this static assertion checks were added which make the user aware of this issue.
Additionally some related documentation was added/extended.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
