### PR TITLE
Document and git ignore include overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ Thumbs.db
 /cache/
 
 # /conf/
-/conf/import/*.conf
+/conf/import/**/*.conf
 /conf/import/msg_conf.txt
 
 # /log/

--- a/doc/global_configuration.md
+++ b/doc/global_configuration.md
@@ -24,11 +24,65 @@ An include directive must appear on its own line and takes this form:
 Any backslashes or double quotes in the filename must be escaped as `\\` and
 `\"`, respectively.
 
+## Changing a global configuration based on the server
+
+Include directives will first look into
+`conf/import/include/[SERVERNAME]/[INCLUDE_PATH]` first, and after that,
+search for the file in `[INCLUDE_PATH]`.
+
+Where:
+- `[SERVERNAME]` stands for the server executable that is reading the config, it may be:
+	- `login-server` (`login-server.exe` in Windows systems)
+	- `char-sever` (`char-server.exe` in Windows systems)
+	- `map-server` (`map-server.exe` in Windows systems)
+- `[INCLUDE_PATH]` the value given to the `@include` directive.
+
+It is important to note that, when a file is created in include folder,
+the original file will **NOT** be loaded.
+In other words, if you are creating an include file to change only 1 setting,
+make sure to copy the other ones too, or they will not be defined.
+
+### Example
+
+For example, SQL connection settings is defined in
+`conf/global/sql_connection.conf`,
+and servers include it by using the following `@include` directive:
+
+```
+	@include "conf/global/sql_connection.conf"
+```
+
+If you want to change char server's SQL connection settings, in an Unix system,
+you may create the file
+`conf/import/include/char-server/conf/global/sql_connection.conf`
+with your settings in it, for example:
+
+```
+	sql_connection: {
+		// Those settings are copied as is
+		// because we are no longer loading the original file
+		db_hostname: "127.0.0.1"
+		db_port: 3306
+		db_username: "ragnarok"
+		db_password: "ragnarok"
+		
+		// This is the actual change
+		db_database: "hercules"
+	}
+```
+
+This would make char server use `hercules` as its database name.
+
+> For Windows systems, the folder `char-server` would be called `char-server.exe` instead.
 
 ## How do I stop using global configurations?
 
 To stop using global configuration, all you have to do is copy the contents of
 the file being imported and paste it _exactly_ where the include directive was.
+
+Depending on what you want to achieve,
+[Changing a global configuration based on the server](#changing-a-global-configuration-based-on-the-server)
+may be a better alternative.
 
 ### Example
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
I just noticed that include overrides (introduced on #2881) was not documented at all. This PR documents this quite useful feature.

Also, adding the path of those overrides to `.gitignore`, as they will usually contain server-specific info (and for sql_connection, even passwords), I believe it makes more sense to be ignored. If you think otherwise, feel free to send a change request and I will remove the commit.

**Issues addressed:** None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
