### PR TITLE
Add reading and checking client flags

### DIFF
--- a/conf/login/login-server.conf
+++ b/conf/login/login-server.conf
@@ -146,6 +146,9 @@ login_configuration: {
 		// What version we would allow to connect? (if check_client_version is enabled)
 		client_version_to_connect: 20
 
+		// Check if client flags are the same with compiled hercules version
+		check_client_flags: true
+
 		//==================================================================
 		// Client hash checking system
 		//==================================================================

--- a/conf/login/login-server.conf
+++ b/conf/login/login-server.conf
@@ -146,8 +146,11 @@ login_configuration: {
 		// What version we would allow to connect? (if check_client_version is enabled)
 		client_version_to_connect: 20
 
-		// Check if client flags are the same with compiled hercules version
+		// Check if client flags are same with compiled hercules version.
 		check_client_flags: true
+
+		// Report error on console if wrong client flags detected.
+		report_client_flags_error: true
 
 		//==================================================================
 		// Client hash checking system

--- a/src/common/console.c
+++ b/src/common/console.c
@@ -91,6 +91,7 @@ static void display_title(void)
 	ShowInfo("CPU: '"CL_WHITE"%s [%d]"CL_RESET"'\n", sysinfo->cpu(), sysinfo->cpucores());
 	ShowInfo("Compiled with %s\n", sysinfo->compiler());
 	ShowInfo("Compile Flags: %s\n", sysinfo->cflags());
+	ShowInfo("Feature Flags: 0x%x\n", sysinfo->fflags());
 	ShowInfo("Timer Function Type: %s\n", sysinfo->time());
 	ShowInfo("Packet version: %d " PACKETTYPE "\n", PACKETVER);
 }

--- a/src/common/sysinfo.c
+++ b/src/common/sysinfo.c
@@ -1076,6 +1076,16 @@ static int sysinfo_build_revision(void)
 	return HERCULES_VERSION;
 }
 
+static uint32 sysinfo_fflags(void)
+{
+	const uint32 flags = 0
+#ifdef ENABLE_CASHSHOP_PREVIEW_PATCH
+		| 1
+#endif  // ENABLE_CASHSHOP_PREVIEW_PATCH
+	;
+	return flags;
+}
+
 /**
  * Interface default values initialization.
  */
@@ -1100,6 +1110,7 @@ void sysinfo_defaults(void)
 	sysinfo->vcsrevision_scripts = sysinfo_vcsrevision_scripts;
 	sysinfo->vcsrevision_reload = sysinfo_vcsrevision_reload;
 	sysinfo->build_revision = sysinfo_build_revision;
+	sysinfo->fflags = sysinfo_fflags;
 	sysinfo->is_superuser = sysinfo_is_superuser;
 	sysinfo->init = sysinfo_init;
 	sysinfo->final = sysinfo_final;

