### PR TITLE
Fix mob groups reading rate from wrong object

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -5497,7 +5497,7 @@ static bool mob_read_group_db_libconfig_sub_group(struct config_setting_t *it, e
 
 		int rate = 0;
 		if (config_setting_is_list(entry))
-			rate = libconfig->setting_get_int_elem(it, 1);
+			rate = libconfig->setting_get_int_elem(entry, 1);
 		else
 			rate = 1;
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

fixes #3036


[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
