### PR TITLE
Adds active_transform script command

### DIFF
--- a/db/constants.conf
+++ b/db/constants.conf
@@ -1314,6 +1314,8 @@ constants_db: {
 	SC_SOULGOLEM:                     715
 	SC_SOULDIVISION:                  716
 
+	SC_ACTIVE_MONSTER_TRANSFORM:      717
+
 	comment__: "Emotes"
 	e_gasp:         0
 	e_what:         1

--- a/db/pre-re/sc_config.conf
+++ b/db/pre-re/sc_config.conf
@@ -6396,3 +6396,12 @@ SC_SOULDIVISION: {
 	Icon: "SI_SOULDIVISION"
 	Skill: "SP_SOULDIVISION"
 }
+SC_ACTIVE_MONSTER_TRANSFORM: {
+	Visible: true
+	Flags: {
+		NoDispelReset: true
+		NoBBReset: true
+		NoClearanceReset: true
+	}
+	Icon: "SI_ACTIVE_MONSTER_TRANSFORM"
+}

--- a/db/re/sc_config.conf
+++ b/db/re/sc_config.conf
@@ -6390,3 +6390,12 @@ SC_SOULDIVISION: {
 	Icon: "SI_SOULDIVISION"
 	Skill: "SP_SOULDIVISION"
 }
+SC_ACTIVE_MONSTER_TRANSFORM: {
+	Visible: true
+	Flags: {
+		NoDispelReset: true
+		NoBBReset: true
+		NoClearanceReset: true
+	}
+	Icon: "SI_ACTIVE_MONSTER_TRANSFORM"
+}

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5146,10 +5146,17 @@ due to a wall), the character is pushed only up to the obstacle.
 
 *montransform(<monster id>, <duration>{, <sc_type>{, <val1>{, <val2>{, <val3>{, <val4>}}}}})
 *montransform("<monster name>", <duration>{, <sc_type>{, <val1>{, <val2>{, <val3>{, <val4>}}}}})
+*active_transform(<monster id>, <duration>{, <sc_type>{, <val1>{, <val2>{, <val3>{, <val4>}}}}})
+*active_transform("<monster name>", <duration>{, <sc_type>{, <val1>{, <val2>{, <val3>{, <val4>}}}}})
 
 This command can transform your character into monster and you can still
 use all your skills like a normal character.
-Can only be removed when your killed or if you die or if duration is over.
+Can only be removed when you die or if duration is over.
+
+active_transform works in the same way but it stacks with montransform, and is displayed first.
+This means that you may have a montransform, that effect and an active_transform effect at
+the same time, and the monster from active_transform will show first, once it ends, your appearance
+changes back to the montransform one, if it is still active.
 
 for sc_type, val1, val2, val3, val4, see sc_start(), sc_start2(), sc_start4() commands.
 

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -5051,7 +5051,7 @@ ACMD(disguise)
 		return false;
 	}
 
