### PR TITLE
Fixed MO_CALLSPIRITS on bAutoSpell

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -7659,9 +7659,9 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 			break;
 		
 		case MO_CALLSPIRITS:
-			if(sd) {
-				clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
-				pc->addspiritball(sd, skill->get_time(skill_id, skill_lv), pc->getmaxspiritball(sd, 0));
+			if (sd != NULL) {
+				clif->skill_nodamage(src, bl, skill_id, skill_lv, 1);
+				pc->addspiritball(sd, skill->get_time(skill_id, skill_lv), pc->getmaxspiritball(sd, skill_lv));
 			}
 			break;
 


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
```
{
	Id: 4283
	AegisName: "Greatest_General_Card"
	Name: "Greatest General Card"
	Type: "IT_CARD"
	Buy: 20
	Weight: 10
	Loc: "EQP_ACC"
	Script: <" bonus3 bAutoSpell, MO_CALLSPIRITS,5,2+18*(BaseClass==Job_Acolyte); ">
},
```
clearly says here `MO_CALLSPIRITS` with level 5, should be casted here, which means max spirit should be 5. Currently when used, it only allows to cast 1 spirit which is wrong.

Thanks to @Maginitis at discord.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
