### PR TITLE
Few fixes to RoDEX

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -1079,6 +1079,7 @@ enum fame_list_type {
 
 struct rodex_item {
 	struct item item;
+	// inventory idx when composing a message (-1 if not filled)
 	int idx;
 };
 

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -8636,9 +8636,9 @@ ACMD(itemlist)
 		}
 
 		if( it->refine )
-			StrBuf->Printf(&buf, "%d %s %+d (%s, id: %d)", it->amount, itd->jname, it->refine, itd->name, it->nameid);
+			StrBuf->Printf(&buf, "%d: %d %s %+d (%s, id: %d)", i, it->amount, itd->jname, it->refine, itd->name, it->nameid);
 		else
-			StrBuf->Printf(&buf, "%d %s (%s, id: %d)", it->amount, itd->jname, itd->name, it->nameid);
+			StrBuf->Printf(&buf, "%d: %d %s (%s, id: %d)", i, it->amount, itd->jname, itd->name, it->nameid);
 
 		if( it->equip ) {
 			char equipstr[CHAT_SIZE_MAX];

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -22668,6 +22668,13 @@ static void clif_parse_rodex_remove_item(int fd, struct map_session_data *sd)
 	rodex->remove_item(sd, idx, (int16)rPacket->cnt);
 }
 
+/**
+ * Acknowledges the removal of an item in the message being written.
+ * @param sd player writting the mail
+ * @param idx item inventory index
+ * @param amount amount of items removed from the message or -1 in case of error
+ *               (it should be the same value received in clif_parse_rodex_remove_item)
+ */
 static void clif_rodex_remove_item_result(struct map_session_data *sd, int16 idx, int16 amount)
 {
 #if PACKETVER >= 20140521
@@ -22683,7 +22690,7 @@ static void clif_rodex_remove_item_result(struct map_session_data *sd, int16 idx
 	packet = WFIFOP(fd, 0);
 	packet->PacketType = rodexremoveitem;
 	packet->result = (amount < 0) ? 0 : 1;
-	packet->cnt = (amount < 0) ? 0 : sd->status.inventory[idx].amount - amount;
+	packet->cnt = (amount < 0) ? 0 : amount;
 	packet->index = idx + 2;
 	packet->weight = sd->rodex.tmp.weight / 10;
 	WFIFOSET(fd, sizeof(*packet));

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -22990,6 +22990,13 @@ static void clif_parse_rodex_read_mail(int fd, struct map_session_data *sd)
 
 	const struct PACKET_CZ_REQ_READ_MAIL *rPacket = RFIFOP(fd, 0);
 
+#if PACKETVER_RE_NUM >= 20190508 || PACKETVER_MAIN_NUM >= 20190522 || PACKETVER_ZERO_NUM >= 20190529
+	// After the bulk actions were added, the deleted mails are still clickable, but they send mail_id = -1
+	// Packet dates based on tests and patch notes
+	if (rPacket->MailID == -1)
+		return;
+#endif
+
 	rodex->read_mail(sd, rPacket->MailID);
 }
 

--- a/src/map/rodex.c
+++ b/src/map/rodex.c
@@ -112,10 +112,10 @@ static void rodex_add_item(struct map_session_data *sd, int16 idx, int16 amount)
 		}
 
 		if (i == RODEX_MAX_ITEM && sd->rodex.tmp.items_count < RODEX_MAX_ITEM) {
-			ARR_FIND(0, RODEX_MAX_ITEM, i, sd->rodex.tmp.items[i].idx == 0);
+			ARR_FIND(0, RODEX_MAX_ITEM, i, sd->rodex.tmp.items[i].item.id == 0);
 		}
 	} else if (sd->rodex.tmp.items_count < RODEX_MAX_ITEM) {
-		ARR_FIND(0, RODEX_MAX_ITEM, i, sd->rodex.tmp.items[i].idx == 0);
+		ARR_FIND(0, RODEX_MAX_ITEM, i, sd->rodex.tmp.items[i].idx == -1);
 	} else {
 		i = RODEX_MAX_ITEM;
 	}
@@ -188,6 +188,7 @@ static void rodex_remove_item(struct map_session_data *sd, int16 idx, int16 amou
 			sd->rodex.tmp.type &= ~MAIL_TYPE_ITEM;
 		}
 		memset(&sd->rodex.tmp.items[i], 0x0, sizeof(sd->rodex.tmp.items[0]));