--- a/src/common/sysinfo.h
+++ b/src/common/sysinfo.h
@@ -54,6 +54,7 @@ struct sysinfo_interface {
 	const char *(*vcsrevision_src) (void);
 	const char *(*vcsrevision_scripts) (void);
 	int (*build_revision) (void);
+	uint32 (*fflags) (void);
 	void (*vcsrevision_reload) (void);
 	bool (*is_superuser) (void);
 	void (*init) (void);

--- a/src/login/login.c
+++ b/src/login/login.c
@@ -41,6 +41,7 @@
 #include "common/showmsg.h"
 #include "common/socket.h"
 #include "common/strlib.h"
+#include "common/sysinfo.h"
 #include "common/timer.h"
 #include "common/utils.h"
 
@@ -1066,11 +1067,7 @@ static int login_check_client_version(struct login_session_data *sd)
 
 	// check flags only if enabled and if client flags set to known value
 	if (login->config->check_client_flags && (sd->version & 0x80000000) != 0) {
-		const uint32 emulatorFlags = 0x80000000
-#ifdef ENABLE_CASHSHOP_PREVIEW_PATCH
-			| 1
-#endif  // ENABLE_CASHSHOP_PREVIEW_PATCH
-		;
+		const uint32 emulatorFlags = 0x80000000 | sysinfo->fflags();
 		if (emulatorFlags != sd->version)
 			return 5;
 	}

--- a/src/login/login.c
+++ b/src/login/login.c
@@ -1068,8 +1068,11 @@ static int login_check_client_version(struct login_session_data *sd)
 	// check flags only if enabled and if client flags set to known value
 	if (login->config->check_client_flags && (sd->version & 0x80000000) != 0) {
 		const uint32 emulatorFlags = 0x80000000 | sysinfo->fflags();
-		if (emulatorFlags != sd->version)
+		if (emulatorFlags != sd->version) {
+			if (login->config->report_client_flags_error)
+				ShowNotice("Wrong client flags detected (account: %s, received flags: 0x%x)\n", sd->userid, sd->version);
 			return 5;
+		}
 	}
 
 	return -1;
@@ -1511,6 +1514,7 @@ static void login_config_set_defaults(void)
 	login->config->min_group_id_to_connect = -1;
 	login->config->check_client_version = false;
 	login->config->check_client_flags = true;
+	login->config->report_client_flags_error = true;
 	login->config->client_version_to_connect = 20;
 	login->config->allowed_regs = 1;
 	login->config->time_allowed = 10;
@@ -1873,6 +1877,7 @@ static bool login_config_read_permission(const char *filename, struct config_t *
 	libconfig->setting_lookup_int(setting, "min_group_id_to_connect", &login->config->min_group_id_to_connect);
 	libconfig->setting_lookup_bool_real(setting, "check_client_version", &login->config->check_client_version);
 	libconfig->setting_lookup_bool_real(setting, "check_client_flags", &login->config->check_client_flags);
+	libconfig->setting_lookup_bool_real(setting, "report_client_flags_error", &login->config->report_client_flags_error);
 	libconfig->setting_lookup_uint32(setting, "client_version_to_connect", &login->config->client_version_to_connect);
 
 	if (!login->config_read_permission_hash(filename, config, imported))

--- a/src/login/login.c
+++ b/src/login/login.c
@@ -1056,6 +1056,13 @@ static int login_mmo_auth_new(const char *userid, const char *pass, const char s
 	return -1;
 }
 
+static int login_check_client_version(struct login_session_data *sd)
+{
+	if (login->config->check_client_version && sd->version != login->config->client_version_to_connect)
+		return 5;
+	return -1;
+}
+
 //-----------------------------------------------------
 // Check/authentication of a connection
 //-----------------------------------------------------
@@ -1090,8 +1097,9 @@ static int login_mmo_auth(struct login_session_data *sd, bool isServer)
 	}
 
 	//Client Version check
-	if (login->config->check_client_version && sd->version != login->config->client_version_to_connect)
-		return 5;
+	const int versionError = login->check_client_version(sd);
+	if (versionError != -1)
+		return versionError;
 
 	len = strnlen(sd->userid, NAME_LENGTH);
 
@@ -2285,6 +2293,7 @@ void login_defaults(void)
 	login->auth_failed = login_auth_failed;
 	login->char_server_connection_status = login_char_server_connection_status;
 	login->kick = login_kick;
+	login->check_client_version = login_check_client_version;
 
 	login->config_set_defaults = login_config_set_defaults;
 	login->config_read = login_config_read;

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -110,6 +110,7 @@ struct Login_Config {
 	int min_group_id_to_connect;                    ///< minimum group id to connect
 	bool check_client_version;                      ///< check the clientversion set in the clientinfo ?
 	bool check_client_flags;                        ///< check the clientversion flags set in the clientinfo
+	bool report_client_flags_error;                 ///< report the clientversion flags set errors
 	uint32 client_version_to_connect;               ///< the client version needed to connect (if checking is enabled)
 	int allowed_regs;                               ///< account registration flood protection [Kevin]
 	int time_allowed;                               ///< time in seconds

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -237,6 +237,7 @@ struct login_interface {
 	void (*clear_client_hash_nodes) (void);
 	void (*config_set_md5hash) (struct config_setting_t *setting);
 	uint16 (*convert_users_to_colors) (uint16 users);
+	int (*check_client_version) (struct login_session_data *sd);
 	char *LOGIN_CONF_NAME;
 	char *NET_CONF_NAME; ///< Network configuration filename
 };

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -109,6 +109,7 @@ struct Login_Config {
 	int group_id_to_connect;                        ///< required group id to connect
 	int min_group_id_to_connect;                    ///< minimum group id to connect
 	bool check_client_version;                      ///< check the clientversion set in the clientinfo ?
+	bool check_client_flags;                        ///< check the clientversion flags set in the clientinfo
 	uint32 client_version_to_connect;               ///< the client version needed to connect (if checking is enabled)
 	int allowed_regs;                               ///< account registration flood protection [Kevin]
 	int time_allowed;                               ///< time in seconds


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Client may send special flags in client_version field.
In this pr hercules will compare current server flags and client flags, and if flags different then client will be disconnected.
This will prevent from strange bugs if server or client was created with different features.

For now only supported feature flag is cash show with preview support.

For enable flags in client need enable this patch http://nemo.herc.ws/patches/SendClientFlags/
