### PR TITLE
Conditional comments

### DIFF
--- a/conf/map/script.conf
+++ b/conf/map/script.conf
@@ -69,6 +69,11 @@ script_configuration: {
 	// allows, for example, to use a 'public function OnDeath { ... }' instead
 	// of a 'OnDeath:' label for mob death events.
 	functions_as_events: false
+
+	// Specifies whether GM management scripts should be loaded, allowing
+	// those that consider them a security hazard to completely disable their
+	// functionality.
+	load_gm_scripts: true
 }
 
 import: "conf/import/script.conf"

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -366,6 +366,66 @@ parameter.
 Once an object is defined which has a 'code' field to it's definition, it
 contains script commands which can actually be triggered and executed.
 
+Conditional comments
+--------------------
+
+An extension of the block comment syntax can be used for conditional comments.
+A conditional comment is treated as a block comment when the specified flag is
+not defined and as a normal block of code if it is, in a similar way to #ifdef
+blocks in the C preprocessor. This can be useful to make
+parts of scripts (including top-level commands) optional depending on a server
+feature, a setting or a plugin.
+
+A conditional comment begins with /*@CONDITION followed by whitespace or */ and
+ends with the first */ sequence encountered on a separate line, but the sequence
+//@*/ at the beginning of a line (optionally with indentation) is recommended as
+a terminator, since it provides compatibility with older versions of the script
+engine that don't support conditional comments. The condition flag can be
+negated by prefixing it with an exclamation mark (!). Condition flags consist of
+an uppercase letter followed by a sequence of uppercase letters, digits and
+underscores and are at least three characters long.
+
+The following block is only parsed if FLAG is defined. If not defined, or when
+loaded by an older engine, the block is treated as a block comment:
+
+/*@FLAG
+.@x = 1;
+//@*/
+
+The following block is only parsed if FLAG is not defined. If defined, or when
+loaded by an older engine, the block is treated as a block comment:
+
+/*@!FLAG
+.@x = 1;
+//@*/
+
+The following block is only parsed if FLAG is defined. If not defined, the block
+is treated as a block comment. When loaded by an older engine, the block is also
+parsed:
+
+/*@FLAG*/
+.@x = 1;
+//@*/
+
+The following block is only parsed if FLAG is not defined. If defined, the block
+is treated as a block comment. When loaded by an older engine, the block is also
+parsed.
+
+/*@!FLAG*/
+.@x = 1;
+//@*/
+
+The Hercules core provides the following conditional comment flags (plugins may
+provide more):
+
+- TRUE       - always defined
+- HERCULES   - always defined
+- FALSE      - never defined
+- RENEWAL    - only defined when compiled in renewal mode
+- PRERENEWAL - only defined when compiled in pre-renewal mode
+
+Note: conditional comments cannot be nested.
+
 ~ RID? GID? ~
 
 What a RID is and why do you need to know

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -418,11 +418,12 @@ parsed.
 The Hercules core provides the following conditional comment flags (plugins may
 provide more):
 
-- TRUE       - always defined
-- HERCULES   - always defined
-- FALSE      - never defined
-- RENEWAL    - only defined when compiled in renewal mode
-- PRERENEWAL - only defined when compiled in pre-renewal mode
+- TRUE          - always defined
+- HERCULES      - always defined
+- FALSE         - never defined
+- RENEWAL       - only defined when compiled in renewal mode
+- PRERENEWAL    - only defined when compiled in pre-renewal mode
+- LOADGMSCRIPTS - only defined when script_configuration.load_gm_scripts is true
 
 Note: conditional comments cannot be nested.
 

--- a/npc/battleground/bg_common.txt
+++ b/npc/battleground/bg_common.txt
@@ -336,6 +336,7 @@ bat_room,138,144,4	script	Repairman#bg	4_M_04,{
 	end;
 }
 
+/*@LOADGMSCRIPTS
 //== GM Management NPC =====================================
 bat_room,1,151,3	script	Switch#batgnd	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
@@ -384,7 +385,11 @@ bat_room,1,151,3	script	Switch#batgnd	4_DOG01,{
 		mes("Complete");
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Badges Exchange =======================================
 bat_room,160,150,3	script	Erundek	4_M_MANAGER,{

--- a/npc/battleground/flavius/flavius01.txt
+++ b/npc/battleground/flavius/flavius01.txt
@@ -744,6 +744,7 @@ OnInit:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 bat_b01,1,10,3	script	Release all#b01	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
 	if (.@i == -1) {
@@ -765,4 +766,8 @@ bat_b01,1,10,3	script	Release all#b01	4_DOG01,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/battleground/flavius/flavius02.txt
+++ b/npc/battleground/flavius/flavius02.txt
@@ -744,6 +744,7 @@ OnInit:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 bat_b02,1,10,3	script	Release all#b02	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
 	if (.@i == -1) {
@@ -765,4 +766,8 @@ bat_b02,1,10,3	script	Release all#b02	4_DOG01,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/battleground/tierra/tierra01.txt
+++ b/npc/battleground/tierra/tierra01.txt
@@ -937,6 +937,7 @@ bat_a01,356,326,3	script	Guillaume Camp Soldier#bat_a01_guide	4_M_RASWORD,{
 }
 */
 
+/*@LOADGMSCRIPTS
 bat_a01,1,1,3	script	Release all#a01	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
 	if (.@i == -1) {
@@ -958,4 +959,8 @@ bat_a01,1,1,3	script	Release all#a01	4_DOG01,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/battleground/tierra/tierra02.txt
+++ b/npc/battleground/tierra/tierra02.txt
@@ -937,6 +937,7 @@ bat_a02,356,326,3	script	Guillaume Camp Soldier#bat_a02_guide	4_M_RASWORD,{
 }
 */
 
+/*@LOADGMSCRIPTS
 bat_a02,1,1,3	script	Release all#a02	4_DOG01,{
 	.@i = callfunc("F_GM_NPC",1854,0);
 	if (.@i == -1) {
@@ -958,4 +959,8 @@ bat_a02,1,1,3	script	Release all#a02	4_DOG01,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/dev/test.txt
+++ b/npc/dev/test.txt
@@ -810,6 +810,26 @@ function	script	HerculesSelfTestHelper	{
 	callsub(OnCheckStr, "sprintf (Two args)",   sprintf("'%+05d' '%x'", 5, 0x7f), "'+0005' '7f'");
 	callsub(OnCheckStr, "sprintf (positional)", sprintf("'%2$+05d'", 5, 6), "'+0006'");
 	callsub(OnCheckStr, "sprintf (positional)", sprintf("'%2$s' '%1$c'", "First", "Second"), "'Second' 'F'");
+	.@x = 0;
+	/*@TRUE
+	.@x = 1;
+	//@*/
+	callsub(OnCheck, "Conditional comment (TRUE)", .@x, 1);
+	.@x = 0;
+	/*@!TRUE
+	.@x = 1;
+	//@*/
+	callsub(OnCheck, "Conditional comment (!TRUE)", .@x, 0);
+	.@x = 0;
+	/*@TRUE*/
+	.@x = 1;
+	//@*/
+	callsub(OnCheck, "Conditional comment with fallback (TRUE)", .@x, 1);
+	.@x = 0;
+	/*@!TRUE*/
+	.@x = 1;
+	//@*/
+	callsub(OnCheck, "Conditional comment with fallback (!TRUE)", .@x, 0);
 
 	callsub(OnCheck, "Getdatatype (integer)",              getdatatype(5), DATATYPE_INT);
 	callsub(OnCheck, "Getdatatype (constant string)",      getdatatype("foo"), DATATYPE_STR | DATATYPE_CONST);

--- a/npc/events/gdevent_aru.txt
+++ b/npc/events/gdevent_aru.txt
@@ -1524,6 +1524,7 @@ arug_que01,114,105,3	duplicate(GD_Ev_Flower)	#aru_flower_53	4_YELL_FLOWER
 arug_que01,109,105,3	duplicate(GD_Ev_Flower)	#aru_flower_54	4_RED_FLOWER
 arug_que01,104,105,3	duplicate(GD_Ev_Flower)	#aru_flower_55	4_BLUE_FLOWER
 
