### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/char/int_achievement.c
+++ b/src/char/int_achievement.c
@@ -95,7 +95,7 @@ static int inter_achievement_tosql(int char_id, struct char_achievements *cp, co
 	if (rows) {
 		ShowInfo("achievements saved for char %d (total: %d, saved: %d)\n", char_id, VECTOR_LENGTH(*p), rows);
 
-		/* Sync with inter-db acheivements. */
+		/* Sync with inter-db achievements. */
 		VECTOR_CLEAR(*cp);
 		VECTOR_ENSURE(*cp, VECTOR_LENGTH(*p), 1);
 		VECTOR_PUSHARRAY(*cp, VECTOR_DATA(*p), VECTOR_LENGTH(*p));

--- a/src/common/showmsg.c
+++ b/src/common/showmsg.c
@@ -223,7 +223,7 @@ static int VFPRINTF(HANDLE handle, const char *fmt, va_list argptr)
 			p=q+1; //and start searching again
 		} else {
 			// from here, we will skip the '\033['
-			// we break at the first unprocessible position
+			// we break at the first unprocessable position
 			// assuming regular text is starting there
 			uint8 numbers[16], numpoint=0;
 			CONSOLE_SCREEN_BUFFER_INFO info;
@@ -516,7 +516,7 @@ static int VFPRINTF(FILE *file, const char *fmt, va_list argptr)
 			p=q+1; //and start searching again
 		} else {
 			// from here, we will skip the '\033['
-			// we break at the first unprocessible position
+			// we break at the first unprocessable position
 			// assuming regular text is starting there
 
 			// skip escape and bracket

--- a/src/common/showmsg.h
+++ b/src/common/showmsg.h
@@ -84,7 +84,7 @@ struct config_setting_t;
 #define CL_MAGENTA CL_BT_MAGENTA
 #define CL_CYAN    CL_BT_CYAN
 
-#define CL_SPACE   "           "   // space aquivalent of the print messages
+#define CL_SPACE   "           "   // space equivalent of the print messages
 
 enum msg_type {
 	MSG_NONE,

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -631,7 +631,7 @@ struct Battle_Config {
 	int merc_natural_heal_cap;
 };
 
-/* criteria for battle_config.idletime_critera */
+/* criteria for battle_config.idletime_criteria */
 enum e_battle_config_idletime {
 	BCIDLE_WALK          = 0x001,
 	BCIDLE_USESKILLTOID  = 0x002,

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -3664,7 +3664,7 @@ static bool script_is_permanent_variable(const char *name)
 		return false;
 
 	if (ISALNUM(name[0]) != 0)
-		return true; // Permanent characater variable.
+		return true; // Permanent character variable.
 
 	if (name[0] == '#')
 		return true; // Permanent (global) account variable.

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7690,7 +7690,7 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 			case SC_M_LIFEPOTION:
 			case SC_G_LIFEPOTION:
 				if (val1 == 0) return 0;
-				// val1 = heal percent/amout
+				// val1 = heal percent/amount
 				// val2 = seconds between heals
 				// val4 = total of heals
 				if (val2 < 1) val2 = 1;


### PR DESCRIPTION
There are small typos in:
- src/char/int_achievement.c
- src/common/showmsg.c
- src/common/showmsg.h
- src/map/battle.h
- src/map/script.c
- src/map/status.c

Fixes:
- Should read `unprocessable` rather than `unprocessible`.
- Should read `equivalent` rather than `aquivalent`.
- Should read `criteria` rather than `critera`.
- Should read `character` rather than `characater`.
- Should read `amount` rather than `amout`.
- Should read `achievements` rather than `acheivements`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md