### PR TITLE
Fix getcalendartime when using current time

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3665,7 +3665,9 @@ Example :
 
 *getcalendartime(<hour>, <minute>{, <day of month>{, <day of week>}})
 
-This function returns the timestamp of the next ocurrence of given time.
+This function returns the timestamp of the next ocurrence of a given time.
+If this time is later today, it will stay in the same day, otherwise, it will adjust to a future
+day as needed.
 
 Day of Month specifies a day between 1 and 31 in the future, by default its value is -1 (don't use).
 Day of Week specifies a day in the week and its valid values are:
@@ -3684,6 +3686,12 @@ Examples :
 	getcalendartime(19, 00); // Next 7 pm
 	getcalendartime(19, 00, 6); // Next day 6 of the month, at 7pm
 	getcalendartime(19, 10, -1, 1); // Next Monday, at 7:10pm
+
+Note: If supplied with the current hour and minute, you will get the timestamp for the same
+hour and minute in the next day. For example, if is now August 1st 7:00pm and you use:
+	getcalendartime(gettime(GETTIME_HOUR), gettime(GETTIME_MINUTE));
+
+You will get August 2nd 7pm
 
 ---------------------------------------
 

--- a/npc/dev/test.txt
+++ b/npc/dev/test.txt
@@ -150,6 +150,24 @@ function	script	F_TestVarOfAnotherNPC	{
 	}
 }
 
+function	script	F_TestCalendarNextTime	{
+	.@hour = gettime(GETTIME_HOUR);
+	.@min = gettime(GETTIME_MINUTE);
+	
+	.@result = getcalendartime(.@hour, .@min);
+	.@expected = gettimetick(2) + 24 * 60 * 60;
+	
+	// We give it a range of 70 seconds more or less in the result because:
+	// 1. getcalendartime doesn't take seconds into account, so we may have differing seconds;
+	// 2. We can't mock time, the second may change during the commands execution,
+	//    so we give it a few seconds to spare.
+	// This still gives a good test, because we are looking for 24 hours into the future,
+	// ~3 minutes aren't really an issue for correcteness here.
+	.@check = (.@result >= .@expected - 70 && .@result <= .@expected + 70);
+	
+	return .@check;
+}
+
 function	script	HerculesSelfTestHelper	{
 	if (.once > 0)
 		return .errors;
@@ -833,6 +851,8 @@ function	script	HerculesSelfTestHelper	{
 	callsub(OnCheck, "public local function ownership",          "export test"::Public(), getnpcid());
 	callsub(OnCheck, "public local function var reference test", .@refTest, 1337);
 	callsub(OnCheck, "programatic public local call",            callfunctionofnpc("export test", "RefTest", .@refTest = 1), 1337);
+
+	callsub(OnCheck, "getcalendartime: next occurence of current Hour/Minute", F_TestCalendarNextTime(), true);
 
 	if (.errors) {
 		consolemes(CONSOLEMES_DEBUG, "Script engine self-test   [ \033[0;31mFAILED\033[0m ]");

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -26492,7 +26492,7 @@ static BUILDIN(getcalendartime)
 		if (day_of_month < day) { // Next Month
 			info.tm_mon++;
 		} else if (day_of_month == day) { // Today
-			if (hour < cur_hour || (hour == cur_hour && minute < cur_min)) { // But past time, next month
+			if (hour < cur_hour || (hour == cur_hour && minute <= cur_min)) { // But past time, next month
 				info.tm_mon++;
 			}
 		}
@@ -26519,7 +26519,7 @@ static BUILDIN(getcalendartime)
 			info.tm_mday += (7 - cur_wday + day_of_week);
 		}
 	} else if (day_of_week == -1 && day_of_month == -1) { // Next occurence of hour/min
-		if (hour < cur_hour || (hour == cur_hour && minute < cur_min)) {
+		if (hour < cur_hour || (hour == cur_hour && minute <= cur_min)) {
 			info.tm_mday++;
 		}
 	}


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
When supplied with the current time (hour and minute), `getcalendartime`, in some cases, gives today as the "next occurrence of a time" instead of the same hour/minute of the next day. "Some cases" being dependent on the parameters used.

I believe this is an unexpected behavior, because:
1. the code doesn't go for that rule in all cases;
2. I remember custom scripts having issues because it was used expecting to be the next day (discord discussion);
3. The original reason to make this command was to make quest cooldown to a fixed time, if the user just finished the quest, you wouldn't expect that the cooldown is 0 (or negative).

So I updated it to make an standard of always looking for the next occurrence.

Also added a CI test for that and improved the documentation to clarify this specific case.

It might be a good idea to let users know this may be a breaking change.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None, I think


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
