### PR TITLE
Fixes on rodex zeny retrieval

### DIFF
--- a/src/char/int_rodex.c
+++ b/src/char/int_rodex.c
@@ -482,9 +482,11 @@ static bool inter_rodex_updatemail(int fd, int account_id, int char_id, int64 ma
 	case 1: // Get Zeny
 	{
 		const int64 zeny = inter_rodex->getzeny(mail_id);
-		if (SQL_ERROR == SQL->Query(inter->sql_handle, "UPDATE `%s` SET `zeny` = 0, `type` = `type` & (~2) WHERE `mail_id` = '%"PRId64"'", rodex_db, mail_id)) {
-			Sql_ShowDebug(inter->sql_handle);
-			break;
+		if (zeny != -1) {
+			if (SQL_ERROR == SQL->Query(inter->sql_handle, "UPDATE `%s` SET `zeny` = 0, `type` = `type` & (~2) WHERE `mail_id` = '%"PRId64"'", rodex_db, mail_id)) {
+				Sql_ShowDebug(inter->sql_handle);
+				break;
+			}
 		}
 		mapif->rodex_getzenyack(fd, char_id, mail_id, opentype, zeny);
 		break;

--- a/src/map/intif.c
+++ b/src/map/intif.c
@@ -2652,7 +2652,7 @@ static void intif_parse_RodexCheckName(int fd)
 static void intif_parse_GetZenyAck(int fd)
 {
 	int char_id = RFIFOL(fd, 2);
-	int64 zeny = RFIFOL(fd, 6);
+	int64 zeny = RFIFOQ(fd, 6);
 	int64 mail_id = RFIFOQ(fd, 14);
 	uint8 opentype = RFIFOB(fd, 22);
 	struct map_session_data *sd = map->charid2sd(char_id);

--- a/src/map/rodex.c
+++ b/src/map/rodex.c
@@ -445,6 +445,15 @@ static void rodex_getZenyAck(struct map_session_data *sd, int64 mail_id, int8 op
 		return;
 	}
 
+	// Updates the in-memory copy of this mail
+	// It should never be null, but if it ends up being, that would simply mean that this
+	// mail is gone from the user data, and that's fine, as the char-server did its work.
+	struct rodex_message *msg = rodex->get_mail(sd, mail_id);
+	if (msg != NULL) {
+		msg->type &= ~MAIL_TYPE_ZENY;
+		msg->zeny = 0;
+	}
+
 	if (pc->getzeny(sd, (int)zeny, LOG_TYPE_MAIL, NULL) != 0) {
 		clif->rodex_request_zeny(sd, opentype, mail_id, RODEX_GET_ZENY_FATAL_ERROR);
 		return;
@@ -472,8 +481,6 @@ static void rodex_get_zeny(struct map_session_data *sd, int8 opentype, int64 mai
 		return;
 	}
 
-	msg->type &= ~MAIL_TYPE_ZENY;
-	msg->zeny = 0;
 	intif->rodex_updatemail(sd, mail_id, opentype, 1);
 }
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Small fixes on RoDEX zeny retrieval process (specially for error cases).
1. Fix packet reading for GetZenyAck packet that was reading the `zeny` value using the wrong type;
2. Stop zeroing the mail's zeny if checking for the mail data failed. Otherwise, the value is lost forever;
3. Move the map-server side cleaning of the zeny flag to after the ACK is received, otherwise an error would prevent the player from being able to try again

**Issues addressed:** <!-- Write here the issue number, if any. -->
None, I think

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
