### PR TITLE
OnTouch WARPNPC behavior fixes

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -4517,6 +4517,17 @@ they don't.
 
 ---------------------------------------
 
+*checkhiding({<account id>};
+
+This function returns true if the invoking character is hidden (including
+Hiding, Cloaking and Chase Walk, but excluding GM Perfect Hide) and false
+otherwise.
+
+If <account id> is given, this character will be checked instead of the invoking
+character.
+
+---------------------------------------
+
 *checkvending({"<Player Name>"})
 *checkchatting({"<Player Name>"})
 

--- a/npc/airports/airships.txt
+++ b/npc/airports/airships.txt
@@ -48,6 +48,8 @@ OnUnhide:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	switch ($@airplanelocation) {
 	case 0: warp "yuno",92,260; end;
 	case 1: warp "einbroch",92,278; end;
@@ -665,6 +667,8 @@ airplane_01,243,73,0	script	#AirshipWarp-3	WARPNPC,1,1,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	switch ($@airplanelocation2) {
 	case 0: warp "ra_fild12",292,204; end;
 	case 1:

--- a/npc/airports/hugel.txt
+++ b/npc/airports/hugel.txt
@@ -32,6 +32,8 @@
 hugel,178,142,0	script	toairplane#hugel	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	mes("To use the airship, you are required to pay 1,200 zeny or a Free Airship Ticket.");
 	mes("Would you like to use the service?");
 	next;

--- a/npc/airports/rachel.txt
+++ b/npc/airports/rachel.txt
@@ -34,6 +34,8 @@
 ra_fild12,295,208,0	script	toairplane#rachel	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	mes("To use the airship, you are required to pay 1,200 zeny or a Free Airship Ticket.");
 	mes("Would you like to use the service?");
 	next;

--- a/npc/battleground/flavius/flavius01.txt
+++ b/npc/battleground/flavius/flavius01.txt
@@ -340,6 +340,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	percentheal 100,100;
 	warp "bat_b01",87,73;
 	end;
@@ -385,6 +387,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	percentheal 100,100;
 	warp "bat_b01",312,225;
 	end;

--- a/npc/battleground/flavius/flavius02.txt
+++ b/npc/battleground/flavius/flavius02.txt
@@ -340,6 +340,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	percentheal 100,100;
 	warp "bat_b02",87,73;
 	end;
@@ -385,6 +387,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	percentheal 100,100;
 	warp "bat_b02",312,225;
 	end;

--- a/npc/battleground/tierra/tierra01.txt
+++ b/npc/battleground/tierra/tierra01.txt
@@ -663,13 +663,17 @@ OnTouch:
 }
 
 bat_a01,169,227,0	script	underladd#bat_a01_1	WARPNPC,1,1,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp "bat_a01",178,228;
 	end;
 }
 
 bat_a01,208,164,0	script	underladd#bat_a01_2	WARPNPC,1,1,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp "bat_a01",200,171;
 	end;
 }

--- a/npc/battleground/tierra/tierra02.txt
+++ b/npc/battleground/tierra/tierra02.txt
@@ -663,13 +663,17 @@ OnTouch:
 }
 
 bat_a02,169,227,0	script	underladd#bat_a02_1	WARPNPC,1,1,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp "bat_a02",178,228;
 	end;
 }
 
 bat_a02,208,164,0	script	underladd#bat_a02_2	WARPNPC,1,1,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp "bat_a02",200,171;
 	end;
 }

--- a/npc/custom/battleground/bg_common.txt
+++ b/npc/custom/battleground/bg_common.txt
@@ -1125,6 +1125,8 @@ bat_room,161,158,3	duplicate(bat_aid)	General Guillaume's Aid::bat_aid4	4_M_KY_H
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	set BG_Delay_Tick, gettimetick(2) + 30;
 	warp "bat_room",154,149;
 	end;

--- a/npc/custom/bgqueue/flavius.txt
+++ b/npc/custom/bgqueue/flavius.txt
@@ -372,6 +372,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	percentheal 100,100;
 	warp "bat_b01",87,73;
 	end;
@@ -417,6 +419,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	percentheal 100,100;
 	warp "bat_b01",312,225;
 	end;

--- a/npc/events/halloween_2008.txt
+++ b/npc/events/halloween_2008.txt
@@ -259,6 +259,8 @@ S_TicketExchange:
 
 evt_zombie,16,142,1	script	zombiewarp001	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (@Hallow08Warp == 1) {
 		Hallow08Kill = 2;
 		specialeffect EF_BASH;
@@ -269,6 +271,8 @@ OnTouch:
 
 evt_zombie,122,27,1	script	zombiewarp002	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (@Hallow08Warp == 2) {
 		Hallow08Kill = 2;
 		specialeffect EF_BASH;
@@ -279,6 +283,8 @@ OnTouch:
 
 evt_zombie,267,89,1	script	zombiewarp003	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (@Hallow08Warp == 3) {
 		Hallow08Kill = 2;
 		specialeffect EF_BASH;

--- a/npc/instances/EndlessTower.txt
+++ b/npc/instances/EndlessTower.txt
@@ -1174,7 +1174,9 @@ OnEnable:
 	callfunc("F_Tower_Monster", atoi(replacestr(strnpcinfo(NPC_NAME), "FGate102tower", "")) + 1, strnpcinfo(NPC_MAP), instance_npcname(strnpcinfo(NPC_NAME))+"::OnMyMobDead");
 	end;
 
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	callfunc("F_Tower_Warp", atoi(replacestr(strnpcinfo(NPC_NAME), "FGate102tower", "")) + 1, strnpcinfo(NPC_MAP));
 	end;
 
@@ -1246,7 +1248,9 @@ OnEnable:
 	initnpctimer();
 	end;
 
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	getitem(Dark_Ashes, 1);
 	warp(instance_mapname("2@tower"), 52, 354);
 	end;
@@ -1269,7 +1273,9 @@ OnEnable:
 	enablenpc(instance_npcname("25FGate102tower-2"));
 	end;
 
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("2@tower"), 52, 354);
 	end;
 }
@@ -1375,7 +1381,9 @@ OnEnable:
 	initnpctimer();
 	end;
 
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	getitem(Dark_Ashes, 1);
 	warp(instance_mapname("3@tower"), 52, 354);
 	end;
@@ -1398,7 +1406,9 @@ OnEnable:
 	enablenpc(instance_npcname("50FGate102tower-2"));
 	end;
 
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("3@tower"), 52, 354);
 	end;
 }
@@ -1487,7 +1497,9 @@ OnEnable:
 	initnpctimer();
 	end;
 
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	getitem(Dark_Ashes, 1);
 	warp(instance_mapname("4@tower"), 52, 354);
 	end;
@@ -1510,7 +1522,9 @@ OnEnable:
 	enablenpc(instance_npcname("75FGate102tower-2"));
 	end;
 
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("4@tower"), 52, 354);
 	end;
 }
@@ -1598,7 +1612,9 @@ OnEnable:
 	initnpctimer();
 	end;
 
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	getitem(Dark_Ashes, 1);
 	warp(instance_mapname("5@tower"), 101, 72);
 	end;
@@ -1621,7 +1637,9 @@ OnEnable:
 	enablenpc(instance_npcname("99FGate102tower-2"));
 	end;
 
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("5@tower"), 101, 72);
 	end;
 }

--- a/npc/instances/NydhoggsNest.txt
+++ b/npc/instances/NydhoggsNest.txt
@@ -1787,6 +1787,8 @@ OnEnable:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	'ins_nyd2 = 3;
 	warp(instance_mapname("2@nyd"), 200, 10);
 	end;

--- a/npc/instances/OrcsMemory.txt
+++ b/npc/instances/OrcsMemory.txt
@@ -387,6 +387,8 @@ OnEnable:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("1@orcs"), 168, 130);
 	end;
 
@@ -416,6 +418,8 @@ OnEnable:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("1@orcs"), 85, 85);
 	end;
 
@@ -445,6 +449,8 @@ OnEnable:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("1@orcs"), 38, 110);
 	end;
 
@@ -477,6 +483,8 @@ OnEnable:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("2@orcs"), 32, 171);
 	end;
 }
@@ -711,6 +719,8 @@ OnTimer10000:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("2@orcs"), 47, 93);
 	end;
 }
@@ -742,6 +752,8 @@ OnTimer10000:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("2@orcs"), 107, 55);
 	end;
 }
@@ -787,6 +799,8 @@ OnTimer13110:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("2@orcs"), 167, 95);
 	end;
 }
@@ -835,6 +849,8 @@ OnEnable:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp("gef_fild10", 240, 197);
 	end;
 }