-	if(sd->sc.data[SC_MONSTER_TRANSFORM])
+	if (sd->sc.data[SC_MONSTER_TRANSFORM] != NULL || sd->sc.data[SC_ACTIVE_MONSTER_TRANSFORM] != NULL)
 	{
 		clif->message(fd, msg_fd(fd,1487)); // Character cannot be disguised while in monster form.
 		return false;

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11271,9 +11271,11 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 	if (sd->sc.opt2 != 0) // Client loses these on warp.
 		clif->changeoption(&sd->bl);
 
-	if (sd->sc.data[SC_MONSTER_TRANSFORM] != NULL && battle_config.mon_trans_disable_in_gvg != 0
+	if ((sd->sc.data[SC_MONSTER_TRANSFORM] != NULL || sd->sc.data[SC_ACTIVE_MONSTER_TRANSFORM] != NULL)
+	    && battle_config.mon_trans_disable_in_gvg != 0
 	    && map_flag_gvg2(sd->bl.m)) {
 		status_change_end(&sd->bl, SC_MONSTER_TRANSFORM, INVALID_TIMER);
+		status_change_end(&sd->bl, SC_ACTIVE_MONSTER_TRANSFORM, INVALID_TIMER);
 		clif->message(sd->fd, msg_sd(sd, 1488)); // Transforming into monster is not allowed in Guild Wars.
 	}
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24885,8 +24885,11 @@ static BUILDIN(npcskill)
 	return true;
 }
 
-/* Turns a player into a monster and grants SC attribute effect. [malufett/Hercules]
- * montransform <monster name/id>, <duration>, <sc type>, <val1>, <val2>, <val3>, <val4>; */
+/**
+ * Turns a player into a monster and grants SC attribute effect. [malufett/Hercules]
+ * montransform(<monster name/id>, <duration>, <sc type>, <val1>, <val2>, <val3>, <val4>);
+ * active_montransform(<monster name/id>, <duration>, <sc type>, <val1>, <val2>, <val3>, <val4>);
+ */
 static BUILDIN(montransform)
 {
 	int tick;
@@ -24949,8 +24952,13 @@ static BUILDIN(montransform)
 			return true;
 		}
 
-		status_change_end(&sd->bl, SC_MONSTER_TRANSFORM, INVALID_TIMER); // Clear previous
-		sc_start2(NULL, &sd->bl, SC_MONSTER_TRANSFORM, 100, mob_id, type, tick);
+		enum sc_type transform_type;
+		if (strcmp(script_getfuncname(st), "active_transform") == 0)
+			transform_type = SC_ACTIVE_MONSTER_TRANSFORM;
+		else
+			transform_type = SC_MONSTER_TRANSFORM;
+		status_change_end(&sd->bl, transform_type, INVALID_TIMER); // Clear previous
+		sc_start2(NULL, &sd->bl, transform_type, 100, mob_id, type, tick);
 
 		if (script_hasdata(st, 4))
 			sc_start4(NULL, &sd->bl, type, 100, val1, val2, val3, val4, tick);
@@ -28167,6 +28175,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(issit, "?"),
 
 		BUILDIN_DEF(montransform, "vi?????"), // Monster Transform [malufett/Hercules]
+		BUILDIN_DEF2(montransform, "active_transform", "vi?????"),
 
 		/* New BG Commands [Hercules] */
 		BUILDIN_DEF(bg_create_team,"sii"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24888,7 +24888,7 @@ static BUILDIN(npcskill)
 /**
  * Turns a player into a monster and grants SC attribute effect. [malufett/Hercules]
  * montransform(<monster name/id>, <duration>, <sc type>, <val1>, <val2>, <val3>, <val4>);
- * active_montransform(<monster name/id>, <duration>, <sc type>, <val1>, <val2>, <val3>, <val4>);
+ * active_transform(<monster name/id>, <duration>, <sc type>, <val1>, <val2>, <val3>, <val4>);
  */
 static BUILDIN(montransform)
 {
@@ -24918,18 +24918,20 @@ static BUILDIN(montransform)
 			return false;
 		}
 	}
-	
-	int val1, val2, val3, val4;
-	val1 = val2 = val3 = val4 = 0;
+
+	int val1 = 0;
 	if (script_hasdata(st, 5))
 		val1 = script_getnum(st, 5);
 
+	int val2 = 0;
 	if (script_hasdata(st, 6))
 		val2 = script_getnum(st, 6);
 
+	int val3 = 0;
 	if (script_hasdata(st, 7))
 		val3 = script_getnum(st, 7);
 
+	int val4 = 0;
 	if (script_hasdata(st, 8))
 		val4 = script_getnum(st, 8);
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -24892,39 +24892,35 @@ static BUILDIN(npcskill)
  */
 static BUILDIN(montransform)
 {
-	int tick;
-	enum sc_type type;
-	int mob_id, val1, val2, val3, val4;
-	val1 = val2 = val3 = val4 = 0;
-
-	if( script_isstringtype(st, 2) ) {
+	int mob_id;
+	if (script_isstringtype(st, 2))
 		mob_id = mob->db_searchname(script_getstr(st, 2));
-	} else {
+	else
 		mob_id = mob->db_checkid(script_getnum(st, 2));
-	}
 
-	if( mob_id == 0 ) {
-		if( script_isstringtype(st, 2) )
+	if (mob_id == 0) {
+		if (script_isstringtype(st, 2))
 			ShowWarning("buildin_montransform: Attempted to use non-existing monster '%s'.\n", script_getstr(st, 2));
 		else
 			ShowWarning("buildin_montransform: Attempted to use non-existing monster of ID '%d'.\n", script_getnum(st, 2));
 		return false;
 	}
 
-	tick = script_getnum(st, 3);
-
+	enum sc_type type;
 	if (script_hasdata(st, 4))
 		type = (sc_type)script_getnum(st, 4);
 	else
 		type = SC_NONE;
 
 	if (script_hasdata(st, 4)) {
-		if( !(type > SC_NONE && type < SC_MAX) ) {
+		if (!(type > SC_NONE && type < SC_MAX)) {
 			ShowWarning("buildin_montransform: Unsupported status change id %d\n", type);
 			return false;
 		}
 	}
-
+	
+	int val1, val2, val3, val4;
+	val1 = val2 = val3 = val4 = 0;
 	if (script_hasdata(st, 5))
 		val1 = script_getnum(st, 5);
 
@@ -24937,18 +24933,19 @@ static BUILDIN(montransform)
 	if (script_hasdata(st, 8))
 		val4 = script_getnum(st, 8);
 
+	int tick = script_getnum(st, 3);
 	if (tick != 0) {
 		struct map_session_data *sd = script->rid2sd(st);
 		if (sd == NULL)
 			return false;
 
-		if( battle_config.mon_trans_disable_in_gvg && map_flag_gvg2(sd->bl.m) ) {
-			clif->message(sd->fd, msg_sd(sd,1488)); // Transforming into monster is not allowed in Guild Wars.
+		if (battle_config.mon_trans_disable_in_gvg && map_flag_gvg2(sd->bl.m)) {
+			clif->message(sd->fd, msg_sd(sd, 1488)); // Transforming into monster is not allowed in Guild Wars.
 			return true;
 		}
 
-		if( sd->disguise != -1 ) {
-			clif->message(sd->fd, msg_sd(sd,1486)); // Cannot transform into monster while in disguise.
+		if (sd->disguise != -1) {
+			clif->message(sd->fd, msg_sd(sd, 1486)); // Cannot transform into monster while in disguise.
 			return true;
 		}
 

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -9190,6 +9190,7 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 				val2 = 30 * val1;
 				break;
 			case SC_MONSTER_TRANSFORM:
+			case SC_ACTIVE_MONSTER_TRANSFORM:
 				if (!mob->db_checkid(val1))
 					val1 = MOBID_PORING;
 				break;
@@ -9773,6 +9774,7 @@ static int status_get_val_flag(enum sc_type type)
 		case SC_CASH_PLUSEXP:
 		case SC_CASH_PLUSONLYJOBEXP:
 		case SC_MONSTER_TRANSFORM:
+		case SC_ACTIVE_MONSTER_TRANSFORM:
 		case SC_CASH_RECEIVEITEM:
 		case SC_OVERLAPEXPUP:
 			val_flag |= 1;
@@ -11064,7 +11066,8 @@ static int status_change_end_(struct block_list *bl, enum sc_type type, int tid)
 			sc_start(bl,bl,SC_REBOUND,100,sce->val1,skill->get_time2(ALL_FULL_THROTTLE,sce->val1));
 			break;
 		case SC_MONSTER_TRANSFORM:
-			if( sce->val2 )
+		case SC_ACTIVE_MONSTER_TRANSFORM:
+			if (sce->val2)
 				status_change_end(bl, (sc_type)sce->val2, INVALID_TIMER);
 			break;
 		case SC_OVERED_BOOST:

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -910,6 +910,8 @@ typedef enum sc_type {
 	SC_SOULGOLEM,
 	SC_SOULDIVISION,
 
+	SC_ACTIVE_MONSTER_TRANSFORM,
+
 #ifndef SC_MAX
 	SC_MAX, //Automatically updated max, used in for's to check we are within bounds.
 #endif


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Adds `active_transform` script command. This command works like `montransform` but gives a different SC that is stackable with the `montransform` one. sc_config was based in the `montransform` one.

**Issues addressed:** #2035 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
