### PR TITLE
Fixed signedness of image size

### DIFF
--- a/src/map/packets_struct.h
+++ b/src/map/packets_struct.h
@@ -5032,7 +5032,7 @@ DEFINE_PACKET_HEADER(ZC_MYGUILD_BASIC_INFO, 0x014c);
 struct PACKET_CZ_REQ_UPLOAD_MACRO_DETECTOR {
 	int16 PacketType;
 	char answer[16];
-	int16 imageSize;
+	uint16 imageSize;
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(CZ_REQ_UPLOAD_MACRO_DETECTOR, 0x0a52);
 #endif
@@ -5082,7 +5082,7 @@ DEFINE_PACKET_HEADER(ZC_ACK_APPLY_MACRO_DETECTOR, 0x0a57);
 #if PACKETVER >= 20160330
 struct PACKET_ZC_APPLY_MACRO_DETECTOR {
 	int16 PacketType;
-	int16 imageSize;
+	uint16 imageSize;
 	char captchaKey[4];
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(ZC_APPLY_MACRO_DETECTOR, 0x0a58);
@@ -5142,7 +5142,7 @@ DEFINE_PACKET_HEADER(CZ_REQ_PREVIEW_MACRO_DETECTOR, 0x0a69);
 struct PACKET_ZC_ACK_PREVIEW_MACRO_DETECTOR {
 	int16 PacketType;
 	int captchaFlag;
-	int16 imageSize;
+	uint16 imageSize;
 	char captchaKey[4];
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(ZC_ACK_PREVIEW_MACRO_DETECTOR, 0x0a6a);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Image size is 59454, which is > INT16_MAX.
Therefore uint16 should be used.
The rest of the code should also be checked, as it uses int32 instead of int16 in general.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
