### PR TITLE
Set skill_amotion_delay default value to 0 and applied amotion at castbegin

### DIFF
--- a/conf/map/battle/skill.conf
+++ b/conf/map/battle/skill.conf
@@ -68,11 +68,10 @@ vcast_stat_scale: 530
 
 // What level of leniency should the skill system give for skills when
 // accounting attack motion (ASPD) for casting skills (Note 2, between 0 and 300)
-//
-// NOTE: Setting this to 100% may cause some issues with valid skills not being cast.
-//       The time difference between client and server varies so allowing 90% leniency
-//       should be enough to forgive very small margins of error.
-skill_amotion_leniency: 90
+// NOTE: Some skills do not base its delay on attack motion. Setting this to anything
+// other than 0 might cause incorrect behavior when using skills with none or short
+// animations, although it may block some speedhacks
+skill_amotion_leniency: 0
 
 // Will normal attacks be able to ignore the delay after skills? (Note 1)
 skill_delay_attack_enable: true

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -6778,7 +6778,7 @@ static enum damage_lv battle_weapon_attack(struct block_list *src, struct block_
 				skill->consume_requirement(sd,r_skill,r_lv,3);
 				skill->castend_type(type, src, target, r_skill, r_lv, tick, flag);
 				sd->auto_cast_current.type = AUTOCAST_NONE;
-				sd->ud.canact_tick = tick + skill->delay_fix(src, r_skill, r_lv);
+				sd->ud.canact_tick = max(tick + skill->delay_fix(src, r_skill, r_lv), sd->ud.canact_tick);
 				clif->status_change(src, status->get_sc_icon(SC_POSTDELAY), status->get_sc_relevant_bl_types(SC_POSTDELAY), 1, skill->delay_fix(src, r_skill, r_lv), 0, 0, 1);
 			}
 		}
@@ -7745,7 +7745,7 @@ static const struct battle_data {
 	{ "max_baby_third_parameter",           &battle_config.max_baby_third_parameter,        117,    10,     10000,          },
 	{ "max_extended_parameter",             &battle_config.max_extended_parameter,          125,    10,     10000,          },
 	{ "atcommand_max_stat_bypass",          &battle_config.atcommand_max_stat_bypass,       0,      0,      100,            },
-	{ "skill_amotion_leniency",             &battle_config.skill_amotion_leniency,          90,     0,      300             },
+	{ "skill_amotion_leniency",             &battle_config.skill_amotion_leniency,          0,      0,      300             },
 	{ "mvp_tomb_enabled",                   &battle_config.mvp_tomb_enabled,                1,      0,      1               },
 	{ "mvp_tomb_spawn_delay",               &battle_config.mvp_tomb_spawn_delay,            10000,  0,      INT_MAX         },
 	{ "features/atcommand_suggestions",     &battle_config.atcommand_suggestions_enabled,   0,      0,      1               },

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1830,7 +1830,7 @@ static int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill
 		ud->state.skillcastcancel = 0;
 
 	if (sd == NULL || sd->auto_cast_current.type < AUTOCAST_ABRA || skill->get_cast(skill_id, skill_lv) != 0)
-		ud->canact_tick = tick + casttime + 100;
+		ud->canact_tick = tick + max(casttime, max(status_get_amotion(src), battle_config.min_skill_delay_limit));
 	if( sd )
 	{
 		switch( skill_id )
@@ -1970,7 +1970,7 @@ static int unit_skilluse_pos2(struct block_list *src, short skill_x, short skill
 
 	ud->state.skillcastcancel = castcancel&&casttime>0?1:0;
 	if (sd == NULL || sd->auto_cast_current.type < AUTOCAST_ABRA || skill->get_cast(skill_id, skill_lv) != 0)
-		ud->canact_tick  = tick + casttime + 100;
+		ud->canact_tick = tick + max(casttime, max(status_get_amotion(src), battle_config.min_skill_delay_limit));
 #if 0
 	if (sd) {
 		switch (skill_id) {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Set skill_amotion_delay setting to 0, remove castend motion delay and apply at castbegin.
While the previous setting and behavior could stop some speedhack attempts, it does not fit oficial behavior and produces erratic behavior with the client.

For a more detailed explanation, please check https://github.com/rathena/rathena/issues/944
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->[2703](https://github.com/HerculesWS/Hercules/issues/2703)


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