+/*@LOADGMSCRIPTS
 arug_dun01,5,5,1	script	Event controller#aru_gd	4_DOG01,{
 	if (callfunc("F_GM_NPC",1854,0) < 1) {
 		mes "Incorrect password.";
@@ -1546,4 +1547,8 @@ arug_dun01,5,5,1	script	Event controller#aru_gd	4_DOG01,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/events/gdevent_sch.txt
+++ b/npc/events/gdevent_sch.txt
@@ -1521,6 +1521,7 @@ schg_que01,114,105,3	duplicate(GD_Ev_Flower2)	#sch_flower_53	4_YELL_FLOWER
 schg_que01,109,105,3	duplicate(GD_Ev_Flower2)	#sch_flower_54	4_RED_FLOWER
 schg_que01,104,105,3	duplicate(GD_Ev_Flower2)	#sch_flower_55	4_BLUE_FLOWER
 
+/*@LOADGMSCRIPTS
 schg_dun01,5,5,1	script	Event controller#sch_gd	4_DOG01,{
 	if (callfunc("F_GM_NPC",1854,0) < 1) {
 		mes "Incorrect password.";
@@ -1543,4 +1544,8 @@ schg_dun01,5,5,1	script	Event controller#sch_gd	4_DOG01,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/events/god_se_festival.txt
+++ b/npc/events/god_se_festival.txt
@@ -34,6 +34,7 @@
 //= 1.1
 //=========================================================================
 
+/*@LOADGMSCRIPTS
 // Original name: "Festival Manager#god_se_fes00"
 yuno,1,1,0	script	Festival Manager#gq_fes0	4_F_HUGIRL,{
 	callfunc "F_GM_NPC";
@@ -63,7 +64,11 @@ yuno,1,1,0	script	Festival Manager#gq_fes0	4_F_HUGIRL,{
 		donpcevent "Rmimi Ravies#gq_fes01::OnEnable";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 yuno,118,192,5	script	Rmimi Ravies#gq_fes01	4_F_HUGIRL,{
 	.@GID = getcharid(CHAR_ID_GUILD);
@@ -410,6 +415,7 @@ OnTimer3900000:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 // Original name: "Festival Manager#god_se_fes02"
 rachel,1,1,0	script	Festival Manager#gq_fes2	4_F_HUGIRL,{
 	callfunc "F_GM_NPC";
@@ -439,7 +445,11 @@ rachel,1,1,0	script	Festival Manager#gq_fes2	4_F_HUGIRL,{
 		donpcevent "Rhehe Ravies#gq_fes03::OnEnable";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 rachel,132,117,3	script	Rhehe Ravies#gq_fes03	4_F_HUGIRL,{
 	.@GID = getcharid(CHAR_ID_GUILD);

--- a/npc/instances/EndlessTower.txt
+++ b/npc/instances/EndlessTower.txt
@@ -327,6 +327,7 @@ OnTouch:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 // Original name: "#102Administrator Mode104"
 e_tower,1,1,2	script	#102Administrator Mode	CLEAR_NPC,{
 	callfunc("F_GM_NPC");
@@ -352,7 +353,11 @@ e_tower,1,1,2	script	#102Administrator Mode	CLEAR_NPC,{
 		mes("Enter the password exactly.");
 		close();
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 e_tower,69,117,4	script	Purification Stone#et1	2_MONEMUS,{
 	etower_timer = 0;
@@ -385,6 +390,7 @@ OnTimer1800000:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 e_tower,151,185,4	script	Purification Stone#et2	CLEAR_NPC,{
 	callfunc("F_GM_NPC");
 	etower_timer = 0;
@@ -392,7 +398,10 @@ e_tower,151,185,4	script	Purification Stone#et2	CLEAR_NPC,{
 	close2();
 	warp("e_tower", 75, 108);
 	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Core Functions ========================================
 function	script	F_Tower_Monster	{
@@ -1291,6 +1300,7 @@ OnTimer120000:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 1@tower,71,1,0	script	#Manager Mode1	CLEAR_NPC,{
 	callfunc("F_GM_NPC");
 	mes("Please enter the password.");
@@ -1310,7 +1320,10 @@ OnTimer120000:
 		}
 	}
 	close();
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Levels 26-50 ==========================================
 2@tower,29,365,2	script	Immortal Furnace#1	CLEAR_NPC,{
@@ -1403,6 +1416,7 @@ OnTouch_:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 2@tower,71,1,0	script	#Manager Mode2	CLEAR_NPC,{
 	callfunc("F_GM_NPC");
 	mes("Please enter the password.");
@@ -1422,7 +1436,10 @@ OnTouch_:
 		}
 	}
 	close();
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Levels 51-75 ==========================================
 3@tower,29,365,2	script	Immortal Furnace#2	CLEAR_NPC,{
@@ -1515,6 +1532,7 @@ OnTouch_:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 3@tower,71,1,0	script	#Manager Mode3	CLEAR_NPC,{
 	callfunc("F_GM_NPC");
 	mes("Please enter the password.");
@@ -1534,7 +1552,10 @@ OnTouch_:
 		}
 	}
 	close();
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Levels 76-99 ==========================================
 4@tower,29,365,2	script	Immortal Furnace#3	CLEAR_NPC,{
@@ -1626,6 +1647,7 @@ OnTouch_:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 4@tower,71,1,0	script	#Manager Mode4	CLEAR_NPC,{
 	callfunc("F_GM_NPC");
 	mes("Please enter the password.");
@@ -1645,7 +1667,10 @@ OnTouch_:
 		}
 	}
 	close();
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Level 100 =============================================
 5@tower,106,109,2	script	Lucid Crystal#102	CLEAR_NPC,{
@@ -1828,6 +1853,7 @@ OnEnable:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 5@tower,71,1,0	script	#Manager Mode5	CLEAR_NPC,{
 	callfunc("F_GM_NPC");
 	mes("This NPC manages the crystal on the 100th Level. Please enter the password.");
@@ -1839,7 +1865,10 @@ OnEnable:
 	} else
 		mes("Please enter the correct password.");
 	close();
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Level 101 =============================================
 6@tower,45,89,2	script	Life Spring#1	CLEAR_NPC,{

--- a/npc/instances/NydhoggsNest.txt
+++ b/npc/instances/NydhoggsNest.txt
@@ -2203,6 +2203,7 @@ OnMyPingDead:
 }
 
 //== GM Management NPCs ====================================
+/*@LOADGMSCRIPTS
 sec_in02,36,167,3	script	Nidhoggur Manager	4_M_FAIRYSOLDIER,1,1,{
 	callfunc("F_GM_NPC");
 	mes("Enter the password.");
@@ -2249,8 +2250,13 @@ sec_in02,36,167,3	script	Nidhoggur Manager	4_M_FAIRYSOLDIER,1,1,{
 		mesf("ins_nyd2 is at %d.", ins_nyd2);
 		close();
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
+/*@LOADGMSCRIPTS
 nyd_dun02,7,7,2	script	Purification Admin#nyd2	CLEAR_NPC,2,0,{
 	callfunc("F_GM_NPC");
 	mes("Please enter the password");
@@ -2280,7 +2286,11 @@ nyd_dun02,7,7,2	script	Purification Admin#nyd2	CLEAR_NPC,2,0,{
 	case 5:
 		close();
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 nyd_dun02,88,195,4	script	Purification Stone#nyd2	2_MONEMUS,{
 	erasequest(3135);

--- a/npc/jobs/2-2e/SoulLinker.txt
+++ b/npc/jobs/2-2e/SoulLinker.txt
@@ -681,6 +681,7 @@ OnTimer183000:
 	stopnpctimer;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,35,153,0	script	Soul Linker Var	4_M_OPERATION,{
 	callfunc "F_GM_NPC";
 	mes "[Soul Linker Var]";
@@ -716,4 +717,8 @@ sec_in02,35,153,0	script	Soul Linker Var	4_M_OPERATION,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/kafras/dts_warper.txt
+++ b/npc/kafras/dts_warper.txt
@@ -1168,7 +1168,7 @@ OnTimer15000:
 	end;
 }
 
-/*
+/*@LOADGMSCRIPTS
 // GM only NPC used for modifying values related to the DTS system.
 // Disabled in official script.
 sec_in02,17,160,4	script	Vote Globalvar Girl#yuno	4_F_OPERATION,{
@@ -1325,5 +1325,8 @@ sec_in02,17,160,4	script	Vote Globalvar Girl#yuno	4_F_OPERATION,{
 		mes "Lady Christy...";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
-*/
+//@*/

