### PR TITLE
Add ShowWarning on *setnpcdisplay and *setunitdata for floating npc

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -7281,7 +7281,7 @@ the message, otherwise the npc name will not be shown.
 *setnpcdisplay("<npc name>", <class id>)
 
 Changes the display name and/or display class of the target NPC.
-Returns 0 is successful, 1 if the NPC does not exist.
+Returns 0 is successful, 1 if the NPC does not exist or is a floating npc.
 Size is 0 = normal 1 = small 2 = big.
 
 ---------------------------------------

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -21063,6 +21063,12 @@ static BUILDIN(setunitdata)
 			return false;
 		}
 
+		if (nd->bl.m == -1) {
+			ShowWarning("buildin_setunitdata: Can't set data on npc with no valid map for GID %d.\n", script_getnum(st, 2));
+			script_pushint(st, 0);
+			return false;
+		}
+
 		switch (type) {
 		case UDT_SIZE:
 			nd->status.size = (unsigned char)val;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18889,6 +18889,12 @@ static BUILDIN(setnpcdisplay)
 		return true;
 	}
 
+	if (nd->bl.m == -1) {
+		ShowWarning("buildin_setnpcdisplay: cannot display on an npc with no valid map.\n");
+		script_pushint(st, 1);
+		return false;
+	}
+
 	// update npc
 	if( newname )
 		npc->setdisplayname(nd, newname);


### PR DESCRIPTION
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Issues addressed
follow up https://github.com/HerculesWS/Hercules/pull/2900

### Changes Proposed
Add ShowWarning on `*setnpcdisplay` and `*setunitdata` for floating npc

### Tested with
```c
-	script	asdasd	1_F_MARIA,{
	end;
OnInit:
	setnpcdisplay strnpcinfo(NPC_NAME), WARPNPC;
	setunitdata getnpcid(), UDT_CLASS, Job_Priest;
	end;
}
```
### Affected Branches
* Master

### Known Issues and TODO List
none
since the server no longer crash, now its time to put the warning message on
and able to test it without server keep crashing