### PR TITLE
Prevent users from sending mails using RoDEX on maps with nostorage mapflag.

### DIFF
--- a/conf/messages.conf
+++ b/conf/messages.conf
@@ -516,7 +516,8 @@
 //----------------------
 510: You have %d new emails (%d unread)
 511: Inbox is full (Max %d). Delete some mails.
-// 512-537 FREE
+512: You can't send mails from your current location.
+// 513-537 FREE
 
 // Trade Spoof Messages
 538: Hack on trade: character '%s' (account: %d) try to trade more items that he has.

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -8192,6 +8192,7 @@ ACMD(mapflag)
 		CHECKFLAG(nogstorage);
 		CHECKFLAG(noviewid);
 		CHECKFLAG(specialpopup);
+		CHECKFLAG(nosendmail);
 
 		clif->message(sd->fd, " ");
 		clif->message(sd->fd, msg_fd(fd, 1312)); // Usage: "@mapflag monster_noteleport 1" (0=Off | 1=On)
@@ -8282,6 +8283,7 @@ ACMD(mapflag)
 	SETFLAG(nogstorage);
 	SETFLAG(noviewid);
 	SETFLAG(specialpopup);
+	SETFLAG(nosendmail);
 
 	clif->message(sd->fd, msg_fd(fd, 1314)); // Invalid flag name or flag.
 	clif->message(sd->fd, msg_fd(fd, 1312)); // Usage: "@mapflag monster_noteleport 1" (0=Off | 1=On)
@@ -8294,7 +8296,8 @@ ACMD(mapflag)
 	clif->message(sd->fd, "fog, fireworks, sakura, leaves, nobaseexp, nojobexp, nomobloot, nomvploot,");
 	clif->message(sd->fd, "nightenabled, nodrop, novending, loadevent, nochat, partylock, guildlock,");
 	clif->message(sd->fd, "src4instance, reset, chsysnolocalaj, noknockback, notomb, nocashshop, noautoloot,");
-	clif->message(sd->fd, "pairship_startable, pairship_endable, nostorage, nogstorage, noviewid, specialpopup");
+	clif->message(sd->fd, "pairship_startable, pairship_endable, nostorage, nogstorage, noviewid, specialpopup,");
+	clif->message(sd->fd, "nosendmail");
 
 #undef CHECKFLAG
 #undef SETFLAG

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -17979,6 +17979,12 @@ static void clif_parse_Mail_send(int fd, struct map_session_data *sd)
 		return;
 	}
 
+	if (map->list[sd->bl.m].flag.nosendmail != 0) {
+		clif->message(sd->fd, msg_sd(sd, 512)); // "You can't send mails from your current location."
+		clif->mail_send(fd, true); // fail
+		return;
+	}
+
 	if( DIFF_TICK(sd->cansendmail_tick, timer->gettick()) > 0 ) {
 		clif->message(sd->fd,msg_sd(sd,875)); //"Cannot send mails too fast!!."
 		clif->mail_send(fd, true); // fail

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -5578,6 +5578,15 @@ static bool map_zone_mf_cache(int m, char *flag, char *params)
 			else if (map->list[m].flag.nomobloot != 0)
 				map_zone_mf_cache_add(m, "noloot");
 		}