--- a/npc/other/arena/arena_aco.txt
+++ b/npc/other/arena/arena_aco.txt
@@ -1727,6 +1727,7 @@ arena_room,140,136,3	script	Guide Alias	4_F_NOVICE,{
 	close;
 }
 
+/*@LOADGMSCRIPTS
 arena_room,195,5,3	script	log-on-aco#arena	4_NFWISP,{
 	.@i = callfunc("F_GM_NPC",1357,0);
 	if (.@i == -1) {
@@ -1769,8 +1770,13 @@ arena_room,195,5,3	script	log-on-aco#arena	4_NFWISP,{
 		}
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
+/*@LOADGMSCRIPTS
 arena_room,195,10,3	script	acolink#arena	4_NFWISP,{
 	.@i = callfunc("F_GM_NPC",1357,0);
 	if (.@i == -1) {
@@ -1803,4 +1809,8 @@ arena_room,195,10,3	script	acolink#arena	4_NFWISP,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/other/arena/arena_room.txt
+++ b/npc/other/arena/arena_room.txt
@@ -410,6 +410,7 @@ arena_room,158,82,1	script	Helper Lonik	4_M_ROGUE,{
 	close;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,72,180,3	script	Arena Manager#arena	4_NFWISP,{
 	.@i = callfunc("F_GM_NPC",1357,0);
 	if (.@i == -1) {
@@ -530,8 +531,13 @@ sec_in02,72,180,3	script	Arena Manager#arena	4_NFWISP,{
 			}
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
+/*@LOADGMSCRIPTS
 sec_in02,79,171,3	script	Reward Manager#arena	4_NFWISP,{
 	.@i = callfunc("F_GM_NPC",1357,0);
 	if (.@i == -1) {
@@ -563,7 +569,11 @@ sec_in02,79,171,3	script	Reward Manager#arena	4_NFWISP,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 arena_room,105,93,5	script	Teleporter#arena	1_M_JOBTESTER,{
 	mes "[Teleporter]";
@@ -965,6 +975,7 @@ OnTimer62000:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,72,171,3	script	Picture Manager#arena	4_NFWISP,{
 	.@i = callfunc("F_GM_NPC",1357,0);
 	if (.@i == -1) {
@@ -991,8 +1002,13 @@ sec_in02,72,171,3	script	Picture Manager#arena	4_NFWISP,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
+/*@LOADGMSCRIPTS
 sec_in02,76,176,5	script	Live Broadcast#arena	4_NFWISP,{
 	callfunc "F_GM_NPC";
 	mes "[Live Broadcast]";
@@ -1003,7 +1019,11 @@ sec_in02,76,176,5	script	Live Broadcast#arena	4_NFWISP,{
 	mes "Currently there are "+getmapusers("force_1-2")+" people in party map.";
 	mes "Currently there are "+getmapusers("arena_room")+" people in the waiting room.";
 	close;
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 function	script	Func_Are_Rew	{
 	mes "[Givu]";

--- a/npc/other/marriage.txt
+++ b/npc/other/marriage.txt
@@ -822,6 +822,7 @@ OnTimer180000:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 prt_church,28,178,4	script	The King of Midgart	1_M_PRON_KING,{
 	callfunc "F_GM_NPC";
 	mes "[Vomars]";
@@ -865,8 +866,13 @@ prt_church,28,178,4	script	The King of Midgart	1_M_PRON_KING,{
 		mes "to proceed with weddings.";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
+/*@LOADGMSCRIPTS
 prt_church,20,179,4	script	Divorce Staff	1_F_LIBRARYGIRL,{
 	callfunc "F_GM_NPC";
 	mes "[Bad Ending]";
@@ -912,8 +918,13 @@ prt_church,20,179,4	script	Divorce Staff	1_F_LIBRARYGIRL,{
 		mes "a problem, you come to me.";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
+/*@LOADGMSCRIPTS
 prt_church,22,179,4	script	Remarry Staff	1_F_LIBRARYGIRL,{
 	callfunc "F_GM_NPC";
 	mes "[Wedding Again]";
@@ -970,4 +981,8 @@ prt_church,22,179,4	script	Remarry Staff	1_F_LIBRARYGIRL,{
 		mes "to need a new one, okay?";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/other/monster_race.txt
+++ b/npc/other/monster_race.txt
@@ -3008,6 +3008,7 @@ p_track01,45,42,3	script	Absent Minded Man#single	4_M_SITDOWN,{
 	close;
 }
 
+/*@LOADGMSCRIPTS
 hugel,5,5,3	script	Monster Race Manager	4_M_LGTGUARD,{
 	callfunc "F_GM_NPC";
 	mes "[Monster Race Manager]";
@@ -3059,4 +3060,7 @@ hugel,5,5,3	script	Monster Race Manager	4_M_LGTGUARD,{
 		close;
 	}
 	close;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/quests/dandelion_request.txt
+++ b/npc/quests/dandelion_request.txt
@@ -10229,6 +10229,7 @@ que_job01,68,88,5	script	Simon#mao	4_M_SITDOWN,{
 
 que_job01,70,84,1	duplicate(Simon#mao)	Kimmie	4_F_SITDOWN,0,0
 
+/*@LOADGMSCRIPTS
 sec_in02,38,162,0	script	Morroc Invasion Manager	4_F_SITDOWN,{
 	callfunc "F_GM_NPC";
 	mes "A total of " + $maoattack + " users completed";
@@ -10285,4 +10286,8 @@ sec_in02,38,162,0	script	Morroc Invasion Manager	4_F_SITDOWN,{
 			mes "You have canceled.";
 			close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/quests/first_class/tu_acolyte.txt
+++ b/npc/quests/first_class/tu_acolyte.txt
@@ -1781,6 +1781,7 @@ prt_monk,223,123,3	script	Eavesdrop#tu	HIDDEN_NPC,{
 	}
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,17,156,3	script	1st Job Quest Reset	4_F_JOB_BLACKSMITH,{
 	callfunc "F_GM_NPC";
 	mes "[1st Job Quest]";
@@ -1809,4 +1810,7 @@ sec_in02,17,156,3	script	1st Job Quest Reset	4_F_JOB_BLACKSMITH,{
 	}
 	mes "Completed.";
 	close;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/quests/quests_13_1.txt
+++ b/npc/quests/quests_13_1.txt
@@ -1938,6 +1938,7 @@ moc_ruins,137,89,5	script	Time-Space Gap Guard	4_M_MOC_SOLDIER,{
 	close;
 }
 
+/*@LOADGMSCRIPTS
 moc_fild22b,370,370,3	script	Allied Manager#gm	4W_SAILOR,{
 	callfunc "F_GM_NPC";
 	mes "[Manager]";
@@ -1973,7 +1974,11 @@ moc_fild22b,370,370,3	script	Allied Manager#gm	4W_SAILOR,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== New Surroundings :: ep13_newbs ========================
 mid_camp,222,283,4	script	Marian#ep13bs	4_F_JOB_HUNTER,{
@@ -6956,6 +6961,7 @@ OnTimer300000:
 }
 
 //== Part Time Work :: ep13_alba ===========================
+/*@LOADGMSCRIPTS
 mid_camp,1,1,0	script	#timer_alba01	CLEAR_NPC,{
 	callfunc "F_GM_NPC";
 	mes "Please enter the password";
@@ -6995,6 +7001,12 @@ mid_camp,1,1,0	script	#timer_alba01	CLEAR_NPC,{
 	}
 
 OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
+//@*/
+/*@!LOADGMSCRIPTS*/
+-	script	#timer_alba01	FAKE_NPC,{
+OnInit:
+//@*/
 	$@PartTimeOn = 0;
 	$@PartTimeSlots = 0;
 OnEnable:
