### PR TITLE
Fix a part of sign quest becoming unfinishable for everyone

### DIFF
--- a/npc/quests/the_sign_quest.txt
+++ b/npc/quests/the_sign_quest.txt
@@ -10263,6 +10263,9 @@ que_sign01,122,141,4	script	Witch#s	4_F_NFDEADMGCIAN,{
 			switch(select("Yes", "No")) {
 			case 1:
 				close2;
+				if ($@sign_w1 == 1)
+					end;
+				donpcevent("Timer#witch::OnStart");
 				$@sign_w1 = 1;
 				warp "que_sign01",195,189;
 				end;
@@ -12345,17 +12348,6 @@ OnReset:
 	killmonster "que_sign01","CallMonster#serin::OnMyMobDead";
 }
 
-que_sign01,197,195,0	script	Starter#witch	FAKE_NPC,32,32,{
-OnTouch:
-	donpcevent "Timer#witch::OnStart";
-	disablenpc "Starter#witch";
-	end;
-
-OnEnable:
-	enablenpc "Starter#witch";
-	end;
-}
-
 que_sign01,1,1,0	script	Timer#witch	FAKE_NPC,{
 OnStart:
 	initnpctimer;
@@ -12366,7 +12358,6 @@ OnTimer600000:
 	end;
 
 OnTimer620000:
-	donpcevent "Starter#witch::OnEnable";
 	donpcevent "Warp#witch::OnDisable";
 	donpcevent "CallMonster#witch::OnReset";
 	donpcevent "Serin#witch::OnEnable";
@@ -12440,6 +12431,7 @@ OnTouch:
 		close;
 	}
 	else {
+		donpcevent("Timer#witch::OnStart");
 		$@sign_w1 = 1;
 		warp "que_sign01",197,190;
 		end;

--- a/npc/quests/the_sign_quest.txt
+++ b/npc/quests/the_sign_quest.txt
@@ -9675,6 +9675,8 @@ niflheim,313,70,4	script	Pleasant-Featured Lady#s	4_F_01,{
 			mes "Okay~";
 			mes "Let's go...";
 			close2;
+			if ($@sign_w2 == 1) // prevent others joining.
+				end;
 			donpcevent("Timer#serin::OnStart");
 			$@sign_w2 = 1;
 			warp "que_sign01",199,36;
@@ -9700,6 +9702,8 @@ niflheim,313,70,4	script	Pleasant-Featured Lady#s	4_F_01,{
 		switch(select("Follow the trace.", "Ignore it.")) {
 		case 1:
 			close2;
+			if ($@sign_w2 == 1) // prevent others joining.
+				end;
 			sign_q = 199;
 			donpcevent("Timer#serin::OnStart");
 			$@sign_w2 = 1;

--- a/npc/quests/the_sign_quest.txt
+++ b/npc/quests/the_sign_quest.txt
@@ -9675,6 +9675,7 @@ niflheim,313,70,4	script	Pleasant-Featured Lady#s	4_F_01,{
 			mes "Okay~";
 			mes "Let's go...";
 			close2;
+			donpcevent("Timer#serin::OnStart");
 			$@sign_w2 = 1;
 			warp "que_sign01",199,36;
 			end;
@@ -9700,6 +9701,7 @@ niflheim,313,70,4	script	Pleasant-Featured Lady#s	4_F_01,{
 		case 1:
 			close2;
 			sign_q = 199;
+			donpcevent("Timer#serin::OnStart");
 			$@sign_w2 = 1;
 			warp "que_sign01",199,36;
 			end;
@@ -12306,17 +12308,6 @@ geffen,119,48,0	script	Fountain#s	HIDDEN_NPC,{
 	}
 }
 
-que_sign01,196,44,0	script	Starter#serin	FAKE_NPC,32,32,{
-OnTouch:
-	donpcevent "Timer#serin::OnStart";
-	disablenpc "Starter#serin";
-	end;
-
-OnEnable:
-	enablenpc "Starter#serin";
-	end;
-}
-
 que_sign01,1,0,0	script	Timer#serin	FAKE_NPC,{
 OnStart:
 	initnpctimer;
@@ -12328,7 +12319,6 @@ OnTimer600000:
 
 OnTimer620000:
 	$@sign_w2 = 0;
-	donpcevent "Starter#serin::OnEnable";
 	donpcevent "Serin#serin::OnEnable";
 	donpcevent "Dark Lord#serin::OnDisable";
 	donpcevent "Serin#dummy::OnDisable";


### PR DESCRIPTION
If you timeout or logout before triggering the OnTouch that is in the Room
Serin sends you to, a global variable wasn't being unset.
This locked this part of the quest for everyone and made it impossible
to enter that room anymore, until server restart.

### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

1. Prevent the timer for unlocking the room from not starting when room gets locked.
2. Prevent an exploit, where it was possible to enter Serin's room with more than 1 person in the solo-path of the quest.
3. Prevent the witch's part of sign quest becoming unfinishable for everyone.

**Issues addressed:** None?

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
