### PR TITLE
Fixed permanent SC_VACUUM_EXTREME on multiple targets

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -14231,6 +14231,8 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 				if (basestr > 130)
 					basestr = 130;
 				sg->limit -= 1000 * basestr / 20;
+				if (sg->limit < 0)
+					sg->limit = 0;
 				sc_start(ss, bl, SC_VACUUM_EXTREME, 100, sg->skill_lv, sg->limit);
 
 				if ( !map_flag_gvg(bl->m) && !map->list[bl->m].flag.battleground && !is_boss(bl) ) {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This is part 2 of #2995. This fix is about multiple targets experiencing different duration when hit by SC_VACUUM_EXTREME.

To experience the bug: you must place multiple characters within range of extreme vaccum(atleast 5 targets), then check if all targets can move once the status ends.

FIXME: This is a temporary fix. SC_VACUUM_EXTREME should be same duration to all affected targets instead of splitting the Duration to each target within the AOE.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
