### PR TITLE
Fix Abracadabra / Improvise / itemskill validation

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -13236,14 +13236,14 @@ static void clif_parse_UseSkillToPosSub(int fd, struct map_session_data *sd, uin
 
 	pc->autocast_set_current(sd, skill_id);
 
-	/**
+	/*
 	 * When using clif_item_skill() to initiate the execution of ground skills,
-	 * the client sometimes passes 0 for the skill level in packet 0x0af4.
+	 * the client sometimes passes 0 for the skill level in packet 0x0af4 (and in some clients,
+	 * this may be memory garbage instead of 0).
 	 * In that case sd->autocast.skill_lv is used for the auto-cast data validation,
 	 * since clif_item_skill() is only used for auto-cast skills.
-	 *
-	 **/
-	skill->validate_autocast_data(sd, skill_id, (skill_lv == 0) ? sd->auto_cast_current.skill_lv : skill_lv);
+	 */
+	skill->validate_autocast_data(sd, skill_id, (skill_lv == 0 || skill_lv > MAX_SKILL_LEVEL) ? sd->auto_cast_current.skill_lv : skill_lv);
 
 	if( !(skill->get_inf(skill_id)&INF_GROUND_SKILL) )
 		return; //Using a target skill on the ground? WRONG.

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -6704,6 +6704,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 					VECTOR_ENSURE(sd->auto_cast, 1, 1);
 					VECTOR_PUSH(sd->auto_cast, sd->auto_cast_current);
 					clif->item_skill(sd, abra_skill_id, abra_skill_lv);
+					pc->autocast_clear_current(sd);
 				} else {
 					// mob-casted
 					struct unit_data *ud = unit->bl2ud(src);
@@ -10487,6 +10488,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 					VECTOR_ENSURE(sd->auto_cast, 1, 1);
 					VECTOR_PUSH(sd->auto_cast, sd->auto_cast_current);
 					clif->item_skill(sd, improv_skill_id, improv_skill_lv);
+					pc->autocast_clear_current(sd);
 				} else {
 					struct unit_data *ud = unit->bl2ud(src);
 					int inf = skill->get_inf(improv_skill_id);
@@ -14625,6 +14627,9 @@ static int skill_check_condition_castbegin(struct map_session_data *sd, uint16 s
 		return 1;
 	}
 
+	if ((sd->auto_cast_current.type == AUTOCAST_ABRA || sd->auto_cast_current.type == AUTOCAST_IMPROVISE) && sd->auto_cast_current.skill_id == skill_id)
+		return 1;
+
 	if (pc_has_permission(sd, PC_PERM_SKILL_UNCONDITIONAL) && sd->auto_cast_current.type != AUTOCAST_ITEM) {
 		// GMs don't override the AUTOCAST_ITEM check, otherwise they can use items without them being consumed!
 		sd->state.arrow_atk = skill->get_ammotype(skill_id)?1:0; //Need to do arrow state check.
@@ -15714,6 +15719,9 @@ static int skill_check_condition_castend(struct map_session_data *sd, uint16 ski
 	    && sd->auto_cast_current.type == AUTOCAST_ITEM) || sd->auto_cast_current.type == AUTOCAST_IMPROVISE) {
 		return 1;
 	}
+
+	if ((sd->auto_cast_current.type == AUTOCAST_ABRA || sd->auto_cast_current.type == AUTOCAST_IMPROVISE) && sd->auto_cast_current.skill_id == skill_id)
+		return 1;
 
 	if (pc_has_permission(sd, PC_PERM_SKILL_UNCONDITIONAL) && sd->auto_cast_current.type != AUTOCAST_ITEM) {
 		// GMs don't override the AUTOCAST_ITEM check, otherwise they can use items without them being consumed!

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1838,7 +1838,7 @@ static int unit_skilluse_pos(struct block_list *src, short skill_x, short skill_
 	int ret = unit->skilluse_pos2(src, skill_x, skill_y, skill_id, skill_lv, casttime, castcancel);
 	struct map_session_data *sd = BL_CAST(BL_PC, src);
 
-	if (sd != NULL)
+	if (sd != NULL && sd->auto_cast_current.skill_id != AL_WARP)
 		pc->autocast_remove(sd, sd->auto_cast_current.type, sd->auto_cast_current.skill_id,
 				    sd->auto_cast_current.skill_lv);
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This introduces various fixes to the Abracadabra / Improvise skill validation:

- autocast code is moved to after homun/merc skill ranges so that when any of those are triggered, autocast data is not purged
- abracadabra/improvise is no longer purged immediately after cast, by calling autocast_clear_current in the proper manner
- the abracadabra/improvise skill requirement bypass that was removed in #2657 and related pull requests is re-implemented
- the condition that would get the character stuck and unable to cast other skills until teleporting or relogging when rolling AL_WARP from abracadabra (i.e. because AL_WARP lands in clif_parse_UseSkillMap in 2 steps) is fixed, by not immediately clearing the data after the first one

All credits for the fixes go to Heka of Origins

**Issues addressed:**
- Replaces #2859
- #2823
- #2824

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
