### PR TITLE
RID unexpectied behavior from OnTouchNPC

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24904,12 +24904,8 @@ static BUILDIN(montransform)
 {
 	int tick;
 	enum sc_type type;
-	struct block_list* bl;
 	int mob_id, val1, val2, val3, val4;
 	val1 = val2 = val3 = val4 = 0;
-
-	if( (bl = map->id2bl(st->rid)) == NULL )
-		return true;
 
 	if( script_isstringtype(st, 2) ) {
 		mob_id = mob->db_searchname(script_getstr(st, 2));
@@ -24952,10 +24948,9 @@ static BUILDIN(montransform)
 		val4 = script_getnum(st, 8);
 
 	if (tick != 0) {
-		struct map_session_data *sd = script->id2sd(st, bl->id);
-
+		struct map_session_data *sd = script->rid2sd(st);
 		if (sd == NULL)
-			return true;
+			return false;
 
 		if( battle_config.mon_trans_disable_in_gvg && map_flag_gvg2(sd->bl.m) ) {
 			clif->message(sd->fd, msg_sd(sd,1488)); // Transforming into monster is not allowed in Guild Wars.
@@ -24967,11 +24962,11 @@ static BUILDIN(montransform)
 			return true;
 		}
 
-		status_change_end(bl, SC_MONSTER_TRANSFORM, INVALID_TIMER); // Clear previous
-		sc_start2(NULL, bl, SC_MONSTER_TRANSFORM, 100, mob_id, type, tick);
+		status_change_end(&sd->bl, SC_MONSTER_TRANSFORM, INVALID_TIMER); // Clear previous
+		sc_start2(NULL, &sd->bl, SC_MONSTER_TRANSFORM, 100, mob_id, type, tick);
 
 		if (script_hasdata(st, 4))
-			sc_start4(NULL, bl, type, 100, val1, val2, val3, val4, tick);
+			sc_start4(NULL, &sd->bl, type, 100, val1, val2, val3, val4, tick);
 	}
 
 	return true;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -16803,16 +16803,14 @@ static BUILDIN(nude)
  *------------------------------------------*/
 static BUILDIN(atcommand)
 {
-	struct map_session_data *sd, *dummy_sd = NULL;
+	struct map_session_data *sd = NULL;
+	struct map_session_data *dummy_sd = NULL;
 	int fd;
 	const char* cmd;
 
 	cmd = script_getstr(st,2);
 
-	if (st->rid) {
-		sd = script->rid2sd(st);
-		if (sd == NULL)
-			return true;
+	if (st->rid != 0 && (sd = map->id2sd(st->rid)) != NULL) {
 		fd = sd->fd;
 	} else { //Use a dummy character.
 		sd = dummy_sd = pc->get_dummy_sd();
@@ -16832,7 +16830,8 @@ static BUILDIN(atcommand)
 			aFree(dummy_sd);
 		return false;
 	}
-	if (dummy_sd) aFree(dummy_sd);
+	if (dummy_sd)
+		aFree(dummy_sd);
 	return true;
 }
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -16429,12 +16429,11 @@ static int soundeffect_sub(struct block_list *bl, va_list ap)
  *------------------------------------------*/
 static BUILDIN(soundeffectall)
 {
-	struct block_list* bl;
 	const char* name;
 	int type;
 
-	bl = (st->rid) ? &(script->rid2sd(st)->bl) : map->id2bl(st->oid);
-	if (!bl)
+	struct block_list *bl = st->rid != 0 ? map->id2bl(st->rid) : map->id2bl(st->oid);
+	if (bl == NULL)
 		return true;
 
 	name = script_getstr(st,2);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -7831,7 +7831,8 @@ static BUILDIN(getarraysize)
 		return false;// not a variable
 	}
 
-	script_pushint(st, script->array_highest_key(st,st->rid ? script->rid2sd(st) : NULL,reference_getname(data),reference_getref(data)));
+	struct map_session_data *sd = st->rid != 0 ? map->id2sd(st->rid) : NULL;
+	script_pushint(st, script->array_highest_key(st, sd, reference_getname(data), reference_getref(data)));
 	return true;
 }
 static int script_array_index_cmp(const void *a, const void *b)

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24667,16 +24667,14 @@ static BUILDIN(unbindatcmd)
 
 static BUILDIN(useatcmd)
 {
-	struct map_session_data *sd, *dummy_sd = NULL;
+	struct map_session_data *sd = NULL;
+	struct map_session_data *dummy_sd = NULL;
 	int fd;
 	const char* cmd;
 
 	cmd = script_getstr(st,2);
 
-	if (st->rid) {
-		sd = script->rid2sd(st);
-		if (sd == NULL)
-			return true;
+	if (st->rid != 0 && (sd = map->id2sd(st->rid)) != NULL) {
 		fd = sd->fd;
 	} else {
 		// Use a dummy character.
@@ -24699,7 +24697,8 @@ static BUILDIN(useatcmd)
 	}
 
 	atcommand->exec(fd, sd, cmd, true);
-	if (dummy_sd) aFree(dummy_sd);
+	if (dummy_sd)
+		aFree(dummy_sd);
 	return true;
 }
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -26941,7 +26941,7 @@ static BUILDIN(clan_join)
 	if (script_hasdata(st, 3))
 		sd = map->id2sd(script_getnum(st, 3));
 	else
-		sd = map->id2sd(st->rid);
+		sd = script->rid2sd(st);
 
 	if (sd == NULL) {
 		script_pushint(st, false);
@@ -26966,7 +26966,7 @@ static BUILDIN(clan_leave)
 	if (script_hasdata(st, 2))
 		sd = map->id2sd(script_getnum(st, 2));
 	else
-		sd = map->id2sd(st->rid);
+		sd = script->rid2sd(st);
 
 	if (sd == NULL) {
 		script_pushint(st, false);
@@ -27011,7 +27011,7 @@ static BUILDIN(clan_master)
 
 static BUILDIN(airship_respond)
 {
-	struct map_session_data *sd = map->id2sd(st->rid);
+	struct map_session_data *sd = script->rid2sd(st);
 	int32 flag = script_getnum(st, 2);
 
 	if (sd == NULL)

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -696,7 +696,8 @@ struct script_state {
 	int start,end;
 	int pos;
 	enum e_script_state state;
-	int rid,oid;
+	int rid; ///< GID of the player attached to the script (or the mob, when called through OnTouchNPC)
+	int oid;
 	struct script_code *script;
 	struct sleep_data {
 		int tick,timer,charid;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This updates various functions in script.c to be aware that the `struct script_state::rid` field may contain a mob's GID alternatively to a player's, when called through `OnTouchNPC`. This fixes various errors, such as the one described in #2989 and #2990.

**Issues addressed:** #2989

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
