### PR TITLE
Update mob.c

### DIFF
--- a/conf/map/battle/drops.conf
+++ b/conf/map/battle/drops.conf
@@ -160,3 +160,10 @@ option_drop_max_loop: 10
 // Does autoloot take into account player bonuses and penalties? (Note 1)
 // If RENEWAL_DROP, Bubble Gum, or any other modifiers are active autoloot will take them into account.
 autoloot_adjust: false
+
+// The maximum value that an item's drop rate can be boosted to by bonuses (10000 means 100%)
+// This only limits drop-time bonuses (cash shop SCs, race-specific drop rate modifiers, luk or size custom influence,
+// renewal level modifiers, etc) and is bypassed by higher values in the mob database's drop rates and the server's
+// drop rates.
+// Default value: 9000 (official). Set to 10000 to disable.
+item_drop_bonus_max_threshold: 9000

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7610,6 +7610,7 @@ static const struct battle_data {
 	{ "item_rate_adddrop",                  &battle_config.item_rate_adddrop,               100,    0,      1000000,        },
 	{ "item_rate_add_chain",                &battle_config.item_rate_add_chain,             100,    0,      1000000,        },
 	{ "item_rate_treasure",                 &battle_config.item_rate_treasure,              100,    0,      1000000,        },
+	{ "item_drop_bonus_max_threshold",      &battle_config.item_drop_bonus_max_threshold,   9000,   0,      10000,          },
 	{ "prevent_logout",                     &battle_config.prevent_logout,                  10000,  0,      60000,          },
 	{ "alchemist_summon_reward",            &battle_config.alchemist_summon_reward,         1,      0,      2,              },
 	{ "drops_by_luk",                       &battle_config.drops_by_luk,                    0,      0,      INT_MAX,        },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -304,9 +304,21 @@ struct Battle_Config {
 	int party_show_share_picker;
 	int show_picker_item_type;
 	int attack_attr_none;
-	int item_rate_mvp, item_rate_common, item_rate_common_boss, item_rate_card, item_rate_card_boss,
-	item_rate_equip, item_rate_equip_boss, item_rate_heal, item_rate_heal_boss, item_rate_use,
-	item_rate_use_boss, item_rate_treasure, item_rate_adddrop, item_rate_add_chain;
+	int item_rate_mvp;
+	int item_rate_common;
+	int item_rate_common_boss;
+	int item_rate_card;
+	int item_rate_card_boss;
+	int item_rate_equip;
+	int item_rate_equip_boss;
+	int item_rate_heal;
+	int item_rate_heal_boss;
+	int item_rate_use;
+	int item_rate_use_boss;
+	int item_rate_treasure;
+	int item_rate_adddrop;
+	int item_rate_add_chain;
+	int item_drop_bonus_max_threshold;
 
 	int logarithmic_drops;
 	int item_drop_common_min,item_drop_common_max; // Added by TyrNemesis^

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2745,7 +2745,7 @@ static int mob_dead(struct mob_data *md, struct block_list *src, int type)
 
 					// When PK Mode is enabled, increase item drop rate bonus of each items by 25% when there is a 20 level difference between the player and the monster.[KeiKun]
 					if (battle_config.pk_mode && (md->level - sd->status.base_level >= 20))
-						drop_rate_bonus += 25; // flat 25% bonus 
+						drop_rate_bonus += 25; // flat 25% bonus
 
 					drop_rate_bonus += sd->dropaddrace[md->status.race] + (is_boss(src) ? sd->dropaddrace[RC_BOSS] : sd->dropaddrace[RC_NONBOSS]); // bonus2 bDropAddRace[KeiKun]
 
@@ -2755,10 +2755,9 @@ static int mob_dead(struct mob_data *md, struct block_list *src, int type)
 					if (sd->sc.data[SC_OVERLAPEXPUP] != NULL)
 						drop_rate_bonus += sd->sc.data[SC_OVERLAPEXPUP]->val2;
 
-					drop_rate = (int)(0.5 + drop_rate * drop_rate_bonus / 100.);
-
-					// Make sure drop rate does not go beyond 100% after the drop rate modifiers are applied
-					drop_rate = min(drop_rate, 10000);
+					if (drop_rate_bonus != 100) {
+						drop_rate = (int)(0.5 + drop_rate * drop_rate_bonus / 100.);
+					}
 				}
 			}
 
@@ -2779,6 +2778,9 @@ static int mob_dead(struct mob_data *md, struct block_list *src, int type)
 				drop_rate = max(drop_rate, 0);
 			else
 				drop_rate = max(drop_rate, 1);
+
+			// Make sure the bonuses don't make the drop rate grow past the configured threshold (unless it already was)
+			drop_rate = min(drop_rate, max(md->db->dropitem[i].p, battle_config.item_drop_bonus_max_threshold));
 
 			// attempt to drop the item
 			if (rnd() % 10000 >= drop_rate)

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2757,8 +2757,8 @@ static int mob_dead(struct mob_data *md, struct block_list *src, int type)
 
 					drop_rate = (int)(0.5 + drop_rate * drop_rate_bonus / 100.);
 
-					// Limit drop rate, default: 90%
-					drop_rate = min(drop_rate, 9000);
+					// Make sure drop rate does not go beyond 100% after the drop rate modifiers are applied
+					drop_rate = min(drop_rate, 10000);
 				}
 			}
 


### PR DESCRIPTION
Right now if you try to put 100% drop rate on drops.conf, it will show correctly on @mi and @rates but monsters will not really drop items by 100% chance. Monsters will only drop items by 90% chance even if @mi and @rates say 100%. This change fixes that.

<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
