### PR TITLE
Fix grfio on big size grfs

### DIFF
--- a/src/common/grfio.c
+++ b/src/common/grfio.c
@@ -44,7 +44,7 @@ struct grf_filelist {
 	int srclen;         ///< compressed size
 	int srclen_aligned;
 	int declen;         ///< original size
-	int srcpos;         ///< position of entry in grf
+	int64 srcpos;         ///< position of entry in grf
 	int next;           ///< index of next filelist entry with same hash (-1: end of entry chain)
 	char type;
 	char fn[256-4*5];   ///< file name

--- a/src/common/grfio.c
+++ b/src/common/grfio.c
@@ -47,7 +47,7 @@ struct grf_filelist {
 	int srcpos;         ///< position of entry in grf
 	int next;           ///< index of next filelist entry with same hash (-1: end of entry chain)
 	char type;
-	char fn[128-4*5];   ///< file name
+	char fn[256-4*5];   ///< file name
 	char *fnd;          ///< if the file was cloned, contains name of original file
 	int8 gentry;        ///< read grf file select
 };


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes a couple of issues where the grfio library fails to load the kRO GRF.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
