### PR TITLE
Fix permanent vacuum extreme status.

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -13944,7 +13944,11 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 			} else {
 				struct status_data *bst = status->get_base_status(bl);
 				nullpo_ret(bst);
-				sg->limit -= 1000 * bst->str/20;
+
+				int basestr = bst->str;
+				if (basestr > 130)
+					basestr = 130;
+				sg->limit -= 1000 * basestr / 20;
 				sc_start(ss, bl, SC_VACUUM_EXTREME, 100, sg->skill_lv, sg->limit);
 
 				if ( !map_flag_gvg(bl->m) && !map->list[bl->m].flag.battleground && !is_boss(bl) ) {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This fixes vacuum extreme status gets permanent until you logout or die. This should force the max time reduction to 6.5 secs, vs before which exceed up to 18 secs(depends on target strength) when level 5 extreme vacuum only has 12 secs max duration.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:**  #2919


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
