### PR TITLE
ensure free cast modifies speed rate instead of sets it

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -5051,19 +5051,20 @@ static unsigned short status_calc_speed(struct block_list *bl, struct status_cha
 	if( sc == NULL || ( sd && sd->state.permanent_speed ) )
 		return (unsigned short)cap_value(speed,MIN_WALK_SPEED,MAX_WALK_SPEED);
 
-	if (sd && sd->ud.skilltimer != INVALID_TIMER)
-	{
-		if (sd->ud.skill_id == LG_EXEEDBREAK) {
-			speed_rate = 160 - 10 * sd->ud.skill_lv;
-		} else if ((skill->get_inf2(sd->ud.skill_id) & INF2_FREE_CAST_REDUCED) != 0) {
-			speed_rate = 175 - 5 * sd->ud.skill_lv;
-		} else if (pc->checkskill(sd, SA_FREECAST) > 0) {
-			speed_rate = 175 - 5 * pc->checkskill(sd,SA_FREECAST);
-		}
-	}
+	bool skillTimerIsValid = sd != NULL && sd->ud.skilltimer != INVALID_TIMER;
+
+	if (skillTimerIsValid && sd->ud.skill_id == LG_EXEEDBREAK)
+		speed_rate = 160 - 10 * sd->ud.skill_lv;
+
 	if (speed_rate == -1)
 	{
 		speed_rate = 100;
+		if (skillTimerIsValid) {
+			if ((skill->get_inf2(sd->ud.skill_id) & INF2_FREE_CAST_REDUCED) != 0)
+				speed_rate = 175 - 5 * sd->ud.skill_lv;
+			else if (pc->checkskill(sd, SA_FREECAST) > 0)
+				speed_rate = 175 - 5 * pc->checkskill(sd, SA_FREECAST);
+		}
 
 		//GetMoveHasteValue2()
 		{


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
\* not sure if `skillTimerIsValid` is considered a frowned-upon mixed case name.  Please recommend a better name if you'd prefer one
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Ensure free cast modifies the walking speed of a unit rather than sets it.  This is to fix a (potential) bug where a cursed unit gets 75% of their original walk speed by using free cast.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#2976 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
