### PR TITLE
Implement official behavior for Acid Demonstration Armor & Weapon breaking

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1950,7 +1950,8 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 			break;
 
 		case CR_ACIDDEMONSTRATION:
-			skill->break_equip(bl, EQP_WEAPON|EQP_ARMOR, 100*skill_lv, BCT_ENEMY);
+			if (dstsd != NULL) // [Aegis] Doesn't apply for non-player characters.
+				skill->break_equip(bl, EQP_WEAPON | EQP_ARMOR, 100 * skill_lv, BCT_ENEMY);
 			break;
 
 		case TK_DOWNKICK:


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

On Hercules we're currently applying the strip effect from rogues when the Armor & Weapon Break triggers for non-player characters. This is wrong, nothing should happen.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