+		sd->rodex.tmp.items[i].idx = -1;
 		clif->rodex_remove_item_result(sd, idx, 0);
 		return;
 	}
@@ -563,7 +564,7 @@ static void rodex_get_items(struct map_session_data *sd, int8 opentype, int64 ma
 }
 
 /// Cleans user's RoDEX related data
-/// - should be called everytime we're going to stop using rodex in this character
+/// - should be called everytime we're going to start/stop using rodex in this character
 /// @param sd : Target to clean
 /// @param flag :
 ///     0 - clear everything
@@ -577,6 +578,10 @@ static void rodex_clean(struct map_session_data *sd, int8 flag)
 
 	sd->state.workinprogress &= ~2;
 	memset(&sd->rodex.tmp, 0x0, sizeof(sd->rodex.tmp));
+
+	// idx 0 is still a valid index, set it to -1 to ensure it is not in use.
+	for (int i = 0; i < RODEX_MAX_ITEM; ++i)
+		sd->rodex.tmp.items[i].idx = -1;
 }
 
 /// User request to open rodex, load mails from char-server

--- a/src/map/rodex.c
+++ b/src/map/rodex.c
@@ -191,14 +191,12 @@ static void rodex_remove_item(struct map_session_data *sd, int16 idx, int16 amou
 		}
 		memset(&sd->rodex.tmp.items[i], 0x0, sizeof(sd->rodex.tmp.items[0]));
 		sd->rodex.tmp.items[i].idx = -1;
-		clif->rodex_remove_item_result(sd, idx, 0);
-		return;
+	} else {
+		it->amount -= amount;
+		sd->rodex.tmp.weight -= itd->weight * amount;
 	}
 
-	it->amount -= amount;
-	sd->rodex.tmp.weight -= itd->weight * amount;
-
-	clif->rodex_remove_item_result(sd, idx, it->amount);
+	clif->rodex_remove_item_result(sd, idx, amount);
 }
 
 /// Request if character with given name exists and returns information about him

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -26730,7 +26730,7 @@ static BUILDIN(navigateto)
 #endif
 }
 
