### PR TITLE
Fix an issue with captcha compression on linux

### DIFF
--- a/src/map/macro.c
+++ b/src/map/macro.c
@@ -400,7 +400,9 @@ static bool macro_read_captcha_db_libconfig_sub_loadbmp(const char *filepath, st
 	memset(cd->image_data, 0, CAPTCHA_BMP_SIZE);
 
 	// Compress the data into the destination
-	grfio->encode_zip(cd->image_data, (unsigned long *)&cd->image_size, bmp_data, CAPTCHA_BMP_SIZE);
+	unsigned long com_size = 0;
+	grfio->encode_zip(cd->image_data, &com_size, bmp_data, CAPTCHA_BMP_SIZE);
+	cd->image_size = (int)com_size;
 
 	fclose(fp);
 	aFree(bmp_data);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixes an inconsistency causing captcha images loaded server side to fail zlib compression on non-windows systems.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

Privately reported by Afonso

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
