### PR TITLE
Fix grade enchant ui status result order

### DIFF
--- a/src/map/grader.c
+++ b/src/map/grader.c
@@ -335,24 +335,23 @@ void grader_enchant_start(struct map_session_data *sd, int idx, int mat_idx, boo
 
 	const int grade_chance = gi->success_chance + (use_blessing ? gi->blessing.bonus * blessing_amount : 0);
 	if (rnd() % 100 >= grade_chance) {
+		if ((gi->announce & GRADE_ANNOUNCE_FAILURE) != 0)
+			clif->announce_grade_status(sd, sd->status.inventory[idx].nameid, sd->status.inventory[idx].grade, false, ALL_CLIENT);
+
 		switch (gmaterial->failure_behavior) {
 		case GRADE_FAILURE_BEHAVIOR_KEEP:
 			clif->grade_enchant_result(sd, idx, (enum grade_level)sd->status.inventory[idx].grade, GRADE_UPGRADE_FAILED_KEEP);
 			break;
 		case GRADE_FAILURE_BEHAVIOR_DOWNGRADE:
+			clif->grade_enchant_result(sd, idx, (enum grade_level)sd->status.inventory[idx].grade, GRADE_UPGRADE_FAILED_DOWNGRADE);
 			sd->status.inventory[idx].grade -= 1;
 			sd->status.inventory[idx].grade = cap_value(sd->status.inventory[idx].grade, ITEM_GRADE_NONE, ITEM_GRADE_MAX - 1);
-			clif->grade_enchant_result(sd, idx, (enum grade_level)sd->status.inventory[idx].grade, GRADE_UPGRADE_FAILED_DOWNGRADE);
 			break;
 		case GRADE_FAILURE_BEHAVIOR_DESTROY:
-			pc->delitem(sd, idx, 1, 0, DELITEM_FAILREFINE, LOG_TYPE_GRADE);
 			clif->grade_enchant_result(sd, idx, (enum grade_level)sd->status.inventory[idx].grade, GRADE_UPGRADE_FAILED_DESTROY);
+			pc->delitem(sd, idx, 1, 0, DELITEM_FAILREFINE, LOG_TYPE_GRADE);
 			break;
 		}
-
-		if ((gi->announce & GRADE_ANNOUNCE_FAILURE) != 0)
-			clif->announce_grade_status(sd, sd->status.inventory[idx].nameid, sd->status.inventory[idx].grade, false, ALL_CLIENT);
-
 	} else {
 		sd->status.inventory[idx].refine = 0; // Hardcoded in the client
 		sd->status.inventory[idx].grade += 1;

--- a/src/map/refine.c
+++ b/src/map/refine.c
@@ -112,6 +112,9 @@ static void refine_refinery_refine_request(struct map_session_data *sd, int item
 	if (rnd() % 100 >= refine_chance) {
 		clif->misceffect(&sd->bl, 2);
 
+		if ((req->announce & REFINE_ANNOUNCE_FAILURE) != 0)
+			clif->announce_refine_status(sd, sd->status.inventory[item_index].nameid, sd->status.inventory[item_index].refine, false, ALL_CLIENT);
+
 		int failure_behabior = (use_blacksmith_blessing) ? REFINE_FAILURE_BEHAVIOR_KEEP : req->req[i].failure_behavior;
 		switch (failure_behabior) {
 		case REFINE_FAILURE_BEHAVIOR_KEEP:
@@ -131,9 +134,6 @@ static void refine_refinery_refine_request(struct map_session_data *sd, int item
 			pc->delitem(sd, item_index, 1, 0, DELITEM_FAILREFINE, LOG_TYPE_REFINE);
 			break;
 		}
-
-		if ((req->announce & REFINE_ANNOUNCE_FAILURE) != 0)
-			clif->announce_refine_status(sd, sd->status.inventory[item_index].nameid, sd->status.inventory[item_index].refine, false, ALL_CLIENT);
 	} else {
 		sd->status.inventory[item_index].refine += 1;
 		sd->status.inventory[item_index].refine = cap_value(sd->status.inventory[item_index].refine, 0, MAX_REFINE);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes an issue where the item is changed/deleted before the status update is sent in the grade enchant interface.

Thanks to @Lemongrass3110 for letting me know about the issue.

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
