### PR TITLE
Report to console if a missing message is requested

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -126,6 +126,8 @@ static const char *atcommand_msg(int msg_number)
 	if(atcommand->msg_table[0][msg_number] != NULL && atcommand->msg_table[0][msg_number][0] != '\0')
 		return atcommand->msg_table[0][msg_number];
 
+	ShowWarning("atcommand_msg: Invalid message number was specified: %d", msg_number);
+	Assert_report(0);
 	return "??";
 }
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

If show_msg() requests a message code which is not present in messages.conf, a "??" will be provided silently.
This raises a warning so maintainers and fork owners can debug and fix their messages.conf file.

(This should not happen normally).

**Issues addressed:** None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