--- a/npc/instances/SealedShrine.txt
+++ b/npc/instances/SealedShrine.txt
@@ -790,6 +790,8 @@ OnInstanceInit:
 //== To 2F Warp ============================================
 1@cata,281,12,0	script	ins_bapho_to_2f	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (countitem(Token_Of_Apostle) > 0) {
 		delitem(Token_Of_Apostle, countitem(Token_Of_Apostle));
 		'ins_baphomet = 5;

--- a/npc/jobs/2-1/assassin.txt
+++ b/npc/jobs/2-1/assassin.txt
@@ -1446,6 +1446,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Thomas#ASNTEST::OnDisable";
 	if (ASSIN_Q == 3)
 		ASSIN_Q = 3;
@@ -1594,6 +1596,8 @@ OnTouch:
 
 in_moc_16,182,169,0	script	Maze Assistant	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (ASSIN_Q == 5 || ASSIN_Q == 6) {
 		warp "in_moc_16",181,183;
 		++ASSIN_Q;

--- a/npc/jobs/2-1/hunter.txt
+++ b/npc/jobs/2-1/hunter.txt
@@ -1239,6 +1239,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Manager#hnt::OnReset";
 	donpcevent "Waiting Room#hnt::OnStart";
 	HNTR_Q = 16;

--- a/npc/jobs/2-1/priest.txt
+++ b/npc/jobs/2-1/priest.txt
@@ -1306,6 +1306,8 @@ OnDisable:
 
 job_prist,24,109,4	script	prst1_1	WARPNPC,3,3,{
 OnTouch:
+	if (checkhiding())
+		end;
 	.@mobs = getvariableofnpc(.MyMobs,"Zombie_Generator#prst");
 	if (BaseJob == Job_Priest) warp "job_prist",168,17;
 	else if (BaseClass == Job_Acolyte && .@mobs < 1) {
@@ -1610,6 +1612,8 @@ OnTouch:
 
 job_prist,168,180,4	script	prst2_1	WARPNPC,3,3,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (BaseJob == Job_Priest) warp "job_prist",98,40;
 	else if (BaseClass == Job_Acolyte) {
 		warp "job_prist",98,40;
@@ -1716,6 +1720,8 @@ OnDisable:
 
 job_prist,98,105,4	script	prst3_1	WARPNPC,3,3,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (BaseJob == Job_Priest) {
 		warp "prt_church",15,36;
 		end;

--- a/npc/jobs/2-2/crusader.txt
+++ b/npc/jobs/2-2/crusader.txt
@@ -1218,6 +1218,8 @@ OnDead:
 
 job_cru,98,105,4	script	 Summoner#cr5	WARPNPC,3,3,{
 OnTouch:
+	if (checkhiding())
+		end;
 	CRUS_Q = 6;
 	changequest 3010,3011;
 	warp "prt_castle",164,28;
@@ -1426,6 +1428,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "prt_castle",35,147;
 	donpcevent "Monster Summon#cr0::OnReset";
 	donpcevent "Monster Summon#cr4::OnReset";

--- a/npc/jobs/2-2/monk.txt
+++ b/npc/jobs/2-2/monk.txt
@@ -1992,6 +1992,8 @@ monk_test,386,388,4	script	Apprentice Monk#mk	4_M_MINISTER,{
 
 monk_test,387,350,0	script	Supervisor#race_monk	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (MONK_Q >= 15 && MONK_Q <= 23) {
 		MONK_Q += 1;
 		warp "monk_test",385,388;
@@ -2346,6 +2348,8 @@ OnDisable:
 
 monk_test,166,278,0	script	exit_monk#1	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "[Proctor]";
 	mes "You did well. Please return to Tomoon, he's waiting for you.";
 	MONK_Q = 27;
@@ -2453,6 +2457,8 @@ OnDisable:
 
 monk_test,166,178,0	script	exit_monk#2	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "[Proctor]";
 	mes "You did well. Please return to Tomoon, he's waiting for you.";
 	MONK_Q = 27;
@@ -2560,6 +2566,8 @@ OnDisable:
 
 monk_test,270,278,0	script	exit_monk#3	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "[Proctor]";
 	mes "You did well. Please return to Tomoon, he's waiting for you.";
 	MONK_Q = 27;

--- a/npc/jobs/2-2/rogue.txt
+++ b/npc/jobs/2-2/rogue.txt
@@ -1030,6 +1030,8 @@ S_CheckItems:
 
 cmd_fild09,106,195,0	script	Warp#1	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "[???]";
 	mes "Who's there?!";
 	mes "Who would dare";
@@ -1100,6 +1102,8 @@ OnTouch:
 
 cmd_fild09,335,143,0	script	Warp#2	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "[???]";
 	mes "Who's there?!";
 	mes "Who would dare";
@@ -1170,6 +1174,8 @@ OnTouch:
 
 cmd_fild04,304,180,0	script	Warp#3	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "[???]";
 	mes "Who's there?!";
 	mes "Who would dare";
@@ -1290,6 +1296,8 @@ in_rogue,272,135,1	script	Hermanthorn Jr#rg	4_M_03,{
 
 in_rogue,270,130,0	script	he_to_rogue#rg	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "^3355FFThe door is locked. You'll need to enter the four number combination to open it.^000000";
 	next;
 	input(.@input);
@@ -1400,6 +1408,8 @@ OnMyMobDead:
 
 in_rogue,9,389,0	script	oneway_to_gu	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "gen_ro#4::OnDisable";
 	ROGUE_Q = 17;
 	warp "in_rogue",367,10;
@@ -1665,6 +1675,8 @@ in_rogue,177,109,1	script	Antonio junior#rg	4_M_ORIENT01,{
 
 in_rogue,370,320,0	script	quest_out	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	ROGUE_Q = 16;
 	warp "in_rogue",378,113;
 	end;

--- a/npc/other/arena/arena_aco.txt
+++ b/npc/other/arena/arena_aco.txt
@@ -36,6 +36,8 @@
 
 arena_room,114,102,0	script	onlyaco#arena	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (BaseClass == Job_Acolyte) {
 		warp "arena_room",135,129;
 		end;
@@ -1045,6 +1047,8 @@ OnMyMobDead:
 
 force_5-1,62,26,0	script	force_08_01#aco	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "force_5-1",40,26;
 	if (BaseJob == Job_Acolyte) {
 		enablenpc "force_01start#aco";
@@ -1057,6 +1061,8 @@ OnTouch:
 
 force_5-1,99,124,0	script	force_exit#aco	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Trocco#aco1::OnTimerOff";
 	donpcevent "#arn_timer_aco::OnEnable";
 	mapwarp "force_5-1","prt_are_in",21,35;

--- a/npc/other/arena/arena_lvl50.txt
+++ b/npc/other/arena/arena_lvl50.txt
@@ -312,6 +312,8 @@ OnReset_All:
 
 force_1-1,62,26,1	script	force_08_01#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Heel and Toe#arena::On01_Start";
 	warp "force_1-1",40,26;
 	end;
@@ -319,6 +321,8 @@ OnTouch:
 
 force_1-1,25,44,1	script	force_01_02#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Heel and Toe#arena::On02_Start";
 	warp "force_1-1",25,69;
 	end;
@@ -326,6 +330,8 @@ OnTouch:
 
 force_1-1,25,134,1	script	force_02_03#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "arena#50::OnReset_02";
 	donpcevent "Heel and Toe#arena::On03_Start";
 	warp "force_1-1",25,159;
@@ -334,6 +340,8 @@ OnTouch:
 
 force_1-1,44,174,1	script	force_03_04#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Heel and Toe#arena::On04_Start";
 	warp "force_1-1",69,174;
 	end;
@@ -341,6 +349,8 @@ OnTouch:
 
 force_1-1,134,174,1	script	force_04_05#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Heel and Toe#arena::On05_Start";
 	warp "force_1-1",159,174;
 	end;
@@ -348,6 +358,8 @@ OnTouch:
 
 force_1-1,174,155,1	script	force_05_06#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Heel and Toe#arena::On06_Start";
 	warp "force_1-1",174,130;
 	end;
@@ -355,6 +367,8 @@ OnTouch:
 
 force_1-1,174,65,1	script	force_06_07#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Heel and Toe#arena::On07_Start";
 	warp "force_1-1",174,40;
 	end;
@@ -362,6 +376,8 @@ OnTouch:
 
 force_1-1,155,26,1	script	force_07_08#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Heel and Toe#arena::On08_Start";
 	warp "force_1-1",132,26;
 	enablenpc "force_08_09#50";
@@ -370,6 +386,8 @@ OnTouch:
 
 force_1-1,99,54,1	script	force_08_09#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Heel and Toe#arena::On09_Start";
 	warp "force_1-1",99,82;
 	end;
@@ -377,6 +395,8 @@ OnTouch:
 
 force_1-1,99,124,1	script	force_exit#50	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Heel and Toe#arena::OnTimerOff";
 	donpcevent "#arn_timer_50::OnEnable";
 	mapwarp "force_1-1","prt_are_in",22,191,0,0;

--- a/npc/other/arena/arena_lvl60.txt
+++ b/npc/other/arena/arena_lvl60.txt
@@ -322,6 +322,8 @@ OnReset_All:
 
 force_2-1,62,26,1	script	force_08_01#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Minilover#arena::On01_Start";
 	warp "force_2-1",40,26;
 	end;
@@ -329,6 +331,8 @@ OnTouch:
 
 force_2-1,25,44,1	script	force_01_02#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Minilover#arena::On02_Start";
 	warp "force_2-1",25,69;
 	end;
@@ -336,6 +340,8 @@ OnTouch:
 
 force_2-1,25,134,1	script	force_02_03#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "arena#60::OnReset_02";
 	donpcevent "Minilover#arena::On03_Start";
 	warp "force_2-1",25,159;
@@ -344,6 +350,8 @@ OnTouch:
 
 force_2-1,44,174,1	script	force_03_04#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Minilover#arena::On04_Start";
 	warp "force_2-1",69,174;
 	end;
@@ -351,6 +359,8 @@ OnTouch:
 
 force_2-1,134,174,1	script	force_04_05#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Minilover#arena::On05_Start";
 	warp "force_2-1",159,174;
 	end;
@@ -358,6 +368,8 @@ OnTouch:
 
 force_2-1,174,155,1	script	force_05_06#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Minilover#arena::On06_Start";
 	warp "force_2-1",174,130;
 	end;
@@ -365,6 +377,8 @@ OnTouch:
 
 force_2-1,174,65,1	script	force_06_07#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Minilover#arena::On07_Start";
 	warp "force_2-1",174,40;
 	end;
@@ -372,6 +386,8 @@ OnTouch:
 
 force_2-1,155,26,1	script	force_07_08#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Minilover#arena::On08_Start";
 	warp "force_2-1",132,26;
 	enablenpc "force_08_09#60";
@@ -380,6 +396,8 @@ OnTouch:
 
 force_2-1,99,54,1	script	force_08_09#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Minilover#arena::On09_Start";
 	warp "force_2-1",99,82;
 	end;
@@ -387,6 +405,8 @@ OnTouch:
 
 force_2-1,99,124,1	script	force_exit#60	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Minilover#arena::OnTimerOff";
 	donpcevent "#arn_timer_60::OnEnable";
 	mapwarp "force_2-1","prt_are_in",22,139,0,0;

--- a/npc/other/arena/arena_lvl70.txt
+++ b/npc/other/arena/arena_lvl70.txt
@@ -330,6 +330,8 @@ OnReset_All:
 
 force_3-1,62,26,1	script	force_08_01#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::On01_Start";
 	warp "force_3-1",40,26;
 	end;
@@ -337,6 +339,8 @@ OnTouch:
 
 force_3-1,25,44,1	script	force_01_02#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::On02_Start";
 	warp "force_3-1",25,69;
 	end;
@@ -344,6 +348,8 @@ OnTouch:
 
 force_3-1,25,134,1	script	force_02_03#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::On03_Start";
 	warp "force_3-1",25,159;
 	end;
@@ -351,6 +357,8 @@ OnTouch:
 
 force_3-1,44,174,1	script	force_03_04#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::On04_Start";
 	warp "force_3-1",69,174;
 	end;
@@ -358,6 +366,8 @@ OnTouch:
 
 force_3-1,134,174,1	script	force_04_05#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::On05_Start";
 	warp "force_3-1",159,174;
 	end;
@@ -365,6 +375,8 @@ OnTouch:
 
 force_3-1,174,155,1	script	force_05_06#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::On06_Start";
 	warp "force_3-1",174,130;
 	end;
@@ -372,6 +384,8 @@ OnTouch:
 
 force_3-1,174,65,1	script	force_06_07#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::On07_Start";
 	warp "force_3-1",174,40;
 	end;
@@ -379,6 +393,8 @@ OnTouch:
 
 force_3-1,155,26,1	script	force_07_08#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::On08_Start";
 	warp "force_3-1",132,26;
 	enablenpc "force_08_09#70";
@@ -387,6 +403,8 @@ OnTouch:
 
 force_3-1,99,54,1	script	force_08_09#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::On09_Start";
 	warp "force_3-1",99,82;
 	end;
@@ -394,6 +412,8 @@ OnTouch:
 
 force_3-1,99,124,1	script	force_exit#70	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Cadillac#arena::OnTimerOff";
 	donpcevent "#arn_timer_70::OnEnable";
 	mapwarp "force_3-1","prt_are_in",22,87,0,0;

--- a/npc/other/arena/arena_lvl80.txt
+++ b/npc/other/arena/arena_lvl80.txt
@@ -333,6 +333,8 @@ OnReset_All:
 
 force_4-1,62,26,1	script	force_08_01#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::On01_Start";
 	warp "force_4-1",40,26;
 	end;
@@ -340,6 +342,8 @@ OnTouch:
 
 force_4-1,25,44,1	script	force_01_02#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::On02_Start";
 	warp "force_4-1",25,69;
 	end;
@@ -347,6 +351,8 @@ OnTouch:
 
 force_4-1,25,134,1	script	force_02_03#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::On03_Start";
 	warp "force_4-1",25,159;
 	end;
@@ -354,6 +360,8 @@ OnTouch:
 
 force_4-1,44,174,1	script	force_03_04#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::On04_Start";
 	warp "force_4-1",69,174;
 	end;
@@ -362,6 +370,8 @@ OnTouch:
 
 force_4-1,134,174,1	script	force_04_05#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::On05_Start";
 	warp "force_4-1",159,174;
 	end;
@@ -369,6 +379,8 @@ OnTouch:
 
 force_4-1,174,155,1	script	force_05_06#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::On06_Start";
 	warp "force_4-1",174,130;
 	end;
@@ -376,6 +388,8 @@ OnTouch:
 
 force_4-1,174,65,1	script	force_06_07#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::On07_Start";
 	warp "force_4-1",174,40;
 	end;
@@ -383,6 +397,8 @@ OnTouch:
 
 force_4-1,155,26,1	script	force_07_08#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::On08_Start";
 	warp "force_4-1",132,26;
 	enablenpc "force_08_09#80";
@@ -391,6 +407,8 @@ OnTouch:
 
 force_4-1,99,54,1	script	force_08_09#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::On09_Start";
 	warp "force_4-1",99,82;
 	end;
@@ -398,6 +416,8 @@ OnTouch:
 
 force_4-1,99,124,1	script	force_exit#80	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	donpcevent "Octus#arena::OnTimerOff";
 	donpcevent "#arn_timer_80::OnEnable";
 	mapwarp "force_4-1","prt_are_in",73,192,0,0;

--- a/npc/other/arena/arena_party.txt
+++ b/npc/other/arena/arena_party.txt
@@ -434,6 +434,8 @@ OnReset:
 
 force_1-2,95,187,0	script	force_09_exit	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	$arena_minptend = gettime(GETTIME_MINUTE);
 	$arena_secptend = gettime(GETTIME_SECOND);
 	warp "prt_are_in",73,139;

--- a/npc/other/hugel_bingo.txt
+++ b/npc/other/hugel_bingo.txt
@@ -767,6 +767,8 @@ OnTouch:
 que_bingo,49,136,0	script	go3#bingo	WARPNPC,1,1,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	switch($@hu_bingob) {
 		case 0: warp "que_bingo",49,125; break;
 		case 1: warp "que_bingo",53,121; break;

--- a/npc/other/pvp.txt
+++ b/npc/other/pvp.txt
@@ -407,6 +407,8 @@ pvp_room,86,85,4	duplicate(PVPSpectator)	Spectator's Entrance#4	8W_SOLDIER
 //== Spectator Warps =======================================
 -	script	Combat Square Staff#dum::PVPSpecWarp	FAKE_NPC,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "[Combat Square Staff]";
 	mes "May I help you?";
 	if (select("To the center viewer seat.", "Leave Combat Square.") == 1) {
@@ -422,6 +424,8 @@ pvp_2vs2,74,74,0	duplicate(PVPSpecWarp)	Combat Square Staff#3	WARPNPC,1,1
 pvp_2vs2,74,5,0	duplicate(PVPSpecWarp)	Combat Square Staff#4	WARPNPC,1,1
 
 pvp_2vs2,40,40,0	script	Combat Square Staff#5	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	mes "[Combat Square Staff]";
 	mes "May I help you?";
 	switch(select("To the side viewer seat.", "Leave Combat Square.")) {
@@ -441,6 +445,8 @@ pvp_2vs2,40,40,0	script	Combat Square Staff#5	WARPNPC,1,1,{
 //== PVP Area Exit warp ====================================
 pvp_room,51,19,0	script	out#eventpvp	WARPNPC,4,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "[Combat Square Staff]";
 	mes "Did you have fun in Combat Square?";
 	mes "May I ask where you want to go?";

--- a/npc/other/turbo_track.txt
+++ b/npc/other/turbo_track.txt
@@ -1631,6 +1631,8 @@ turbo_n_1,236,3,0	duplicate(WaterTrap#tt_main)	flasher#n1-48b	FAKE_NPC,3,0
 
 -	script	snake01#tt_main	FAKE_NPC,{
 OnTouch:
+	if (checkhiding())
+		end;
 	.@turbo2 = rand(1,7);
 	if (.@turbo2 < 3) warp strnpcinfo(NPC_MAP),370,292;
 	if (.@turbo2 < 5) warp strnpcinfo(NPC_MAP),295,293;
@@ -1648,6 +1650,8 @@ turbo_n_1,324,279,0	duplicate(snake01#tt_main)	snake01#n1	WARPNPC,1,1
 
 -	script	snake02#tt_main	FAKE_NPC,{
 OnTouch:
+	if (checkhiding())
+		end;
 	.@turbo2 = rand(1,8);
 	if (.@turbo2 < 3) warp strnpcinfo(NPC_MAP),287,256;
 	if (.@turbo2 < 5) warp strnpcinfo(NPC_MAP),303,256;
@@ -1665,6 +1669,8 @@ turbo_n_1,332,279,0	duplicate(snake02#tt_main)	snake02#n1	WARPNPC,1,1
 
 -	script	snake03#tt_main	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	.@turbo2 = rand(1,8);
 	if (.@turbo2 < 3) warp strnpcinfo(NPC_MAP),279,292;
 	if (.@turbo2 < 5) warp strnpcinfo(NPC_MAP),311,292;
@@ -1682,6 +1688,8 @@ turbo_n_1,324,270,0	duplicate(snake03#tt_main)	snake03#n1	WARPNPC,1,1
 
 -	script	snake04#tt_main	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	.@turbo2 = rand(1,7);
 	if (.@turbo2 < 3) warp strnpcinfo(NPC_MAP),363,256;
 	if (.@turbo2 < 5) warp strnpcinfo(NPC_MAP),295,293;
@@ -1738,6 +1746,8 @@ turbo_n_1,90,46,0	duplicate(SnakeHunt#tt_main)	hunting#n1	HIDDEN_NPC
 
 -	script	cos#tt_main	FAKE_NPC,{
 OnTouch:
+	if (checkhiding())
+		end;
 	.@n = charat(strnpcinfo(NPC_NAME_HIDDEN),getstrlen(strnpcinfo(NPC_NAME_HIDDEN))-1);
 	switch (.@n) {
 		case 1:
@@ -1941,6 +1951,8 @@ turbo_n_1,222,65,0	duplicate(TurboHint_4#tt_main)	#n1NoWayOut7	FAKE_NPC,1,1
 -	script	cos_end#tt_main	FAKE_NPC,{
 	function	GetNumber;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@w$ = callfunc("F_tt");
 	if (.@w$ == "n1") $@end_time = gettimetick(0);
 	mapannounce strnpcinfo(NPC_MAP),strcharinfo(PC_NAME) +" has just arrived at the Finish Line! Congratulations!",bc_map,"0xFFFF00";
@@ -1991,6 +2003,8 @@ turbo_n_1,371,47,0	duplicate(cos_end#tt_main)	#cos_n1_end	WARPNPC,1,1
 
 -	script	cos_end2#tt_main	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	.@w$ = callfunc("F_tt");
 	mapannounce strnpcinfo(NPC_MAP),strcharinfo(PC_NAME) +" is second to reach the Finish Line! Congratulations!",bc_map,"0xFFFF00";
 	if (.@w$ == "e8" || .@w$ == "n8") setarray .@pts, 28961,40;
@@ -2013,6 +2027,8 @@ turbo_n_16,371,51,0	duplicate(cos_end2#tt_main)	#cos_n16_end2	WARPNPC,1,1
 
 -	script	cos_end3#tt_main	FAKE_NPC,{
 OnTouch:
+	if (checkhiding())
+		end;
 	.@w$ = callfunc("F_tt");
 	mapannounce strnpcinfo(NPC_MAP),"" + strcharinfo(PC_NAME) +" is third to reach the Finish Line! Congratulations!",bc_map,"0xFFFF00";
 	if (.@w$ == "e8" || .@w$ == "n8") setarray .@pts, 28971,30;
@@ -2055,6 +2071,8 @@ turbo_n_1,316,365,0	duplicate(DSwitch#tt_main)	Disposable_Switch#n1	FAKE_NPC,1,1
 
 -	script	Flasher#tt_main	FAKE_NPC,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mapannounce strnpcinfo(NPC_MAP),strcharinfo(PC_NAME) +" has just passed the Flasher Maze!",bc_map,"0x70DBDB";
 	warp strnpcinfo(NPC_MAP),185,227;
 	end;
@@ -3609,6 +3627,8 @@ turbo_n_1,340,55,0	duplicate(TurboTrap_2#tt_main)	trap_n1#F48	HIDDEN_WARP_NPC,1,
 -	script	bing_1#tt_main	FAKE_NPC,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@w$ = callfunc("F_tt");
 	.@bing1 = rand(1,10);
 	if (.@bing1 > 0 && .@bing1 < 4)
@@ -3635,6 +3655,8 @@ turbo_n_16,217,214,0	duplicate(bing_1#tt_main)	bing#n16	WARPNPC,3,3
 -	script	bing_2#tt_main	FAKE_NPC,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	switch (rand(1,10)) {
 		case 1: warp strnpcinfo(NPC_MAP),217,232; break;
 		case 2: warp strnpcinfo(NPC_MAP),233,207; break;
@@ -4598,6 +4620,8 @@ S_ExchangePoints:
 
 alde_gld,183,204,0	script	en_turbo	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (checkweight(Knife,1) == 0) {
 		mes "^3355FFWait a second!";
 		mes "Right now, you're carrying";

--- a/npc/pre-re/jobs/1-1/swordman.txt
+++ b/npc/pre-re/jobs/1-1/swordman.txt
@@ -377,27 +377,39 @@ job_sword1,223,243,0	warp	checkp1-2#swd_1	1,1,job_sword1,11,206
 job_sword1,223,205,0	warp	checkp2-3#swd_1	1,1,job_sword1,11,168
 
 job_sword1,7,245,0	script	Test Hall Staff#swd_4	WARPNPC,1,3,{
+	if (checkhiding())
+		end;
 	callfunc "F_JobSwdTestStaff",10,245;
 }
 
 job_sword1,8,207,0	script	Test Hall Staff#swd_5	WARPNPC,1,6,{
+	if (checkhiding())
+		end;
 	callfunc "F_JobSwdTestStaff",11,207;
 }
 
 job_sword1,8,169,0	script	Test Hall Staff#swd_6	WARPNPC,1,6,{
+	if (checkhiding())
+		end;
 	callfunc "F_JobSwdTestStaff",11,169;
 }
 
 job_sword1,192,244,0	script	Test Hall Staff#swd_7	WARPNPC,1,3,{
+	if (checkhiding())
+		end;
 	callfunc "F_JobSwdTestStaff2","1st",215,244;
 }
 
 job_sword1,193,207,0	script	Test Hall Staff#swd_8	WARPNPC,1,3,{
+	if (checkhiding())
+		end;
 	callfunc "F_JobSwdTestStaff2","2nd",215,205;
 	warp "job_sword1",215,205;
 }
 
 job_sword1,193,168,0	script	Test Hall Staff#swd_9	WARPNPC,1,3,{
+	if (checkhiding())
+		end;
 	callfunc "F_JobSwdTestStaff2","3rd",215,167;
 }
 

--- a/npc/pre-re/warps/fields/morroc_fild.txt
+++ b/npc/pre-re/warps/fields/morroc_fild.txt
@@ -60,7 +60,12 @@ moc_fild03,70,341,0	warp	mocf04-1	5,2,moc_fild02,332,23
 //moc_fild04,14,98,0	warp	mocf07	1,11,moc_fild05,378,119
 //moc_fild04,175,18,0	warp	mocf08	3,2,moc_fild08,170,380
 //moc_fild04,19,206,0	warp	mocf09	3,15,moc_fild05,373,208
-//moc_fild04,219,327,0	script	mocf016	WARPNPC,3,4,{ @anthell = 0; warp "anthell01",35,262; }
+//moc_fild04,219,327,0	script	mocf016	WARPNPC,3,4,{
+//	if (checkhiding())
+//		end;
+//	@anthell = 0;
+//	warp("anthell01", 35, 262);
+//}
 //moc_fild04,292,381,0	warp	mocf01-2	10,1,moc_fild01,76,25
 //moc_fild04,314,381,0	warp	mocf01-3	10,1,moc_fild01,76,25
 //moc_fild04,336,381,0	warp	mocf01-4	10,1,moc_fild01,76,25
@@ -113,7 +118,12 @@ moc_fild13,308,49,0	warp	mocf06-1	2,4,moc_fild03,20,37
 //moc_fild14,196,382,0	warp	mocf16-1	4,2,moc_fild08,204,19
 //moc_fild15,104,16,0	warp	mocf26	9,2,moc_fild16,125,380
 //moc_fild15,158,363,0	warp	mocf18-1	6,2,moc_fild09,126,23
-//moc_fild15,258,253,0	script	mocf017	WARPNPC,3,3,{ @anthell = 1; warp "anthell01",35,262; }
+//moc_fild15,258,253,0	script	mocf017	WARPNPC,3,3,{
+//	if (checkhiding())
+//		end;
+//	@anthell = 1;
+//	warp("anthell01", 35, 262);
+//}
 //moc_fild15,348,18,0	warp	mocf27	5,2,moc_fild16,334,379
 //moc_fild15,367,276,0	warp	mocf25-1	2,4,moc_fild14,19,278
 //moc_fild15,38,105,0	warp	mocf23-1	2,4,moc_fild11,376,197

--- a/npc/pre-re/warps/fields/veins_fild.txt
+++ b/npc/pre-re/warps/fields/veins_fild.txt
@@ -53,6 +53,8 @@ ve_fild05,200,330,0	warp	ve_fild5-1	1,1,ve_fild03,222,48
 ve_fild05,359,192,0	warp	ve_fild5-2	1,1,ve_fild06,80,183
 ve_fild06,153,220,0	warp	ve_fild6-1	1,1,veins,218,355
 ve_fild06,81,177,0	script	ve_fild6-2	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (rand(2))
 		warp "ve_fild04",115,55;
 	else

--- a/npc/quests/dandelion_request.txt
+++ b/npc/quests/dandelion_request.txt
@@ -2180,6 +2180,8 @@ morocc,43,108,5	script	Sharp-Looking Kid	4_KID01,{
 morocc,45,110,1	script	#maobar1	WARPNPC,2,2,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if(mao_request || Class == Job_Assassin || Class == Job_Assassin_Cross) warp "que_job01",9,94;
 	else
 	{
@@ -2251,6 +2253,8 @@ OnTouch:
 que_job01,6,94,1	script	#maobar2	WARPNPC,2,2,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "morocc",45,103;
 	end;
 }
@@ -2258,6 +2262,8 @@ OnTouch:
 que_job01,17,48,1	script	#maobar3	WARPNPC,2,2,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",68,92;
 	end;
 }
@@ -2265,6 +2271,8 @@ OnTouch:
 que_job01,68,96,1	script	#maobar4	WARPNPC,2,2,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",17,53;
 	end;
 }
@@ -2272,6 +2280,8 @@ OnTouch:
 que_job01,80,77,1	script	#maobar5	WARPNPC,2,2,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if(mao_request > 1) warp "que_job01",61,50;
 	else
 	{
@@ -2382,6 +2392,8 @@ OnTouch:
 que_job01,65,50,1	script	#maobar4-2	WARPNPC,2,2,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",84,77;
 	end;
 }
@@ -2739,6 +2751,8 @@ que_job01,49,49,5	script	Tao	4_F_YUNYANG,{
 que_job01,51,55,1	script	#roombar1	WARPNPC,1,1,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if(mao_request == 2 || mao_request == 24 || mao_request == 28 || mao_request == 29 || mao_request == 123 || mao_request == 126 || mao_request == 127 || prt_curse == 24)
 	{
 		if(!$@maobar_room)
@@ -2856,6 +2870,8 @@ OnTouch:
 que_job01,51,44,1	script	#roombar2	WARPNPC,1,1,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if(mao_request == 25 || (mao_request > 102 && mao_request < 123))
 	{
 		if(mao_request == 121)
@@ -2978,6 +2994,8 @@ OnEnter:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",52,50;
 	end;
 }
@@ -2993,6 +3011,8 @@ OnEnter:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",52,50;
 	end;
 }
@@ -3000,6 +3020,8 @@ OnTouch:
 que_job01,11,4,1	script	#maoexit1	WARPNPC,1,1,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",52,50;
 	donpcevent "#maobartimer1::OnStop";
 	end;
@@ -3008,6 +3030,8 @@ OnTouch:
 que_job01,80,27,1	script	#maoexit2	WARPNPC,1,1,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",52,50;
 	donpcevent "#maobartimer2::OnStop";
 	end;
@@ -3016,6 +3040,8 @@ OnTouch:
 que_job01,144,61,1	script	#maoexit3	WARPNPC,1,1,{
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",52,50;
 	donpcevent "#maobartimer2::OnStop";
 	end;

--- a/npc/quests/kiel_hyre_quest.txt
+++ b/npc/quests/kiel_hyre_quest.txt
@@ -4892,6 +4892,8 @@ OnTouch:
 // After 30-40 seonds this NPC should be disabled.
 kh_mansion,29,27,0	script	Kiehl_Room_Warp	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "kh_kiehl01",10,31;
 	end;
 
@@ -5165,6 +5167,8 @@ yuno,250,132,0	script	Old Lady#kh	4_F_05,{
 //- Warp portal into Rosimier Mansion -
 yuno,273,141,0	script	Rosimmir_Entrance	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (countitem(Rosimier_Key) < 1) {
 		mes "That mansion seems to have";
 		mes "been destroyed by the time.";
@@ -5776,6 +5780,8 @@ OnTimer30000:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "kh_kiehl01",55,33;
 	end;
 }
@@ -5832,6 +5838,8 @@ OnTimer30000:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "kh_kiehl01",173,52;
 	end;
 }
@@ -5890,6 +5898,8 @@ OnTimer30000:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "kh_kiehl01",68,108;
 	end;
 }
@@ -5945,6 +5955,8 @@ OnTimer30000:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "kh_kiehl01",49,177;
 	end;
 }
@@ -6150,6 +6162,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if (KielHyreQuest >= 46)
 		warp "kh_kiehl02",50,7;
 	else
@@ -6755,6 +6769,8 @@ OnInit:
 //- Kiehl's Room; Kiehl_Room_Exit -
 kh_kiehl02,50,59,0	script	Kiehl_Room_Exit	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (getmapusers("kh_kiehl02") < 1)
 		donpcevent "KiehlRoom::OnReset";
 	warp "lighthalzen",193,202;

--- a/npc/quests/okolnir.txt
+++ b/npc/quests/okolnir.txt
@@ -391,6 +391,8 @@ que_qsch05,345,82,3	duplicate(Wish Maiden#gq_main)	Wish Maiden#gq_sch05	4_F_VALK
 	.@sub$ = callfunc("F_Okolnir");
 
 OnTouch:
+	if (checkhiding())
+		end;
 	.@sub$ = callfunc("F_Okolnir");
 	.@saram = getmapusers("que_q"+.@sub$);
 	if (.@saram < 21) {
@@ -956,6 +958,8 @@ que_qsch05,2,3,0	duplicate(#miro_yf_main)	#miro_yf_sch05	CLEAR_NPC
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	.@sub$ = callfunc("F_Okolnir");
 	if (countitem(Crystal_Key)) {
 		mes "The Warp Gate responds to the Crystal Key.";
@@ -1532,6 +1536,8 @@ que_qsch05,1,8,0	duplicate(#gd_main_mobctrl)	#gd_sch05_mobctrl	CLEAR_NPC
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	.@sub$ = callfunc("F_Okolnir");
 	if (compare(strnpcinfo(NPC_NAME),"windpath03")) {
 		warp "que_q"+.@sub$,119,103;
@@ -2290,6 +2296,8 @@ que_qsch05,252,340,3	duplicate(Wish Maiden#main_gift)	Wish Maiden#sch05_gift	4_F
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	.@t$ = ((compare(strnpcinfo(NPC_MAP),"aru"))?"arug_cas0":"schg_cas0")+(charat(strnpcinfo(NPC_MAP),getstrlen(strnpcinfo(NPC_MAP))-1));
 	warp .@t$,157,369;
 	end;

--- a/npc/quests/quests_13_1.txt
+++ b/npc/quests/quests_13_1.txt
@@ -11978,6 +11978,8 @@ morocc,43,108,5	script	Sharp-Looking Boy#dan_07	4_KID01,{
 
 morocc,45,110,0	script	que_job01#01	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (BaseJob == Job_Assassin) {
 		warp "que_job01",9,94;
 		end;
@@ -12205,6 +12207,8 @@ que_job01,82,95,3	script	Bar Master#moc2_01	1_ETC_01,{
 
 que_job01,80,77,0	script	que_job01#04	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (BaseJob == Job_Assassin || mao_request > 0 || mao_morocc2 > 4) {
 		warp "que_job01",61,50;
 		end;
@@ -12413,6 +12417,8 @@ OnReset:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "[Tao]";
 	if (prt_curse == 24) {
 		if ($@moc_mao_room1 == 0) {
@@ -12519,6 +12525,8 @@ OnTouch:
 
 que_job01,11,4,0	script	que_job01#room1_out	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",52,50;
 	donpcevent " #room1timer::OnStop";
 	end;
@@ -12573,6 +12581,8 @@ OnReset:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((mao_morocc2 > 4) && (mao_morocc2 < 10)) {
 		if ($@moc_mao_room2 == 0) {
 			$@moc_mao_room2 = 1; //Global Variable
@@ -12717,6 +12727,8 @@ OnTouch:
 
 que_job01,80,27,0	script	que_job01#room2_1_out	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",52,50;
 	donpcevent " #room2timer::OnStop";
 	end;
@@ -12724,6 +12736,8 @@ OnTouch:
 
 que_job01,144,61,0	script	que_job01#room2_2_out	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",52,50;
 	donpcevent " #room2timer::OnStop";
 	end;

--- a/npc/quests/quests_13_2.txt
+++ b/npc/quests/quests_13_2.txt
@@ -1860,6 +1860,8 @@ man_in01,175,59,5	script	Snorren#ep13_13	4_MAN_PIOM,{
 
 man_in01,183,58,0	script	to_in013ep13mdwarp01	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((ep13_mdrama > 17) && (ep13_mdrama < 24)) {
 		warp "man_in01",13,125;
 		end;
@@ -2533,6 +2535,8 @@ spl_in02,239,93,3	duplicate(Arc#ep13md_l02)	Terra#ep13md_l03	4_F_FAIRYKID6
 
 splendide,287,140,0	script	terrashome_in	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (ep13_mdrama > 25) {
 		warp "spl_in02",237,89;
 		end;

--- a/npc/quests/quests_ein.txt
+++ b/npc/quests/quests_ein.txt
@@ -4191,6 +4191,8 @@ einbroch,51,52,0	script	Security#ein	WARPNPC,1,1,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if (((Shinokas_Quest == 7) || (lhz_heart == 9)) || (lhz_heart == 10)) {
 		mes "[Security System]";
 		mes "^8B0000*Beep Boop*^000000";

--- a/npc/quests/quests_hugel.txt
+++ b/npc/quests/quests_hugel.txt
@@ -9824,6 +9824,8 @@ OnTouch:
 
 hu_in01,15,108,0	script	alex#warp	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (hg_odin == 17) {
 		mes "[Alex]";
 		mes "Haven't you found it yet?";
@@ -9914,6 +9916,8 @@ OnTouch:
 
 hugel,52,90,0	script	alex#warp2	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (hg_odin > 59) warp "hu_in01",102,90;
 	else if (hg_odin > 21 && hg_odin < 60) warp "hu_in01",173,90;
 	else warp "hu_in01",33,90;
@@ -9922,12 +9926,16 @@ OnTouch:
 
 hu_in01,155,70,0	script	alex#warp3	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "^3355FFThe door is locked.^000000";
 	close;
 }
 
 hu_in01,155,108,0	script	alex#warp4	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "^3355FFThe door is locked.^000000";
 	close;
 }

--- a/npc/quests/quests_juperos.txt
+++ b/npc/quests/quests_juperos.txt
@@ -4896,6 +4896,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "jupe_core",rand(149,151),286;
 	end;
 }
@@ -4936,6 +4938,8 @@ OnTimer10000:
 
 juperos_02,33,59,0	script	jupe_goto2F	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	switch(rand(1,4)) {
 	case 1: warp "juperos_01",120,72; end;
 	case 2: warp "juperos_01",120,112; end;

--- a/npc/quests/quests_lighthalzen.txt
+++ b/npc/quests/quests_lighthalzen.txt
@@ -3371,7 +3371,7 @@ yuno_in04,168,117,3	script	Book#lhz	HIDDEN_NPC,{
 
 //== Cursed Spirit Quest ===================================
 lhz_dun01,147,106,0	script	#kiz01-1	FAKE_NPC,3,3,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0 ) {
 		if (lhz_curse == 0) {
 			soundeffect "loli_ruri_stand.wav",0;
@@ -3411,7 +3411,7 @@ lhz_dun01,66,212,0	duplicate(#kiz01-1)	#kiz01-3	FAKE_NPC,3,3
 lhz_dun01,225,198,0	duplicate(#kiz01-1)	#kiz01-4	FAKE_NPC,3,3
 
 lhz_dun02,244,229,0	script	#kiz02-1	FAKE_NPC,3,3,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0 ) {
 		if (lhz_curse == 0) {
 			soundeffect "tao_gunka_stand.wav",0;
@@ -3451,7 +3451,7 @@ lhz_dun02,267,278,0	duplicate(#kiz02-1)	#kiz02-3	FAKE_NPC,3,3
 lhz_dun02,94,199,0	duplicate(#kiz02-1)	#kiz02-4	FAKE_NPC,3,3
 
 lhz_dun03,244,51,0	script	#kiz03-1	FAKE_NPC,3,3,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0 ) {
 		if (lhz_curse == 0) {
 			soundeffect "tao_gunka_stand.wav",0;
@@ -3490,7 +3490,7 @@ lhz_dun03,123,191,0	duplicate(#kiz03-1)	#kiz03-2	FAKE_NPC,3,3
 lhz_dun03,74,140,0	duplicate(#kiz03-1)	#kiz03-3	FAKE_NPC,3,3
 
 lighthalzen,344,278,0	script	#kiz03	FAKE_NPC,2,2,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0 ) {
 		if (lhz_curse == 0) {
 			soundeffect "tao_gunka_stand.wav",0;
@@ -3541,7 +3541,7 @@ OnTouch_:
 }
 
 lhz_in03,178,22,0	script	#kiz04	FAKE_NPC,2,2,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0 ) {
 		if (lhz_curse == 0) {
 			sc_start SC_CURSE,1000,0;
@@ -3620,7 +3620,7 @@ OnTouch_:
 }
 
 lighthalzen,295,227,0	script	#kiz05	FAKE_NPC,2,2,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0 ) {
 		if (lhz_curse == 0) {
 			sc_start SC_CURSE,1000,0;
@@ -3666,7 +3666,7 @@ OnTouch_:
 }
 
 lighthalzen,364,315,0	script	#kiz06	FAKE_NPC,3,3,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0 ) {
 		if (lhz_curse == 0) {
 			sc_start SC_CURSE,1000,0;
@@ -3725,7 +3725,7 @@ OnTouch_:
 }
 
 lhz_in01,113,150,0	script	#kiz07	FAKE_NPC,3,3,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0 ) {
 		if (lhz_curse == 0) {
 			sc_start SC_CURSE,1000,0;
@@ -3779,7 +3779,7 @@ OnTouch_:
 }
 
 lhz_in01,272,227,0	script	#kiz08	FAKE_NPC,2,2,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0 ) {
 		if (lhz_curse == 0) {
 			sc_start SC_CURSE,1000,0;
@@ -3863,7 +3863,7 @@ OnTouch_:
 }
 
 lhz_in01,206,129,0	script	#kiz09	FAKE_NPC,5,5,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0) {
 		if (lhz_curse == 12) {
 			mes "............";
@@ -4153,7 +4153,7 @@ lhz_que01,29,24,3	script	#li_researcher	4_M_SAGE_A,{
 }
 
 lhz_in01,282,166,0	script	#kiz10	FAKE_NPC,3,3,{
-OnTouch_:
+OnTouch:
 	if (countitem(Armlet_Of_Prisoner) > 0) {
 		if (lhz_curse == 16) {
 			if (checkweight(Knife,1) == 0) {
@@ -4327,7 +4327,7 @@ lhz_que01,90,71,5	script	#li_bird	PECOPECO,3,3,{
 	mes "You're a fool!";
 	close;
 
-OnTouch_:
+OnTouch:
 	mes "[Peco Peco]";
 	mes "You're a fool!";
 	mes "You're a fool!";
@@ -5169,6 +5169,8 @@ lhz_in03,32,162,3	script	Crippled Girl#li_tre	1_M_INNKEEPER,{
 }
 
 lighthalzen,324,322,0	script	#li_door	WARPNPC,2,2,{
+	end;
+
 OnTouch:
 	if (checkhiding())
 		end;
@@ -5203,7 +5205,7 @@ OnTouch:
 lhz_in03,12,162,0	warp	#to_lhz	1,1,lighthalzen,321,322
 
 lighthalzen,319,321,0	script	#li_bother	FAKE_NPC,2,2,{ //3,3
-OnTouch_:
+OnTouch:
 	if ((lhz_curse == 24 ) || (lhz_curse == 25)) {
 		mes ".............";
 		next;
@@ -6273,7 +6275,7 @@ lhz_in01,286,226,3	script	Secretary Slierre#li	4_F_ZONDAGIRL,{
 }
 
 lhz_que01,94,24,0	script	#li_end	FAKE_NPC,2,2,{
-OnTouch_:
+OnTouch:
 	if (lhz_curse > 30) {
 		mes "^3131FFThere's no trace of";
 		mes "that mad scientist. Only";
@@ -6289,6 +6291,8 @@ OnTouch_:
 }
 
 lhz_in01,43,114,0	script	#li_toend	WARPNPC,1,1,{
+	end;
+
 OnTouch:
 	if (checkhiding())
 		end;

--- a/npc/quests/quests_lighthalzen.txt
+++ b/npc/quests/quests_lighthalzen.txt
@@ -1711,6 +1711,8 @@ lhz_cube,250,184,0	script	Door#cube	HIDDEN_NPC,{
 
 lhz_dun02,224,6,0	script	Exit1#lt	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (MISC_QUEST&512) {
 		warp "lhz_cube",231,90;
 		end;
@@ -5167,7 +5169,9 @@ lhz_in03,32,162,3	script	Crippled Girl#li_tre	1_M_INNKEEPER,{
 }
 
 lighthalzen,324,322,0	script	#li_door	WARPNPC,2,2,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	if ((lhz_curse > 19) && (lhz_curse < 23)) {
 		mes "^3355FFThe door is locked.^000000";
 		lhz_curse = lhz_curse+1;
@@ -6285,7 +6289,9 @@ OnTouch_:
 }
 
 lhz_in01,43,114,0	script	#li_toend	WARPNPC,1,1,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	if (lhz_curse > 30) {
 		warp "lhz_que01",97,30;
 	}

--- a/npc/quests/quests_morocc.txt
+++ b/npc/quests/quests_morocc.txt
@@ -187,6 +187,8 @@ morocc,43,108,5	script	Sharp-Looking Kid#dan_07	4_KID01,{
 
 morocc,45,110,0	script	que_job01#01	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (BaseJob == Job_Assassin) {
 		warp "que_job01",9,94;
 		end;
@@ -212,6 +214,8 @@ que_job01,68,96,0	warp	que_job01#03	2,2,que_job01,17,53
 
 que_job01,80,77,0	script	que_job01#04	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (BaseJob == Job_Assassin) {
 		warp "que_job01",61,50;
 		end;
@@ -664,6 +668,8 @@ OnReset:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if (prt_curse == 24) {
 		if ($@maobar_room == 0) {
 			$@maobar_room = 1;
@@ -781,6 +787,8 @@ que_job01,51,44,0	warp	que_job01#room_2	1,1,que_job01,80,23
 
 que_job01,11,4,0	script	que_job01#room1_out	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "que_job01",52,50;
 	donpcevent " #room1timer::OnStop";
 	end;
@@ -7519,6 +7527,8 @@ OnDisable:
 
 prt_castle,318,276,0	script	#eisen	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((nkprince_eisen == 4) || (nkprince_eisen == 5)) {
 		donpcevent "Prince#another_ern::OnEnable";
 		nkprince_eisen = 5;
@@ -7611,6 +7621,8 @@ OnTouch:
 
 prt_castle,336,276,0	script	#ern	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (questprogress(10023) == 1) {
 		donpcevent "Prince#eisen6::OnEnable";
 	}
@@ -7620,6 +7632,8 @@ OnTouch:
 
 prt_castle,300,276,0	script	#erich	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (questprogress(10020) == 1) {
 		donpcevent "Prince#eisen1::OnEnable";
 	}
@@ -7629,6 +7643,8 @@ OnTouch:
 
 prt_castle,330,271,0	script	#helmut	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (questprogress(10022) == 1) {
 		donpcevent "Prince#eisen3::OnEnable";
 	}
@@ -7638,6 +7654,8 @@ OnTouch:
 
 prt_castle,348,271,0	script	#poe	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (questprogress(10018) == 1) {
 		donpcevent "Prince#eisen4::OnEnable";
 	}
@@ -7647,6 +7665,8 @@ OnTouch:
 
 prt_castle,354,276,0	script	#peter	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (questprogress(10019) == 1) {
 		donpcevent "Prince#eisen5::OnEnable";
 	}
@@ -7656,6 +7676,8 @@ OnTouch:
 
 prt_castle,310,271,0	script	#urgen	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (questprogress(10021) == 1) {
 		donpcevent "Prince#eisen2::OnEnable";
 	}

--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -9320,6 +9320,8 @@ moc_pryd04,126,120,0	script	Soldier#rus26	4_M_RUSMAN1,{
 mosk_dun01,45,250,3	script	1#rus27	WARPNPC,3,3,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "mosk_que",49,22;
 	end;
 

--- a/npc/quests/quests_nameless.txt
+++ b/npc/quests/quests_nameless.txt
@@ -1134,6 +1134,8 @@ nameless_in,12,37,0	script	Out_from_Monastery	WARPNPC,1,1,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if (aru_monas == 19) {
 		aru_monas = 20;
 		warp "nameless_n",168,252;
@@ -1149,6 +1151,8 @@ nameless_i,168,257,0	script	outtoin_01#mo	WARPNPC,1,1,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if (aru_monas == 18 || aru_monas == 19) {
 		warp "nameless_in",12,41;
 		end;

--- a/npc/quests/quests_rachel.txt
+++ b/npc/quests/quests_rachel.txt
@@ -3739,6 +3739,8 @@ OnTimer60000:
 
 ice_dun03,150,137,0	script	#ice_4f_1	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "ice_dun04",33,144;
 	end;
 
@@ -3749,6 +3751,8 @@ OnInit:
 
 ice_dun03,138,148,0	script	#ice_4f_2	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "ice_dun04",33,144;
 	end;
 
@@ -3759,6 +3763,8 @@ OnInit:
 
 ice_dun03,161,148,0	script	#ice_4f_3	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "ice_dun04",33,144;
 	end;
 
@@ -3769,6 +3775,8 @@ OnInit:
 
 ice_dun03,151,162,0	script	#ice_4f_4	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "ice_dun04",33,144;
 	end;
 
@@ -3780,6 +3788,8 @@ OnInit:
 //== Donation Lottery Quest/High Priest Quest :: rachel_oz & rachel_ma1 =
 ra_temple,119,180,0	script	Temple Entrance#ra_tem	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ($rachel_donate >= 10000) {
 		if (MISC_QUEST & 8192) { warp "ra_temin",169,23; end; }
 
@@ -4705,6 +4715,8 @@ que_rachel,165,37,0	duplicate(nemma01)	nemma04	FAKE_NPC,5,5
 que_rachel,160,37,0	duplicate(nemma01)	nemma05	FAKE_NPC,5,5
 
 que_rachel,169,18,0	script	Quest Temple Exit#ra_tem	WARPNPC,2,2,{
+	if (checkhiding())
+		end;
 	mes "^3355FFThe gate is closed.^000000";
 	next;
 	switch(select("Push Gate", "Examine Gate", "Kick Gate", "Smash Gate with Weapon")) {
@@ -6801,6 +6813,8 @@ ra_temin,134,134,3	duplicate(raofficeguard)	Pope's Office Guard#2ra	4_M_MASK1
 
 ra_temin,134,131,0	script	gyoin1#rachel	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (ra_tem_q == 16)
 		warp "ra_temin",276,239;
 	else if ((ra_tem_q > 16) || (MISC_QUEST & 8192)){
@@ -6825,6 +6839,8 @@ OnTouch:
 ra_temin,275,226,0	script	#rachel33	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (aru_em == 21)
 		warp "que_temsky",99,11;
 	else
@@ -7285,6 +7301,8 @@ OnTouch:
 
 ra_temin,28,319,0	script	saint1#rachel	WARPNPC,4,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((ra_tem_q > 21) || (MISC_QUEST & 8192)) { warp "ra_san01",140,135; end; }
 
 	if (ra_tem_q == 21) {

--- a/npc/quests/quests_veins.txt
+++ b/npc/quests/quests_veins.txt
@@ -7243,7 +7243,9 @@ thor_camp,98,209,5	script	Thor Volcano Soldier#vo9	4_DST_SOLDIER,{
 }
 
 thor_v02,143,78,0	script	#totcamp	WARPNPC,2,2,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	if (rachel_camel < 24) {
 		warp "que_thor",65,55;
 		end;
@@ -7253,13 +7255,17 @@ OnTouch_:
 }
 
 que_thor,69,56,0	script	#tov_1	WARPNPC,2,2,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp "thor_v02",146,84;
 	end;
 }
 
 que_thor,187,56,0	script	#tov_2	WARPNPC,2,2,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	warp "thor_v02",146,84;
 	end;
 }

--- a/npc/quests/seals/sleipnir_seal.txt
+++ b/npc/quests/seals/sleipnir_seal.txt
@@ -1856,6 +1856,8 @@ que_god01,84,95,0	script	Switch#God0	HIDDEN_NPC,{
 
 que_god01,84,92,0	script	god_sl_w0	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((god_sl_1 > 1) && (god_sl_1 < 51)) {
 		mes "^3355FFThe door is locked. You slide your temporary pass on the security device on the right side of the door, and the door unlocks.^000000";
 		next;
@@ -1883,6 +1885,8 @@ que_god01,49,97,0	script	Switch#God1	HIDDEN_NPC,{
 
 que_god01,46,97,0	script	god_sl_w1	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((god_sl_1 > 1) && (god_sl_1 < 51)) {
 		mes "^3355FFThe door is locked. You slide your temporary pass on the security device on the right side of the door, and the door unlocks.^000000";
 		next;
@@ -1910,6 +1914,8 @@ que_god01,19,97,0	script	Switch#God2	HIDDEN_NPC,{
 
 que_god01,16,97,0	script	god_sl_w2	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((god_sl_1 > 1) && (god_sl_1 < 51)) {
 		mes "^3355FFThe door is locked. You slide your temporary pass on the security device on the right side of the door, and the door unlocks.^000000";
 		next;
@@ -1937,6 +1943,8 @@ que_god01,14,80,0	script	Switch#God3	HIDDEN_NPC,{
 
 que_god01,17,80,0	script	god_sl_w3	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((god_sl_1 > 1) && (god_sl_1 < 51)) {
 		mes "^3355FFThe door is locked. You slide your temporary pass on the security device on the right side of the door, and the door unlocks.^000000";
 		next;
@@ -1964,6 +1972,8 @@ que_god01,44,80,0	script	Switch#God4	HIDDEN_NPC,{
 
 que_god01,47,80,0	script	god_sl_w4	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((god_sl_1 > 1) && (god_sl_1 < 51)) {
 		mes "^3355FFThe door is locked. You slide your temporary pass on the security device on the right side of the door, and the door unlocks.^000000";
 		next;

--- a/npc/quests/thana_quest.txt
+++ b/npc/quests/thana_quest.txt
@@ -895,6 +895,8 @@ OnInit:
 	disablenpc "3rdf_warp#tt";
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (thana_tower == 0) warp "tha_t02",227,158;
 	else warp "tha_t03",219,159;
 	end;
@@ -2080,6 +2082,8 @@ OnOn2:
 	initnpctimer;
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@touch = 1;
 OnTimer6000:
 	if (($@thana_summon == 0) || ($@thana_summon == 6)) {
@@ -2314,6 +2318,8 @@ tha_t04,81,36,0	warp	to 5th Floor	1,1,tha_t05,62,8
 tha_t06,119,120,0	script	to 7th Floor	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (eaclass()&(EAJL_2|EAJL_UPPER) || eaclass()&EAJL_THIRD || ((Class == Job_SuperNovice || Class == Job_Taekwon || Class == Job_Star_Gladiator || Class == Job_Soul_Linker || BaseClass == Job_Ninja || Class == Job_Gunslinger) && BaseLevel > 94)) {
 		if (countitem(Key_Black) > 0) {
 			mes "The shadow of a Black Key is gleaming in the center of the portal.";

--- a/npc/quests/the_sign_quest.txt
+++ b/npc/quests/the_sign_quest.txt
@@ -12251,6 +12251,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	callfunc("F_UpdateSignVars");
 	.@geffenia_warp = rand(1,4);
 	if (.@geffenia_warp == 1) warp "gefenia01",58,169;
@@ -12418,6 +12420,8 @@ que_sign02,0,0,0,0	monster	Wraith Dead	1566,8,0,0,0
 
 que_sign02,378,235,0	script	sign_w6	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	callfunc "F_UpdateSignVars";
 	if ((countitem(Seal_Of_Witch) == 1) && ((sign_q != 124) || (sign_q != 125) || (sign_q != 126))) {
 		warp "que_sign01",197,190;

--- a/npc/re/instances/BuwayaCave.txt
+++ b/npc/re/instances/BuwayaCave.txt
@@ -127,6 +127,8 @@ ma_fild02,312,317,5	script	Guard#buwaya_cave	4_MAL_SOLDIER,{
 ma_fild02,315,323,0	script	Cave Entrance#buwaya	WARPNPC,2,2,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (BaseLevel < 130) {
 		mes("[Guard]");
 		mes("People under ^ff0000level 130^000000");
@@ -287,6 +289,8 @@ OnEnable:
 	enablenpc(instance_npcname("#box_out"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@x = rand(1, 20) + 97;
 	.@y = rand(1, 20) + 74;
 	warp(instance_mapname("1@ma_c"), .@x, .@y);
@@ -447,6 +451,8 @@ OnEnable:
 	enablenpc(instance_npcname("#cave_out"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	mes("Would like to go out?");
 	next();
 	if (select("Yes!", "No, I will stay.") == 1)

--- a/npc/re/instances/HazyForest.txt
+++ b/npc/re/instances/HazyForest.txt
@@ -1090,6 +1090,8 @@ bif_fild01,38,374,0	script	Mysterious Flower#ep14_1	CLEAR_NPC,{
 1@mist,109,70,0	script	a1_a2	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (!questprogress(7211, PLAYTIME))
 		setquest(7211);
 	warp(instance_mapname("1@mist"), 116, 40);

--- a/npc/re/instances/MalangdoCulvert.txt
+++ b/npc/re/instances/MalangdoCulvert.txt
@@ -551,6 +551,8 @@ OnInstanceInit:
 	disablenpc(instance_npcname("Culvert Entrance#i"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (BaseLevel >= 140)
 		warp(instance_mapname("2@pump"), 38, 88);
 	else
@@ -943,6 +945,8 @@ OnInstanceInit:
 	disablenpc(instance_npcname(strnpcinfo(NPC_NAME)));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	warp("mal_in01", 161, 32);
 	end;
 }

--- a/npc/re/instances/OldGlastHeim.txt
+++ b/npc/re/instances/OldGlastHeim.txt
@@ -748,6 +748,8 @@ OnEnable:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	.@map1$ = instance_mapname("1@gl_k");
 	.@map2$ = instance_mapname("2@gl_k");
 	switch (atoi(replacestr(strnpcinfo(NPC_NAME_HIDDEN), "ghinstancewarp", ""))) {

--- a/npc/re/instances/WolfchevLaboratory.txt
+++ b/npc/re/instances/WolfchevLaboratory.txt
@@ -1338,6 +1338,8 @@ lhz_dun03,239,78,1	script	lhz_dun03_lhz_dun04	WARPNPC,1,1,{
 	end;
 
 	OnTouch:
+		if (checkhiding())
+			end;
 		if (lght_duk01 > 0 && lght_duk01 < 6) {
 			mes "In order to investigate human experimentation, I had to go down whilst I didn't want to because of gruesome sound.";
 			close2;
@@ -2245,6 +2247,8 @@ lhz_dun04,147,279,0	script	Laboratory Entrance#memo	CLEAR_NPC,{
 		end;
 
 	OnTouch:
+		if (checkhiding())
+			end;
 		warp instance_mapname("1@lhz"), 151, 29;
 		end;
 }
@@ -2611,6 +2615,8 @@ lhz_dun04,147,279,0	script	Laboratory Entrance#memo	CLEAR_NPC,{
 		end;
 
 	OnTouch:
+		if (checkhiding())
+			end;
 		warp instance_mapname("1@lhz"), 84, 28;
 		end;
 }
@@ -2809,6 +2815,8 @@ lhz_dun04,147,279,0	script	Laboratory Entrance#memo	CLEAR_NPC,{
 		end;
 
 	OnTouch:
+		if (checkhiding())
+			end;
 		warp instance_mapname("1@lhz"), 137, 100;
 		end;
 }

--- a/npc/re/instances/ghost_palace.txt
+++ b/npc/re/instances/ghost_palace.txt
@@ -306,6 +306,8 @@ OnInstanceInit:
 }
 
 1@spa,54,28,0	script	#gp3warp	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (!'gp5) {
 		warp("1@spa", 218, 186);
 	} else {

--- a/npc/re/instances/octopus_cave.txt
+++ b/npc/re/instances/octopus_cave.txt
@@ -352,6 +352,8 @@ OnEnable:
 	enablenpc(instance_npcname(strnpcinfo(NPC_NAME)));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("1@cash"), 198, 99);
 	end;
 }
@@ -671,6 +673,8 @@ OnInstanceInit:
 	disablenpc(instance_npcname("oct_boss_warp"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(instance_mapname("1@cash"), 210, 172);
 	end;
 }
@@ -681,6 +685,8 @@ OnInstanceInit:
 	disablenpc(instance_npcname(strnpcinfo(NPC_NAME)));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	mes("Do you want to go out from the octopus dungeon?");
 	next();
 	if (select("No!", "Yes!") == 2)

--- a/npc/re/instances/saras_memory.txt
+++ b/npc/re/instances/saras_memory.txt
@@ -432,6 +432,8 @@ OnEnable:
 	enablenpc(instance_npcname("#sarawarp1"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@map$ = instance_mapname("1@sara");
 	warp(.@map$, 94, 320);
 	end;
@@ -449,6 +451,8 @@ OnEnable:
 	enablenpc(instance_npcname("#sarawarp2"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@map$ = instance_mapname("1@sara");
 	warp(.@map$, 230, 316);
 	end;
@@ -466,6 +470,8 @@ OnEnable:
 	enablenpc(instance_npcname("#sarawarp3"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@map$ = instance_mapname("1@sara");
 	warp(.@map$, 263, 94);
 	end;
@@ -483,6 +489,8 @@ OnEnable:
 	enablenpc(instance_npcname("#sarawarp4"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@map$ = instance_mapname("1@sara");
 	warp(.@map$, 164, 81);
 	end;
@@ -500,6 +508,8 @@ OnEnable:
 	enablenpc(instance_npcname("#sarawarp5"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@map$ = instance_mapname("1@sara");
 	warp(.@map$, 155, 196);
 	end;
@@ -517,6 +527,8 @@ OnEnable:
 	enablenpc(instance_npcname("#sarawarp6"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	.@map$ = instance_mapname("1@sara");
 	warp(.@map$, 89, 175);
 	if (getcharid(CHAR_ID_CHAR) == getpartyleader(getcharid(CHAR_ID_PARTY), 2))
@@ -536,6 +548,8 @@ OnEnable:
 	enablenpc(instance_npcname("#sarawarp7"));
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	completequest(15003);
 	warp("dali", 134, 111);
 	end;

--- a/npc/re/jobs/3-1/guillotine_cross.txt
+++ b/npc/re/jobs/3-1/guillotine_cross.txt
@@ -3835,6 +3835,8 @@ L_Info:
 job3_guil01,80,77,0	script	#gate_to_guil05	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (job_3rd_gc > 3)
 		warp "job3_guil01",60,50;
 	else {
@@ -3848,6 +3850,8 @@ OnTouch:
 job3_guil01,51,55,0	script	#gate_to_guil07	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (job_3rd_gc == 4 || job_3rd_gc == 14 || job_3rd_gc > 17)
 		warp "job3_guil01",12,7;
 	else {
@@ -3865,6 +3869,8 @@ OnTouch:
 job3_guil01,51,44,0	script	#gate_to_guil09	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (job_3rd_gc == 11 || job_3rd_gc == 12)
 		warp "job3_guil01",79,23;
 	else if (job_3rd_gc > 19)

--- a/npc/re/jobs/3-2/shadow_chaser.txt
+++ b/npc/re/jobs/3-2/shadow_chaser.txt
@@ -2504,6 +2504,8 @@ s_atelier,26,68,3	script	Vito#sc11_lgt	4_M_KHMAN,{
 tha_t01,149,228,0	script	#shadowc02	WARPNPC,2,2,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	mes "You can feel weird power.";
 	if (BaseJob == Job_Rogue && job_sha == 27) {
 		mes "You are getting dizzy.";

--- a/npc/re/quests/eden/eden_common.txt
+++ b/npc/re/quests/eden/eden_common.txt
@@ -287,6 +287,8 @@ malaya,238,206,6	duplicate(eto)	Eden Teleport Officer#32	4_F_NOVICE
 
 moc_para01,30,10,0	script	#eden_out	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	switch (nak_warp) {
 		case 1: warp "prontera",116,72; end;
 		case 2: warp "moc_ruins",64,161; end;

--- a/npc/re/quests/quests_brasilis.txt
+++ b/npc/re/quests/quests_brasilis.txt
@@ -2724,7 +2724,9 @@ bra_in01,7,181,5	script	Curator#bra	4_M_BRZ_MAN2,{
 }
 
 bra_in01,12,185,0	script	inbathroom#bra	WARPNPC,1,1,{
-OnTouch_:
+OnTouch:
+	if (checkhiding())
+		end;
 	if (brazil_ghost > 6)
 		warp "bra_in01",138,176;
 	else {

--- a/npc/re/quests/quests_eclage.txt
+++ b/npc/re/quests/quests_eclage.txt
@@ -110,6 +110,8 @@ ecl_fild01,97,322,0	script	#ep14_2Entrance	WARPNPC,3,3,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if (ep14_2_oliver < 3) {
 		mes "[Security Guard]";
 		mes "Please wait a minute.";
@@ -2330,6 +2332,8 @@ eclage,292,265,0	script	#ep14_2Yube Entrance	WARPNPC,2,2,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	if (ep14_2_oliver < 15) {
 		mes "- Looks like the door is locked. -";
 		close;

--- a/npc/re/warps/cities/eclage.txt
+++ b/npc/re/warps/cities/eclage.txt
@@ -50,6 +50,8 @@ ecl_in02,157,68,0	warp	in02-3_in02-2	1,1,ecl_in02,83,18
 ecl_in01,84,68,0	script	in01e_hub2-1	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (ep14_2_mylord == 29) {
 		warp "ecl_hub01",106,31;
 	}
@@ -63,6 +65,8 @@ ecl_hub01,127,95,0	warp	hub2-2_hub3-1	1,1,ecl_hub01,18,32
 ecl_hub01,18,34,0	script	hub3-1_hub2-2	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (ep14_2_mylord == 29) {
 		warp "ecl_hub01",135,14;
 	}

--- a/npc/re/warps/cities/izlude.txt
+++ b/npc/re/warps/cities/izlude.txt
@@ -78,6 +78,8 @@ iz_int,27,30,0	script	noviship#room1-1	WARPNPC,2,2,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp(strnpcinfo(NPC_MAP), 51, 30);
 	end;
 
@@ -92,6 +94,8 @@ iz_int,47,30,3	script	noviship#room1-2	WARPNPC,2,2,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	@display = 0;
 	warp(strnpcinfo(NPC_MAP), 22, 30);
 	end;
@@ -101,6 +105,8 @@ iz_int,56,15,0	script	noviship	WARPNPC,2,2,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	savepoint("int_land"+strnpcinfo(NPC_NAME_HIDDEN), 77, 101);
 	warp("int_land"+strnpcinfo(NPC_NAME_HIDDEN), 85, 107);
 	end;
@@ -110,6 +116,8 @@ int_land,49,57,0	script	noviship#izlude	WARPNPC,2,2,{
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	mes("^4d4dffOnce you left this island there is no way back.");
 	mes("Are you sure you want to go directly to Izlude?^000000");
 	next();

--- a/npc/re/warps/cities/malaya.txt
+++ b/npc/re/warps/cities/malaya.txt
@@ -57,6 +57,8 @@ ma_in01,105,160,0	warp	mf_in_minga_mf_minga	1,1,ma_fild01,248,190
 malaya,178,211,0	script	malaya_inn	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (malaya_hi < 10) {
 		mes "Door is closed. It seems to be keeping its eyes on you.";
 		close;
@@ -68,6 +70,8 @@ OnTouch:
 malaya,112,212,0	script	malaya_ws	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (malaya_hi < 20) {
 		mes "Door is closed. It seems to be keeping its eyes on you.";
 		close;
@@ -79,6 +83,8 @@ OnTouch:
 malaya,299,167,0	script	malaya_ts	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (malaya_hi < 20) {
 		mes "Door is closed. It seems to be keeping its eyes on you.";
 		close;
@@ -90,6 +96,8 @@ OnTouch:
 malaya,261,240,0	script	malaya_shop	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (malaya_hi < 20) {
 		mes "Door is closed. It seems to be keeping its eyes on you.";
 		close;
@@ -101,6 +109,8 @@ OnTouch:
 malaya,300,211,0	script	malaya_house01	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (malaya_hi < 10) {
 		mes "Door is closed. It seems to be keeping its eyes on you.";
 		close;
@@ -112,6 +122,8 @@ OnTouch:
 // Jeepney Warps
 //============================================================
 function	script	F_Malaya_Warp	{
+	if (checkhiding())
+		return;
 	mes "Where would you like to go?";
 	next;
 	.@i$ = getarg(select("Back outside",getarg(1)+" Jeepney",getarg(2)+" Jeepney") - 1);

--- a/npc/re/warps/fields/morroc_fild.txt
+++ b/npc/re/warps/fields/morroc_fild.txt
@@ -61,7 +61,12 @@ moc_fild03,70,341,0	warp	mocf04-1	5,2,moc_fild02,332,23
 //moc_fild04,14,98,0	warp	mocf07	1,11,moc_fild05,378,119
 //moc_fild04,175,18,0	warp	mocf08	3,2,moc_fild08,170,380
 //moc_fild04,19,206,0	warp	mocf09	3,15,moc_fild05,373,208
-//moc_fild04,219,327,0	script	mocf016	WARPNPC,3,4,{ @anthell = 0; warp "anthell01",35,262; }
+//moc_fild04,219,327,0	script	mocf016	WARPNPC,3,4,{
+//	if (checkhiding())
+//		end;
+//	@anthell = 0;
+//	warp("anthell01", 35, 262);
+//}
 //moc_fild04,292,381,0	warp	mocf01-2	10,1,moc_fild01,76,25
 //moc_fild04,314,381,0	warp	mocf01-3	10,1,moc_fild01,76,25
 //moc_fild04,336,381,0	warp	mocf01-4	10,1,moc_fild01,76,25
@@ -114,7 +119,12 @@ moc_fild13,308,49,0	warp	mocf06-1	2,4,moc_fild03,20,37
 //moc_fild14,196,382,0	warp	mocf16-1	4,2,moc_fild08,204,19
 //moc_fild15,104,16,0	warp	mocf26	9,2,moc_fild16,125,380
 //moc_fild15,158,363,0	warp	mocf18-1	6,2,moc_fild09,126,23
-//moc_fild15,258,253,0	script	mocf017	WARPNPC,3,3,{ @anthell = 1; warp "anthell01",35,262; }
+//moc_fild15,258,253,0	script	mocf017	WARPNPC,3,3,{
+//	if (checkhiding())
+//		end;
+//	@anthell = 1;
+//	warp("anthell01", 35, 262);
+//}
 //moc_fild15,348,18,0	warp	mocf27	5,2,moc_fild16,334,379
 //moc_fild15,367,276,0	warp	mocf25-1	2,4,moc_fild14,19,278
 //moc_fild15,38,105,0	warp	mocf23-1	2,4,moc_fild11,376,197

--- a/npc/re/warps/fields/veins_fild.txt
+++ b/npc/re/warps/fields/veins_fild.txt
@@ -54,6 +54,8 @@ ve_fild04,115,50,0	warp	ve_fild4-3	1,1,ve_fild06,80,183
 ve_fild06,153,220,0	warp	ve_fild6-1	1,1,veins,218,355
 /*
 ve_fild06,81,177,0	script	ve_fild6-2	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (rand(2))
 		warp "ve_fild04",115,55;
 	else

--- a/npc/warps/cities/umbala.txt
+++ b/npc/warps/cities/umbala.txt
@@ -50,6 +50,8 @@ umbala,107,130,0	warp	um_houseB1-1	1,1,um_in,99,66
 um_in,99,63,0	warp	um_houseB1-2	1,1,umbala,108,127
 umbala,220,189,0	script	um_shaman1-1	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (event_umbala == 7) {
 		warp "um_in",32,71;
 	}

--- a/npc/warps/cities/yuno.txt
+++ b/npc/warps/cities/yuno.txt
@@ -105,6 +105,8 @@ yuno_in01,101,85,0	warp	yun66	1,1,yuno,245,144
 
 // Juno In05 (Entering Random Warps) -------------------------------------------
 yuno_in05,153,141,0	script	#yun63	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (rand(2))
 		warp "yuno_in05",192,102;
 	else
@@ -113,6 +115,8 @@ yuno_in05,153,141,0	script	#yun63	WARPNPC,1,1,{
 }
 // Juno In05 (Random Warps - Cross Shaped) -------------------------------------
 yuno_in05,196,102,0	script	#yun64	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "yuno_in05",169,102; end;
 		case 1: warp "yuno_in05",128,82;  end;
@@ -120,6 +124,8 @@ yuno_in05,196,102,0	script	#yun64	WARPNPC,1,1,{
 	}
 }
 yuno_in05,181,116,0	script	#yun65	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "yuno_in05",181,94; end;
 		case 1: warp "yuno_in05",176,13; end;
@@ -127,6 +133,8 @@ yuno_in05,181,116,0	script	#yun65	WARPNPC,1,1,{
 	}
 }
 yuno_in05,165,102,0	script	#yun66	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (rand(2))
 		warp "yuno_in05",192,102;
 	else
@@ -134,6 +142,8 @@ yuno_in05,165,102,0	script	#yun66	WARPNPC,1,1,{
 	end;
 }
 yuno_in05,181,91,0	script	#yun67	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (rand(2))
 		warp "yuno_in05",181,112;
 	else
@@ -142,6 +152,8 @@ yuno_in05,181,91,0	script	#yun67	WARPNPC,1,1,{
 }
 // Juno In05 (Random Warps - T-Shaped) -----------------------------------------
 yuno_in05,148,82,0	script	#yun68	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "yuno_in05",169,102; end;
 		case 1: warp "yuno_in05",128,82;  end;
@@ -149,6 +161,8 @@ yuno_in05,148,82,0	script	#yun68	WARPNPC,1,1,{
 	}
 }
 yuno_in05,125,82,0	script	#yun69	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (rand(2))
 		warp "yuno_in05",192,102;
 	else
@@ -156,6 +170,8 @@ yuno_in05,125,82,0	script	#yun69	WARPNPC,1,1,{
 	end;
 }
 yuno_in05,136,71,0	script	#yun70	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "yuno_in05",181,112; end;
 		case 1: warp "yuno_in05",16,185;  end;
@@ -164,6 +180,8 @@ yuno_in05,136,71,0	script	#yun70	WARPNPC,1,1,{
 }
 // Juno In05 (Random Warps - Other) --------------------------------------------
 yuno_in05,16,188,0	script	#yun71	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "yuno_in05",181,94; end;
 		case 1: warp "yuno_in05",176,13; end;
@@ -171,6 +189,8 @@ yuno_in05,16,188,0	script	#yun71	WARPNPC,1,1,{
 	}
 }
 yuno_in05,176,9,0	script	#yun72	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (rand(2))
 		warp "yuno_in05",181,112;
 	else
@@ -178,6 +198,8 @@ yuno_in05,176,9,0	script	#yun72	WARPNPC,1,1,{
 	end;
 }
 yuno_in05,176,52,0	script	#yun73	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "yuno_in05",181,94; end;
 		case 1: warp "yuno_in05",176,13; end;
@@ -186,6 +208,8 @@ yuno_in05,176,52,0	script	#yun73	WARPNPC,1,1,{
 }
 // Juno In05 (Destination - Room) ----------------------------------------------
 yuno_in05,40,178,0	script	#yun74	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "yuno_in05",181,94; end;
 		case 1: warp "yuno_in05",176,13; end;
@@ -193,6 +217,8 @@ yuno_in05,40,178,0	script	#yun74	WARPNPC,1,1,{
 	}
 }
 yuno_in05,47,186,0	script	#yun75	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "yuno_in05",181,94; end;
 		case 1: warp "yuno_in05",176,13; end;

--- a/npc/warps/dungeons/alde_dun.txt
+++ b/npc/warps/dungeons/alde_dun.txt
@@ -46,6 +46,8 @@ alde_dun02,187,234,0	warp	ald007	2,2,c_tower3,65,147
 
 //== Random B2 =============================================
 alde_dun02,267,41,4	script	ald008r	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (rand(2))
 		warp "c_tower3",168,252;
 	else
@@ -59,6 +61,8 @@ alde_dun03,276,48,0	warp	ald012	2,2,c_tower1,235,223
 
 //== Random B3-1 ===========================================
 alde_dun03,130,125,4	script	ald014r	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "c_tower2",228,267; end;
 		case 1: warp "alde_dun03",130,130; end;
@@ -68,6 +72,8 @@ alde_dun03,130,125,4	script	ald014r	WARPNPC,1,1,{
 
 //== Random 3-2 ============================================
 alde_dun03,171,127,4	script	ald015r	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "c_tower2",13,282; end;
 		case 1: warp "alde_dun03",175,131; end;
@@ -81,6 +87,8 @@ alde_dun04,32,74,0	warp	aldd19	1,1,alde_dun02,187,239
 alde_dun04,208,58,0	warp	aldd20	2,2,alde_dun04,268,74
 alde_dun04,272,74,0	warp	aldd021	2,2,alde_dun04,204,62
 alde_dun04,80,34,4	script	ald022r	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "c_tower2",13,282; end;
 		case 1: warp "alde_dun03",175,131; end;

--- a/npc/warps/dungeons/c_tower.txt
+++ b/npc/warps/dungeons/c_tower.txt
@@ -44,6 +44,8 @@ c_tower2,273,26,0	warp	clt005	1,1,c_tower1,235,223
 //== Level 2 ===============================================
 //- Random 2-1 -
 c_tower2,13,288,4	script	clt006r	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "c_tower2",13,282; end;
 		case 1: warp "alde_dun03",175,131; end;
@@ -53,6 +55,8 @@ c_tower2,13,288,4	script	clt006r	WARPNPC,1,1,{
 
 //- Random 2-2 -
 c_tower2,223,267,4	script	clt007r	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "c_tower2",288,267; end;
 		case 1: warp "alde_dun03",130,130; end;
@@ -69,6 +73,8 @@ c_tower3,146,8,0	warp	clt013	1,1,c_tower1,235,223
 
 //- Random 3-1 -
 c_tower3,163,252,4	script	clt014r	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (rand(2))
 		warp "c_tower3",168,252;
 	else
@@ -78,6 +84,8 @@ c_tower3,163,252,4	script	clt014r	WARPNPC,1,1,{
 
 //- Random 3-2 -
 c_tower3,240,7,4	script	clt015r	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "c_tower2",13,282; end;
 		case 1: warp "alde_dun03",175,131; end;
@@ -87,6 +95,8 @@ c_tower3,240,7,4	script	clt015r	WARPNPC,1,1,{
 
 //- Random 3-3 -
 c_tower3,252,24,4	script	clt016r	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(3)) {
 		case 0: warp "c_tower2",228,267; end;
 		case 1: warp "alde_dun03",130,130; end;
@@ -108,6 +118,8 @@ c_tower4,204,57,0	warp	clt026	1,1,c_tower4,65,77
 
 //- Random 4-1 -
 c_tower4,75,156,4	script	clt027r	WARPNPC,0,0,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "c_tower3",168,252; end;
 		case 1: warp "alde_dun02",262,41; end;
@@ -118,6 +130,8 @@ c_tower4,75,156,4	script	clt027r	WARPNPC,0,0,{
 
 //- Random 4-2 -
 c_tower4,68,79,4	script	clt028r	WARPNPC,0,0,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "c_tower2",13,282; end;
 		case 1: warp "alde_dun03",175,131; end;
@@ -128,6 +142,8 @@ c_tower4,68,79,4	script	clt028r	WARPNPC,0,0,{
 
 //- Random 4-3 -
 c_tower4,142,151,4	script	clt029r	WARPNPC,0,0,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "c_tower3",168,252; end;
 		case 1: warp "alde_dun02",262,41; end;
@@ -138,6 +154,8 @@ c_tower4,142,151,4	script	clt029r	WARPNPC,0,0,{
 
 //- Random 4-4 -
 c_tower4,151,96,4	script	clt030r	WARPNPC,0,0,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "c_tower2",228,267; end;
 		case 1: warp "alde_dun03",130,130; end;
@@ -148,6 +166,8 @@ c_tower4,151,96,4	script	clt030r	WARPNPC,0,0,{
 
 //- Random 4-5 -
 c_tower4,189,40,4	script	clt031r	WARPNPC,2,2,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "c_tower2",228,267; end;
 		case 1: warp "alde_dun03",130,130; end;

--- a/npc/warps/dungeons/kh_dun.txt
+++ b/npc/warps/dungeons/kh_dun.txt
@@ -46,6 +46,8 @@ kh_dun01,232,176,0	warp	kh_dun_03	1,1,kh_dun01,63,12
 //== Second Floor -> First floor Random warp ===============
 kh_dun02,43,195,0	script	kh_dun04	WARPNPC,1,1,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if (rand(1,2) == 1) {
 		warp "kh_dun01",41,206;
 	}

--- a/npc/warps/dungeons/lhz_dun.txt
+++ b/npc/warps/dungeons/lhz_dun.txt
@@ -47,6 +47,8 @@ lhz_dun01,18,145,0	warp	lhz_dun4-1	1,1,lhz_dun02,17,150
 lhz_dun02,17,156,0	warp	lhz_dun4-2	1,1,lhz_dun01,18,150
 lhz_dun02,149,149,4	script	lhz_dun5-1	WARPNPC,2,2,{
 OnTouch:
+	if (checkhiding())
+		end;
 	if ((Upper != 1 && BaseLevel<95) || (Upper == 1 && BaseLevel<90)) {
 		warp "lhz_dun02",145,149;
 	}
@@ -220,6 +222,8 @@ lhz_cube,123,26,0	script	cubew09-4	WARPNPC,1,1,{
 
 //== Function for Random Warps =============================
 function	script	randomw	{
+	if (checkhiding())
+		return;
 	switch(rand(3)) {
 	case 1: warp "lhz_cube",66,136; end;
 	case 2: warp "lhz_cube",66,74; end;

--- a/npc/warps/dungeons/mosk_dun.txt
+++ b/npc/warps/dungeons/mosk_dun.txt
@@ -40,6 +40,8 @@ mosk_in,215,36,0	warp	babayagaout		1,1,mosk_dun02,53,217
 mosk_dun02,53,220,4	script	#babayagain	WARPNPC,1,1,{
 	end;
 OnTouch:
+	if (checkhiding())
+		end;
 	if (mos_nowinter == 11) {
 		donpcevent "Soldier1#mos::OnEnable";
 		donpcevent "Soldier2#mos::OnEnable";

--- a/npc/warps/dungeons/pay_dun.txt
+++ b/npc/warps/dungeons/pay_dun.txt
@@ -42,6 +42,8 @@ pay_dun02,137,128,0	warp	payd03	4,1,pay_dun03,155,159
 pay_dun02,16,63,0	warp	payd02-1	2,7,pay_dun01,283,28
 pay_dun03,155,161,0	warp	payd03-1	2,1,pay_dun02,137,126
 pay_dun03,127,62,4	script	payd04r	WARPNPC,2,2,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "pay_dun04",201,204; end;
 		case 1: warp "pay_dun04",189,43; end;

--- a/npc/warps/dungeons/prt_maze.txt
+++ b/npc/warps/dungeons/prt_maze.txt
@@ -130,6 +130,8 @@ prt_maze03,22,194,0	warp	mazewarp5301	1,1,prt_maze03,175,48	/*To No.3-20*/
 prt_maze03,5,186,0	warp	mazewarp5302	1,1,prt_maze03,151,134	/*To No.3-9*/
 //3rd Floor No.02
 prt_maze03,58,194,0	script	#mazewarp5303	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "prt_maze03",98,151; end;	/*To No.3-8*/
 		case 1: warp "prt_maze03",137,128; end;	/*To No.3-9*/
@@ -188,6 +190,8 @@ prt_maze03,14,45,0	warp	mazewarp5337	1,1,prt_maze03,88,174	/*To No.3-3*/
 prt_maze03,5,58,0	warp	mazewarp5338	1,1,prt_maze03,191,15	/*To No.3-25*/
 // 3rd Floor No.17
 prt_maze03,74,74,0	script	#mazewarp5339	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "prt_maze03",98,151; end;	/*To No.3-8*/
 		case 1: warp "prt_maze03",137,128; end;	/*To No.3-9*/
@@ -204,6 +208,8 @@ prt_maze03,85,56,0	warp	mazewarp5344	1,1,prt_maze03,176,31	/*To No.3-25*/
 // 3rd Floor No.19
 prt_maze03,137,74,0	warp	mazewarp5345	1,1,prt_maze03,102,168	/*To No.3-3*/
 prt_maze03,139,45,0	script	#mazewarp5346	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "prt_maze03",98,151; end;	/*To No.3-8*/
 		case 1: warp "prt_maze03",137,128; end;	/*To No.3-9*/
@@ -228,6 +234,8 @@ prt_maze03,114,22,0	warp	mazewarp5356	1,1,prt_maze03,104,71	/*To No.3-18*/
 prt_maze03,85,13,0	warp	mazewarp5357	1,1,prt_maze03,23,8	/*To No.3-21*/
 // 3rd Floor No.24
 prt_maze03,154,22,0	script	#mazewarp5358	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "prt_maze03",98,151; end;	/*To No.3-8*/
 		case 1: warp "prt_maze03",137,128; end;	/*To No.3-9*/

--- a/npc/warps/dungeons/ra_san.txt
+++ b/npc/warps/dungeons/ra_san.txt
@@ -34,6 +34,8 @@
 //=========================================================================
 
 ra_san01,139,13,0	script	sanctuary01	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (ra_tem_q == 21) { warp "que_san04",119,110; end; }
 	switch(rand(3)) {
 		case 1:  warp "ra_san02",213,275; break;

--- a/npc/warps/fields/abyss_warper.txt
+++ b/npc/warps/fields/abyss_warper.txt
@@ -173,6 +173,8 @@ OnInit:
 	end;
 
 OnTouch:
+	if (checkhiding())
+		end;
 	warp "abyss_01",260,268;
 	end;
 

--- a/npc/warps/fields/glastheim.txt
+++ b/npc/warps/fields/glastheim.txt
@@ -73,6 +73,8 @@ gl_knt02,157,292,0	warp	gl16-1	1,1,gl_knt01,150,286
 gl_knt02,289,138,0	warp	gl17-1	1,1,gl_knt01,292,144
 gl_prison,149,183,0	warp	gl18-1	1,1,gl_prison1,150,14
 gl_prison,11,70,0	script	gl18-2	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	switch(rand(4)) {
 		case 0: warp "gl_cas01",163,193; end;
 		case 1: warp "gl_cas01",238,192; end;

--- a/npc/warps/fields/jawaii.txt
+++ b/npc/warps/fields/jawaii.txt
@@ -41,5 +41,7 @@ jawaii_in,133,107,0	warp	jawaiiwarp003	1,1,jawaii,111,199
 jawaii_in,88,117,0	warp	jawaiiwarp004	1,1,jawaii,109,186
 jawaii,192,215,0	warp	jawaiiwarp005	1,1,jawaii_in,28,94
 jawaii_in,27,91,4	script	jawaiiwarp006	WARPNPC,1,1,{
+	if (checkhiding())
+		end;
 	if (getpartnerid() > 0) warp "jawaii",192,218; else warp "jawaii_in",27,94;
 }

--- a/npc/warps/guildcastles.txt
+++ b/npc/warps/guildcastles.txt
@@ -383,6 +383,8 @@ aldeg_cas04,108,210,0	warp	aldeg-4-14_aldeg-4-4	1,1,aldeg_cas04,186,92
 aldeg_cas04,132,231,0	script	aldeg-4-15_aldeg-4-	WARPNPC,1,1,{
 
 OnTouch:
+	if (checkhiding())
+		return;
 	switch (rand(1,5)) {
 		case 1:	warp "aldeg_cas04",152,210; end;
 		case 2:	warp "aldeg_cas04",111,210; end;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10997,6 +10997,29 @@ static BUILDIN(end)
 	return true;
 }
 
+/// Checks if the player is hidden (Hiding, Cloaking or Chase Walk)
+///
+/// checkhiding({<account id>}) -> <bool>
+static BUILDIN(checkhiding)
+{
+	struct map_session_data *sd;
+
+	if (script_hasdata(st, 2))
+		sd = map->id2sd(script_getnum(st, 2));
+	else
+		sd = script->rid2sd(st);
+
+	if (sd == NULL)
+		return true;// no player attached, report source
+
+	if (pc_ishiding(sd))
+		script_pushint(st, 1);
+	else
+		script_pushint(st, 0);
+
+	return true;
+}
+
 /// Checks if the player has that effect state (option).
 ///
 /// checkoption(<option>) -> <bool>
@@ -27945,6 +27968,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(setnpcdir,"*"), // [4144]
 		BUILDIN_DEF(getnpcclass,"?"), // [4144]
 		BUILDIN_DEF(getmapxy,"rrri?"), //by Lorky [Lupus]
+		BUILDIN_DEF(checkhiding, "?"),
 		BUILDIN_DEF(checkoption1,"i?"),
 		BUILDIN_DEF(checkoption2,"i?"),
 		BUILDIN_DEF(guildgetexp,"i"),


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes some issues and inconsistencies related to `WARPNPC` scripted warps and other `OnTouch_` NPCs.

- `WARPNPC` scripts that were using `OnTouch_` have been changed to `OnTouch` to prevent players from abusing the `OnTouch_` serialization mechanism to prevent others from accessing the warp, especially in cases where a dialogue appears. (`OnTouch_` triggers in a serial way, not processing subsequent touches until the script has terminated for the previous trigger).
- The same fix as above has been applied to several (non-warp) touch events in the Cursed Spirit quest, suffering from the same issue.
- A check has been added to prevent hidden characters (through Hiding, Cloaking or Chase Walking) from accessing WARPNPC warps, so that they behave consistently with normal, non-scripted, warps.
- The helper script command `checkhiding()` has been added in order to simplify and centralize the check for the above fix. The command returns true when a character is hiding and false otherwise. The same could have been achieved by calling `checkoption(Option_Hide | Option_Cloak | Option_Chasewalk)`, but delegating the low level decision of what counts as hiding to each script (and having to edit each script in future if a new hiding skill is added that sets a different option) didn't seem ideal.

**Issues addressed:** N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
