### PR TITLE
Some renewal skill fixes

### DIFF
--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -33913,7 +33913,7 @@ conflicting with SJ_LIGHTOFMOON
 	SkillType: {
 		Self: true
 	}
-	AttackType: "Misc"
+	AttackType: "Weapon"
 	Element: "Ele_Weapon"
 	DamageType: {
 		SplashArea: true
@@ -33931,21 +33931,21 @@ conflicting with SJ_LIGHTOFMOON
 		Lv9: 5
 		Lv10: 5
 	}
-	NumberOfHits: 0
+	NumberOfHits: 1
 	AfterCastActDelay: 500
 	FixedCastTime: -1
 	Requirements: {
 		SPCost: {
-			Lv1: 8
-			Lv2: 9
-			Lv3: 10
-			Lv4: 11
-			Lv5: 12
-			Lv6: 13
-			Lv7: 14
-			Lv8: 15
-			Lv9: 16
-			Lv10: 17
+			Lv1: 12
+			Lv2: 14
+			Lv3: 16
+			Lv4: 18
+			Lv5: 20
+			Lv6: 22
+			Lv7: 24
+			Lv8: 26
+			Lv9: 28
+			Lv10: 30
 		}
 		AmmoTypes: {
 			A_KUNAI: true

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -19592,6 +19592,7 @@ skill_db: (
 	Element: "Ele_Fire"
 	DamageType: {
 		SplashArea: true
+		IgnoreFlee: true
 	}
 	SplashRange: {
 		Lv1: 1

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -398,6 +398,8 @@ static int64 battle_attr_fix(struct block_list *src, struct block_list *target, 
 			ratio += skill->enchant_eff[sc->data[SC_DELUGE]->val1-1];
 		if(sc->data[SC_FIRE_CLOAK_OPTION] && atk_elem == ELE_FIRE)
 			damage += damage * sc->data[SC_FIRE_CLOAK_OPTION]->val2 / 100;
+		if (sc->data[SC_TELEKINESIS_INTENSE] != NULL && atk_elem == ELE_GHOST)
+			damage += damage * sc->data[SC_TELEKINESIS_INTENSE]->val3 / 100;
 	}
 	if( target && target->type == BL_SKILL ) {
 		if( atk_elem == ELE_FIRE && battle->get_current_skill(target) == GN_WALLOFTHORN ) {
@@ -3900,10 +3902,6 @@ static struct Damage battle_calc_magic_attack(struct block_list *src, struct blo
 						ShowError("0 enemies targeted by %d:%s, divide per 0 avoided!\n", skill_id, skill->get_name(skill_id));
 				}
 
-				if (sc){
-					if( sc->data[SC_TELEKINESIS_INTENSE] && s_ele == ELE_GHOST )
-						ad.damage += ad.damage * sc->data[SC_TELEKINESIS_INTENSE]->val3 / 100;
-				}
 				switch(skill_id){
 					case MG_FIREBOLT:
 					case MG_COLDBOLT:

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -5136,7 +5136,12 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 			case RK_DRAGONBREATH_WATER:
 				wd.damage = ((status_get_hp(src) / 50) + (status_get_max_sp(src) / 4)) * skill_lv;
 				wd.damage = wd.damage * status->get_lv(src) / 150;
-				if (sd) wd.damage = wd.damage * (95 + 5 * pc->checkskill(sd, RK_DRAGONTRAINING)) / 100;
+				if (sd != NULL)
+					wd.damage = wd.damage * (95 + 5 * pc->checkskill(sd, RK_DRAGONTRAINING)) / 100;
+#ifdef RENEWAL
+				wd.damage = battle->attr_fix(src, target, battle->calc_cardfix2(src, target, wd.damage, s_ele, nk, wd.flag), s_ele, tstatus->def_ele, tstatus->ele_lv);
+#endif
+				wd.flag |= BF_LONG;
 				break;
 			default:
 			{


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed:

Fixes skills reported on #1597
- [x] Splash Kunai
- Updated damage formula to `3 * (Kunai Atk+ Weapon Atk + Base Atk)) * (Skill Level + 5) / 5`
- Pierce attack modifier no longer applies to it
- Element comes from kunai rather weapon
- SP Cost gets increase and Hit count should be 1 
- [x] Dragon Breath
- It should now apply elemental modifier and ignores target's flee.
- [x] Intense Telekinesis
- Damage should now be 3x when skill element is ghost.
<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
