### PR TITLE
Fix Soul Exhale behavior

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -9186,6 +9186,8 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 			{
 				unsigned int sp1 = 0, sp2 = 0;
 				if (dstmd) {
+					if ((dstmd->status.mode & MD_BOSS) != 0)
+						break; // [Aegis] can't use this on bosses
 					if (dstmd->state.soul_change_flag) {
 						if(sd) clif->skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0, 0);
 						break;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -9197,6 +9197,9 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 					status->heal(src, 0, sp2, STATUS_HEAL_SHOWEFFECT);
 					clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
 					break;
+				} else if (dstsd != NULL) {
+					if (tsc != NULL && tsc->data[SC_BERSERK] != NULL)
+						break; // [Aegis] can't use on berserked players.
 				}
 				sp1 = sstatus->sp;
 				sp2 = tstatus->sp;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -6416,7 +6416,7 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 					break; // You can use Phantom Thurst on party members in normal maps too. [pakpil]
 			}
 
-			if( inf&BCT_ENEMY
+			if ((inf & BCT_ENEMY) != 0 && ud->skill_id != PF_SOULCHANGE // PF_SOULCHANGE is a friendly skill in Aegis under all circumstances.
 			 && (sc = status->get_sc(target)) != NULL && sc->data[SC_FOGWALL]
 			 && rnd() % 100 < 75
 			) {


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Make PF_SOULCHANGE not useable on berserked characters
- Make PF_SOULCHANGE not useable on bosses as on officials
- Make SC_FOGWALL never miss PF_SOULCHANGE under any condition as on officials

Verified on pre-re and re Aegis.

**Issues addressed:** None?


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
