### PR TITLE
Fix ci builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # gcc, clang-8, clang-9 removed for reduce number of jobs
-        CC: ["gcc-10", "clang-10"]
+        CC: ["gcc-10", "clang-11"]
         RENEWAL: [""]
         CLIENT_TYPE: ["", "--enable-packetver-re", "--enable-packetver-zero"]
         SANITIZER: [""]
@@ -24,7 +24,7 @@ jobs:
         exclude:
           - PACKET_VERSION: "--enable-packetver=20100105"
             CLIENT_TYPE: "--enable-packetver-zero"
-          - CC: "clang-10"
+          - CC: "clang-11"
             LTO: "--enable-lto"
     container:
       image: debian:unstable

--- a/.github/workflows/clang11_test.yml
+++ b/.github/workflows/clang11_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # clang-8, clang-9 removed for reduce number of jobs
-        CC: [clang-10]
+        CC: [clang-11]
         RENEWAL: ["", "--disable-renewal"]
         CLIENT_TYPE: ["", "--enable-packetver-re", "--enable-packetver-zero"]
         SANITIZER: ["--disable-manager", "--disable-manager --enable-sanitize=full"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -283,14 +283,22 @@ zero-2018:clang-7:
 
 pre_re:clang-8:
   <<: *branch_exceptions
-  <<: *prerequisites
+  before_script:
+    - echo "Building $CI_BUILD_NAME"
+    - uname -a
+    - echo 'deb http://ftp.debian.org/debian buster-backports main' >> /etc/apt/sources.list
+    - ./tools/ci/retry.sh apt-get update
+    - ./tools/ci/retry.sh apt-get install -t buster-backports -y -qq clang-8
+    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
+    - ./tools/ci/travis.sh getplugins || true
   stage: secondary
-  image: debian:unstable
+  image: debian:buster
   services:
     - mariadb:10
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: clang-8 mariadb-client libmariadbclient-dev-compat python2
+    INSTALL_PACKAGES: mariadb-client libmariadbclient-dev-compat python2
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-8 --enable-debug --enable-Werror --enable-buildbot --disable-renewal
@@ -298,14 +306,22 @@ pre_re:clang-8:
 
 re:clang-8:
   <<: *branch_exceptions
-  <<: *prerequisites
+  before_script:
+    - echo "Building $CI_BUILD_NAME"
+    - uname -a
+    - echo 'deb http://ftp.debian.org/debian buster-backports main' >> /etc/apt/sources.list
+    - ./tools/ci/retry.sh apt-get update
+    - ./tools/ci/retry.sh apt-get install -t buster-backports -y -qq clang-8
+    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
+    - ./tools/ci/travis.sh getplugins || true
   stage: secondary
-  image: debian:unstable
+  image: debian:buster
   services:
     - mariadb:10
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: clang-8 mariadb-client libmariadbclient-dev-compat python2
+    INSTALL_PACKAGES: mariadb-client libmariadbclient-dev-compat python2
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-8 --enable-debug --enable-Werror --enable-buildbot
@@ -313,14 +329,22 @@ re:clang-8:
 
 zero-2018:clang-8:
   <<: *branch_exceptions
-  <<: *prerequisites
+  before_script:
+    - echo "Building $CI_BUILD_NAME"
+    - uname -a
+    - echo 'deb http://ftp.debian.org/debian buster-backports main' >> /etc/apt/sources.list
+    - ./tools/ci/retry.sh apt-get update
+    - ./tools/ci/retry.sh apt-get install -t buster-backports -y -qq clang-8
+    - ./tools/ci/retry.sh apt-get install -y -qq $INSTALL_PACKAGES $DEBIAN_COMMON_PACKAGES
+    - ./tools/ci/travis.sh importdb ragnarok ragnarok ragnarok $SQLHOST
+    - ./tools/ci/travis.sh getplugins || true
   stage: clients
-  image: debian:unstable
+  image: debian:buster
   services:
     - mariadb:10
   variables:
     <<: *base_vars
-    INSTALL_PACKAGES: clang-8 mariadb-client libmariadbclient-dev-compat python2
+    INSTALL_PACKAGES: mariadb-client libmariadbclient-dev-compat python2
     SQLHOST: mariadb
   script:
     - ./tools/ci/travis.sh build CC=clang-8 --enable-debug --enable-Werror --enable-buildbot --enable-packetver-zero --enable-packetver=20180511


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR fixes the CI builds that are currently failing:

- The GitHub Workflows builds were referencing a `clang-10` package that is no longer available in Debian. The closest replacement is `clang-11`, available in bullseye and sid.
- The GitLab CI builds were referencing a `clang-8` package that is no longer available in the base Debian repository, but it is available in the buster-backports repository.

**Issues addressed:** N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
