### PR TITLE
getunitdata/setunitdata: Adds UDT_OPTIONS and changes UDT_CLASS to work with Job sprites

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -10608,6 +10608,7 @@ Applicable Data Types (available as constants) -
 	UDT_STATADD:              Status Points - for NPCs.
 	UDT_GROUP:                group id
 	UDT_DAMAGE_TAKEN_RATE:    damage taken rate of a unit.
+	UDT_OPTIONS:              options
 
 returns 0 if value could not be set, 1 if successful.
 
@@ -10672,6 +10673,7 @@ Applicable Data types (available as constants) -
 	UDT_MERC_KILLCOUNT:       Kill count for mercenaries.
 	UDT_GROUP:                group id
 	UDT_DAMAGE_TAKEN_RATE:    damage taken rate of a unit.
+	UDT_OPTIONS:              options
 
 returns -1 if value could not be retrieved.
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -20726,6 +20726,9 @@ static BUILDIN(setunitdata)
 	case UDT_DAMAGE_TAKEN_RATE:
 		setunitdata_check_bounds(4, 1, INT_MAX);
 		break;
+	case UDT_OPTIONS:
+		setunitdata_check_bounds(4, 0, INT_MAX);
+		break;
 	default:
 		break;
 	}
@@ -20936,6 +20939,9 @@ static BUILDIN(setunitdata)
 			break;
 		case UDT_DAMAGE_TAKEN_RATE:
 			md->dmg_taken_rate = (int)val;
+			break;
+		case UDT_OPTIONS:
+			md->sc.option = (int)val;
 			break;
 		default:
 			ShowWarning("buildin_setunitdata: Invalid data type '%d' for mob unit.\n", type);
@@ -21813,6 +21819,7 @@ static BUILDIN(getunitdata)
 		case UDT_ADELAY:      script_pushint(st, md->status.adelay); break;
 		case UDT_DMOTION:     script_pushint(st, md->status.dmotion); break;
 		case UDT_DAMAGE_TAKEN_RATE: script_pushint(st, md->dmg_taken_rate); break;
+		case UDT_OPTIONS: script_pushint(st, md->sc.option); break;
 		default:
 			ShowWarning("buildin_getunitdata: Invalid data type '%s' for Mob unit.\n", udtype);
 			script_pushint(st, -1);
@@ -29475,6 +29482,7 @@ static void script_hardcoded_constants(void)
 	script->set_constant("UDT_BODY2", UDT_BODY2, false, false);
 	script->set_constant("UDT_GROUP", UDT_GROUP, false, false);
 	script->set_constant("UDT_DAMAGE_TAKEN_RATE", UDT_DAMAGE_TAKEN_RATE, false, false);
+	script->set_constant("UDT_OPTIONS", UDT_OPTIONS, false, false);
 
 	script->constdb_comment("getguildonline types");
 	script->set_constant("GUILD_ONLINE_ALL", GUILD_ONLINE_ALL, false, false);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -20828,7 +20828,10 @@ static BUILDIN(setunitdata)
 			clif->spawn(bl);
 			break;
 		case UDT_CLASS:
-			mob->class_change(md, val);
+			if ((val >= JOB_NOVICE && val <= JOB_MAX_BASIC) || (val >= JOB_NOVICE_HIGH && val <= JOB_MAX))
+				md->vd->class = val;
+			else
+				mob->class_change(md, val);
 			clif->clearunit_area(bl, CLR_OUTSIGHT);
 			clif->spawn(bl);
 			break;

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -441,6 +441,7 @@ enum script_unit_data_types {
 	UDT_BODY2,
 	UDT_GROUP,
 	UDT_DAMAGE_TAKEN_RATE,
+	UDT_OPTIONS,
 	UDT_MAX
 };
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
1. Adds UDT_OPTIONS to getunitdata/setunitdata. This is so people can use data when from mobs who are using job sprites. E.g.
```
{
	Id: 3990
	SpriteName: "Novice_Sprite"
	Name: "Novice"
	Hp: 100000
	Element: ("Ele_Ghost", 4)
	ViewData: {
		SpriteId: 0
		ShieldId: 4
		HairStyleId: 4
		HairColorId: 1
		BodyColorId: 1
		Gender: "SEX_MALE"
		Options: 16
	}
},
```
Then in a script, `getunitdata(<GID>, UDT_OPTIONS)` would return 16.
2. Second commit makes it so if you use setunitdata with a job id, e.g. `setunitdata(<GID>, UDT_CLASS, 0)` would set the mob sprite to Novice.
**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
