### PR TITLE
quest log fixes and quest atcommand

### DIFF
--- a/conf/messages.conf
+++ b/conf/messages.conf
@@ -1692,5 +1692,20 @@
 1529: 1 item has been graded.
 1530: %d items have been graded.
 
+// @quest
+1531: Usage: @quest <action> <quest id>. Action:
+1532: -- "add" or "set": adds this quest to the player (as a new quest)
+1533: -- "del" or "delete": removes this quest from player's log
+1534: -- "complete": marks this quest as complete
+1535: This quest does not exist.
+1536: You already have this quest.
+1537: Failed to add quest.
+1538: Quest added to your log.
+1539: You don't have this quest in your log.
+1540: Failed to erase quest.
+1541: Quest was removed from your log.
+1542: Failed to complete quest.
+1543: Quest was marked as complete in your log.
+
 // Custom translations
 import: conf/import/msg_conf.txt

--- a/doc/atcommands.txt
+++ b/doc/atcommands.txt
@@ -756,6 +756,17 @@ Deletes all items in cart, but does not remove the cart.
 
 ---------------------------------------
 
+@quest <action> <quest id>
+
+Changes player's quest log, performing "action" on "quest id".
+
+action:
+-- add or set: Includes "quest id" in player's quest log
+-- del or delete: Removes "quest id" from player's quest log
+-- complete: Marks "quest id" as complete in player's quest log (must have the quest)
+
+---------------------------------------
+
 @cleanarea
 @cleanmap
 

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -9312,6 +9312,86 @@ ACMD(set)
 	return true;
 }
 
