### PR TITLE
Fix CI build failures caused by Ubuntu 21.10 going EOL

### DIFF
--- a/.github/workflows/controller.yml
+++ b/.github/workflows/controller.yml
@@ -36,6 +36,10 @@ jobs:
     needs: build
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/gccold2.yml
+  gccold3:
+    needs: build
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/gccold3.yml
   gccsnapshot_test:
     needs: build
     if: ${{ !failure() && !cancelled() }}

--- a/.github/workflows/gccold1.yml
+++ b/.github/workflows/gccold1.yml
@@ -24,7 +24,7 @@ jobs:
           - PACKET_VERSION: "--enable-packetver=20100105"
             CLIENT_TYPE: "--enable-packetver-zero"
     container:
-      image: ubuntu:21.10
+      image: ubuntu:22.04
     services:
       mariadb:
         image: mariadb:latest

--- a/.github/workflows/gccold1.yml
+++ b/.github/workflows/gccold1.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        CC: ["gcc-10", "gcc-9", "gcc-8"]
+        CC: ["gcc-10", "gcc-9"]
         RENEWAL: [""]
         CLIENT_TYPE: ["", "--enable-packetver-re", "--enable-packetver-zero"]
         SANITIZER: ["--disable-manager --enable-sanitize=full"]

--- a/.github/workflows/gccold3.yml
+++ b/.github/workflows/gccold3.yml
@@ -1,4 +1,4 @@
-name: gcc_old2
+name: gcc_old3
 
 on: [workflow_call, pull_request]
 
@@ -7,14 +7,14 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python2 libzstd-dev
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python libzstd-dev
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        CC: ["gcc-8", "gcc-7"]
+        CC: ["gcc-6", "gcc-5", "gcc-4.8"]
         RENEWAL: [""]
         CLIENT_TYPE: ["", "--enable-packetver-re", "--enable-packetver-zero"]
         SANITIZER: ["--disable-manager --enable-sanitize=full"]
@@ -24,7 +24,7 @@ jobs:
           - PACKET_VERSION: "--enable-packetver=20100105"
             CLIENT_TYPE: "--enable-packetver-zero"
     container:
-      image: ubuntu:20.04
+      image: ubuntu:18.04
     services:
       mariadb:
         image: mariadb:latest


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes GitHub Actions CI build failures caused by an unsupported Ubuntu distribution not finding its package repositories online.

Ubuntu 21.10, used by the `gcc-10`, `gcc-9` and `gcc-8` CI builds is EOL since 2022-07-14. The image has been replaced with alternative versions that include the same packages.

The following changes have been made:

- `gcc-10` and `gcc-9` have been moved from 21.10 to to 22.04 LTS, which will be under standard support until April 2027 and EOL in April 2032 (workflow `gccold1`).
- `gcc-8` has been moved from 21.10 to to 20.04 LTS, which will be under standard support until April 2025 and EOL in April 2030 (moved from workflow `gccold1` to `gccold2`).
- `gcc-7` has been moved from 18.04 LTS to to 20.04 LTS, as described above (workflow `gccold2`).
- `gcc-6`, `gcc-5` and `gcc-4.8` have been left on 18.04 LTS, which will be under standard support until April 2023 and EOL in April 2028 (moved from workflow `gccold2` to `gccold3`).

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
