### PR TITLE
Haste Effect ignores some statuses

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -5509,10 +5509,6 @@ static unsigned short status_calc_speed(struct block_list *bl, struct status_cha
 						val = max(val, sc->data[SC_STOMACHACHE]->val2);
 					if (sc->data[SC_MARSHOFABYSS]) // It stacks to other statuses so always put this at the end.
 						val = max(50, val + 10 * sc->data[SC_MARSHOFABYSS]->val1);
-					if (sc->data[SC_MOVHASTE_POTION]) { // Doesn't affect the movement speed by Quagmire, Decrease Agi, Slow Grace [Frost]
-						if (sc->data[SC_DEC_AGI] || sc->data[SC_QUAGMIRE] || sc->data[SC_DONTFORGETME] || sc->data[SC_CREATINGSTAR] != NULL)
-							return 0;
-					}
 					if (sc->data[SC_CATNIPPOWDER])
 						val = max(val, sc->data[SC_CATNIPPOWDER]->val3);
 					if (sc->data[SC_ENSEMBLEFATIGUE] != NULL)
@@ -7357,6 +7353,13 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 	PRAGMA_GCC46(GCC diagnostic ignored "-Wswitch-enum")
 	// Check for inmunities / sc fails
 	switch (type) {
+		case SC_DEC_AGI:
+		case SC_QUAGMIRE:
+		case SC_DONTFORGETME:
+		case SC_CREATINGSTAR:
+			if (sc->data[SC_MOVHASTE_POTION])
+				return 0;
+			break;
 		case SC_DRUMBATTLE:
 		case SC_NIBELUNGEN:
 		case SC_INTOABYSS:


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR should fix guyak item(haste/boost movement speed) where it should ignore certain statuses.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