+/**
+ * Sends @quest command help text to fd
+ * @param fd 
+ */
+static void atcommand_quest_help(int fd)
+{
+	clif->message(fd, msg_fd(fd, 1531));
+	clif->message(fd, msg_fd(fd, 1532));
+	clif->message(fd, msg_fd(fd, 1533));
+	clif->message(fd, msg_fd(fd, 1534));
+}
+
+ACMD(quest)
+{
+	char subcmd[20];
+	int quest_id;
+
+	// @quest add|set <quest id>
+	// @quest del|delete <quest id>
+	// @quest complete <quest id>
+	if (!*message || sscanf(message, "%19s %d", subcmd, &quest_id) < 2) {
+		atcommand->quest_help(fd);
+		return true;
+	}
+
+	struct quest_db *qi = quest->db(quest_id);
+	if (qi == &quest->dummy) {
+		clif->message(fd, msg_fd(fd, 1535));
+		return true;
+	}
+
+	if (strcmpi(subcmd, "add") == 0 || strcmpi(subcmd, "set") == 0) {
+		if (quest->check(sd, quest_id, HAVEQUEST) >= 0) {
+			clif->message(fd, msg_fd(fd, 1536));
+			return true;
+		}
+
+		if (quest->add(sd, quest_id, 0) != 0) {
+			clif->message(fd, msg_fd(fd, 1537));
+			return true;
+		}
+
+		clif->message(fd, msg_fd(fd, 1538));
+		return true;
+	}
+
+	if (strcmpi(subcmd, "del") == 0 || strcmpi(subcmd, "delete") == 0) {
+		if (quest->check(sd, quest_id, HAVEQUEST) == -1) {
+			clif->message(fd, msg_fd(fd, 1539));
+			return true;
+		}
+
+		if (quest->delete(sd, quest_id) != 0) {
+			clif->message(fd, msg_fd(fd, 1540));
+			return true;
+		}
+
+		clif->message(fd, msg_fd(fd, 1541));
+		return true;
+	}
+
+	if (strcmpi(subcmd, "complete") == 0) {
+		if (quest->check(sd, quest_id, HAVEQUEST) == -1) {
+			clif->message(fd, msg_fd(fd, 1539));
+			return true;
+		}
+
+		if (quest->update_status(sd, quest_id, Q_COMPLETE) != 0) {
+			clif->message(fd, msg_fd(fd, 1542));
+			return true;
+		}
+
+		clif->message(fd, msg_fd(fd, 1543));
+		return true;
+	}
+
+	atcommand->quest_help(fd);
+	return true;
+}
+
 ACMD(reloadquestdb)
 {
 	quest->reload();
@@ -10680,6 +10760,7 @@ static void atcommand_basecommands(void)
 		ACMD_DEF(font),
 		ACMD_DEF(accinfo),
 		ACMD_DEF(set),
+		ACMD_DEF(quest),
 		ACMD_DEF(reloadquestdb),
 		ACMD_DEF(undisguiseguild),
 		ACMD_DEF(disguiseguild),
@@ -11377,6 +11458,7 @@ void atcommand_defaults(void)
 	atcommand->commands_sub = atcommand_commands_sub;
 	atcommand->getring = atcommand_getring;
 	atcommand->channel_help = atcommand_channel_help;
+	atcommand->quest_help = atcommand_quest_help;
 	atcommand->cmd_db_clear = atcommand_db_clear;
 	atcommand->cmd_db_clear_sub = atcommand_db_clear_sub;
 	atcommand->doload = atcommand_doload;

--- a/src/map/atcommand.h
+++ b/src/map/atcommand.h
@@ -41,7 +41,7 @@ struct config_setting_t;
  * Defines
  **/
 #define ATCOMMAND_LENGTH 50
-#define MAX_MSG 1530
+#define MAX_MSG 1543
 #define msg_txt(idx) atcommand->msg(idx)
 #define msg_sd(sd,msg_number) atcommand->msgsd((sd),(msg_number))
 #define msg_fd(fd,msg_number) atcommand->msgfd((fd),(msg_number))
@@ -148,6 +148,7 @@ struct atcommand_interface {
 	int (*mutearea_sub) (struct block_list *bl,va_list ap);
 	void (*getring) (struct map_session_data* sd);
 	void (*channel_help) (int fd, const char *command, bool can_create);
+	void (*quest_help) (int fd);
 	/* */
 	void (*commands_sub) (struct map_session_data* sd, const int fd, AtCommandType type);
 	void (*cmd_db_clear) (void);

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -18889,7 +18889,7 @@ static void clif_quest_add(struct map_session_data *sd, struct quest *qd)
 	nullpo_retv(qd);
 
 	qi = quest->db(qd->quest_id);
-	Assert_retv(qi->objectives_count < MAX_QUEST_OBJECTIVES);
+	Assert_retv(qi->objectives_count <= MAX_QUEST_OBJECTIVES);
 
 	len = sizeof(struct packet_quest_add_header)
 	            + MAX_QUEST_OBJECTIVES * sizeof(struct packet_quest_hunt_sub); // >= than the actual length
@@ -18970,7 +18970,7 @@ static void clif_quest_update_objective(struct map_session_data *sd, struct ques
 	nullpo_retv(qd);
 
 	qi = quest->db(qd->quest_id);
-	Assert_retv(qi->objectives_count < MAX_QUEST_OBJECTIVES);
+	Assert_retv(qi->objectives_count <= MAX_QUEST_OBJECTIVES);
 
 	len = sizeof(struct packet_quest_update_header)
 	            + MAX_QUEST_OBJECTIVES * sizeof(struct packet_quest_update_hunt); // >= than the actual length
@@ -19016,7 +19016,7 @@ static void clif_quest_notify_objective(struct map_session_data *sd, struct ques
 	nullpo_retv(qd);
 
 	qi = quest->db(qd->quest_id);
-	Assert_retv(qi->objectives_count < MAX_QUEST_OBJECTIVES);
+	Assert_retv(qi->objectives_count <= MAX_QUEST_OBJECTIVES);
 
 	len = sizeof(struct packet_quest_hunt_info)
 	            + MAX_QUEST_OBJECTIVES * sizeof(struct packet_quest_hunt_info_sub); // >= than the actual length

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -19028,10 +19028,19 @@ static void clif_quest_notify_objective(struct map_session_data *sd, struct ques
 	packet->PacketType = questUpdateType2;
 
 	for (i = 0; i < qi->objectives_count; i++) {
+		int mob_id = qi->objectives[i].mob;
+		if (mob_id == 0) {
+			if (quest_mobtypeisenabled(qi->objectives[i].mobtype)) {
+				mob_id = QUEST_MOBTYPE_ID;
+			} else if (qi->objectives[i].mapid >= 0) {
+				mob_id = QUEST_MAPWIDE_ID;
+			}
+		}
+
 		real_len += sizeof(packet->info[i]);
 
 		packet->info[i].questID = qd->quest_id;
-		packet->info[i].mob_id = qi->objectives[i].mob;
+		packet->info[i].mob_id = mob_id;
 		packet->info[i].maxCount = qi->objectives[i].count;
 		packet->info[i].count = qd->count[i];
 	}

--- a/src/map/quest.c
+++ b/src/map/quest.c
@@ -1045,6 +1045,23 @@ static bool quest_questinfo_validate_mercenary_class(struct map_session_data *sd
 	return true;
 }
 
+static enum quest_mobtype quest_mobsize2client(uint8 size)
+{
+	switch (size) {
+	case SZ_SMALL:
+		return QMT_SZ_SMALL;
+
+	case SZ_MEDIUM:
+		return QMT_SZ_MEDIUM;
+
+	case SZ_BIG:
+		return QMT_SZ_LARGE;
+
+	default:
+		return 0;
+	}
+}
+
 static enum quest_mobtype quest_mobele2client(uint8 type)
 {
 	switch (type) {
@@ -1176,6 +1193,7 @@ void quest_defaults(void)
 	quest->questinfo_validate_homunculus_type = quest_questinfo_validate_homunculus_type;
 	quest->questinfo_validate_quests = quest_questinfo_validate_quests;
 	quest->questinfo_validate_mercenary_class = quest_questinfo_validate_mercenary_class;
+	quest->mobsize2client = quest_mobsize2client;
 	quest->mobele2client = quest_mobele2client;
 	quest->mobrace2client = quest_mobrace2client;
 }

--- a/src/map/quest.h
+++ b/src/map/quest.h
@@ -35,14 +35,17 @@ struct mob_data;
 #define QUEST_MAPWIDE_ID 10363 // MobId handled by the client to display MapName
 #define QUEST_MOBTYPE_ID 31999 // MobId handled by the client to display Mob properties
 
-#define quest_mobtype2client(type) ((1 << (type).size) | quest->mobele2client((type).ele) | quest->mobrace2client((type).race))
+#define quest_mobtype2client(type) (\
+	((type).size_enabled ? quest->mobsize2client((type).size) : 0) \
+	| ((type).ele_enabled ? quest->mobele2client((type).ele) : 0) \
+	| ((type).race_enabled ? quest->mobrace2client((type).race) : 0))
 #define quest_mobtypeisenabled(type) ((type).size_enabled || (type).ele_enabled || (type).race_enabled)
 
 enum quest_mobtype {
 	// Monster Sizes
-	QMT_SZ_SMALL         = 0x01,
-	QMT_SZ_MEDIUM        = 0x02,
-	QMT_SZ_LARGE         = 0x04,
+	QMT_SZ_SMALL         = 0x10,
+	QMT_SZ_MEDIUM        = 0x20,
+	QMT_SZ_LARGE         = 0x40,
 
 	// Monster Races
 	QMT_RC_DEMIHUMAN     = 0x80,
@@ -178,6 +181,7 @@ struct quest_interface {
 	bool (*questinfo_validate_homunculus_type) (struct map_session_data *sd, struct questinfo *qi);
 	bool (*questinfo_validate_quests) (struct map_session_data *sd, struct questinfo *qi);
 	bool (*questinfo_validate_mercenary_class) (struct map_session_data *sd, struct questinfo *qi);
+	enum quest_mobtype (*mobsize2client) (uint8 size);
 	enum quest_mobtype (*mobele2client) (uint8 type);
 	enum quest_mobtype (*mobrace2client) (uint8 type);
 };

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -234,6 +234,8 @@ typedef void (*HPMHOOK_pre_atcommand_getring) (struct map_session_data **sd);
 typedef void (*HPMHOOK_post_atcommand_getring) (struct map_session_data *sd);
 typedef void (*HPMHOOK_pre_atcommand_channel_help) (int *fd, const char **command, bool *can_create);
 typedef void (*HPMHOOK_post_atcommand_channel_help) (int fd, const char *command, bool can_create);
+typedef void (*HPMHOOK_pre_atcommand_quest_help) (int *fd);
+typedef void (*HPMHOOK_post_atcommand_quest_help) (int fd);
 typedef void (*HPMHOOK_pre_atcommand_commands_sub) (struct map_session_data **sd, const int *fd, AtCommandType *type);
 typedef void (*HPMHOOK_post_atcommand_commands_sub) (struct map_session_data *sd, const int fd, AtCommandType type);
 typedef void (*HPMHOOK_pre_atcommand_cmd_db_clear) (void);
@@ -7002,6 +7004,8 @@ typedef bool (*HPMHOOK_pre_quest_questinfo_validate_quests) (struct map_session_
 typedef bool (*HPMHOOK_post_quest_questinfo_validate_quests) (bool retVal___, struct map_session_data *sd, struct questinfo *qi);
 typedef bool (*HPMHOOK_pre_quest_questinfo_validate_mercenary_class) (struct map_session_data **sd, struct questinfo **qi);
 typedef bool (*HPMHOOK_post_quest_questinfo_validate_mercenary_class) (bool retVal___, struct map_session_data *sd, struct questinfo *qi);
+typedef enum quest_mobtype (*HPMHOOK_pre_quest_mobsize2client) (uint8 *size);
+typedef enum quest_mobtype (*HPMHOOK_post_quest_mobsize2client) (enum quest_mobtype retVal___, uint8 size);
 typedef enum quest_mobtype (*HPMHOOK_pre_quest_mobele2client) (uint8 *type);
 typedef enum quest_mobtype (*HPMHOOK_post_quest_mobele2client) (enum quest_mobtype retVal___, uint8 type);
 typedef enum quest_mobtype (*HPMHOOK_pre_quest_mobrace2client) (uint8 *type);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -190,6 +190,8 @@ struct {
 	struct HPMHookPoint *HP_atcommand_getring_post;
 	struct HPMHookPoint *HP_atcommand_channel_help_pre;
 	struct HPMHookPoint *HP_atcommand_channel_help_post;
+	struct HPMHookPoint *HP_atcommand_quest_help_pre;
+	struct HPMHookPoint *HP_atcommand_quest_help_post;
 	struct HPMHookPoint *HP_atcommand_commands_sub_pre;
 	struct HPMHookPoint *HP_atcommand_commands_sub_post;
 	struct HPMHookPoint *HP_atcommand_cmd_db_clear_pre;
@@ -5534,6 +5536,8 @@ struct {
 	struct HPMHookPoint *HP_quest_questinfo_validate_quests_post;
 	struct HPMHookPoint *HP_quest_questinfo_validate_mercenary_class_pre;
 	struct HPMHookPoint *HP_quest_questinfo_validate_mercenary_class_post;
+	struct HPMHookPoint *HP_quest_mobsize2client_pre;
+	struct HPMHookPoint *HP_quest_mobsize2client_post;
 	struct HPMHookPoint *HP_quest_mobele2client_pre;
 	struct HPMHookPoint *HP_quest_mobele2client_post;
 	struct HPMHookPoint *HP_quest_mobrace2client_pre;
@@ -7555,6 +7559,8 @@ struct {
 	int HP_atcommand_getring_post;
 	int HP_atcommand_channel_help_pre;
 	int HP_atcommand_channel_help_post;
+	int HP_atcommand_quest_help_pre;
+	int HP_atcommand_quest_help_post;
 	int HP_atcommand_commands_sub_pre;
 	int HP_atcommand_commands_sub_post;
 	int HP_atcommand_cmd_db_clear_pre;
@@ -12899,6 +12905,8 @@ struct {
 	int HP_quest_questinfo_validate_quests_post;
 	int HP_quest_questinfo_validate_mercenary_class_pre;
 	int HP_quest_questinfo_validate_mercenary_class_post;
+	int HP_quest_mobsize2client_pre;
+	int HP_quest_mobsize2client_post;
 	int HP_quest_mobele2client_pre;
 	int HP_quest_mobele2client_post;
 	int HP_quest_mobrace2client_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -111,6 +111,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(atcommand->mutearea_sub, HP_atcommand_mutearea_sub) },
 	{ HP_POP(atcommand->getring, HP_atcommand_getring) },
 	{ HP_POP(atcommand->channel_help, HP_atcommand_channel_help) },
+	{ HP_POP(atcommand->quest_help, HP_atcommand_quest_help) },
 	{ HP_POP(atcommand->commands_sub, HP_atcommand_commands_sub) },
 	{ HP_POP(atcommand->cmd_db_clear, HP_atcommand_cmd_db_clear) },
 	{ HP_POP(atcommand->cmd_db_clear_sub, HP_atcommand_cmd_db_clear_sub) },
@@ -2830,6 +2831,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(quest->questinfo_validate_homunculus_type, HP_quest_questinfo_validate_homunculus_type) },
 	{ HP_POP(quest->questinfo_validate_quests, HP_quest_questinfo_validate_quests) },
 	{ HP_POP(quest->questinfo_validate_mercenary_class, HP_quest_questinfo_validate_mercenary_class) },
+	{ HP_POP(quest->mobsize2client, HP_quest_mobsize2client) },
 	{ HP_POP(quest->mobele2client, HP_quest_mobele2client) },
 	{ HP_POP(quest->mobrace2client, HP_quest_mobrace2client) },
 /* refine_interface */

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -2240,6 +2240,32 @@ void HP_atcommand_channel_help(int fd, const char *command, bool can_create) {
 	}
 	return;
 }
+void HP_atcommand_quest_help(int fd) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_atcommand_quest_help_pre > 0) {
+		void (*preHookFunc) (int *fd);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_atcommand_quest_help_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_atcommand_quest_help_pre[hIndex].func;
+			preHookFunc(&fd);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.atcommand.quest_help(fd);
+	}
+	if (HPMHooks.count.HP_atcommand_quest_help_post > 0) {
+		void (*postHookFunc) (int fd);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_atcommand_quest_help_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_atcommand_quest_help_post[hIndex].func;
+			postHookFunc(fd);
+		}
+	}
+	return;
+}
 void HP_atcommand_commands_sub(struct map_session_data *sd, const int fd, AtCommandType type) {
 	int hIndex = 0;
 	if (HPMHooks.count.HP_atcommand_commands_sub_pre > 0) {
@@ -73687,6 +73713,33 @@ bool HP_quest_questinfo_validate_mercenary_class(struct map_session_data *sd, st
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_quest_questinfo_validate_mercenary_class_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_quest_questinfo_validate_mercenary_class_post[hIndex].func;
 			retVal___ = postHookFunc(retVal___, sd, qi);
+		}
+	}
+	return retVal___;
+}
+enum quest_mobtype HP_quest_mobsize2client(uint8 size) {
+	int hIndex = 0;
+	enum quest_mobtype retVal___ = QMT_RC_DEMIHUMAN;
+	if (HPMHooks.count.HP_quest_mobsize2client_pre > 0) {
+		enum quest_mobtype (*preHookFunc) (uint8 *size);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_quest_mobsize2client_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_quest_mobsize2client_pre[hIndex].func;
+			retVal___ = preHookFunc(&size);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.quest.mobsize2client(size);
+	}
+	if (HPMHooks.count.HP_quest_mobsize2client_post > 0) {
+		enum quest_mobtype (*postHookFunc) (enum quest_mobtype retVal___, uint8 size);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_quest_mobsize2client_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_quest_mobsize2client_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, size);
 		}
 	}
 	return retVal___;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR introduces a few fixes to quest log:
1. Quests with 3 objectives doesn't fail an assertion anymore.

2. Quests using monster size, race or element as condition were giving out some wrong labelling.

For example, a quest for "hunting fire monsters" would give something like "fire formless monsters", while actually just checking for fire element. That was due to the code not checking whether a race/element of 0 meant no race/element, or the race/element that actually has ID = 0 (as they are 0-based).

3. Fixes the bitmask value for size

Quests that asked for a monster size were not being sent correctly to the client. I tested on 2019-12-24. I will be honest... I went by trial and error until the label showed up... so I am not sure if this changes in newer clients (@Asheraf do you know if they change at some future client?)

4. Fixes mobid not being sent on ZC_HUNTING_QUEST_INFO for special cases (map name / race / size / element)

This prevented the client from displaying the targets when the player first got the quest, requiring the user to log out / back in to actually see their objectives.

---

Also, I took the chance to add `@quest` atcommand. This atcommand allows the user to manipulate their quest log, I find it useful for debugging/development purposes (saves the need to make npcs/db changes to add/remove quests from your character)

**Issues addressed:** <!-- Write here the issue number, if any. -->
None, I think

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style