@@ -8471,6 +8483,7 @@ man_fild03,104,248,0	duplicate(manukrock)	Mysterious Rock#16	CLEAR_NPC
 man_fild03,91,272,0	duplicate(manukrock)	Mysterious Rock#17	CLEAR_NPC
 man_fild03,95,301,0	duplicate(manukrock)	Mysterious Rock#18	CLEAR_NPC
 
+/*@LOADGMSCRIPTS
 sec_in02,80,171,0	script	Piece of crack#sec	2_MONEMUS,{
 	callfunc "F_GM_NPC";
 	mes "1~3000";
@@ -8483,7 +8496,10 @@ sec_in02,80,171,0	script	Piece of crack#sec	2_MONEMUS,{
 	}
 	ep13_yong1 = .@input;
 	close;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Report from the New World :: ep13_1_edq ===============
 mid_campin,90,121,5	script	Hibba Agip	4_M_REDSWORD,{

--- a/npc/quests/quests_13_2.txt
+++ b/npc/quests/quests_13_2.txt
@@ -4567,6 +4567,7 @@ OnTimer300000:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 mid_camp,7,3,0	script	Translator Preparation#1	4_M_PAY_SOLDIER,{
 	callfunc "F_GM_NPC";
 	mes "[EP13 Translator Quest Preparation]";
@@ -4624,7 +4625,11 @@ mid_camp,7,3,0	script	Translator Preparation#1	4_M_PAY_SOLDIER,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Daily Quests :: ep13_2_tre ============================
 // - Midgard Ore
@@ -7274,6 +7279,7 @@ OnTouch:
 nyd_dun01,255,142,0	warp	nynm_dun1f_to_2f	1,1,nyd_dun02,61,265
 nyd_dun02,56,264,0	warp	nynm_dun2f_to_1f	1,1,nyd_dun01,249,143
 
+/*@LOADGMSCRIPTS
 nyd_dun02,1,1,0	script	ep13_nd2f_mng	CLEAR_NPC,{
 	callfunc "F_GM_NPC";
 	mes "Enter password.";
@@ -7295,7 +7301,15 @@ nyd_dun02,1,1,0	script	ep13_nd2f_mng	CLEAR_NPC,{
 		mes "Invalid.";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
+	end;
+//@*/
 
+/*@!LOADGMSCRIPTS*/
+-	script	ep13_nd2f_mng	FAKE_NPC,{
+//@*/
 OnReset:
 	donpcevent "ep13_warp_s1::OnEnable";
 	donpcevent "ep13_warp_s3::OnEnable";

--- a/npc/quests/quests_ein.txt
+++ b/npc/quests/quests_ein.txt
@@ -2683,6 +2683,7 @@ ein_in01,95,239,3	script	Conveyor#ins2	HIDDEN_NPC,{
 	end;
 }
 
+/*@LOADGMSCRIPTS
 //- Administrator NPC used to rig the invasion in Einbroch. -
 sec_in02,127,86,3	script	Factory Quest Test	4_M_REPAIR,{
 	.@i = callfunc("F_GM_NPC",8028,0,0,9000);
@@ -2729,7 +2730,11 @@ sec_in02,127,86,3	script	Factory Quest Test	4_M_REPAIR,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Murder Quest :: ein_main_tre ==========================
 einbech,165,105,7	script	Buender Hikeman#ein	4_M_EINOLD,{

--- a/npc/quests/quests_juperos.txt
+++ b/npc/quests/quests_juperos.txt
@@ -4945,6 +4945,7 @@ OnTouch:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 //== GM Management NPC =====================================
 sec_in02,39,167,0	script	Juperos Manager	4_F_OPERATION,{
 	callfunc "F_GM_NPC";
@@ -5007,4 +5008,8 @@ sec_in02,39,167,0	script	Juperos Manager	4_F_OPERATION,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/quests/quests_lighthalzen.txt
+++ b/npc/quests/quests_lighthalzen.txt
@@ -10308,6 +10308,7 @@ lhz_dun02,282,278,0	script	Broken Machine	HIDDEN_NPC,{
 	}
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,17,170,4	script	boss::lght_boss_admin	1_M_SIGNMONK,{
 	callfunc "F_GM_NPC";
 	mes "[Patch]";
@@ -10327,7 +10328,11 @@ sec_in02,17,170,4	script	boss::lght_boss_admin	1_M_SIGNMONK,{
 	mes " ";
 	mes ""+lght_boss;
 	close;
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 lhz_in02,19,274,2	script	Maintenance Guy	4_M_REPAIR,{
 
@@ -12003,6 +12008,7 @@ OnTouch:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 airplane_01,10,10,3	script	#LyozienSwitch	HIDDEN_NPC,{
 	callfunc "F_GM_NPC";
 	mes "[Lyozien Switch]";
@@ -12043,4 +12049,8 @@ airplane_01,10,10,3	script	#LyozienSwitch	HIDDEN_NPC,{
 		mes "/mm airplane_01.gat 96 48";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/quests/quests_morocc.txt
+++ b/npc/quests/quests_morocc.txt
@@ -2004,6 +2004,7 @@ OnTimer5415000:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,14,43,5	script	Morroc GlobalVar Admin::MorrocAdmin_sec	4_F_RUSGREEN,{
 	callfunc "F_GM_NPC";
 	mes "[Helper]";
@@ -2079,8 +2080,13 @@ sec_in02,14,43,5	script	Morroc GlobalVar Admin::MorrocAdmin_sec	4_F_RUSGREEN,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+
 moc_fild21,5,5,5	duplicate(MorrocAdmin_sec)	Morroc GlobalVar Admin::MorrocAdmin_moc	4_F_RUSGREEN
+//@*/
 
 //== The Crow of the Fate ==================================
 moc_ruins,137,70,3	script	Book-Touching Man#garas	1_M_02,{

--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -11897,6 +11897,7 @@ pay_dun04,163,186,0	script	Ghost Tree#rus45	HIDDEN_NPC,{
 	end;
 }
 
