### PR TITLE
Fix countnameditem() always returning 0

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -8375,8 +8375,7 @@ static BUILDIN(countnameditem)
 			sd->status.inventory[i].amount > 0 &&
 			sd->status.inventory[i].nameid == id->nameid &&
 			sd->status.inventory[i].card[0] == CARD0_CREATE &&
-			sd->status.inventory[i].card[2] == sd->status.char_id &&
-			sd->status.inventory[i].card[3] == sd->status.char_id >> 16)
+			sd->status.char_id == (int)MakeDWord(sd->status.inventory[i].card[2], sd->status.inventory[i].card[3]))
 		{
 			count += sd->status.inventory[i].amount;
 		}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The card check was always failing because card2 was tested against the whole char_id rather than just its lower 16 bits.
The check is now done by using the appropriate `MakeDWord()` function to recompose the char_id from card2 and card3

**Issues addressed:** N/A, the problem was reported privately

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
