### PR TITLE
Fixes on instance information/destruction

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -19430,13 +19430,13 @@ static void clif_font(struct map_session_data *sd)
 /*==========================================
  * Instancing Window
  *------------------------------------------*/
-static int clif_instance(int instance_id, int type, int flag)
+static int clif_instance(int instance_id, enum instance_window_info_type type, int flag)
 {
 	struct map_session_data *sd = NULL;
 	unsigned char buf[255];
 	enum send_target target = PARTY;
 
-	switch( instance->list[instance_id].owner_type ) {
+	switch (instance->list[instance_id].owner_type) {
 		case IOT_NONE:
 			return 0;
 		case IOT_GUILD:
@@ -19455,52 +19455,52 @@ static int clif_instance(int instance_id, int type, int flag)
 			break;
 	}
 
-	if( !sd )
+	if (!sd)
 		return 0;
 
-	switch( type ) {
-		case 1:
+	switch (type) {
+		case INSTANCE_WND_INFO_CREATE:
 			// S 0x2cb <Instance name>.61B <Standby Position>.W
 			// Required to start the instancing information window on Client
 			// This window re-appear each "refresh" of client automatically until type 4 is send to client.
-			WBUFW(buf,0) = 0x02CB;
-			memcpy(WBUFP(buf,2),instance->list[instance_id].name,INSTANCE_NAME_LENGTH);
-			WBUFW(buf,63) = flag;
-			clif->send(buf,packet_len(0x02CB),&sd->bl,target);
+			WBUFW(buf, 0) = 0x02CB;
+			memcpy(WBUFP(buf, 2), instance->list[instance_id].name, INSTANCE_NAME_LENGTH);
+			WBUFW(buf, 63) = flag;
+			clif->send(buf, packet_len(0x02CB), &sd->bl, target);
 			break;
-		case 2:
+		case INSTANCE_WND_INFO_QUEUE_POS:
 			// S 0x2cc <Standby Position>.W
 			// To announce Instancing queue creation if no maps available
 			// flag is priority, negative value mean cancel reservation
-			WBUFW(buf,0) = 0x02CC;
-			WBUFW(buf,2) = flag;
-			clif->send(buf,packet_len(0x02CC),&sd->bl,target);
+			WBUFW(buf, 0) = 0x02CC;
+			WBUFW(buf, 2) = flag;
+			clif->send(buf, packet_len(0x02CC), &sd->bl, target);
 			break;
-		case 3:
-		case 4:
+		case INSTANCE_WND_INFO_PROGRESS_TIME:
+		case INSTANCE_WND_INFO_IDLE_TIME:
 			// S 0x2cd <Instance Name>.61B <Instance Remaining Time>.L <Instance Noplayers close time>.L
-			WBUFW(buf,0) = 0x02CD;
-			memcpy(WBUFP(buf,2),instance->list[instance_id].name,61);
-			if( type == 3 ) {
-				WBUFL(buf,63) = instance->list[instance_id].progress_timeout;
-				WBUFL(buf,67) = 0;
+			WBUFW(buf, 0) = 0x02CD;
+			memcpy(WBUFP(buf, 2), instance->list[instance_id].name, 61);
+			if (type == INSTANCE_WND_INFO_PROGRESS_TIME) {
+				WBUFL(buf, 63) = instance->list[instance_id].progress_timeout;
+				WBUFL(buf, 67) = 0;
 			} else {
-				WBUFL(buf,63) = 0;
-				WBUFL(buf,67) = instance->list[instance_id].idle_timeout;
+				WBUFL(buf, 63) = 0;
+				WBUFL(buf, 67) = instance->list[instance_id].idle_timeout;
 			}
-			clif->send(buf,packet_len(0x02CD),&sd->bl,target);
+			clif->send(buf, packet_len(0x02CD), &sd->bl, target);
 			break;
-		case 5:
+		case INSTANCE_WND_INFO_DESTROY:
 			// S 0x2ce <Message ID>.L
 			// 0 = Notification (EnterLimitDate update?)
 			// 1 = The Memorial Dungeon expired; it has been destroyed
 			// 2 = The Memorial Dungeon's entry time limit expired; it has been destroyed
 			// 3 = The Memorial Dungeon has been removed.
 			// 4 = Create failure (removes the instance window)
-			WBUFW(buf,0) = 0x02CE;
-			WBUFL(buf,2) = flag;
+			WBUFW(buf, 0) = 0x02CE;
+			WBUFL(buf, 2) = flag;
 			//WBUFL(buf,6) = EnterLimitDate;
-			clif->send(buf,packet_len(0x02CE),&sd->bl,target);
+			clif->send(buf, packet_len(0x02CE), &sd->bl, target);
 			break;
 	}
 	return 0;

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11426,7 +11426,8 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 	if (first_time) {
 		int i;
 
-		ARR_FIND(0, instance->instances, i, instance->list[i].owner_type == IOT_CHAR && instance->list[i].owner_id == sd->status.account_id);
+		ARR_FIND(0, instance->instances, i, instance_is_active(instance->list[i])
+		    && instance->list[i].owner_type == IOT_CHAR && instance->list[i].owner_id == sd->status.account_id);
 
 		if (i < instance->instances) {
 			sd->instances = 1;

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -857,6 +857,33 @@ enum bossmap_info_type {
 };
 
 /**
+ * Instance information window update types.
+ */
+enum instance_window_info_type {
+	/**
+	 * Informs about instance creation
+	 */
+	INSTANCE_WND_INFO_CREATE = 1,
+	/**
+	 * Informs an update in instance queue position
+	 */
+	INSTANCE_WND_INFO_QUEUE_POS = 2,
+	/**
+	 * Informs the instance is in progress (has players on it) and when it will timeout
+	 */
+	INSTANCE_WND_INFO_PROGRESS_TIME = 3,
+	/**
+	 * Informs the instance is idle (no players on it) and when it will timeout
+	 */
+	INSTANCE_WND_INFO_IDLE_TIME = 4,
+	/**
+	 * Informs the instance was destroyed.
+	 * @see instance_destroy_reason for reason flag values.
+	 */
+	INSTANCE_WND_INFO_DESTROY = 5,
+};
+
+/**
  * Clif.c Interface
  **/
 struct clif_interface {
@@ -1309,7 +1336,7 @@ struct clif_interface {
 	void (*sendbgemblem_area) (struct map_session_data *sd);
 	void (*sendbgemblem_single) (int fd, struct map_session_data *sd);
 	/* instance-related */
-	int (*instance) (int instance_id, int type, int flag);
+	int (*instance) (int instance_id, enum instance_window_info_type type, int flag);
 	void (*instance_join) (int fd, int instance_id);
 	void (*instance_leave) (int fd);
 	/* pet-related */

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -190,7 +190,7 @@ static int instance_create(int owner_id, const char *name, enum instance_owner_t
 static int instance_add_map(const char *name, int instance_id, bool usebasename, const char *map_name)
 {
 	int16 m = map->mapname2mapid(name);
-	int i, im = -1;
+	int i, im = MAPID_NONE;
 	size_t num_cell, size, j;
 
 	nullpo_retr(-1, name);
@@ -543,6 +543,7 @@ static void instance_del_map(int16 m)
 
 	map->removemapdb(&map->list[m]);
 	memset(&map->list[m], 0x00, sizeof(map->list[0]));
+	map->list[m].m = MAPID_NONE; // Marks this map as unallocated so server doesn't try to clean it up later on.
 	map->list[m].name[0] = 0;
 	map->list[m].instance_id = -1;
 	map->list[m].mob_delete_timer = INVALID_TIMER;

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -828,6 +828,9 @@ static void do_reload_instance(void)
 	int i, k;
 
 	for(i = 0; i < instance->instances; i++) {
+		if (!instance_is_valid(i))
+			continue; // don't try to restart an invalid instance
+
 		for(k = 0; k < instance->list[i].num_map; k++) {
 			if( !map->list[map->list[instance->list[i].map[k]].instance_src_map].flag.src4instance )
 				break;

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -574,9 +574,10 @@ static void instance_destroy(int instance_id)
 		return; // nothing to do
 
 	enum instance_destroy_reason type = INSTANCE_DESTROY_OTHER;
-	if( instance->list[instance_id].progress_timeout && instance->list[instance_id].progress_timeout <= now )
+	bool idle = (instance->list[instance_id].users == 0);
+	if (!idle && instance->list[instance_id].progress_timeout && instance->list[instance_id].progress_timeout <= now)
 		type = INSTANCE_DESTROY_PROG_TIMEOUT;
-	else if( instance->list[instance_id].idle_timeout && instance->list[instance_id].idle_timeout <= now )
+	else if (idle && instance->list[instance_id].idle_timeout && instance->list[instance_id].idle_timeout <= now)
 		type = INSTANCE_DESTROY_IDLE_TIMEOUT;
 
 	clif->instance(instance_id, INSTANCE_WND_INFO_DESTROY, type); // Report users this instance has been destroyed

--- a/src/map/instance.h
+++ b/src/map/instance.h
@@ -46,6 +46,25 @@ enum instance_owner_type {
 	IOT_MAX,
 };
 
+/**
+ * Reason for instance being destroyed.
+ * Note: These numbers are client-dependent.
+ */
+enum instance_destroy_reason {
+	/**
+	 * Time to progress in the instance has expired.
+	 */
+	INSTANCE_DESTROY_PROG_TIMEOUT = 1,
+	/**
+	 * The instance has been empty for too long.
+	 */
+	INSTANCE_DESTROY_IDLE_TIMEOUT = 2,
+	/**
+	 * Other reason
+	 */
+	INSTANCE_DESTROY_OTHER = 3,
+};
+
 struct instance_data {
 	unsigned short id;
 	char name[INSTANCE_NAME_LENGTH]; ///< Instance Name - required for clif functions.

--- a/src/map/instance.h
+++ b/src/map/instance.h
@@ -31,10 +31,19 @@ struct map_session_data;
 
 #define INSTANCE_NAME_LENGTH (60+1)
 
+/**
+ * true if instance is in an active/playable state.
+ * In other words, if a player can interact with it.
+ * 
+ * @param inst instance_data to be checked
+ */
+#define instance_is_active(inst) ((inst).state == INSTANCE_IDLE || (inst).state == INSTANCE_BUSY)
+
 typedef enum instance_state {
 	INSTANCE_FREE,
 	INSTANCE_IDLE,
-	INSTANCE_BUSY
+	INSTANCE_BUSY,
+	INSTANCE_DESTROYING,
 } instance_state;
 
 enum instance_owner_type {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -948,6 +948,11 @@ struct map_drop_list {
 	int drop_per;
 };
 
+/**
+ * Map ID (m) for "none" or unallocated map.
+ */
+#define MAPID_NONE -1
+
 struct map_data {
 	char name[MAP_NAME_LENGTH];
 	uint16 index; // The map index used by the mapindex* functions.

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -1860,8 +1860,8 @@ typedef void (*HPMHOOK_pre_clif_sendbgemblem_area) (struct map_session_data **sd
 typedef void (*HPMHOOK_post_clif_sendbgemblem_area) (struct map_session_data *sd);
 typedef void (*HPMHOOK_pre_clif_sendbgemblem_single) (int *fd, struct map_session_data **sd);
 typedef void (*HPMHOOK_post_clif_sendbgemblem_single) (int fd, struct map_session_data *sd);
-typedef int (*HPMHOOK_pre_clif_instance) (int *instance_id, int *type, int *flag);
-typedef int (*HPMHOOK_post_clif_instance) (int retVal___, int instance_id, int type, int flag);
+typedef int (*HPMHOOK_pre_clif_instance) (int *instance_id, enum instance_window_info_type *type, int *flag);
+typedef int (*HPMHOOK_post_clif_instance) (int retVal___, int instance_id, enum instance_window_info_type type, int flag);
 typedef void (*HPMHOOK_pre_clif_instance_join) (int *fd, int *instance_id);
 typedef void (*HPMHOOK_post_clif_instance_join) (int fd, int instance_id);
 typedef void (*HPMHOOK_pre_clif_instance_leave) (int *fd);

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -18880,11 +18880,11 @@ void HP_clif_sendbgemblem_single(int fd, struct map_session_data *sd) {
 	}
 	return;
 }
-int HP_clif_instance(int instance_id, int type, int flag) {
+int HP_clif_instance(int instance_id, enum instance_window_info_type type, int flag) {
 	int hIndex = 0;
 	int retVal___ = 0;
 	if (HPMHooks.count.HP_clif_instance_pre > 0) {
-		int (*preHookFunc) (int *instance_id, int *type, int *flag);
+		int (*preHookFunc) (int *instance_id, enum instance_window_info_type *type, int *flag);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_instance_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_clif_instance_pre[hIndex].func;
@@ -18899,7 +18899,7 @@ int HP_clif_instance(int instance_id, int type, int flag) {
 		retVal___ = HPMHooks.source.clif.instance(instance_id, type, flag);
 	}
 	if (HPMHooks.count.HP_clif_instance_post > 0) {
-		int (*postHookFunc) (int retVal___, int instance_id, int type, int flag);
+		int (*postHookFunc) (int retVal___, int instance_id, enum instance_window_info_type type, int flag);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_instance_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_clif_instance_post[hIndex].func;
 			retVal___ = postHookFunc(retVal___, instance_id, type, flag);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR fixes some issues around instance information and destruction, that could cause visual glitches and assertion failures. Also, I have changed the response numbers into an enum to make it clear. Those are the issues addressed:

**Issue 1:** When players were moved out of an instance due to it being expired, they were receiving the information that the instance actually went Idle instead of destroyed. That was caused because when moving players out of the instance, it is still considered a valid instance, and this triggers the idle check.

To fix that, instances are now marked as "being destroyed", and thus invalid, before moving players out of it.

**Issue 2:** When a player had a Player Instance attached to them, even after being destroyed, they were still receiving the instance info when logging back in. That was caused because the check for player instance on login was not taking into account if the instance was freed or not (via `.state`).

To fix that, instance data is now fully cleaned up upon destruction (using `memset` instead of only zeroing a few fields) and the state check was added to the login process. `memset` step is not necessarily required, but it would avoid future issues if someone forget to check the state.

**Issue 3:** An assert failure when reloading scripts after playing an instance. That was caused due to instance reload trying to recreate a freed instance.

**Issue 4:** An assert failure when shutting the server down after playing an instance. That was caused due to hercules trying to free the already freed instance map.

**Issue 5:** In some cases, the wrong reason code was provided when an instance gets destroyed. It now checks for instance idle state to help choosing the proper reason.

**Issues addressed:** None, I think

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
