### PR TITLE
Made view_data for mob unit changes persistent

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -317,8 +317,8 @@ static struct view_data *mob_get_viewdata(int class_)
  * Create unique view data associated to a spawned monster.
  * @param md: Mob to adjust
  */
-void mob_set_dynamic_viewdata(struct mob_data *md) {
-
+static void mob_set_dynamic_viewdata(struct mob_data *md)
+{
 	nullpo_retv(md);
 
 	// If it is a valid monster and it has not already been created
@@ -341,8 +341,8 @@ void mob_set_dynamic_viewdata(struct mob_data *md) {
  * Free any view data associated to a spawned monster.
  * @param md: Mob to free
  */
-void mob_free_dynamic_viewdata(struct mob_data *md) {
-
+static void mob_free_dynamic_viewdata(struct mob_data *md)
+{
 	nullpo_retv(md);
 
 	// If it is a valid monster and it has already been allocated

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -4115,11 +4115,11 @@ static int mob_clone_delete(struct mob_data *md)
 
 	nullpo_ret(md);
 	class_ = md->class_;
-	if (class_ >= MOB_CLONE_START && class_ < MOB_CLONE_END
-		&& mob->db_data[class_]!=NULL) {
+	if (class_ >= MOB_CLONE_START && class_ < MOB_CLONE_END && mob->db_data[class_] != NULL) {
 		mob->destroy_mob_db(class_);
 		//Clear references to the db
 		md->db = mob->dummy;
+		mob->free_dynamic_viewdata(md);
 		md->vd = NULL;
 		return 1;
 	}

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -322,19 +322,17 @@ static void mob_set_dynamic_viewdata(struct mob_data *md)
 	nullpo_retv(md);
 
 	// If it is a valid monster and it has not already been created
-	if (!md->vd_changed) {
-		// Allocate a dynamic entry
-		struct view_data *vd = (struct view_data*)aMalloc(sizeof(struct view_data));
+	if (md->vd_changed)
+		return;
 
-		// Copy the current values
-		memcpy(vd, md->vd, sizeof(struct view_data));
-
-		// Update the pointer to the new entry
-		md->vd = vd;
-
-		// Flag it as changed so it is freed later on
-		md->vd_changed = true;
-	}
+	// Allocate a dynamic entry
+	struct view_data *vd = (struct view_data *)aMalloc(sizeof(struct view_data));
+	// Copy the current values
+	memcpy(vd, md->vd, sizeof(struct view_data));
+	// Update the pointer to the new entry
+	md->vd = vd;
+	// Flag it as changed so it is freed later on
+	md->vd_changed = true;
 }
 
 /**
@@ -346,16 +344,15 @@ static void mob_free_dynamic_viewdata(struct mob_data *md)
 	nullpo_retv(md);
 
 	// If it is a valid monster and it has already been allocated
-	if (md->vd_changed) {
-		// Free it
-		aFree(md->vd);
+	if (!md->vd_changed)
+		return;
 
-		// Remove the reference
-		md->vd = NULL;
-
-		// Unflag it as changed
-		md->vd_changed = false;
-	}
+	// Free it
+	aFree(md->vd);
+	// Remove the reference
+	md->vd = NULL;
+	// Unflag it as changed
+	md->vd_changed = false;
 }
 
 /*==========================================

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -215,6 +215,7 @@ struct mob_data {
 	struct block_list bl;
 	struct unit_data  ud;
 	struct view_data *vd;
+	bool vd_changed;
 	struct status_data status, *base_status; //Second one is in case of leveling up mobs, or tiny/large mobs.
 	struct status_change sc;
 	struct mob_db *db; //For quick data access (saves doing mob_db(md->class_) all the time) [Skotlex]
@@ -515,6 +516,8 @@ struct mob_interface {
 	int (*db_searchname_array) (struct mob_db **data, int size, const char *str, int flag);
 	int (*db_checkid) (const int id);
 	struct view_data* (*get_viewdata) (int class_);
+	void (*set_dynamic_viewdata) (struct mob_data *md);
+	void (*free_dynamic_viewdata) (struct mob_data *md);
 	int (*parse_dataset) (struct spawn_data *data);
 	struct mob_data* (*spawn_dataset) (struct spawn_data *data, int npc_id);
 	int (*get_random_id) (int type, int flag, int lv);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -20434,6 +20434,22 @@ static BUILDIN(setunitdata)
 			return false;
 		}
 
+		// Check if the view data will be modified
+		switch (type) {
+		case UDT_SEX:
+		//case UMOB_CLASS: // Called by status_set_viewdata
+		case UDT_HAIRSTYLE:
+		case UDT_HAIRCOLOR:
+		case UDT_HEADBOTTOM:
+		case UDT_HEADMIDDLE:
+		case UDT_HEADTOP:
+		case UDT_CLOTHCOLOR:
+		case UDT_SHIELD:
+		case UDT_WEAPON:
+			mob->set_dynamic_viewdata(md);
+			break;
+		}
+
 		switch (type) {
 		case UDT_SIZE:
 			md->status.size = (unsigned char)val;
@@ -20484,9 +20500,13 @@ static BUILDIN(setunitdata)
 			break;
 		case UDT_SEX:
 			md->vd->sex = (char)val;
+			clif->clearunit_area(bl, CLR_OUTSIGHT);
+			clif->spawn(bl);
 			break;
 		case UDT_CLASS:
 			mob->class_change(md, val);
+			clif->clearunit_area(bl, CLR_OUTSIGHT);
+			clif->spawn(bl);
 			break;
 		case UDT_HAIRSTYLE:
 			clif->changelook(bl, LOOK_HAIR, val);

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -6327,10 +6327,17 @@ static void status_set_viewdata(struct block_list *bl, int class_)
 	case BL_MOB:
 	{
 		struct mob_data *md = BL_UCAST(BL_MOB, bl);
-		if (vd != NULL)
+		if (vd != NULL) {
+			mob->free_dynamic_viewdata(md);
+			
 			md->vd = vd;
-		else
+		} else if (pc->db_checkid(class_)) {
+			mob->set_dynamic_viewdata(md);
+			
+			md->vd->class = class_;
+		} else {
 			ShowError("status_set_viewdata (MOB): No view data for class %d\n", class_);
+		}
 	}
 		break;
 	case BL_PET:

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -6329,11 +6329,9 @@ static void status_set_viewdata(struct block_list *bl, int class_)
 		struct mob_data *md = BL_UCAST(BL_MOB, bl);
 		if (vd != NULL) {
 			mob->free_dynamic_viewdata(md);
-			
 			md->vd = vd;
 		} else if (pc->db_checkid(class_)) {
 			mob->set_dynamic_viewdata(md);
-			
 			md->vd->class = class_;
 		} else {
 			ShowError("status_set_viewdata (MOB): No view data for class %d\n", class_);

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -3019,6 +3019,9 @@ static int unit_free(struct block_list *bl, enum clr_type clrtype)
 		case BL_MOB:
 		{
 			struct mob_data *md = BL_UCAST(BL_MOB, bl);
+
+			mob->free_dynamic_viewdata(md);
+
 			if( md->spawn_timer != INVALID_TIMER )
 			{
 				timer->delete(md->spawn_timer,mob->delayspawn);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [√] I have followed [proper Hercules code styling][code].
- [√] I have read and understood the [contribution guidelines][cont] before making this PR.
- [√] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Made view_data for mob unit changes persistent.
As of now, if we use setunitdata to change the view_data of a mob, it works but it overwrites the data, not changing the view data for that specific unit.

It's a PR from rathena
All credits to: @Lemongrass3110 

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