-static bool rodex_sendmail_sub(struct script_state *st, struct rodex_message *msg)
+static bool buildin_rodex_sendmail_sub(struct script_state *st, struct rodex_message *msg)
 {
 	const char *sender_name, *title, *body;
 	const char *func_name = script->getfuncname(st);
@@ -26790,7 +26790,7 @@ static BUILDIN(rodex_sendmail)
 	int item_count = 0, i = 0, param = 7;
 
 	// Common parameters - sender/message/zeny
-	if (rodex_sendmail_sub(st, &msg) == false)
+	if (script->buildin_rodex_sendmail_sub(st, &msg) == false)
 		return false;
 
 	// Item list
@@ -26858,7 +26858,7 @@ static BUILDIN(rodex_sendmail2)
 	int item_count = 0, i = 0, param = 7;
 
 	// Common parameters - sender/message/zeny
-	if (rodex_sendmail_sub(st, &msg) == false)
+	if (script->buildin_rodex_sendmail_sub(st, &msg) == false)
 		return false;
 
 	// Item list
@@ -29395,6 +29395,7 @@ void script_defaults(void)
 	script->buildin_query_sql_sub = buildin_query_sql_sub;
 	script->buildin_instance_warpall_sub = buildin_instance_warpall_sub;
 	script->buildin_mobuseskill_sub = buildin_mobuseskill_sub;
+	script->buildin_rodex_sendmail_sub = buildin_rodex_sendmail_sub;
 	script->cleanfloor_sub = script_cleanfloor_sub;
 	script->run_func = run_func;
 	script->getfuncname = script_getfuncname;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -26753,25 +26753,25 @@ static bool rodex_sendmail_sub(struct script_state *st, struct rodex_message *ms
 	}
 
 	sender_name = script_getstr(st, 3);
-	if (strlen(sender_name) >= NAME_LENGTH) {
-		ShowError("script:rodex_sendmail: Sender name must not be bigger than %d!\n", NAME_LENGTH - 1);
+	if (strlen(sender_name) >= sizeof(msg->sender_name)) {
+		ShowError("script:rodex_sendmail: Sender name must not be longer than %lu characters!\n", sizeof(msg->sender_name) - 1);
 		return false;
 	}
-	safestrncpy(msg->sender_name, sender_name, NAME_LENGTH);
+	safestrncpy(msg->sender_name, sender_name, sizeof(msg->sender_name));
 
 	title = script_getstr(st, 4);
-	if (strlen(title) >= RODEX_TITLE_LENGTH) {
-		ShowError("script:rodex_sendmail: Mail Title must not be bigger than %d!\n", RODEX_TITLE_LENGTH - 1);
+	if (strlen(title) >= sizeof(msg->title)) {
+		ShowError("script:rodex_sendmail: Mail Title must not be longer than %lu characters!\n", sizeof(msg->title) - 1);
 		return false;
 	}
-	safestrncpy(msg->title, title, RODEX_TITLE_LENGTH);
+	safestrncpy(msg->title, title, sizeof(msg->title));
 
 	body = script_getstr(st, 5);
-	if (strlen(body) >= MAIL_BODY_LENGTH) {
-		ShowError("script:rodex_sendmail: Mail Message must not be bigger than %d!\n", RODEX_BODY_LENGTH - 1);
+	if (strlen(body) >= sizeof(msg->body)) {
+		ShowError("script:rodex_sendmail: Mail Message must not be longer than %lu characters!\n", sizeof(msg->body) - 1);
 		return false;
 	}
-	safestrncpy(msg->body, body, MAIL_BODY_LENGTH);
+	safestrncpy(msg->body, body, sizeof(msg->body));
 
 	if (script_hasdata(st, 6)) {
 		msg->zeny = script_getnum(st, 6);

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -1048,6 +1048,7 @@ struct script_interface {
 	int (*buildin_query_sql_sub) (struct script_state *st, struct Sql *handle);
 	int (*buildin_instance_warpall_sub) (struct block_list *bl, va_list ap);
 	int (*buildin_mobuseskill_sub) (struct block_list *bl, va_list ap);
+	bool (*buildin_rodex_sendmail_sub) (struct script_state *st, struct rodex_message *msg);
 	int (*cleanfloor_sub) (struct block_list *bl, va_list ap);
 	int (*run_func) (struct script_state *st);
 	bool (*sprintf_helper) (struct script_state *st, int start, struct StringBuf *out);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR fixes a few issues on RoDEX, specially in message creation. Some of them produced **visual glitches** that could lead to the user sending wrong attachment. Also, as I was reading the code I tried to simplify and style fix some parts to make easier to read, I did it in separate commits so it doesn't hide behind the real fixes, let me know if some commit should be squashed.

Finally, it exposes the script command helper function `rodex_sendmail_sub` in the script interface, it is now named `buildin_rodex_sendmail_sub` to match other similar functions.

To help debug it I added the inventory index (`idx`) to the `@itemlist` command, if you think it doesn't belong there, I am fine with removing it :)

The issues addressed are the following:

#### Fix 1
 **Issue when attaching the first item in inventory (idx = 0)**: RoDEX code was assuming that idx = 0 means a free attachment slot, this produced 2 issues:

Case 1:
    - Attach item idx = 0
    - Attach another item
    - Click send
    - **Result before:** 2 items were displayed in client, but only the 2nd item was actually sent
    - **Result now:** both items are displayed and sent
   
Case 2:
    - Attach the item idx = 0
    - Attach another item
    - Remove the "Another item"
    - Try to remove the item idx = 0
    - **Result before:** You got a generic error, you couldn't remove the item (closing RoDEX window makes it appear in your inventory again, no item loss)
    - **Result now:** both items are removable

#### Fix 2
 **Issue when removing parts of a stack**: there was an issue in the packet that acknowledges the removal of an item in the message being written. This made it display negative or higher number of items in the window. They were visual glitches, and closing the window would return it back to normal.

Example:
    - Get 10 of item 501 (an stackable item)
    - Put 5 in the message (5 inventory / 5 message)
    - Move 3 from the message back to the inventory
    - **Before:** You would see something like 13 in inventory and -5 in message
    - **Now:** You will correctly see 8 in inventory and 2 in message

#### Fix 3
Newer clients, after the "bulk actions" update keeps deleted messages "rows" in the screen after deletion until you refresh. Those rows are still clickable, but the client sends the mail id as "-1", which would never find a proper message. So now we just ignore those requests for mail_id = -1.

PACKETVER checks were made based on manual tests for Ragexe and Ragexe zero, and on patch notes for RE

#### Fix 4
`rodex_sendmail` script command was wrongly checking the body length. Instead of `RODEX_BODY_LENGTH` it was using `MAIL_BODY_LENGTH`, which is used by the old mail system and is shorter than the real limit. I changed those checks to use the array size directly.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None, I think

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
