### PR TITLE
Remove python2 dependency from the CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python2 libzstd-dev
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python3 libzstd-dev
 
 jobs:
   build:

--- a/.github/workflows/clang15_test.yml
+++ b/.github/workflows/clang15_test.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python2 libzstd-dev
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python3 libzstd-dev
 
 jobs:
   build:

--- a/.github/workflows/gcc_test.yml
+++ b/.github/workflows/gcc_test.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python2 libzstd-dev
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python3 libzstd-dev
 
 jobs:
   build:

--- a/.github/workflows/gccold1.yml
+++ b/.github/workflows/gccold1.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python2 libzstd-dev
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python3 libzstd-dev
 
 jobs:
   build:

--- a/.github/workflows/gccold2.yml
+++ b/.github/workflows/gccold2.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python2 libzstd-dev
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python3 libzstd-dev
 
 jobs:
   build:

--- a/.github/workflows/gccold3.yml
+++ b/.github/workflows/gccold3.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python libzstd-dev
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python3 libzstd-dev
 
 jobs:
   build:

--- a/.github/workflows/gccsnapshot_test.yml
+++ b/.github/workflows/gccsnapshot_test.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python2 libzstd-dev gcc gcc-snapshot
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python3 libzstd-dev gcc gcc-snapshot
 
 jobs:
   build:

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python2 libzstd-dev
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python3 libzstd-dev
 
 jobs:
   build:

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python2 libzstd-dev
+  DEBIAN_COMMON_PACKAGES: make zlib1g-dev libpcre3-dev git python3 libzstd-dev
 
 jobs:
   build:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: 'ragnarok'
   MYSQL_PASSWORD: 'ragnarok'
   MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-  DEBIAN_COMMON_PACKAGES: php php-dom composer wget
+  DEBIAN_COMMON_PACKAGES: php php-xml composer wget
 
 jobs:
   build:

--- a/tools/validateinterfaces.py
+++ b/tools/validateinterfaces.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 # -*- coding: utf8 -*-
 #
 # This file is part of Hercules.


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This removes the last leftovers of python2 in the tools and uses python3 only in the CI builds. Debian unstable seems to have dropped python2, so we can no longer rely on it. The scripts seem to be compatible with python3 (since june 2020) even though validateinterfaces was still executed through python2.

**Issues addressed:** N/A - CI build failures on master

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
