### PR TITLE
Daehyon Card bonus effect on wrong Weapon Class

### DIFF
--- a/db/re/item_db.conf
+++ b/db/re/item_db.conf
@@ -48518,9 +48518,9 @@ item_db: (
 	Weight: 10
 	Loc: "EQP_WEAPON"
 	Script: <"
-		if((getiteminfo(getequipid(EQI_HAND_R),11)==3)||(getiteminfo(getequipid(EQI_HAND_R),11)==4)) {
-			bonus bBaseAtk,100;
-		}
+		.@equip = getiteminfo(getequipid(EQI_HAND_R), 11);
+		if (.@equip == 2 || .@equip == 3)
+			bonus(bBaseAtk, 100);
 	">
 },
 {


### PR DESCRIPTION
…D or TWOHANDSWORD.

<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes `Daehyon_Card` script effect should only work on _One or Two Handed Sword_.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** #2996  <!-- Write here the issue number, if any. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