+	} else if (strcmpi(flag, "nosendmail") == 0) {
+		if (state != 0 && map->list[m].flag.nosendmail != 0)
+			;/* nothing to do */
+		else {
+			if (state != 0)
+				map_zone_mf_cache_add(m, "nosendmail\toff");
+			else if (map->list[m].flag.nosendmail != 0)
+				map_zone_mf_cache_add(m, "nosendmail");
+		}
 	}
 
 	// Map Zones

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -1046,6 +1046,7 @@ struct map_data {
 		unsigned nostorage : 2;
 		unsigned nogstorage : 2;
 		unsigned nopet : 1;
+		unsigned nosendmail : 1;
 		uint32 noviewid; ///< noviewid (bitmask - @see enum equip_pos)
 		int32 specialpopup;
 	} flag;

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -5193,6 +5193,8 @@ static const char *npc_parse_mapflag(const char *w1, const char *w2, const char 
 		map->list[m].flag.nostorage = (state != 0) ? cap_value(atoi(w4), 1, 3) : 0;
 	else if (strcmpi(w3, "nogstorage") == 0)
 		map->list[m].flag.nogstorage = (state != 0) ? cap_value(atoi(w4), 1, 3) : 0;
+	else if (strcmpi(w3, "nosendmail") == 0)
+		map->list[m].flag.nosendmail = (state != 0) ? 1 : 0;
 	else if (strcmpi(w3, "nopet") == 0)
 		map->list[m].flag.nopet = (state != 0) ? 1 : 0;
 	else if (strcmpi(w3, "nomapchannelautojoin") == 0)

--- a/src/map/rodex.c
+++ b/src/map/rodex.c
@@ -237,6 +237,11 @@ static int rodex_send_mail(struct map_session_data *sd, const char *receiver_nam
 		return RODEX_SEND_MAIL_FATAL_ERROR;
 	}
 
+	if (!pc_has_permission(sd, PC_PERM_BYPASS_NOSTORAGE) && (map->list[sd->bl.m].flag.nostorage & 2)) {
+		rodex->clean(sd, 1);
+		return RODEX_SEND_MAIL_FATAL_ERROR;
+    }
+
 	if (zeny < 0) {
 		rodex->clean(sd, 1);
 		return RODEX_SEND_MAIL_FATAL_ERROR;

--- a/src/map/rodex.c
+++ b/src/map/rodex.c
@@ -237,10 +237,10 @@ static int rodex_send_mail(struct map_session_data *sd, const char *receiver_nam
 		return RODEX_SEND_MAIL_FATAL_ERROR;
 	}
 
-	if (!pc_has_permission(sd, PC_PERM_BYPASS_NOSTORAGE) && (map->list[sd->bl.m].flag.nostorage & 2)) {
+	if (map->list[sd->bl.m].flag.nosendmail != 0) {
 		rodex->clean(sd, 1);
 		return RODEX_SEND_MAIL_FATAL_ERROR;
-    }
+	}
 
 	if (zeny < 0) {
 		rodex->clean(sd, 1);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -14535,6 +14535,7 @@ static BUILDIN(getmapflag)
 		case MF_SRC4INSTANCE: script_pushint(st, map->list[m].flag.src4instance); break;
 		case MF_CVC: script_pushint(st, map->list[m].flag.cvc); break;
 		case MF_SPECIALPOPUP: script_pushint(st, map->list[m].flag.specialpopup); break;
+		case MF_NOSENDMAIL: script_pushint(st, map->list[m].flag.nosendmail); break;
 		}
 	}
 
@@ -14673,6 +14674,7 @@ static BUILDIN(setmapflag)
 		case MF_SRC4INSTANCE: map->list[m].flag.src4instance = 1; break;
 		case MF_CVC: map->list[m].flag.cvc = 1; break;
 		case MF_SPECIALPOPUP: map->list[m].flag.specialpopup = val; break;
+		case MF_NOSENDMAIL: map->list[m].flag.nosendmail = 1; break;
 		}
 	}
 
@@ -14769,6 +14771,7 @@ static BUILDIN(removemapflag)
 		case MF_SRC4INSTANCE: map->list[m].flag.src4instance = 0; break;
 		case MF_CVC: map->list[m].flag.cvc = 0; break;
 		case MF_SPECIALPOPUP: map->list[m].flag.specialpopup = 0; break;
+		case MF_NOSENDMAIL: map->list[m].flag.nosendmail = 0; break;
 		}
 	}
 
@@ -29628,6 +29631,7 @@ static void script_hardcoded_constants(void)
 	script->set_constant("MF_SRC4INSTANCE", MF_SRC4INSTANCE, false, false);
 	script->set_constant("MF_CVC", MF_CVC, false, false);
 	script->set_constant("MF_SPECIALPOPUP", MF_SPECIALPOPUP, false, false);
+	script->set_constant("MF_NOSENDMAIL", MF_NOSENDMAIL, false, false);
 
 	script->constdb_comment("Job masks / Job map_ids");
 

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -353,6 +353,7 @@ enum {
 	MF_SRC4INSTANCE,
 	MF_CVC,
 	MF_SPECIALPOPUP,
+	MF_NOSENDMAIL,
 };
 
 enum navigation_service {


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Prevent users from sending mails using RoDEX on maps with nostorage mapflag.

Makes sense on my head but **I have not checked official behavior**, thus I advise checking if it is possible to use RoDEX not only to send but also to receive mails on these maps.

I would kindly appreciate if the PR was closed if this is not a desired or official behavior.

**Issues addressed:** None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
