### PR TITLE
Fix shadowed pinfo symbol

### DIFF
--- a/src/map/enchantui.c
+++ b/src/map/enchantui.c
@@ -309,13 +309,13 @@ static bool enchantui_read_db_libconfig_normal_info(const struct config_setting_
 	return true;
 }
 
-static bool enchantui_read_db_libconfig_perfect_info(const struct config_setting_t *it, struct enchant_info_perfect *pinfo, int n, const char *source)
+static bool enchantui_read_db_libconfig_perfect_info(const struct config_setting_t *it, struct enchant_info_perfect *perfect_info, int n, const char *source)
 {
 	nullpo_retr(false, it);
-	nullpo_retr(false, pinfo);
+	nullpo_retr(false, perfect_info);
 	nullpo_retr(false, source);
 
-	VECTOR_INIT(*pinfo);
+	VECTOR_INIT(*perfect_info);
 
 	int i = 0;
 	struct config_setting_t *entry = NULL;
@@ -340,8 +340,8 @@ static bool enchantui_read_db_libconfig_perfect_info(const struct config_setting
 		if (materials != NULL && !enchantui->read_db_libconfig_materials_list(materials, &perfentry.Materials, n, source))
 			continue;
 
-		VECTOR_ENSURE(*pinfo, 1, 1);
-		VECTOR_PUSH(*pinfo, perfentry);
+		VECTOR_ENSURE(*perfect_info, 1, 1);
+		VECTOR_PUSH(*perfect_info, perfentry);
 	}
 
 	return true;

--- a/src/map/enchantui.h
+++ b/src/map/enchantui.h
@@ -104,7 +104,7 @@ struct enchantui_interface {
 	bool (*read_db_libconfig_slot_info_sub) (const struct config_setting_t *it, struct enchant_slot_info *sinfo, int n, const char *source);
 	bool (*read_db_libconfig_gradebonus) (const struct config_setting_t *it, struct enchant_slot_info *sinfo, int n, const char *source);
 	bool (*read_db_libconfig_normal_info) (const struct config_setting_t *it, struct enchant_info_normal *ninfo, int n, const char *source);
-	bool (*read_db_libconfig_perfect_info) (const struct config_setting_t *it, struct enchant_info_perfect *pinfo, int n, const char *source);
+	bool (*read_db_libconfig_perfect_info) (const struct config_setting_t *it, struct enchant_info_perfect *perfect_info, int n, const char *source);
 	bool (*read_db_libconfig_upgrade_info) (const struct config_setting_t *it, struct enchant_info_upgrade *uinfo, int n, const char *source);
 	bool (*read_db_libconfig_reset_info) (const struct config_setting_t *it, struct enchant_info_reset *rinfo, int n, const char *source);
 	bool (*read_db_libconfig_materials_list) (const struct config_setting_t *it, struct itemlist *materials, int n, const char *source);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -3080,8 +3080,8 @@ typedef bool (*HPMHOOK_pre_enchantui_read_db_libconfig_gradebonus) (const struct
 typedef bool (*HPMHOOK_post_enchantui_read_db_libconfig_gradebonus) (bool retVal___, const struct config_setting_t *it, struct enchant_slot_info *sinfo, int n, const char *source);
 typedef bool (*HPMHOOK_pre_enchantui_read_db_libconfig_normal_info) (const struct config_setting_t **it, struct enchant_info_normal **ninfo, int *n, const char **source);
 typedef bool (*HPMHOOK_post_enchantui_read_db_libconfig_normal_info) (bool retVal___, const struct config_setting_t *it, struct enchant_info_normal *ninfo, int n, const char *source);
-typedef bool (*HPMHOOK_pre_enchantui_read_db_libconfig_perfect_info) (const struct config_setting_t **it, struct enchant_info_perfect **pinfo, int *n, const char **source);
-typedef bool (*HPMHOOK_post_enchantui_read_db_libconfig_perfect_info) (bool retVal___, const struct config_setting_t *it, struct enchant_info_perfect *pinfo, int n, const char *source);
+typedef bool (*HPMHOOK_pre_enchantui_read_db_libconfig_perfect_info) (const struct config_setting_t **it, struct enchant_info_perfect **perfect_info, int *n, const char **source);
+typedef bool (*HPMHOOK_post_enchantui_read_db_libconfig_perfect_info) (bool retVal___, const struct config_setting_t *it, struct enchant_info_perfect *perfect_info, int n, const char *source);
 typedef bool (*HPMHOOK_pre_enchantui_read_db_libconfig_upgrade_info) (const struct config_setting_t **it, struct enchant_info_upgrade **uinfo, int *n, const char **source);
 typedef bool (*HPMHOOK_post_enchantui_read_db_libconfig_upgrade_info) (bool retVal___, const struct config_setting_t *it, struct enchant_info_upgrade *uinfo, int n, const char *source);
 typedef bool (*HPMHOOK_pre_enchantui_read_db_libconfig_reset_info) (const struct config_setting_t **it, struct enchant_info_reset **rinfo, int *n, const char **source);

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -34733,15 +34733,15 @@ bool HP_enchantui_read_db_libconfig_normal_info(const struct config_setting_t *i
 	}
 	return retVal___;
 }
-bool HP_enchantui_read_db_libconfig_perfect_info(const struct config_setting_t *it, struct enchant_info_perfect *pinfo, int n, const char *source) {
+bool HP_enchantui_read_db_libconfig_perfect_info(const struct config_setting_t *it, struct enchant_info_perfect *perfect_info, int n, const char *source) {
 	int hIndex = 0;
 	bool retVal___ = false;
 	if (HPMHooks.count.HP_enchantui_read_db_libconfig_perfect_info_pre > 0) {
-		bool (*preHookFunc) (const struct config_setting_t **it, struct enchant_info_perfect **pinfo, int *n, const char **source);
+		bool (*preHookFunc) (const struct config_setting_t **it, struct enchant_info_perfect **perfect_info, int *n, const char **source);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_enchantui_read_db_libconfig_perfect_info_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_enchantui_read_db_libconfig_perfect_info_pre[hIndex].func;
-			retVal___ = preHookFunc(&it, &pinfo, &n, &source);
+			retVal___ = preHookFunc(&it, &perfect_info, &n, &source);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -34749,13 +34749,13 @@ bool HP_enchantui_read_db_libconfig_perfect_info(const struct config_setting_t *
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.enchantui.read_db_libconfig_perfect_info(it, pinfo, n, source);
+		retVal___ = HPMHooks.source.enchantui.read_db_libconfig_perfect_info(it, perfect_info, n, source);
 	}
 	if (HPMHooks.count.HP_enchantui_read_db_libconfig_perfect_info_post > 0) {
-		bool (*postHookFunc) (bool retVal___, const struct config_setting_t *it, struct enchant_info_perfect *pinfo, int n, const char *source);
+		bool (*postHookFunc) (bool retVal___, const struct config_setting_t *it, struct enchant_info_perfect *perfect_info, int n, const char *source);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_enchantui_read_db_libconfig_perfect_info_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_enchantui_read_db_libconfig_perfect_info_post[hIndex].func;
-			retVal___ = postHookFunc(retVal___, it, pinfo, n, source);
+			retVal___ = postHookFunc(retVal___, it, perfect_info, n, source);
 		}
 	}
 	return retVal___;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixes a warning about a shadowed `pinfo` symbol. The name `pinfo` is reserved for use by the `struct hplugin_info` in HPM plugins.

**Issues addressed:** None

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
