### PR TITLE
Stop units from moving when dead

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -175,6 +175,9 @@ static int unit_walk_toxy_sub(struct block_list *bl)
 	if (ud == NULL)
 		return 2;
 
+	if (status->isdead(bl))
+		return 1;
+
 	struct walkpath_data wpd = {0};
 
 	if (!path->search(&wpd, bl, bl->m, bl->x, bl->y, ud->to_x, ud->to_y, ud->state.walk_easy, CELL_CHKNOPASS))

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -361,6 +361,9 @@ static int unit_walk_toxy_timer(int tid, int64 tick, int id, intptr_t data)
 	if (ud->walkpath.path_pos >= ud->walkpath.path_len)
 		return 1;
 
+	if (status->isdead(bl)) // Should not be able to move
+		return 1;
+
 	enum unit_dir dir = ud->walkpath.path[ud->walkpath.path_pos];
 	Assert_retr(1, dir >= UNIT_DIR_FIRST && dir < UNIT_DIR_MAX);
 	int x = bl->x;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Stop units from moving and, consequently, notifying the client when the unit is already dead and the server is going to send a notification to vanish such unit. Fixes mobs walking around or standing when killed.

This issue has been already discussed here https://github.com/HerculesWS/Hercules/issues/2109 with some insights, however, I think this patch is fine as this "move request" should never be done after death. Nonetheless and, as precaution, this check could be made against BL_MOB only, which uses a timer and it's the main reason this visual bug appears.

**Issues addressed:** <!-- Write here the issue number, if any. -->
https://github.com/HerculesWS/Hercules/issues/2047
https://github.com/HerculesWS/Hercules/issues/2109

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