+/*@LOADGMSCRIPTS
 mosk_dun01,3,3,3	script	Koshei GlobalVar#admin	4_F_RUSCHILD,{
 	callfunc "F_GM_NPC";
 	mes "[Koshei GlobalVar]";
@@ -11948,4 +11949,8 @@ mosk_dun01,3,3,3	script	Koshei GlobalVar#admin	4_F_RUSCHILD,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/quests/quests_nameless.txt
+++ b/npc/quests/quests_nameless.txt
@@ -1483,6 +1483,7 @@ OnTouch:
 	}
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,15,15,4	script	boss::boss_aru_monas	1_M_SIGNMONK,{
 	callfunc "F_GM_NPC";
 	mes "[Patch]";
@@ -1512,7 +1513,11 @@ sec_in02,15,15,4	script	boss::boss_aru_monas	1_M_SIGNMONK,{
 		lost_boy = 0;
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Rachel Addition :: aruna_nir ==========================
 ra_temple,165,57,5	script	Niren#ss	4_F_MADAME,{

--- a/npc/quests/quests_veins.txt
+++ b/npc/quests/quests_veins.txt
@@ -2648,6 +2648,7 @@ comodo,135,299,0	script	Young Man#sch2	1_M_SIGNMONK,{
 	}
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,10,43,4	script	Extra Story Patch	1_M_SIGNMONK,{
 	callfunc "F_GM_NPC";
 	mes "[Patch]";
@@ -2660,7 +2661,10 @@ sec_in02,10,43,4	script	Extra Story Patch	1_M_SIGNMONK,{
 	mes " ";
 	mes ""+que_sch;
 	close;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Siblings Quest :: veins_camel =========================
 veins,327,185,3	script	Kid#camelcamel	4_M_DST_CHILD,{

--- a/npc/quests/seals/god_global.txt
+++ b/npc/quests/seals/god_global.txt
@@ -34,6 +34,7 @@
 //= 1.2
 //=========================================================================
 
+/*@LOADGMSCRIPTS
 sec_in02,15,170,0	script	Golbal var	4_F_CHNDRESS3,{
 	callfunc "F_GM_NPC";
 	mes "[Check]";
@@ -120,6 +121,12 @@ L_Var:
 	close;
 
 OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
+//@*/
+/*@!LOADGMSCRIPTS*/
+-	script	Golbal var	FAKE_NPC,{
+OnInit:
+//@*/
 	// Seals roll at 25/50 in Renewal and 50/100 in Pre-Renewal.
 	if (RENEWAL) {
 		$@god_check1 = 25;

--- a/npc/quests/seals/god_weapon_creation.txt
+++ b/npc/quests/seals/god_weapon_creation.txt
@@ -816,6 +816,7 @@ OnTimer615000:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 // Original name: "Godly Item Quests Related#god"
 que_god01,293,3,0	script	Godly Item Quests#god	4_F_01,{
 	callfunc "F_GM_NPC";
@@ -857,4 +858,8 @@ que_god01,293,3,0	script	Godly Item Quests#god	4_F_01,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/re/instances/BakonawaLake.txt
+++ b/npc/re/instances/BakonawaLake.txt
@@ -121,6 +121,7 @@ ma_scene01,174,179,4	script	Taho	4_M_DEWZATIMAN,{
 	}
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,26,26,4	script	Bakonawa's Rage	4_M_DEWZATIMAN,{
 	callfunc("F_GM_NPC");
 	mes("[Taho]");
@@ -132,7 +133,10 @@ sec_in02,26,26,4	script	Bakonawa's Rage	4_M_DEWZATIMAN,{
 		malaya_bakona2 = 15;
 	}
 	close();
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 1@ma_b,62,52,4	script	Taho#nf	4_M_DEWZATIMAN,{
 	mes("[Taho]");

--- a/npc/re/instances/BangungotHospital.txt
+++ b/npc/re/instances/BangungotHospital.txt
@@ -350,6 +350,7 @@ L_Complete:
 	return;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,27,30,0	script	Bangungot Gate	2_MONEMUS,{
 	callfunc "F_GM_NPC";
 	mes "Password";
@@ -371,7 +372,11 @@ sec_in02,27,30,0	script	Bangungot Gate	2_MONEMUS,{
 		case 10: completequest 11309; close;
 		case 11: close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Instance Scripts ======================================
 1@ma_h,43,157,0	script	#Memorial Start	HIDDEN_WARP_NPC,2,2,{

--- a/npc/re/jobs/2e/kagerou_oboro.txt
+++ b/npc/re/jobs/2e/kagerou_oboro.txt
@@ -2740,6 +2740,7 @@ OnMyMobDead:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 //== GM Control Panel ======================================
 job_ko,3,1,4	script	Battle Test Control#ko	4_M_KAGE_OLD,{
 	callfunc "F_GM_NPC";
@@ -2771,8 +2772,12 @@ job_ko,3,1,4	script	Battle Test Control#ko	4_M_KAGE_OLD,{
 	next;
 	mes "Control has completed.";
 	close;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
+/*@LOADGMSCRIPTS
 job_ko,4,1,4	script	Guide#ko_helper	4_M_KAGE_OLD,{
 	callfunc "F_GM_NPC";
 	if (callfunc("F_GM_NPC",1854,0) == 1) {
@@ -2864,4 +2869,7 @@ job_ko,4,1,4	script	Guide#ko_helper	4_M_KAGE_OLD,{
 		close;
 	}
 	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/re/jobs/3-1/archbishop.txt
+++ b/npc/re/jobs/3-1/archbishop.txt
@@ -1655,6 +1655,7 @@ OnTouch:
 }
 */
 
+/*@LOADGMSCRIPTS
 job3_arch01,1,1,1	script	control#arch	CLEAR_NPC,{
 	callfunc "F_GM_NPC";
 	mes "[Troll]";
@@ -1681,7 +1682,11 @@ job3_arch01,1,1,1	script	control#arch	CLEAR_NPC,{
 		mes "Enter the correct password!";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 odin_tem02,30,181,0	script	#wherearch01	HIDDEN_WARP_NPC,10,10,{
 OnTouch:

--- a/npc/re/jobs/3-1/guillotine_cross.txt
+++ b/npc/re/jobs/3-1/guillotine_cross.txt
@@ -3876,6 +3876,7 @@ OnTouch:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 job3_guil02,1,3,0	script	#GMhelper01_gc	CLEAR_NPC,{
 	callfunc "F_GM_NPC";
 	mes "What can I do for you?";
@@ -3913,8 +3914,13 @@ job3_guil02,1,3,0	script	#GMhelper01_gc	CLEAR_NPC,{
 		mes "-_-.";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
+/*@LOADGMSCRIPTS
 job3_guil03,1,8,0	script	#GMhelper02_gc	CLEAR_NPC,{
 	callfunc "F_GM_NPC";
 	mes "What can I do for you?";
@@ -3984,4 +3990,8 @@ job3_guil03,1,8,0	script	#GMhelper02_gc	CLEAR_NPC,{
 		mes "-_-.";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/re/jobs/3-1/ranger.txt
+++ b/npc/re/jobs/3-1/ranger.txt
@@ -1773,6 +1773,7 @@ job3_rang01,90,43,3	script	Ranger Master#jr_29	4_M_REIDIN_KURS,{
 	}
 }
 
+/*@LOADGMSCRIPTS
 job3_rang01,58,1,0	script	Worker#job_ranger	4_M_ORIENT01,{
 	callfunc "F_GM_NPC";
 	switch(select("Enable Waiting Room", "Disable Waiting Room", "Enable 1st Test", "Disable 1st Test", "Enable 2nd Test", "Disable 2nd Test", "Enable 3rd Test", "Disable 3rd Test", "Cancel")) {
@@ -1818,4 +1819,8 @@ job3_rang01,58,1,0	script	Worker#job_ranger	4_M_ORIENT01,{
 	case 9:
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/re/jobs/3-1/rune_knight.txt
+++ b/npc/re/jobs/3-1/rune_knight.txt
@@ -2152,6 +2152,7 @@ OnMyMobDead:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,34,167,3	script	R.Knight Job Manager	4_M_KNIGHT_SILVER,1,1,{
 	callfunc "F_GM_NPC";
 	mes "Enter the Password.";
@@ -2171,5 +2172,9 @@ sec_in02,34,167,3	script	R.Knight Job Manager	4_M_KNIGHT_SILVER,1,1,{
 		}
 	}
 	close;
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
 job3_rune01,1,1,3	duplicate(R.Knight Job Manager)	#renshucheck	CLEAR_NPC
+//@*/

--- a/npc/re/jobs/3-1/warlock.txt
+++ b/npc/re/jobs/3-1/warlock.txt
@@ -1070,6 +1070,7 @@ OnTimer6000:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 job3_war01,1,2,0	script	Button Girl#wl	1_F_01,{
 	callfunc "F_GM_NPC";
 	switch(select("Open Arena", "Close Arena", "Open the Chamber of Magic", "Close the Chamber of Magic", "Hollow Stone On", "Hollow Stone Off", "Cancel")) {
@@ -1106,7 +1107,11 @@ job3_war01,1,2,0	script	Button Girl#wl	1_F_01,{
 	case 7:
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 spl_fild02,0,0,0,0	monster	Bradium Golem	2049,20,5000,0,0
 spl_fild02,0,0,0,0	monster	Naga	2047,20,5000,0,0

--- a/npc/re/jobs/3-2/royal_guard.txt
+++ b/npc/re/jobs/3-2/royal_guard.txt
@@ -516,6 +516,7 @@ OnTouch:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,12,43,3	script	sorcereryal	1_M_LIBRARYMASTER,1,1,{
 	callfunc "F_GM_NPC";
 	switch(select("Royal Guard", "Rune Knight", "Sorcerer")) {
@@ -556,4 +557,8 @@ sec_in02,12,43,3	script	sorcereryal	1_M_LIBRARYMASTER,1,1,{
 		}
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/re/jobs/3-2/sura.txt
+++ b/npc/re/jobs/3-2/sura.txt
@@ -850,6 +850,7 @@ sword_1-1,223,167,2	script	Master#job_shu	4_M_SURA,{
 	end;
 }
 
+/*@LOADGMSCRIPTS
 sword_2-1,1,2,0	script	Button Girl#sura	1_F_01,{
 	callfunc "F_GM_NPC";
 	switch(select("Turn on arena.", "Turn off arena.", "Turn on the living room.", "Turn on Buddy.", "Turn on Gara.", "Turn off all.", "Close")) {
@@ -884,4 +885,8 @@ sword_2-1,1,2,0	script	Button Girl#sura	1_F_01,{
 	case 7:
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/re/jobs/repair.txt
+++ b/npc/re/jobs/repair.txt
@@ -254,6 +254,7 @@ in_rogue,376,104,4	duplicate(Valerie#sign)	Valerie#sc	2_BULLETIN_BOARD
 ve_in,244,122,4	duplicate(Valerie#sign)	Valerie#shu	2_BULLETIN_BOARD
 xmas,166,209,4	duplicate(Valerie#sign)	Valerie#wan	2_BULLETIN_BOARD
 
+/*@LOADGMSCRIPTS
 sec_in02,12,40,5	script	Job Repair	1_M_LIBRARYMASTER,1,1,{
 	callfunc "F_GM_NPC";
 	mes "Please input your password.";
@@ -288,4 +289,7 @@ sec_in02,12,40,5	script	Job Repair	1_M_LIBRARYMASTER,1,1,{
 		ADVJOB = 15;
 	}
 	close;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/re/quests/eden/eden_quests.txt
+++ b/npc/re/quests/eden/eden_quests.txt
@@ -4292,6 +4292,7 @@ moc_para01,112,79,3	script	Weapons Expert BK#2nd11	4_M_REPAIR,{
 	close;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,25,33,4	script	Assistant#para_suvquest	4_M_BABYCAT,{
 	callfunc "F_GM_NPC";
 	mes "Password";
@@ -4310,4 +4311,8 @@ sec_in02,25,33,4	script	Assistant#para_suvquest	4_M_BABYCAT,{
 		mes "......meow wee.";
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/npc/re/quests/quests_dicastes.txt
+++ b/npc/re/quests/quests_dicastes.txt
@@ -188,6 +188,7 @@ dic_dun01,266,113,5	script	Curious Sapha#ep13_3_	4_MAN_BENKUNI,{
 	}
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,16,43,5	script	Scaraba Dungeon Entrance	4_MAN_BENKUNI,{
 	callfunc "F_GM_NPC";
 	mes "Setting you for dungeon entry.";
@@ -200,7 +201,10 @@ sec_in02,16,43,5	script	Scaraba Dungeon Entrance	4_MAN_BENKUNI,{
 	} else
 		mes "Wrong Password";
 	close;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Vigilantes ============================================
 -	script	Vigilante#main	FAKE_NPC,{
@@ -449,6 +453,7 @@ dic_in01,254,119,0	script	Item Storage#01	CLEAR_NPC,{
 	end;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,10,42,1	script	13.3 Related Reset	4_MAN_BENKUNI,{
 	callfunc "F_GM_NPC";
 	mes "[Reset]";
@@ -460,7 +465,10 @@ sec_in02,10,42,1	script	13.3 Related Reset	4_MAN_BENKUNI,{
 	}
 	freeloop(0);
 	close;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Civil Services ========================================
 function	script	que_dic	{

--- a/npc/re/quests/quests_malangdo.txt
+++ b/npc/re/quests/quests_malangdo.txt
@@ -3528,6 +3528,7 @@ malangdo,129,146,3	script	Crime Prevention Staff	4_CAT_SAILOR2,{
 	close;
 }
 
+/*@LOADGMSCRIPTS
 malangdo,3,1,3	script	Guidance for quest#ml	4_MASK_SMOKEY,{
 	if (callfunc("F_GM_NPC",1854,0) < 1) {
 		mes "[Helper]";
@@ -3573,7 +3574,11 @@ malangdo,3,1,3	script	Guidance for quest#ml	4_MASK_SMOKEY,{
 		malang_bad_guys = 10;
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Clean the Ship :: mal_day_qook ========================
 mal_in02,76,63,7	script	Cleanyang	4_CAT_SAILOR1,{

--- a/npc/re/quests/quests_malaya.txt
+++ b/npc/re/quests/quests_malaya.txt
@@ -6549,6 +6549,7 @@ OnTouch:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 // Original name: "Bakonawa Introduction Quest Helper#bako1"
 sec_in02,10,16,5	script	Bakonawa Intro Helper	4_MASK_SMOKEY,{
 	if (callfunc("F_GM_NPC",1854,0) < 1) {
@@ -6604,7 +6605,11 @@ sec_in02,10,16,5	script	Bakonawa Intro Helper	4_MASK_SMOKEY,{
 		}
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Nurse in Port Malaya :: malaya_bang ===================
 function	script	F_Malaya_Nurse	{
@@ -8259,6 +8264,7 @@ $malaya_pintados_03  - Number of dyestuffs collected. (range: 0~300)
 $malaya_pintados_04$ - Last player to create a tattoo.
 */
 
+/*@LOADGMSCRIPTS
 ma_fild01,1,1,4	script	Pintados Manager#pin	4_F_KHELLISIA,{
 	if (callfunc("F_GM_NPC",1854,0) == 1) {
 		mes "Bingo!";
@@ -8372,7 +8378,14 @@ ma_fild01,1,1,4	script	Pintados Manager#pin	4_F_KHELLISIA,{
 //	if ($malaya_pintados_00 > 0)
 //		donpcevent "Pintados Manager#pin::OnEnableNPC";
 //	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
+	end;
+//@*/
 
+/*@!LOADGMSCRIPTS*/
+-	script	Pintados Manager#pin	FAKE_NPC,{
+//@*/
 OnTimer1800000:
 	//$malaya_pintados_00 = $malaya_pintados_00;
 	if ($malaya_pintados_00 > 0 && $malaya_pintados_00 < 344) {

--- a/npc/re/quests/quests_mora.txt
+++ b/npc/re/quests/quests_mora.txt
@@ -532,11 +532,15 @@ spl_fild02,183,1,0	duplicate(#mora_bush_timer)	Bush4Timer	4_F_FAIRYKID5
 spl_fild02,184,1,0	duplicate(#mora_bush_timer)	Bush5Timer	4_F_FAIRYKID5
 spl_fild02,186,1,0	duplicate(#mora_bush_timer)	Bush6Timer	4_F_FAIRYKID5
 
+/*@LOADGMSCRIPTS
 spl_fild02,187,1,0	script	Field Bush Switch	4_F_FAIRYKID5,{
 	callfunc "F_GM_NPC";
 	donpcevent "Bush#ep14_1_bs1::OnEnable";
 	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 splendide,183,117,4	script	Tired-looking Fairy	4_F_FAIRYKID3,{
 	if (!isequipped(2782)) {
@@ -1466,6 +1470,7 @@ splendide,121,260,4	script	Daphrer#ep14_1_bs	4_F_FAIRY,{
 	close;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,35,175,0	script	Theore Set Guid	4_F_FAIRYKID,{
 	callfunc "F_GM_NPC";
 	switch(select("Set0", "Set33", "Set2_0")) {
@@ -1480,7 +1485,11 @@ sec_in02,35,175,0	script	Theore Set Guid	4_F_FAIRYKID,{
 		ep14_1_bs2 = 0;
 		end;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Chesire's New Day :: ep14_1_cheshir2 ==================
 dic_in01,262,191,0	script	#ep14_1_xq02	HIDDEN_WARP_NPC,0,3,{
@@ -5097,6 +5106,7 @@ mora,104,172,7	script	Victim#pa0829	4_F_MORAFINE1,{
 	close;
 }
 
+/*@LOADGMSCRIPTS
 sec_in02,29,34,5	script	Initializing Mora Sanjo	4_MAN_NITT,{
 	callfunc "F_GM_NPC";
 	mes "Enter your password";
@@ -5115,7 +5125,11 @@ sec_in02,29,34,5	script	Initializing Mora Sanjo	4_MAN_NITT,{
 		ep14_1_mistwoods = 10;
 		close;
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/
 
 //== Mora Daily Quests - Souls :: md_cadaver_in ============
 // callfunc "mora_remains",<quest ID>,<NPC name>,<Mora Coin amount>,<reward ID>,<max reward amount>;

--- a/npc/re/woe-fe/invest_main.txt
+++ b/npc/re/woe-fe/invest_main.txt
@@ -401,6 +401,7 @@ OnReset:
 	end;
 }
 
+/*@LOADGMSCRIPTS
 prt_gld,2,2,0	script	Investment_total#fund00	CLEAR_NPC,{
 	callfunc "F_GM_NPC";
 	mes "Is this not working properly?";
@@ -421,8 +422,15 @@ prt_gld,2,2,0	script	Investment_total#fund00	CLEAR_NPC,{
 		mes "I don't need to adjust anything now.";
 		close;
 	}
+	end;
 
 OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
+//@*/
+/*@!LOADGMSCRIPTS*/
+-	script	Investment_total#fund00	FAKE_NPC,{
+OnInit:
+//@*/
 	if (callfunc("F_Invest_Status") == 1) {
 		initnpctimer;
 		donpcevent "Investment_total#fund00::OnVarInit";

--- a/npc/warps/other/arena.txt
+++ b/npc/warps/other/arena.txt
@@ -80,6 +80,7 @@ force_1-2,158,178,0	warp	force_08_09	1,1,force_1-2,133,178
 force_1-2,55,178,0	warp	force_09_10	1,1,force_1-2,29,178
 force_1-2,33,178,0	warp	force_10_09	1,1,force_1-2,59,178
 
+/*@LOADGMSCRIPTS
 // GM Control Panel
 //============================================================
 sec_in02,79,180,3	script	#arenacontrol	4_DOG01,{
@@ -112,4 +113,8 @@ sec_in02,79,180,3	script	#arenacontrol	4_DOG01,{
 			close;
 		}
 	}
+	end;
+OnInit:
+	consolemes(CONSOLEMES_INFO, "GM script loaded: %s", strnpcinfo(NPC_NAME_UNIQUE));
 }
+//@*/

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -5236,6 +5236,7 @@ static bool script_config_read(const char *filename, bool imported)
 	libconfig->setting_lookup_bool_real(setting, "warn_func_mismatch_argtypes", &script->config.warn_func_mismatch_argtypes);
 	libconfig->setting_lookup_bool_real(setting, "functions_private_by_default", &script->config.functions_private_by_default);
 	libconfig->setting_lookup_bool_real(setting, "functions_as_events", &script->config.functions_as_events);
+	libconfig->setting_lookup_bool_real(setting, "load_gm_scripts", &script->config.load_gm_scripts);
 	libconfig->setting_lookup_int(setting, "check_cmdcount", &script->config.check_cmdcount);
 	libconfig->setting_lookup_int(setting, "check_gotocount", &script->config.check_gotocount);
 	libconfig->setting_lookup_int(setting, "input_min_value", &script->config.input_min_value);
@@ -6115,6 +6116,7 @@ static void do_init_script(bool minimal)
 	script->declare_conditional_feature("RENEWAL", false);
 	script->declare_conditional_feature("PRERENEWAL", true);
 #endif
+	script->declare_conditional_feature("LOADGMSCRIPTS", script->config.load_gm_scripts);
 
 	if (minimal)
 		return;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -777,6 +777,39 @@ static const char *script_skip_space(const char *p)
 		else if( *p == '/' && p[1] == '*' )
 		{// block comment
 			p += 2;
+			if (*p == '@') {
+				const char *cond = p + 1;
+				bool negated = false;
+				int len = 0;
+				if (*cond == '!') {
+					negated = true;
+					cond++;
+				}
+				if (ISUPPER(cond[0])) {
+					len++;
+					while (ISUPPER(cond[len]) || ISDIGIT(cond[len]) || cond[len] == '_')
+						len++;
+				}
+				if (len >= 3 && cond[len] != '_' && !ISALNUM(cond[len])) {
+					int found = false;
+					int i;
+					ARR_FIND(0, VECTOR_LENGTH(script->conditional_features), i, strncmp(cond, VECTOR_INDEX(script->conditional_features, i), len) != 0);
+					if (i != VECTOR_LENGTH(script->conditional_features))
+						found = true;
+					if (negated)
+						found = !found;
+					p = cond + len; // Skip
+					while (ISSPACE(*p) && *p != '\n' && *p != '\r') // Condition stops at the line boundary
+						p++;
+					if (*p == '*' && p[1] == '/')
+						p += 2;
+					if (found)
+						continue; // Condition met: continue skipping whitespace
+					// else fall through and keep skipping until the end of the comment
+				} else {
+					script->disp_warning_message("script:script->skip_space: Invalid conditional comment: missing condition.", cond);
+				}
+			}
 			for(;;)
 			{
 				if( *p == '\0' ) {
@@ -5371,6 +5404,52 @@ static void script_generic_ui_array_expand(unsigned int plus)
 	script->generic_ui_array_size += plus + 100;
 	RECREATE(script->generic_ui_array, unsigned int, script->generic_ui_array_size);
 }
+
+static void script_declare_conditional_feature(const char *feature, bool enabled)
+{
+	nullpo_retv(feature);
+
+	if (!ISUPPER(feature[0])) {
+		ShowError("Invalid conditional feature '%s': identifier must begin with an uppercasee letter\n", feature);
+		return;
+	}
+	int i;
+	for (i = 1; feature[i] != '\0'; i++) {
+		if (!ISUPPER(feature[i]) && !ISDIGIT(feature[i]) && feature[i] != '_') {
+			ShowError("Invalid conditional feature '%s': identifier must be only composed of uppercase letters, numbers and/or underscores\n", feature);
+			return;
+		}
+	}
+	if (i < 3) {
+		ShowError("Invalid conditional feature '%s': identifier must be at least 3 characters long\n", feature);
+		return;
+	}
+	if (enabled == false && strcmp(feature, "TRUE") == 0) {
+		ShowError("Conditional feature '%s' cannot be disabled.\n", feature);
+		return;
+	}
+	if (enabled == true && strcmp(feature, "FALSE") == 0) {
+		ShowError("Conditional feature '%s' cannot be enabled.\n", feature);
+		return;
+	}
+
+	if (enabled) {
+		ARR_FIND(0, VECTOR_LENGTH(script->conditional_features), i, strcmp(feature, VECTOR_INDEX(script->conditional_features, i)) == 0);
+		if (i != VECTOR_LENGTH(script->conditional_features))
+			return; // Already declared
+		char *name = aStrdup(feature);
+		VECTOR_ENSURE(script->conditional_features, 1, 1);
+		VECTOR_PUSH(script->conditional_features, name);
+	} else {
+		ARR_FIND(0, VECTOR_LENGTH(script->conditional_features), i, strcmp(feature, VECTOR_INDEX(script->conditional_features, i)) == 0);
+		if (i == VECTOR_LENGTH(script->conditional_features))
+			return; // Not declared
+		char *name = VECTOR_INDEX(script->conditional_features, i);
+		VECTOR_ERASE(script->conditional_features, i);
+		aFree(name);
+	}
+}
+
 /*==========================================
  * Destructor
  *------------------------------------------*/
@@ -5480,6 +5559,11 @@ static void do_final_script(void)
 		VECTOR_CLEAR(VECTOR_INDEX(script->hqi, i).entries);
 	}
 	VECTOR_CLEAR(script->hqi);
+
+	while (VECTOR_LENGTH(script->conditional_features) > 0) {
+		aFree(VECTOR_POP(script->conditional_features));
+	}
+	VECTOR_CLEAR(script->conditional_features);
 
 	if( script->word_buf != NULL )
 		aFree(script->word_buf);
@@ -6020,6 +6104,17 @@ static void do_init_script(bool minimal)
 	script->read_constdb(false);
 	script->load_parameters();
 	script->hardcoded_constants();
+
+	script->declare_conditional_feature("TRUE", true);
+	script->declare_conditional_feature("FALSE", false);
+	script->declare_conditional_feature("HERCULES", true);
+#ifdef RENEWAL
+	script->declare_conditional_feature("RENEWAL", true);
+	script->declare_conditional_feature("PRERENEWAL", false);
+#else
+	script->declare_conditional_feature("RENEWAL", false);
+	script->declare_conditional_feature("PRERENEWAL", true);
+#endif
 
 	if (minimal)
 		return;
@@ -29264,6 +29359,7 @@ void script_defaults(void)
 
 	VECTOR_INIT(script->buf);
 	VECTOR_INIT(script->translation_buf);
+	VECTOR_INIT(script->conditional_features);
 
 	script->parse_options = 0;
 	script->buildin_set_ref = 0;
@@ -29544,4 +29640,5 @@ void script_defaults(void)
 	script->run_item_lapineddukddak_script = script_run_item_lapineddukddak_script;
 
 	script->sellitemcurrency_add = script_sellitemcurrency_add;
+	script->declare_conditional_feature = script_declare_conditional_feature;
 }

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -891,6 +891,9 @@ struct script_interface {
 	struct script_string_buf parse_simpleexpr_strbuf;
 	/* */
 	int parse_cleanup_timer_id;
+
+	VECTOR_DECL(char *) conditional_features;
+
 	/*  */
 	void (*init) (bool minimal);
 	void (*final) (void);
@@ -1097,6 +1100,7 @@ struct script_interface {
 	void (*run_item_rental_start_script) (struct map_session_data *sd, struct item_data *data, int oid);
 	void (*run_item_lapineddukddak_script) (struct map_session_data *sd, struct item_data *data, int oid);
 	bool (*sellitemcurrency_add) (struct npc_data *nd, struct script_state* st, int argIndex);
+	void (*declare_conditional_feature) (const char *feature, bool enabled);
 };
 
 #ifdef HERCULES_CORE

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -592,6 +592,7 @@ struct Script_Config {
 	bool warn_func_mismatch_paramnum;
 	bool functions_private_by_default;
 	bool functions_as_events;
+	bool load_gm_scripts;
 	int check_cmdcount;
 	int check_gotocount;
 	int input_min_value;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Note: This is a feature that I initially developed for personal use (drafted in 2015, in use in a much less refined form since 2017), but since there seems to be some interest in having it as part of the Hercules core, I decided to clean up the code a bit so that it's more usable and release it as part of Hercules.

This adds support for **conditional comments** in scripts.

Conditional comments are similar to #ifdef directives in the C preprocessor, allowing to exclude parts of a script depending on whether a certain flag is enabled or not.

The feature is designed to offer backward compatibility to scripts that use it, letting older engines seamlessly ignore the conditional part as if it was a comment.

#### Syntax 

 A conditional comment begins with `/*@CONDITION` followed by whitespace or `*/` and ends with the first `*/` sequence encountered on a separate line, but the sequence `//@*/` at the beginning of a line (optionally with indentation) is recommended as a terminator, since it provides compatibility with older versions of the script engine that don't support conditional comments.

The condition flag can be negated by prefixing it with an exclamation mark (`!`).

Condition flags consist of an uppercase letter followed by a sequence of uppercase letters, digits and underscores and are at least three characters long.

Note: conditional comments cannot be nested (in the same way how block comments cannot be nested).

#### Examples

The following block is only parsed if FLAG is defined. If not defined, or when loaded by an older engine, the block is treated as a block comment:

```
/*@FLAG
.@x = 1;
//@*/
```

The following block is only parsed if FLAG is not defined. If defined, or when loaded by an older engine, the block is treated as a block comment:

```
/*@!FLAG
.@x = 1;
//@*/
```

The following block is only parsed if FLAG is defined. If not defined, the block is treated as a block comment. When loaded by an older engine, the block is also parsed:

```
/*@FLAG*/
.@x = 1;
//@*/
```

The following block is only parsed if FLAG is not defined. If defined, the block is treated as a block comment. When loaded by an older engine, the block is also parsed.

```
/*@!FLAG*/
.@x = 1;
//@*/
```

#### Condition flags

 The Hercules core provides the following conditional comment flags (plugins may provide more):

| Flag | Decription |
| --- | --- |
| `TRUE` | Always defined |
| `HERCULES` | Always defined |
| `FALSE` | Never defined |
| `RENEWAL` | Only defined when compiled in renewal mode |
| `PRERENEWAL` | Only defined when compiled in pre-renewal mode |
| `LOADGMSCRIPTS` | Only defined when `script_configuration.load_gm_scripts` is `true` |

#### Applications

A first application of the flags is included in this pull request: conditionally loading the GM management scripts (that may be considered by some as a security hazard) based on a server setting.

When the `script_configuration.load_gm_scripts` flag in the script configuration is set to `false`, the `LOADGMSCRIPTS` conditional feature is not defined in the script engine.

Compliant scripts put their GM management NPCs in a conditional block controlled by that flag (all the built-in scripts have been updated to support this feature).

#### Plugins

Plugins can define conditional flags at runtime by calling script->declare_conditional_feature("FLAG_NAME"), allowing scripts to behave differently when a plugin is loaded.

One such example is the [naviluagenerator](https://github.com/HerculesWS/StaffPlugins/tree/conditional-comments/Haru/naviluagenerator) plugin in the StaffPlugins repository. The plugin defines the `NAVILUAGENERATOR` feature and compliant scripts can define conditional code to generate better navi lua scripts as follows:

Example exposing a warper NPC as a normal warp to the navi lua:

```
/* Overrides for navi link generation */
/*@NAVILUAGENERATOR
// The following line is only defined when the navi lua generator plugin is loaded. It defines a fake warp
// where the Lighthalzen guard stands, to let the navi generator know there's a route through the guard.
lhz_in01,35,226,0	warp	Rekenber Guard#li01-w	2,2,lhz_in01,37,225
//@*/
lhz_in01,35,226,5	script	Rekenber Guard#li01	4_M_LGTGUARD2,{
	if (isequipped(2241) && isequipped(2243)) {
		mes "[Rekenber Guard]";
		mes "^3355FF(Whoa, it's a member";
		mes "of the staff!)^000000 Good day!";
		close2;
		warp "lhz_in01",37,225;
		end;
	}
	// rest of the script omitted for example purposes
}
```


Example hiding a super secret quest NPC from the navi system:

```
/* Block disabled for navi link generation */
/*@!NAVILUAGENERATOR*/
morocc,140,155,3	script	Eddie#secret	4_M_ROGUE,{
	mes "[Eddie]";
	mes "Hi! I'm a super secret quest NPC";
}
//@*/
```

Example exposing a scripted mob spawn as a normal monster to the navi system:

```
/* Block disabled for navi link generation */
/*@!NAVILUAGENERATOR*/
lhz_dun03,2,2,0	script	summon_boss_lt	FAKE_NPC,{
OnInit:
	initnpctimer;
	end;

OnTimer6000000:
	if (rand(1,6) == 1) {
		donpcevent "summon_boss_lt::OnSummon";
		stopnpctimer;
	}
	end;
	// Rest of the script omitted for example purposes

OnMyMVPDead:
	killmonster "lhz_dun03","summon_boss_lt::OnMVP";
	initnpctimer;
	end;

//Required to keep from erroring
OnMVP:
	end;
}
//@*/

/* Overrides for navi link generation */
/*@NAVILUAGENERATOR
lhz_dun03,0,0,0,0	monster	Lord Knight Seyren	1640,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	Assassin Cross Eremes	1641,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	MasterSmith Howard	1642,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	High Priest Margaretha	1643,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	Sniper Cecil	1644,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	High Wizard Kathryne	1645,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	Lord Knight Seyren	1646,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	Assassin Cross Eremes	1647,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	MasterSmith Howard	1648,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	High Priest Margaretha	1649,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	Sniper Cecil	1650,1,6000000,1800000,1
lhz_dun03,0,0,0,0	monster	High Wizard Kathryne	1651,1,6000000,1800000,1
//@*/
```

I have a number of such overrides already written, but those will be part of a separate release to keep this PR shorter.

**Issues addressed:** N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
