### PR TITLE
Fix HLIF_CHANGE not using max MATK only for pre-renewal

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -606,6 +606,8 @@ static int64 battle_calc_base_damage2(struct status_data *st, struct weapon_atk 
 	nullpo_retr(damage, st);
 	nullpo_retr(damage, wa);
 	if (!sd) { //Mobs/Pets
+		if (sc != NULL && sc->data[SC_HLIF_CHANGE] != NULL)
+			return st->matk_max; // [Aegis] simply uses raw max matk for base damage when Mental Charge active
 		if(flag&4) {
 			atkmin = st->matk_min;
 			atkmax = st->matk_max;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Checked via official server software ep 11.2
The function is only used for pre-renewal calls, thus no ifdefs.

**Issues addressed:** None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
