### PR TITLE
Fix an issue with saving homunculus exp when it reaches max level

### DIFF
--- a/src/map/homunculus.h
+++ b/src/map/homunculus.h
@@ -212,7 +212,7 @@ struct homunculus_interface {
 	void (*delspiritball) (struct homun_data *hd, int count, int type);
 	int8 (*get_intimacy_grade) (struct homun_data *hd);
 	int (*get_max_level) (struct homun_data *hd);
-	uint64 (*get_exp) (struct homun_data *hd, int idx);
+	uint64 (*get_exp_next) (struct homun_data *hd);
 };
 
 #ifdef HERCULES_CORE


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes an issue where `homun->get_exp` does into take into consideration that the exp value for max level is uninitialized, so it has been replaced with `homun->get_exp_next` which works the same way as `pc->nextbaseexp` and resolves the issue.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3097

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
