### PR TITLE
Fix an error causing conditional feature checks to always be true

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -791,9 +791,9 @@ static const char *script_skip_space(const char *p)
 						len++;
 				}
 				if (len >= 3 && cond[len] != '_' && !ISALNUM(cond[len])) {
-					int found = false;
+					bool found = false;
 					int i;
-					ARR_FIND(0, VECTOR_LENGTH(script->conditional_features), i, strncmp(cond, VECTOR_INDEX(script->conditional_features, i), len) != 0);
+					ARR_FIND(0, VECTOR_LENGTH(script->conditional_features), i, strncmp(cond, VECTOR_INDEX(script->conditional_features, i), len) == 0);
 					if (i != VECTOR_LENGTH(script->conditional_features))
 						found = true;
 					if (negated)


### PR DESCRIPTION
Signed-off-by: Haru <haru@dotalux.com>

### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes an inverted test condition (string inequality instead of string equality) that would make the conditional feature test always succeed.

**Issues addressed:** N/A

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
