### PR TITLE
Skill rebalance from kro

### DIFF
--- a/db/re/sc_config.conf
+++ b/db/re/sc_config.conf
@@ -145,6 +145,8 @@ SC_TWOHANDQUICKEN: {
 	}
 	CalcFlags: {
 		Aspd: true
+		Cri: true
+		Hit: true
 	}
 	Icon: "SI_TWOHANDQUICKEN"
 	Skill: "KN_TWOHANDQUICKEN"
@@ -200,6 +202,7 @@ SC_ANGELUS: {
 	}
 	CalcFlags: {
 		Def2: true
+		Maxhp: true
 	}
 	Icon: "SI_ANGELUS"
 	Skill: "AL_ANGELUS"
@@ -215,6 +218,7 @@ SC_BLESSING: {
 		Str: true
 		Int: true
 		Dex: true
+		Hit: true
 	}
 	Icon: "SI_BLESSING"
 	Skill: "AL_BLESSING"
@@ -228,6 +232,7 @@ SC_INC_AGI: {
 	CalcFlags: {
 		Agi: true
 		Speed: true
+		Aspd: true
 	}
 	Icon: "SI_INC_AGI"
 	Skill: "AL_INCAGI"
@@ -344,6 +349,7 @@ SC_ADRENALINE: {
 	}
 	CalcFlags: {
 		Aspd: true
+		Hit: true
 	}
 	Icon: "SI_ADRENALINE"
 	Skill: "BS_ADRENALINE"
@@ -390,6 +396,7 @@ SC_SHOUT: {
 	}
 	CalcFlags: {
 		Str: true
+		Batk: true
 	}
 	Icon: "SI_SHOUT"
 	Skill: "MC_LOUD"
@@ -837,6 +844,9 @@ SC_ASSUMPTIO: {
 	Flags: {
 		Buff: true
 		NoMagicBlocked: true
+	}
+	CalcFlags: {
+		Def2: true
 	}
 	Icon: "SI_ASSUMPTIO"
 	Skill: "HP_ASSUMPTIO"

--- a/db/re/size_fix.txt
+++ b/db/re/size_fix.txt
@@ -3,5 +3,5 @@
 // Columns: Weapon type, Rows: Target size.
 // Unarmed, Knife, 1H Sword, 2H Sword, 1H Spear, 2H Spears, 1H Axe, 2H Axe, Mace, 2H Mace, Staff, Bow, Knuckle, Musical Instrument, Whip, Book, Katar, Revolver, Rifle, Shotgun, Gatling Gun, Grenade Launcher, Fuuma Shuriken, 2H Staff
 100,100, 75, 75, 75, 75, 50, 50, 75, 75,100,100,100, 75, 75,100, 75,100,100,100,100,100, 75,100	// Size: Small
-100, 75,100, 75, 75, 75, 75, 75,100,100,100,100, 75,100,100,100,100,100,100,100,100,100, 75,100	// Size: Medium
-100, 50, 75,100,100,100,100,100,100,100,100, 75, 50, 75, 50, 50, 75,100,100,100,100,100,100,100	// Size: Large
+100, 75,100, 75, 75, 75, 75, 75,100,100,100,100,100,100,100,100,100,100,100,100,100,100, 75,100	// Size: Medium
+100, 50, 75,100,100,100,100,100,100,100,100, 75, 75, 75, 50, 50, 75,100,100,100,100,100,100,100	// Size: Large

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -424,7 +424,7 @@ skill_db: (
 	}
 	SplashRange: 2
 	KnockBackTiles: 2
-	AfterCastActDelay: 2000
+	AfterCastActDelay: 500
 	CoolDown: 2000
 	SkillData2: 10000
 	FixedCastTime: 0
@@ -681,18 +681,7 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: 400
-	AfterCastActDelay: {
-		Lv1: 1200
-		Lv2: 1200
-		Lv3: 1600
-		Lv4: 1600
-		Lv5: 2000
-		Lv6: 2000
-		Lv7: 2400
-		Lv8: 2400
-		Lv9: 2800
-		Lv10: 2500
-	}
+	AfterCastActDelay: 1400
 	FixedCastTime: 100
 	Requirements: {
 		SPCost: {
@@ -740,40 +729,29 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: {
-		Lv1: 640
-		Lv2: 960
-		Lv3: 1280
-		Lv4: 1600
-		Lv5: 1920
-		Lv6: 2100
-		Lv7: 1560
-		Lv8: 2880
-		Lv9: 3200
-		Lv10: 3520
-	}
-	AfterCastActDelay: {
-		Lv1: 1000
-		Lv2: 1200
-		Lv3: 1400
-		Lv4: 1600
-		Lv5: 1800
+		Lv1: 500
+		Lv2: 800
+		Lv3: 1100
+		Lv4: 1400
+		Lv5: 1700
 		Lv6: 2000
-		Lv7: 2200
-		Lv8: 2400
-		Lv9: 2600
-		Lv10: 2800
+		Lv7: 2300
+		Lv8: 2600
+		Lv9: 2900
+		Lv10: 3200
 	}
+	AfterCastActDelay: 1400
 	FixedCastTime: {
-		Lv1: 160
-		Lv2: 240
-		Lv3: 320
-		Lv4: 400
-		Lv5: 480
-		Lv6: 700
-		Lv7: 640
-		Lv8: 720
-		Lv9: 800
-		Lv10: 880
+		Lv1: 300
+		Lv2: 400
+		Lv3: 500
+		Lv4: 600
+		Lv5: 700
+		Lv6: 800
+		Lv7: 900
+		Lv8: 1000
+		Lv9: 1100
+		Lv10: 1200
 	}
 	Requirements: {
 		SPCost: {
@@ -810,7 +788,7 @@ skill_db: (
 	Element: "Ele_Water"
 	InterruptCast: true
 	CastTime: 640
-	AfterCastActDelay: 1500
+	AfterCastActDelay: 500
 	SkillData2: {
 		Lv1: 3000
 		Lv2: 6000
@@ -903,42 +881,9 @@ skill_db: (
 	}
 	SplashRange: 2
 	InterruptCast: true
-	CastTime: {
-		Lv1: 1280
-		Lv2: 1280
-		Lv3: 1280
-		Lv4: 1280
-		Lv5: 1280
-		Lv6: 800
-		Lv7: 800
-		Lv8: 800
-		Lv9: 800
-		Lv10: 800
-	}
-	AfterCastActDelay: {
-		Lv1: 1500
-		Lv2: 1500
-		Lv3: 1500
-		Lv4: 1500
-		Lv5: 1500
-		Lv6: 1000
-		Lv7: 1000
-		Lv8: 1000
-		Lv9: 1000
-		Lv10: 1000
-	}
-	FixedCastTime: {
-		Lv1: 320
-		Lv2: 320
-		Lv3: 320
-		Lv4: 320
-		Lv5: 320
-		Lv6: 200
-		Lv7: 200
-		Lv8: 200
-		Lv9: 200
-		Lv10: 200
-	}
+	CastTime: 800
+	AfterCastActDelay: 700
+	FixedCastTime: 200
 	Requirements: {
 		SPCost: 25
 	}
@@ -1043,40 +988,29 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: {
-		Lv1: 640
-		Lv2: 960
-		Lv3: 1280
-		Lv4: 1600
-		Lv5: 1920
-		Lv6: 2100
-		Lv7: 1560
-		Lv8: 2880
-		Lv9: 3200
-		Lv10: 3520
-	}
-	AfterCastActDelay: {
-		Lv1: 1000
-		Lv2: 1200
-		Lv3: 1400
-		Lv4: 1600
-		Lv5: 1800
+		Lv1: 500
+		Lv2: 800
+		Lv3: 1100
+		Lv4: 1400
+		Lv5: 1700
 		Lv6: 2000
-		Lv7: 2200
-		Lv8: 2400
-		Lv9: 2600
-		Lv10: 2800
+		Lv7: 2300
+		Lv8: 2600
+		Lv9: 2900
+		Lv10: 3200
 	}
+	AfterCastActDelay: 1400
 	FixedCastTime: {
-		Lv1: 160
-		Lv2: 240
-		Lv3: 320
-		Lv4: 400
-		Lv5: 480
-		Lv6: 700
-		Lv7: 640
-		Lv8: 720
-		Lv9: 800
-		Lv10: 880
+		Lv1: 300
+		Lv2: 400
+		Lv3: 500
+		Lv4: 600
+		Lv5: 700
+		Lv6: 800
+		Lv7: 900
+		Lv8: 1000
+		Lv9: 1100
+		Lv10: 1200
 	}
 	Requirements: {
 		SPCost: {
@@ -1124,40 +1058,29 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: {
-		Lv1: 640
-		Lv2: 960
-		Lv3: 1280
-		Lv4: 1600
-		Lv5: 1920
-		Lv6: 2100
-		Lv7: 1560
-		Lv8: 2880
-		Lv9: 3200
-		Lv10: 3520
-	}
-	AfterCastActDelay: {
-		Lv1: 1000
-		Lv2: 1200
-		Lv3: 1400
-		Lv4: 1600
-		Lv5: 1800
+		Lv1: 500
+		Lv2: 800
+		Lv3: 1100
+		Lv4: 1400
+		Lv5: 1700
 		Lv6: 2000
-		Lv7: 2200
-		Lv8: 2400
-		Lv9: 2600
-		Lv10: 2800
+		Lv7: 2300
+		Lv8: 2600
+		Lv9: 2900
+		Lv10: 3200
 	}
+	AfterCastActDelay: 1400
 	FixedCastTime: {
-		Lv1: 160
-		Lv2: 240
-		Lv3: 320
-		Lv4: 400
-		Lv5: 480
-		Lv6: 700
-		Lv7: 640
-		Lv8: 720
-		Lv9: 800
-		Lv10: 880
+		Lv1: 300
+		Lv2: 400
+		Lv3: 500
+		Lv4: 600
+		Lv5: 700
+		Lv6: 800
+		Lv7: 900
+		Lv8: 1000
+		Lv9: 1100
+		Lv10: 1200
 	}
 	Requirements: {
 		SPCost: {
@@ -1205,16 +1128,16 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: {
-		Lv1: 640
-		Lv2: 1280
-		Lv3: 1920
-		Lv4: 2560
-		Lv5: 3200
-		Lv6: 3840
-		Lv7: 4480
-		Lv8: 5120
-		Lv9: 5760
-		Lv10: 6400
+		Lv1: 2700
+		Lv2: 2900
+		Lv3: 3100
+		Lv4: 3300
+		Lv5: 3500
+		Lv6: 3700
+		Lv7: 3900
+		Lv8: 4100
+		Lv9: 4300
+		Lv10: 4500
 	}
 	AfterCastActDelay: {
 		Lv1: 2000
@@ -1229,18 +1152,7 @@ skill_db: (
 		Lv10: 2000
 	}
 	SkillData1: 500
-	FixedCastTime: {
-		Lv1: 160
-		Lv2: 320
-		Lv3: 480
-		Lv4: 640
-		Lv5: 800
-		Lv6: 960
-		Lv7: 1120
-		Lv8: 1280
-		Lv9: 1440
-		Lv10: 1600
-	}
+	FixedCastTime: 1500
 	Requirements: {
 		SPCost: {
 			Lv1: 29
@@ -2219,20 +2131,22 @@ skill_db: (
 	Description: "Brandish Spear"
 	MaxLevel: 10
 	Range: -2
-	Hit: "BDT_SKILL"
+	Hit: "BDT_MULTIHIT"
 	SkillType: {
 		Enemy: true
 	}
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
+	NumberOfHits: -3
 	DamageType: {
 		NoDamage: true
 	}
 	KnockBackTiles: 3
-	CastTime: 350
 	FixedCastTime: 350
+	AfterCastActDelay: 500
+	CoolDown: 1000
 	Requirements: {
-		SPCost: 12
+		SPCost: 24
 		WeaponTypes: {
 			1HSpears: true
 			2HSpears: true
@@ -2404,7 +2318,8 @@ skill_db: (
 	Description: "Bowling Bash"
 	MaxLevel: 10
 	Range: -2
-	Hit: "BDT_SKILL"
+	Hit: "BDT_MULTIHIT"
+	NumberOfHits: 2
 	SkillType: {
 		Enemy: true
 	}
@@ -2417,9 +2332,9 @@ skill_db: (
 	DamageType: {
 		SplashArea: true
 	}
-	SplashRange: 1
-	KnockBackTiles: 1
-	CastTime: 350
+	SplashRange: 2
+	KnockBackTiles: 5
+	CoolDown: 1000
 	FixedCastTime: 350
 	Requirements: {
 		SPCost: {
@@ -2466,10 +2381,9 @@ skill_db: (
 	StatusChange: "SC_IMPOSITIO"
 	Description: "Impositio Manus"
 	MaxLevel: 5
-	Range: 9
 	Hit: "BDT_SKILL"
 	SkillType: {
-		Friend: true
+		Self: true
 	}
 	SkillInfo: {
 		BlockedByStasis: true
@@ -2477,23 +2391,27 @@ skill_db: (
 	AttackType: "Magic"
 	DamageType: {
 		NoDamage: true
+		SplashArea: true
 	}
+	SplashRange: 18
 	InterruptCast: true
-	AfterCastActDelay: 3000
-	SkillData1: 60000
-	FixedCastTime: 0
+	CastTime: 1000
+	AfterCastActDelay: 1000
+	CoolDown: 30000
+	SkillData1: 120000
+	FixedCastTime: 500
 	Requirements: {
 		SPCost: {
-			Lv1: 13
-			Lv2: 16
-			Lv3: 19
-			Lv4: 22
-			Lv5: 25
-			Lv6: 28
-			Lv7: 31
-			Lv8: 34
-			Lv9: 37
-			Lv10: 40
+			Lv1: 59
+			Lv2: 62
+			Lv3: 65
+			Lv4: 68
+			Lv5: 71
+			Lv6: 74
+			Lv7: 77
+			Lv8: 80
+			Lv9: 83
+			Lv10: 86
 		}
 	}
 },
@@ -2503,35 +2421,35 @@ skill_db: (
 	StatusChange: "SC_SUFFRAGIUM"
 	Description: "Suffragium"
 	MaxLevel: 3
-	Range: 9
 	Hit: "BDT_SKILL"
 	SkillType: {
-		Friend: true
-	}
-	SkillInfo: {
-		NoCastSelf: true
+		Self: true
 	}
 	AttackType: "Magic"
 	DamageType: {
 		NoDamage: true
+		SplashArea: true
 	}
+	SplashRange: 18
 	InterruptCast: true
-	AfterCastActDelay: 2000
-	SkillData1: {
-		Lv1: 30000
-		Lv2: 20000
-		Lv3: 10000
-		Lv4: 1
-		Lv5: 1
-		Lv6: 1
-		Lv7: 1
-		Lv8: 1
-		Lv9: 1
-		Lv10: 1
-	}
-	FixedCastTime: 0
+	CastTime: 1000
+	AfterCastActDelay: 1000
+	CoolDown: 30000
+	SkillData1: 60000
+	FixedCastTime: 500
 	Requirements: {
-		SPCost: 8
+		SPCost: {
+			Lv1: 45
+			Lv2: 57
+			Lv3: 69
+			Lv4: 81
+			Lv5: 93
+			Lv6: 115
+			Lv7: 127
+			Lv8: 139
+			Lv9: 151
+			Lv10: 163
+		}
 	}
 },
 {
@@ -3010,8 +2928,9 @@ skill_db: (
 		Lv10: 10
 	}
 	InterruptCast: true
-	CastTime: 12000
-	AfterCastActDelay: 4000
+	CastTime: 4000
+	CoolDown: 6000
+	AfterCastActDelay: 1000
 	SkillData1: {
 		Lv1: 5000
 		Lv2: 6000
@@ -3024,7 +2943,7 @@ skill_db: (
 		Lv9: 13000
 		Lv10: 14000
 	}
-	FixedCastTime: 3000
+	FixedCastTime: 1000
 	Requirements: {
 		SPCost: {
 			Lv1: 40
@@ -3233,22 +3152,23 @@ skill_db: (
 		Lv10: 5
 	}
 	InterruptCast: true
-	CastTime: 9600
-	AfterCastActDelay: {
-		Lv1: 2000
+	CastTime: 6300
+	AfterCastActDelay: 1000
+	CoolDown: {
+		Lv1: 2500
 		Lv2: 3000
-		Lv3: 3000
+		Lv3: 3500
 		Lv4: 4000
-		Lv5: 4000
+		Lv5: 4500
 		Lv6: 5000
-		Lv7: 5000
+		Lv7: 5500
 		Lv8: 6000
-		Lv9: 6000
+		Lv9: 6500
 		Lv10: 7000
 	}
 	SkillData1: 500
 	SkillData2: 5000
-	FixedCastTime: 2400
+	FixedCastTime: 1500
 	Requirements: {
 		SPCost: {
 			Lv1: 20
@@ -3316,29 +3236,18 @@ skill_db: (
 		Lv10: 7
 	}
 	CastTime: {
-		Lv1: 1600
-		Lv2: 1920
-		Lv3: 2240
-		Lv4: 2560
-		Lv5: 2880
-		Lv6: 3200
-		Lv7: 3520
-		Lv8: 3840
-		Lv9: 4160
-		Lv10: 4480
+		Lv1: 2000
+		Lv2: 2200
+		Lv3: 2400
+		Lv4: 2600
+		Lv5: 2800
+		Lv6: 3000
+		Lv7: 3200
+		Lv8: 3400
+		Lv9: 3600
+		Lv10: 3800
 	}
-	FixedCastTime: {
-		Lv1: 400
-		Lv2: 480
-		Lv3: 560
-		Lv4: 640
-		Lv5: 720
-		Lv6: 800
-		Lv7: 880
-		Lv8: 960
-		Lv9: 1040
-		Lv10: 1120
-	}
+	FixedCastTime: 500
 	Requirements: {
 		SPCost: {
 			Lv1: 20
@@ -3372,46 +3281,25 @@ skill_db: (
 	}
 	AttackType: "Magic"
 	Element: "Ele_Wind"
-	NumberOfHits: -10
+	NumberOfHits: -20
 	InterruptCast: true
 	CastTime: {
-		Lv1: 9600
-		Lv2: 9280
-		Lv3: 8960
-		Lv4: 8640
-		Lv5: 8320
-		Lv6: 8000
-		Lv7: 7680
-		Lv8: 7360
-		Lv9: 7040
-		Lv10: 6720
+		Lv1: 6300
+		Lv2: 6100
+		Lv3: 5900
+		Lv4: 5700
+		Lv5: 5500
+		Lv6: 5300
+		Lv7: 5100
+		Lv8: 4900
+		Lv9: 4700
+		Lv10: 4500
 	}
-	AfterCastActDelay: 5000
-	SkillData1: 4000
-	SkillData2: {
-		Lv1: 5500
-		Lv2: 6000
-		Lv3: 6500
-		Lv4: 7000
-		Lv5: 7500
-		Lv6: 8000
-		Lv7: 8500
-		Lv8: 9000
-		Lv9: 9500
-		Lv10: 10000
-	}
-	FixedCastTime: {
-		Lv1: 2400
-		Lv2: 2320
-		Lv3: 2240
-		Lv4: 2160
-		Lv5: 2080
-		Lv6: 2000
-		Lv7: 1920
-		Lv8: 1840
-		Lv9: 1760
-		Lv10: 1680
-	}
+	AfterCastActDelay: 1000
+	CoolDown: 5000
+	SkillData1: 1000
+	SkillData2: 18000 //copied that from rathena, I assume this are Duration1 and Duration2
+	FixedCastTime: 1500
 	Requirements: {
 		SPCost: {
 			Lv1: 60
@@ -3645,32 +3533,22 @@ skill_db: (
 	InterruptCast: true
 	KnockBackTiles: 2
 	CastTime: {
-		Lv1: 3840
-		Lv2: 4480
-		Lv3: 5120
-		Lv4: 5760
-		Lv5: 6400
-		Lv6: 7040
-		Lv7: 7680
-		Lv8: 8320
-		Lv9: 8960
-		Lv10: 9600
+		Lv1: 4500
+		Lv2: 4700
+		Lv3: 4900
+		Lv4: 5100
+		Lv5: 5300
+		Lv6: 5500
+		Lv7: 5700
+		Lv8: 5900
+		Lv9: 6100
+		Lv10: 6300
 	}
-	AfterCastActDelay: 5000
+	AfterCastActDelay: 1000
+	CoolDown: 6000
 	SkillData1: 4600
 	SkillData2: 12000
-	FixedCastTime: {
-		Lv1: 960
-		Lv2: 1120
-		Lv3: 1280
-		Lv4: 1440
-		Lv5: 1600
-		Lv6: 1760
-		Lv7: 1920
-		Lv8: 2080
-		Lv9: 2240
-		Lv10: 2400
-	}
+	FixedCastTime: 1500
 	Requirements: {
 		SPCost: 78
 	}
@@ -3717,40 +3595,40 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: {
-		Lv1: 448
-		Lv2: 896
-		Lv3: 1344
-		Lv4: 1792
-		Lv5: 2240
-		Lv6: 2240
-		Lv7: 2240
-		Lv8: 2240
-		Lv9: 2240
-		Lv10: 2240
+		Lv1: 1200
+		Lv2: 1700
+		Lv3: 2200
+		Lv4: 2700
+		Lv5: 3200
+		Lv6: 3700
+		Lv7: 4200
+		Lv8: 4700
+		Lv9: 5200
+		Lv10: 5700
 	}
 	AfterCastActDelay: {
 		Lv1: 1000
-		Lv2: 1200
-		Lv3: 1400
-		Lv4: 1600
-		Lv5: 1800
-		Lv6: 2000
-		Lv7: 2200
-		Lv8: 2400
-		Lv9: 2600
-		Lv10: 2800
+		Lv2: 1100
+		Lv3: 1200
+		Lv4: 1300
+		Lv5: 1400
+		Lv6: 1500
+		Lv7: 1600
+		Lv8: 1700
+		Lv9: 1800
+		Lv10: 1900
 	}
 	FixedCastTime: {
-		Lv1: 112
-		Lv2: 224
-		Lv3: 336
-		Lv4: 448
-		Lv5: 560
-		Lv6: 560
-		Lv7: 560
-		Lv8: 560
-		Lv9: 560
-		Lv10: 560
+		Lv1: 400
+		Lv2: 600
+		Lv3: 800
+		Lv4: 1000
+		Lv5: 1200
+		Lv6: 1400
+		Lv7: 1600
+		Lv8: 1800
+		Lv9: 2000
+		Lv10: 2200
 	}
 	Requirements: {
 		SPCost: {
@@ -3798,43 +3676,33 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: {
-		Lv1: 640
-		Lv2: 1280
-		Lv3: 1920
-		Lv4: 2560
-		Lv5: 3200
-		Lv6: 3200
-		Lv7: 3200
-		Lv8: 3200
-		Lv9: 3200
-		Lv10: 3200
+		Lv1: 1100
+		Lv2: 1300
+		Lv3: 1500
+		Lv4: 1700
+		Lv5: 1900
+		Lv6: 2100
+		Lv7: 2300
+		Lv8: 2500
+		Lv9: 2700
+		Lv10: 2900
 	}
-	AfterCastActDelay: 1000
+	AfterCastActDelay: 500
 	SkillData1: 500
-	FixedCastTime: {
-		Lv1: 160
-		Lv2: 320
-		Lv3: 480
-		Lv4: 640
-		Lv5: 800
-		Lv6: 800
-		Lv7: 800
-		Lv8: 800
-		Lv9: 800
-		Lv10: 800
-	}
+	FixedCastTime: 800
+	CoolDown: 1000
 	Requirements: {
 		SPCost: {
-			Lv1: 28
-			Lv2: 32
-			Lv3: 36
-			Lv4: 40
-			Lv5: 44
-			Lv6: 48
-			Lv7: 52
-			Lv8: 56
-			Lv9: 60
-			Lv10: 64
+			Lv1: 26
+			Lv2: 28
+			Lv3: 30
+			Lv4: 32
+			Lv5: 34
+			Lv6: 36
+			Lv7: 38
+			Lv8: 40
+			Lv9: 42
+			Lv10: 44
 		}
 	}
 	Unit: {
@@ -4385,7 +4253,8 @@ skill_db: (
 		Lv10: 1
 	}
 	SkillData2: 5000
-	FixedCastTime: 1000
+	CastTime: 500
+	FixedCastTime: 300
 	Requirements: {
 		SPCost: 10
 		Items: {
@@ -4742,7 +4611,8 @@ skill_db: (
 		Lv9: 1
 		Lv10: 1
 	}
-	FixedCastTime: 1000
+	CastTime: 500
+	FixedCastTime: 300
 	Requirements: {
 		SPCost: 10
 		Items: {
@@ -4797,7 +4667,8 @@ skill_db: (
 		Lv9: 180000
 		Lv10: 200000
 	}
-	FixedCastTime: 1000
+	CastTime: 500
+	FixedCastTime: 300
 	Requirements: {
 		SPCost: 15
 		Items: {
@@ -5076,9 +4947,10 @@ skill_db: (
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
 	NumberOfHits: -8
-	AfterCastWalkDelay: 2000
+	AfterCastWalkDelay: 500
 	SkillData2: 5000
 	FixedCastTime: 0
+	CoolDown: 1000
 	SkillDelayOptions: {
 		IgnoreStatusEffect: true
 	}
@@ -5303,40 +5175,29 @@ skill_db: (
 	InterruptCast: true
 	CastTime: 500
 	SkillData1: {
-		Lv1: 5000
-		Lv2: 5500
-		Lv3: 6000
-		Lv4: 6500
+		Lv1: 11000
+		Lv2: 10000
+		Lv3: 9000
+		Lv4: 8000
 		Lv5: 7000
-		Lv6: 7500
-		Lv7: 8000
-		Lv8: 8500
-		Lv9: 9000
-		Lv10: 9500
+		Lv6: 6000
+		Lv7: 5000
+		Lv8: 4000
+		Lv9: 3000
+		Lv10: 2000
 	}
-	SkillData2: {
-		Lv1: 15000
-		Lv2: 20000
-		Lv3: 25000
-		Lv4: 30000
-		Lv5: 35000
-		Lv6: 40000
-		Lv7: 45000
-		Lv8: 50000
-		Lv9: 55000
-		Lv10: 60000
-	}
+	SkillData2: 20000
 	CoolDown: {
-		Lv1: 7500
-		Lv2: 8000
-		Lv3: 8500
-		Lv4: 9000
-		Lv5: 9500
-		Lv6: 10000
-		Lv7: 10500
-		Lv8: 11000
-		Lv9: 11500
-		Lv10: 12000
+		Lv1: 11000
+		Lv2: 10000
+		Lv3: 9000
+		Lv4: 8000
+		Lv5: 7000
+		Lv6: 6000
+		Lv7: 5000
+		Lv8: 4000
+		Lv9: 3000
+		Lv10: 2000
 	}
 	FixedCastTime: 500
 	Requirements: {
@@ -5351,9 +5212,6 @@ skill_db: (
 			Lv8: 26
 			Lv9: 28
 			Lv10: 30
-		}
-		Items: {
-			Red_Gemstone: 1
 		}
 	}
 },
@@ -5653,9 +5511,13 @@ skill_db: (
 	AttackType: "Weapon"
 	DamageType: {
 		NoDamage: true
+		SplashArea: true
 	}
+	SplashRange: -1
 	SkillData1: 300000
-	FixedCastTime: 0
+	CastTime: 1000
+	FixedCastTime: 500
+	Cooldown: 30000
 	Requirements: {
 		SPCost: 8
 	}
@@ -5678,8 +5540,8 @@ skill_db: (
 	AttackType: "Magic"
 	Element: "Ele_Holy"
 	InterruptCast: true
-	CastTime: 1600
-	FixedCastTime: 400
+	CastTime: 800
+	FixedCastTime: 200
 	Requirements: {
 		SPCost: 15
 	}
@@ -6739,8 +6601,9 @@ skill_db: (
 	StatusChange: "SC_STUN"
 	Description: "Back Stab"
 	MaxLevel: 10
-	Range: -1
-	Hit: "BDT_SKILL"
+	Range: -2
+	Hit: "BDT_MULTIHIT"
+	NumberOfHits: 1
 	SkillType: {
 		Enemy: true
 	}
@@ -6751,13 +6614,14 @@ skill_db: (
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
 	DamageType: {
-		IgnoreFlee: true
+		IgnoreFlee: false
 	}
 	AfterCastActDelay: 500
 	SkillData1: 5000
 	FixedCastTime: 0
+	CoolDown: 500
 	Requirements: {
-		SPCost: 16
+		SPCost: 12
 	}
 },
 {
@@ -6783,11 +6647,11 @@ skill_db: (
 		SplashArea: true
 	}
 	SplashRange: 3
-	SkillData1: 5000
-	SkillData2: 20000
+	SkillData1: 10000
+	SkillData2: 30000
 	FixedCastTime: 0
 	Requirements: {
-		SPCost: 20
+		SPCost: 15
 		State: "Hiding"
 	}
 },
@@ -7297,16 +7161,16 @@ skill_db: (
 	CastTime: 500
 	AfterCastActDelay: 500
 	SkillData1: {
-		Lv1: 3
-		Lv2: 7
-		Lv3: 10
-		Lv4: 12
-		Lv5: 13
-		Lv6: 13
-		Lv7: 13
-		Lv8: 13
-		Lv9: 13
-		Lv10: 13
+		Lv1: 5
+		Lv2: 15
+		Lv3: 25
+		Lv4: 35
+		Lv5: 45
+		Lv6: 55
+		Lv7: 65
+		Lv8: 75
+		Lv9: 85
+		Lv10: 95
 	}
 	SkillData2: 120000
 	FixedCastTime: 500
@@ -7849,8 +7713,9 @@ skill_db: (
 		IgnoreFlee: true
 	}
 	CastDefRate: 33
-	CastTime: 1500
-	AfterCastActDelay: 1500
+	CastTime: 1000
+	AfterCastActDelay: 500
+	CoolDown: 1000
 	AfterCastWalkDelay: 900
 	SkillData1: 900
 	SkillData2: {
@@ -7865,7 +7730,7 @@ skill_db: (
 		Lv9: 18000
 		Lv10: 19000
 	}
-	FixedCastTime: 1500
+	FixedCastTime: 500
 	Requirements: {
 		SPCost: {
 			Lv1: 37
@@ -7879,7 +7744,6 @@ skill_db: (
 			Lv9: 93
 			Lv10: 100
 		}
-		HPRateCost: 20
 	}
 	Unit: {
 		Id: 0x86
@@ -8082,8 +7946,7 @@ skill_db: (
 		NoDamage: true
 	}
 	InterruptCast: true
-	CastTime: 1000
-	FixedCastTime: 1000
+	FixedCastTime: 500
 	Requirements: {
 		SPCost: 5
 	}
@@ -8186,20 +8049,10 @@ skill_db: (
 	}
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
-	NumberOfHits: {
-		Lv1: 1
-		Lv2: 2
-		Lv3: 3
-		Lv4: 4
-		Lv5: 5
-		Lv6: 6
-		Lv7: 7
-		Lv8: 8
-		Lv9: 9
-		Lv10: 10
-	}
+	NumberOfHits: 1
 	CastTime: 500
 	AfterCastActDelay: 500
+	CoolDown: 1000
 	AfterCastWalkDelay: {
 		Lv1: 0
 		Lv2: 200
@@ -8214,19 +8067,19 @@ skill_db: (
 	}
 	FixedCastTime: 500
 	Requirements: {
-		SPCost: 10
-		SpiritSphereCost: {
-			Lv1: 1
-			Lv2: 2
-			Lv3: 3
-			Lv4: 4
-			Lv5: 5
-			Lv6: 6
-			Lv7: 7
-			Lv8: 8
-			Lv9: 9
-			Lv10: 10
+		SPCost: {
+			Lv1: 12
+			Lv2: 16
+			Lv3: 20
+			Lv4: 24
+			Lv5: 28
+			Lv6: 32
+			Lv7: 36
+			Lv8: 40
+			Lv9: 44
+			Lv10: 48
 		}
+		SpiritSphereCost: 1
 	}
 },
 {
@@ -8398,7 +8251,7 @@ skill_db: (
 		Lv9: 1
 		Lv10: 1
 	}
-	SkillData1: 10000
+	SkillData1: 3000
 	SkillData2: 300000
 	FixedCastTime: {
 		Lv1: 2000
@@ -8527,16 +8380,16 @@ skill_db: (
 	}
 	Requirements: {
 		SPCost: {
-			Lv1: 11
-			Lv2: 12
-			Lv3: 13
-			Lv4: 14
-			Lv5: 15
-			Lv6: 16
-			Lv7: 17
-			Lv8: 18
-			Lv9: 19
-			Lv10: 20
+			Lv1: 3
+			Lv2: 4
+			Lv3: 5
+			Lv4: 6
+			Lv5: 7
+			Lv6: 8
+			Lv7: 9
+			Lv8: 10
+			Lv9: 11
+			Lv10: 12
 		}
 		WeaponTypes: {
 			NoWeapon: true
@@ -8713,10 +8566,10 @@ skill_db: (
 	}
 	InterruptCast: true
 	SkillData1: {
-		Lv1: 1200000
-		Lv2: 1200000
+		Lv1: 600000
+		Lv2: 900000
 		Lv3: 1200000
-		Lv4: 1200000
+		Lv4: 1500000
 		Lv5: 1800000
 		Lv6: 1800000
 		Lv7: 1800000
@@ -8724,11 +8577,12 @@ skill_db: (
 		Lv9: 1800000
 		Lv10: 1800000
 	}
-	FixedCastTime: 3000
+	FixedCastTime: 1000
+	CastTime: 1000
 	Requirements: {
 		SPCost: 40
 		Items: {
-			Boody_Red: 1
+			Scarlet_Pts: 1
 		}
 	}
 },
@@ -8755,10 +8609,10 @@ skill_db: (
 	}
 	InterruptCast: true
 	SkillData1: {
-		Lv1: 1200000
-		Lv2: 1200000
+		Lv1: 600000
+		Lv2: 900000
 		Lv3: 1200000
-		Lv4: 1200000
+		Lv4: 1500000
 		Lv5: 1800000
 		Lv6: 1800000
 		Lv7: 1800000
@@ -8766,11 +8620,12 @@ skill_db: (
 		Lv9: 1800000
 		Lv10: 1800000
 	}
-	FixedCastTime: 3000
+	FixedCastTime: 1000
+	CastTime: 1000
 	Requirements: {
 		SPCost: 40
 		Items: {
-			Crystal_Blue: 1
+			Indigo_Pts: 1
 		}
 	}
 },
@@ -8797,10 +8652,10 @@ skill_db: (
 	}
 	InterruptCast: true
 	SkillData1: {
-		Lv1: 1200000
-		Lv2: 1200000
+		Lv1: 600000
+		Lv2: 900000
 		Lv3: 1200000
-		Lv4: 1200000
+		Lv4: 1500000
 		Lv5: 1800000
 		Lv6: 1800000
 		Lv7: 1800000
@@ -8808,11 +8663,12 @@ skill_db: (
 		Lv9: 1800000
 		Lv10: 1800000
 	}
-	FixedCastTime: 3000
+	FixedCastTime: 1000
+	CastTime: 1000
 	Requirements: {
 		SPCost: 40
 		Items: {
-			Wind_Of_Verdure: 1
+			Yellow_Wish_Pts: 1
 		}
 	}
 },
@@ -8839,10 +8695,10 @@ skill_db: (
 	}
 	InterruptCast: true
 	SkillData1: {
-		Lv1: 1200000
-		Lv2: 1200000
+		Lv1: 600000
+		Lv2: 900000
 		Lv3: 1200000
-		Lv4: 1200000
+		Lv4: 1500000
 		Lv5: 1800000
 		Lv6: 1800000
 		Lv7: 1800000
@@ -8850,11 +8706,12 @@ skill_db: (
 		Lv9: 1800000
 		Lv10: 1800000
 	}
-	FixedCastTime: 3000
+	FixedCastTime: 1000
+	CastTime: 1000
 	Requirements: {
 		SPCost: 40
 		Items: {
-			Yellow_Live: 1
+			Lime_Green_Pts: 1
 		}
 	}
 },
@@ -8914,7 +8771,7 @@ skill_db: (
 			Lv10: 30
 		}
 		Items: {
-			Yellow_Gemstone: 1
+			Blue_Gemstone: 1
 		}
 	}
 	Unit: {
@@ -8975,7 +8832,7 @@ skill_db: (
 			Lv10: 30
 		}
 		Items: {
-			Yellow_Gemstone: 1
+			Blue_Gemstone: 1
 		}
 	}
 	Unit: {
@@ -9036,7 +8893,7 @@ skill_db: (
 			Lv10: 30
 		}
 		Items: {
-			Yellow_Gemstone: 1
+			Blue_Gemstone: 1
 		}
 	}
 	Unit: {
@@ -9497,6 +9354,8 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
+	AfterCastActDelay: 300
+	CoolDown: 10000
 	Requirements: {
 		SPCost: 1
 		WeaponTypes: {
@@ -9524,8 +9383,11 @@ skill_db: (
 	SkillData1: 60000
 	SkillData2: 15000
 	FixedCastTime: 0
+	AfterCastActDelay: 300
+	CastTime: 1000
+	CoolDown: 20000
 	Requirements: {
-		SPCost: 20
+		SPCost: 40
 		WeaponTypes: {
 			Instruments: true
 			Whips: true
@@ -9558,9 +9420,12 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 60000
+	SkillData1: 180000
 	SkillData2: 60000
 	FixedCastTime: 0
+	CastTime: 1000
+	CoolDown: 20000
+	AfterCastActDelay: 300
 	Requirements: {
 		SPCost: 20
 		WeaponTypes: {
@@ -9570,7 +9435,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0x9f
-		Layout: 4
+		Layout: 15
 		Interval: -1
 		Target: "Enemy"
 		Flag: {
@@ -9599,8 +9464,11 @@ skill_db: (
 	SkillData1: 60000
 	SkillData2: 60000
 	FixedCastTime: 0
+	CastTime: 1000
+	CoolDown: 60000
+	AfterCastActDelay: 300
 	Requirements: {
-		SPCost: 30
+		SPCost: 120
 		WeaponTypes: {
 			Instruments: true
 			Whips: true
@@ -9633,21 +9501,24 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 60000
+	SkillData1: 180000
 	SkillData2: 60000
 	FixedCastTime: 0
+	AfterCastActDelay: 300
+	CastTime: 1000
+	CoolDown: 20000
 	Requirements: {
 		SPCost: {
-			Lv1: 38
-			Lv2: 41
-			Lv3: 44
-			Lv4: 47
-			Lv5: 50
-			Lv6: 53
-			Lv7: 56
-			Lv8: 59
-			Lv9: 62
-			Lv10: 65
+			Lv1: 50
+			Lv2: 54
+			Lv3: 58
+			Lv4: 62
+			Lv5: 66
+			Lv6: 70
+			Lv7: 74
+			Lv8: 78
+			Lv9: 82
+			Lv10: 86
 		}
 		WeaponTypes: {
 			Instruments: true
@@ -9656,7 +9527,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xa1
-		Layout: 4
+		Layout: 15
 		Interval: -1
 		Target: "Party"
 		Flag: {
@@ -9732,6 +9603,9 @@ skill_db: (
 	SkillData1: 60000
 	SkillData2: 60000
 	FixedCastTime: 0
+	CastTime: 1000
+	CoolDown: 20000
+	AfterCastActDelay: 300
 	Requirements: {
 		SPCost: 15
 		WeaponTypes: {
@@ -9766,11 +9640,14 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 60000
+	SkillData1: 180000
 	SkillData2: 60000
 	FixedCastTime: 0
+	CastTime: 1000
+	CoolDown: 20000
+	AfterCastActDelay: 300
 	Requirements: {
-		SPCost: 10
+		SPCost: 70
 		WeaponTypes: {
 			Instruments: true
 			Whips: true
@@ -9778,7 +9655,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xa4
-		Layout: 4
+		Layout: 15
 		Interval: -1
 		Target: "Party"
 		Flag: {
@@ -9804,9 +9681,12 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 60000
+	SkillData1: 180000
 	SkillData2: 60000
 	FixedCastTime: 0
+	CastTime: 1000
+	CoolDown: 20000
+	AfterCastActDelay: 300
 	Requirements: {
 		SPCost: 20
 		WeaponTypes: {
@@ -9816,7 +9696,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xa5
-		Layout: 4
+		Layout: 15
 		Interval: -1
 		Target: "Party"
 		Flag: {
@@ -9838,27 +9718,17 @@ skill_db: (
 	Description: "Melody Strike"
 	MaxLevel: 5
 	Range: 9
-	Hit: "BDT_SKILL"
+	Hit: "BDT_MULTIHIT"
 	SkillType: {
 		Enemy: true
 	}
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
-	CastTime: 1200
-	FixedCastTime: 300
+	NumberOfHits: 2
+	CastTime: 500
+	AfterCastActDelay: 300
 	Requirements: {
-		SPCost: {
-			Lv1: 1
-			Lv2: 3
-			Lv3: 5
-			Lv4: 7
-			Lv5: 9
-			Lv6: 11
-			Lv7: 13
-			Lv8: 15
-			Lv9: 17
-			Lv10: 19
-		}
+		SPCost: 12
 		WeaponTypes: {
 			Instruments: true
 		}
@@ -9881,26 +9751,28 @@ skill_db: (
 		Song: true
 		BlockedByStasis: true
 	}
-	AttackType: "Misc"
+	AttackType: "Magic"
+	Element: "Ele_Neutral"
 	DamageType: {
-		NoDamage: true
 		IgnoreFlee: true
 	}
-	SkillData1: 30000
-	SkillData2: 3000
+	SkillData1: 4000
+	SkillData2: 10000
+	CoolDown: 5000
+	AfterCastActDelay: 300
 	FixedCastTime: 0
 	Requirements: {
 		SPCost: {
-			Lv1: 18
-			Lv2: 21
-			Lv3: 24
-			Lv4: 27
-			Lv5: 30
-			Lv6: 33
-			Lv7: 36
-			Lv8: 39
-			Lv9: 42
-			Lv10: 45
+			Lv1: 35
+			Lv2: 38
+			Lv3: 41
+			Lv4: 44
+			Lv5: 47
+			Lv6: 50
+			Lv7: 53
+			Lv8: 56
+			Lv9: 59
+			Lv10: 62
 		}
 		WeaponTypes: {
 			Instruments: true
@@ -9908,8 +9780,8 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xa6
-		Layout: 3
-		Interval: 3000
+		Layout: 4
+		Interval: 10000
 		Target: "Enemy"
 		Flag: {
 			UF_SONG: true
@@ -9932,7 +9804,8 @@ skill_db: (
 		SplashArea: true
 	}
 	SplashRange: -1
-	AfterCastActDelay: 4000
+	AfterCastActDelay: 300
+	CoolDown: 4000
 	SkillData2: {
 		Lv1: 10000
 		Lv2: 11000
@@ -9979,21 +9852,24 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 60000
+	SkillData1: 180000
 	SkillData2: 20000
+	CastTime: 1000
+	AfterCastActDelay: 500
+	CoolDown: 20000
 	FixedCastTime: 0
 	Requirements: {
 		SPCost: {
-			Lv1: 24
-			Lv2: 28
-			Lv3: 32
-			Lv4: 36
-			Lv5: 40
-			Lv6: 44
-			Lv7: 48
-			Lv8: 52
-			Lv9: 56
-			Lv10: 60
+			Lv1: 22
+			Lv2: 24
+			Lv3: 26
+			Lv4: 28
+			Lv5: 30
+			Lv6: 32
+			Lv7: 34
+			Lv8: 36
+			Lv9: 38
+			Lv10: 40
 		}
 		WeaponTypes: {
 			Instruments: true
@@ -10002,7 +9878,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xa7
-		Layout: 3
+		Layout: 15
 		Interval: 3000
 		Target: "All"
 		Flag: {
@@ -10030,21 +9906,24 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 120000
+	SkillData1: 180000
 	SkillData2: 20000
 	FixedCastTime: 0
+	CastTime: 1000
+	AfterCastActDelay: 500
+	CoolDown: 20000
 	Requirements: {
 		SPCost: {
-			Lv1: 38
-			Lv2: 41
-			Lv3: 44
-			Lv4: 47
-			Lv5: 50
-			Lv6: 53
-			Lv7: 56
-			Lv8: 59
-			Lv9: 62
-			Lv10: 65
+			Lv1: 40
+			Lv2: 45
+			Lv3: 50
+			Lv4: 55
+			Lv5: 60
+			Lv6: 65
+			Lv7: 70
+			Lv8: 75
+			Lv9: 80
+			Lv10: 85
 		}
 		WeaponTypes: {
 			Instruments: true
@@ -10053,7 +9932,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xa8
-		Layout: 3
+		Layout: 15
 		Interval: 3000
 		Target: "All"
 		Flag: {
@@ -10083,19 +9962,21 @@ skill_db: (
 	}
 	SkillData1: 180000
 	SkillData2: 20000
-	FixedCastTime: 0
+	FixedCastTime: 1000
+	AfterCastActDelay: 500
+	CoolDown: 20000
 	Requirements: {
 		SPCost: {
-			Lv1: 40
-			Lv2: 45
-			Lv3: 50
-			Lv4: 55
-			Lv5: 60
-			Lv6: 65
-			Lv7: 70
-			Lv8: 75
-			Lv9: 80
-			Lv10: 85
+			Lv1: 65
+			Lv2: 70
+			Lv3: 75
+			Lv4: 80
+			Lv5: 85
+			Lv6: 90
+			Lv7: 95
+			Lv8: 100
+			Lv9: 105
+			Lv10: 110
 		}
 		WeaponTypes: {
 			Instruments: true
@@ -10104,7 +9985,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xa9
-		Layout: 3
+		Layout: 15
 		Interval: 3000
 		Target: "All"
 		Flag: {
@@ -10132,8 +10013,11 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 180000
+	SkillData1: 60000
 	SkillData2: 20000
+	CastTime: 1000
+	AfterCastActDelay: 500
+	CoolDown: 20000
 	FixedCastTime: 0
 	Requirements: {
 		SPCost: {
@@ -10155,7 +10039,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xaa
-		Layout: 3
+		Layout: 15
 		Interval: 6000
 		Target: "All"
 		Flag: {
@@ -10179,27 +10063,17 @@ skill_db: (
 	Description: "Slinging Arrow"
 	MaxLevel: 5
 	Range: 9
-	Hit: "BDT_SKILL"
+	Hit: "BDT_MULTIHIT"
 	SkillType: {
 		Enemy: true
 	}
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
-	CastTime: 1200
-	FixedCastTime: 300
+	NumberOfHits: 2
+	CastTime: 500
+	AfterCastActDelay: 300
 	Requirements: {
-		SPCost: {
-			Lv1: 1
-			Lv2: 3
-			Lv3: 5
-			Lv4: 7
-			Lv5: 9
-			Lv6: 11
-			Lv7: 13
-			Lv8: 15
-			Lv9: 17
-			Lv10: 19
-		}
+		SPCost: 12
 		WeaponTypes: {
 			Whips: true
 		}
@@ -10228,19 +10102,21 @@ skill_db: (
 	}
 	SkillData1: 30000
 	SkillData2: 3000
+	AfterCastActDelay: 300
+	CoolDown: 5000
 	FixedCastTime: 0
 	Requirements: {
 		SPCost: {
-			Lv1: 23
-			Lv2: 26
-			Lv3: 29
-			Lv4: 32
-			Lv5: 35
-			Lv6: 38
-			Lv7: 41
-			Lv8: 44
-			Lv9: 47
-			Lv10: 50
+			Lv1: 35
+			Lv2: 38
+			Lv3: 41
+			Lv4: 44
+			Lv5: 47
+			Lv6: 50
+			Lv7: 53
+			Lv8: 56
+			Lv9: 59
+			Lv10: 62
 		}
 		WeaponTypes: {
 			Whips: true
@@ -10248,7 +10124,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xab
-		Layout: 3
+		Layout: 4
 		Interval: 3000
 		Target: "Enemy"
 		Flag: {
@@ -10272,7 +10148,8 @@ skill_db: (
 		SplashArea: true
 	}
 	SplashRange: -1
-	AfterCastActDelay: 4000
+	AfterCastActDelay: 300
+	CoolDown: 4000
 	SkillData2: 5000
 	FixedCastTime: 0
 	Requirements: {
@@ -10308,21 +10185,24 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 60000
+	SkillData1: 180000
 	SkillData2: 20000
 	FixedCastTime: 0
+	CastTime: 1000
+	CoolDown: 20000
+	AfterCastActDelay: 500
 	Requirements: {
 		SPCost: {
-			Lv1: 22
-			Lv2: 24
-			Lv3: 26
-			Lv4: 28
-			Lv5: 30
-			Lv6: 32
-			Lv7: 34
-			Lv8: 36
-			Lv9: 38
-			Lv10: 40
+			Lv1: 33
+			Lv2: 36
+			Lv3: 39
+			Lv4: 42
+			Lv5: 45
+			Lv6: 48
+			Lv7: 51
+			Lv8: 54
+			Lv9: 57
+			Lv10: 60
 		}
 		WeaponTypes: {
 			Instruments: true
@@ -10331,7 +10211,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xac
-		Layout: 3
+		Layout: 15
 		Interval: 3000
 		Target: "All"
 		Flag: {
@@ -10359,21 +10239,24 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 180000
+	SkillData1: 60000
 	SkillData2: 20000
 	FixedCastTime: 0
+	CastTime: 1000
+	AfterCastActDelay: 500
+	CoolDown: 20000
 	Requirements: {
 		SPCost: {
-			Lv1: 28
-			Lv2: 31
-			Lv3: 34
-			Lv4: 37
-			Lv5: 40
-			Lv6: 43
-			Lv7: 46
-			Lv8: 49
-			Lv9: 52
-			Lv10: 55
+			Lv1: 38
+			Lv2: 41
+			Lv3: 44
+			Lv4: 47
+			Lv5: 50
+			Lv6: 53
+			Lv7: 56
+			Lv8: 59
+			Lv9: 62
+			Lv10: 65
 		}
 		WeaponTypes: {
 			Instruments: true
@@ -10382,7 +10265,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xad
-		Layout: 3
+		Layout: 4
 		Interval: 3000
 		Target: "Enemy"
 		Flag: {
@@ -10409,21 +10292,24 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 120000
+	SkillData1: 180000
 	SkillData2: 20000
 	FixedCastTime: 0
+	CastTime: 1000
+	AfterCastActDelay: 500
+	CoolDown: 20000
 	Requirements: {
 		SPCost: {
-			Lv1: 43
-			Lv2: 46
-			Lv3: 49
-			Lv4: 52
-			Lv5: 55
-			Lv6: 58
-			Lv7: 61
-			Lv8: 64
-			Lv9: 67
-			Lv10: 70
+			Lv1: 40
+			Lv2: 45
+			Lv3: 50
+			Lv4: 55
+			Lv5: 60
+			Lv6: 65
+			Lv7: 70
+			Lv8: 75
+			Lv9: 80
+			Lv10: 85
 		}
 		WeaponTypes: {
 			Instruments: true
@@ -10432,7 +10318,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xae
-		Layout: 3
+		Layout: 15
 		Interval: 3000
 		Target: "All"
 		Flag: {
@@ -10463,18 +10349,21 @@ skill_db: (
 	SkillData1: 180000
 	SkillData2: 20000
 	FixedCastTime: 0
+	CastTime: 1000
+	CoolDown: 20000
+	AfterCastActDelay: 500
 	Requirements: {
 		SPCost: {
-			Lv1: 40
-			Lv2: 45
-			Lv3: 50
-			Lv4: 55
-			Lv5: 60
-			Lv6: 65
-			Lv7: 70
-			Lv8: 75
-			Lv9: 80
-			Lv10: 85
+			Lv1: 60
+			Lv2: 63
+			Lv3: 66
+			Lv4: 69
+			Lv5: 72
+			Lv6: 75
+			Lv7: 78
+			Lv8: 81
+			Lv9: 84
+			Lv10: 87
 		}
 		WeaponTypes: {
 			Instruments: true
@@ -10483,7 +10372,7 @@ skill_db: (
 	}
 	Unit: {
 		Id: 0xaf
-		Layout: 3
+		Layout: 15
 		Interval: 3000
 		Target: "All"
 		Flag: {
@@ -11143,32 +11032,10 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: {
-		Lv1: 25000
-		Lv2: 30000
-		Lv3: 35000
-		Lv4: 40000
-		Lv5: 45000
-		Lv6: 50000
-		Lv7: 55000
-		Lv8: 60000
-		Lv9: 65000
-		Lv10: 70000
-	}
+	SkillData1: 60000
 	FixedCastTime: 0
 	Requirements: {
-		SPCost: {
-			Lv1: 14
-			Lv2: 18
-			Lv3: 22
-			Lv4: 26
-			Lv5: 30
-			Lv6: 34
-			Lv7: 38
-			Lv8: 42
-			Lv9: 46
-			Lv10: 50
-		}
+		SPCost: 20
 	}
 },
 {
@@ -11241,18 +11108,7 @@ skill_db: (
 		Lv9: 2400
 		Lv10: 2400
 	}
-	AfterCastActDelay: {
-		Lv1: 1100
-		Lv2: 1200
-		Lv3: 1300
-		Lv4: 1400
-		Lv5: 1500
-		Lv6: 1600
-		Lv7: 1700
-		Lv8: 1800
-		Lv9: 1900
-		Lv10: 2000
-	}
+	AfterCastActDelay: 500
 	SkillData1: {
 		Lv1: 20000
 		Lv2: 40000
@@ -11463,28 +11319,19 @@ skill_db: (
 	MaxLevel: 5
 	Range: 9
 	Hit: "BDT_MULTIHIT"
+	NumberOfHits: -3
 	SkillType: {
 		Enemy: true
 	}
-	AttackType: "Misc"
+	AttackType: "Magic"
+	Element: "Ele_Holy"
 	DamageType: {
 		IgnoreElement: true
 		IgnoreFlee: true
 		IgnoreDefCards: true
 	}
-	CastTime: 1600
-	AfterCastActDelay: {
-		Lv1: 2000
-		Lv2: 2500
-		Lv3: 3000
-		Lv4: 3500
-		Lv5: 4000
-		Lv6: 4500
-		Lv7: 5000
-		Lv8: 5500
-		Lv9: 6000
-		Lv10: 6500
-	}
+	CastTime: 1000
+	AfterCastActDelay: 1000
 	SkillData2: {
 		Lv1: 2000
 		Lv2: 3000
@@ -11722,18 +11569,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	CastTime: {
-		Lv1: 1000
-		Lv2: 1200
-		Lv3: 1400
-		Lv4: 1600
-		Lv5: 1800
-		Lv6: 2000
-		Lv7: 2200
-		Lv8: 2400
-		Lv9: 2600
-		Lv10: 2800
-	}
+	AfterCastActDelay: 500
 	Requirements: {
 		SPCost: {
 			Lv1: 1
@@ -11844,18 +11680,18 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	AfterCastActDelay: 2000
+	CoolDown: 2000
 	SkillData1: {
 		Lv1: 40000
-		Lv2: 45000
-		Lv3: 50000
-		Lv4: 55000
-		Lv5: 60000
-		Lv6: 65000
-		Lv7: 70000
-		Lv8: 75000
-		Lv9: 80000
-		Lv10: 85000
+		Lv2: 60000
+		Lv3: 80000
+		Lv4: 100000
+		Lv5: 120000
+		Lv6: 140000
+		Lv7: 160000
+		Lv8: 180000
+		Lv9: 200000
+		Lv10: 220000
 	}
 	SkillData2: {
 		Lv1: 20000
@@ -12030,19 +11866,19 @@ skill_db: (
 	Name: "SN_SHARPSHOOTING"
 	Description: "Focused Arrow Strike"
 	MaxLevel: 5
-	Range: 9
+	Range: 11
 	Hit: "BDT_MULTIHIT"
 	SkillType: {
 		Enemy: true
 	}
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
-	SplashRange: 1
+	SplashRange: 2
 	InterruptCast: true
 	SkillInstances: 13
-	CastTime: 1000
-	AfterCastActDelay: 1500
-	FixedCastTime: 1000
+	CastTime: 500
+	AfterCastActDelay: 500
+	FixedCastTime: 500
 	Requirements: {
 		SPCost: {
 			Lv1: 18
@@ -12301,32 +12137,11 @@ skill_db: (
 	Element: "Ele_Weapon"
 	NumberOfHits: -9
 	InterruptCast: true
-	CastTime: {
-		Lv1: 1600
-		Lv2: 1760
-		Lv3: 1920
-		Lv4: 2080
-		Lv5: 2240
-		Lv6: 2400
-		Lv7: 2560
-		Lv8: 2720
-		Lv9: 2880
-		Lv10: 3040
-	}
-	AfterCastActDelay: 2000
-	AfterCastWalkDelay: 2000
-	FixedCastTime: {
-		Lv1: 400
-		Lv2: 440
-		Lv3: 480
-		Lv4: 520
-		Lv5: 560
-		Lv6: 600
-		Lv7: 640
-		Lv8: 680
-		Lv9: 720
-		Lv10: 760
-	}
+	CastTime: 1500
+	AfterCastActDelay: 500
+	AfterCastWalkDelay: 500
+	FixedCastTime: 500
+	CoolDown: 1500
 	SkillDelayOptions: {
 		IgnoreStatusEffect: true
 	}
@@ -12452,43 +12267,10 @@ skill_db: (
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
 	NumberOfHits: 5
-	CastTime: {
-		Lv1: 150
-		Lv2: 250
-		Lv3: 350
-		Lv4: 450
-		Lv5: 500
-		Lv6: 500
-		Lv7: 500
-		Lv8: 500
-		Lv9: 500
-		Lv10: 500
-	}
-	AfterCastActDelay: {
-		Lv1: 1200
-		Lv2: 1400
-		Lv3: 1600
-		Lv4: 1800
-		Lv5: 2000
-		Lv6: 2200
-		Lv7: 2400
-		Lv8: 2600
-		Lv9: 2800
-		Lv10: 3000
-	}
+	CastTime: 250
+	AfterCastActDelay: 1000
 	SkillData2: 1000
-	FixedCastTime: {
-		Lv1: 150
-		Lv2: 250
-		Lv3: 350
-		Lv4: 450
-		Lv5: 500
-		Lv6: 500
-		Lv7: 500
-		Lv8: 500
-		Lv9: 500
-		Lv10: 500
-	}
+	FixedCastTime: 300
 	Requirements: {
 		SPCost: {
 			Lv1: 18
@@ -12591,7 +12373,7 @@ skill_db: (
 	Element: "Ele_Ghost"
 	DamageType: {
 		SplashArea: true
-		SplitDamage: true
+		SplitDamage: false
 	}
 	SplashRange: 1
 	NumberOfHits: {
@@ -12607,10 +12389,11 @@ skill_db: (
 		Lv10: 10
 	}
 	InterruptCast: true
-	CastTime: 800
-	AfterCastActDelay: 1000
+	CastTime: 500
+	Cooldown: 1000
+	AfterCastActDelay: 500
 	SkillData2: 45000
-	FixedCastTime: 200
+	FixedCastTime: 300
 	Requirements: {
 		SPCost: {
 			Lv1: 10
@@ -12640,7 +12423,8 @@ skill_db: (
 	}
 	InterruptCast: true
 	SkillData1: 600000
-	FixedCastTime: 2000
+	FixedCastTime: 1000
+	CoolDown:1000
 	Requirements: {
 		SPCost: 20
 	}
@@ -12702,7 +12486,7 @@ skill_db: (
 		NoDamage: true
 	}
 	InterruptCast: true
-	FixedCastTime: 5000
+	FixedCastTime: 2500
 	CastTimeOptions: {
 		IgnoreDex: true
 		IgnoreStatusEffect: true
@@ -12797,7 +12581,7 @@ skill_db: (
 	}
 	SplashRange: 2
 	CastTime: 250
-	AfterCastActDelay: 500
+	CoolDown: 500
 	SkillData2: {
 		Lv1: 10000
 		Lv2: 5000
@@ -12813,16 +12597,16 @@ skill_db: (
 	FixedCastTime: 250
 	Requirements: {
 		SPCost: {
-			Lv1: 10
-			Lv2: 12
-			Lv3: 14
-			Lv4: 16
-			Lv5: 18
-			Lv6: 20
-			Lv7: 22
-			Lv8: 24
-			Lv9: 26
-			Lv10: 28
+			Lv1: 13
+			Lv2: 16
+			Lv3: 19
+			Lv4: 22
+			Lv5: 25
+			Lv6: 28
+			Lv7: 31
+			Lv8: 34
+			Lv9: 37
+			Lv10: 40
 		}
 	}
 },
@@ -15201,14 +14985,14 @@ skill_db: (
 	Name: "PA_SHIELDCHAIN"
 	Description: "Shield Chain"
 	MaxLevel: 5
-	Range: 5
+	Range: 11
 	Hit: "BDT_MULTIHIT"
 	SkillType: {
 		Enemy: true
 	}
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
-	NumberOfHits: 5
+	NumberOfHits: -5
 	CastTime: 800
 	AfterCastActDelay: 1000
 	FixedCastTime: 200
@@ -15315,55 +15099,56 @@ skill_db: (
 	Description: "Gravitation Field"
 	MaxLevel: 5
 	Range: 18
-	Hit: "BDT_SKILL"
+	Hit: "BDT_MULTIHIT"
+	NumberOfHits: {
+		Lv1: 2
+		Lv2: 4
+		Lv3: 6
+		Lv4: 8
+		Lv5: 10
+		Lv6: 12
+		Lv7: 14
+		Lv8: 16
+		Lv9: 18
+		Lv10: 20
+	}	
 	SkillType: {
 		Place: true
 	}
 	SkillInfo: {
 		BlockedByStasis: true
 	}
-	AttackType: "Misc"
-	Element: "Ele_Earth"
+	AttackType: "Magic"
+	Element: "Ele_Neutral"
 	DamageType: {
 		NoDamage: true
 		IgnoreElement: true
 		IgnoreDefCards: true
 	}
 	InterruptCast: true
-	SkillData1: {
-		Lv1: 5000
-		Lv2: 6000
-		Lv3: 7000
-		Lv4: 8000
-		Lv5: 9000
-		Lv6: 10000
-		Lv7: 11000
-		Lv8: 12000
-		Lv9: 13000
-		Lv10: 14000
-	}
-	FixedCastTime: 5000
+	SkillData1: 100
+	FixedCastTime: 1000
+	CastTime: 5000
+	CoolDown: 5000
+	AfterCastActDelay: 1000
 	Requirements: {
 		SPCost: {
-			Lv1: 20
-			Lv2: 40
-			Lv3: 60
-			Lv4: 80
+			Lv1: 60
+			Lv2: 70
+			Lv3: 80
+			Lv4: 90
 			Lv5: 100
-			Lv6: 120
-			Lv7: 140
-			Lv8: 160
-			Lv9: 180
-			Lv10: 200
-		}
-		Items: {
-			Blue_Gemstone: 1
+			Lv6: 110
+			Lv7: 120
+			Lv8: 130
+			Lv9: 140
+			Lv10: 150
 		}
 	}
 	Unit: {
 		Id: 0xb8
 		Layout: 2
-		Interval: 500
+		Interval: 5100
 		Target: "Enemy"
 		Flag: {
 			UF_NOOVERLAP: true
@@ -18959,8 +18744,7 @@ skill_db: (
 	}
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
-	CastTime: 250
-	FixedCastTime: 250
+	CoolDown: 500
 	Requirements: {
 		SPCost: 40
 	}
@@ -38759,7 +38543,7 @@ skill_db: (
 	}
 	SplashRange: 2
 	KnockBackTiles: 2
-	AfterCastActDelay: 2000
+	AfterCastActDelay: 500
 	CoolDown: 2000
 	SkillData2: 10000
 	FixedCastTime: 0
@@ -38784,8 +38568,9 @@ skill_db: (
 	Name: "MS_BOWLINGBASH"
 	Description: "Bowling_Bash"
 	MaxLevel: 10
-	Range: -2
-	Hit: "BDT_SKILL"
+	Range: 1
+	Hit: "BDT_MULTIHIT"
+	NumberOfHits: 2
 	SkillType: {
 		Enemy: true
 	}
@@ -38794,11 +38579,10 @@ skill_db: (
 	DamageType: {
 		SplashArea: true
 	}
-	SplashRange: 1
-	KnockBackTiles: 1
+	SplashRange: 2
+	KnockBackTiles: 5
 	CastTime: 700
-	AfterCastActDelay: 2500
-	FixedCastTime: 0
+	FixedCastTime: 350
 	Requirements: {
 		SPCost: {
 			Lv1: 13

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2237,7 +2237,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 				case MO_INVESTIGATE:
 #ifdef RENEWAL
 					skillratio += -100 + 100 * skill_lv;
-						if( tsc && tsc->data[SC_BLADESTOP] ) // +50% on targets under Root skill
+						if (tsc && tsc->data[SC_BLADESTOP]) // +50% on targets under Root skill
 						skillratio += skillratio/2;
 #else
 					skillratio += 75 * skill_lv;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2106,7 +2106,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					{
 						int ratio = 100 + 20 * skill_lv;
 						skillratio += ratio - 100;
-						if(skill_lv>3 && flag==1) skillratio += ratio / 2;
+						if (skill_lv>3 && flag == 1) skillratio += ratio / 2;
 						if(skill_lv>6 && flag==1) skillratio += ratio / 4;
 						if(skill_lv>9 && flag==1) skillratio += ratio / 8;
 						if(skill_lv>6 && flag==2) skillratio += ratio / 2;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2123,7 +2123,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					break;
 				case AS_POISONREACT:
 					skillratio += 30 * skill_lv;
-					break;				
+					break;
 				case AS_SONICBLOW:
 #ifdef RENEWAL
 

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2209,7 +2209,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 				case AM_DEMONSTRATION:
 #ifdef RENEWAL
 					skillratio += -100 + 60 * skill_lv;
-						if(sd)
+						if (sd)
 						skillratio += 20 * pc->checkskill(sd,AM_LEARNINGPOTION);
 					break;
 #else			

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2219,7 +2219,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 				case AM_ACIDTERROR:
 #ifdef RENEWAL
 					skillratio += -100 + 200 * skill_lv;
-					if(sd)
+					if (sd)
 						skillratio += 20 * pc->checkskill(sd,AM_LEARNINGPOTION);
 #else
 					skillratio += 40 * skill_lv;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1708,7 +1708,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					break;
 				case BA_DISSONANCE:
 					skillratio += skill_lv * 10;
-							if((skill_lv = pc->checkskill(sd,BA_MUSICALLESSON)) > 0)
+							if ((skill_lv = pc->checkskill(sd, BA_MUSICALLESSON)) > 0)
 							skillratio += (skill_lv * 3);	
 					break;
 #endif	

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2228,7 +2228,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 				case MO_FINGEROFFENSIVE:
 #ifdef RENEWAL
 					skillratio+= 500 + 200 * skill_lv;
-						if( tsc && tsc->data[SC_BLADESTOP] ) // +50% on targets under Root skill
+						if (tsc && tsc->data[SC_BLADESTOP]) // +50% on targets under Root skill
 						skillratio += skillratio/2;
 #else
 					skillratio+= 50 * skill_lv;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -521,7 +521,7 @@ static int64 battle_calc_weapon_damage(struct block_list *src, struct block_list
 	}
 
 #ifdef RENEWAL_EDP
-	if ( sc && sc->data[SC_EDP] && skill_id != AS_GRIMTOOTH && skill_id != AS_VENOMKNIFE && skill_id != ASC_METEORASSAULT ) { //SOUL DESTROYER gets benefit from EDP, but Meteor Assault doesnt
+	if (sc && sc->data[SC_EDP] && skill_id != AS_GRIMTOOTH && skill_id != AS_VENOMKNIFE && skill_id != ASC_METEORASSAULT) { //SOUL DESTROYER gets benefit from EDP, but Meteor Assault doesnt
 		struct status_data *tstatus;
 		tstatus = status->get_status_data(bl);
 		eatk += damage * 0x19 * battle->attr_fix_table[tstatus->ele_lv - 1][ELE_POISON][tstatus->def_ele] / 10000;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1699,7 +1699,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					skillratio += 100;
 					break;
 				case PR_MAGNUS:
-					if(battle->check_undead(tst->race,tst->def_ele) || tst->race==RC_DEMON)
+					if (battle->check_undead(tst->race,tst->def_ele) || tst->race == RC_DEMON)
 					skillratio += 30;
 					break;	
 				case HW_GRAVITATION:

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2371,7 +2371,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					break;
 #ifdef RENEWAL					
 				case PA_PRESSURE:
-						skillratio += +400 + 150 * skill_lv;
+					skillratio += +400 + 150 * skill_lv;
 						RE_LVL_DMOD(100);
 					break;
 #endif

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1707,7 +1707,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					RE_LVL_DMOD(100);
 					break;
 				case BA_DISSONANCE:
-						skillratio += skill_lv * 10;
+					skillratio += skill_lv * 10;
 							if((skill_lv = pc->checkskill(sd,BA_MUSICALLESSON)) > 0)
 							skillratio += (skill_lv * 3);	
 					break;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1687,7 +1687,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 #ifdef RENEWAL			
 					skillratio += 300 + skill_lv * 100; //technically monsters should be using the old one, but w/e
 #else
-					skillratio += 20*skill_lv-20;
+					skillratio += 20 * skill_lv - 20;
 #endif
 					break;
 #ifdef RENEWAL

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2107,7 +2107,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 						int ratio = 100 + 20 * skill_lv;
 						skillratio += ratio - 100;
 						if (skill_lv>3 && flag == 1) skillratio += ratio / 2;
-						if(skill_lv>6 && flag==1) skillratio += ratio / 4;
+						if (skill_lv>6 && flag == 1) skillratio += ratio / 4;
 						if(skill_lv>9 && flag==1) skillratio += ratio / 8;
 						if(skill_lv>6 && flag==2) skillratio += ratio / 2;
 						if(skill_lv>9 && flag==2) skillratio += ratio / 4;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2372,7 +2372,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 #ifdef RENEWAL					
 				case PA_PRESSURE:
 					skillratio += +400 + 150 * skill_lv;
-						RE_LVL_DMOD(100);
+					RE_LVL_DMOD(100);
 					break;
 #endif
 				case WS_CARTTERMINATION:

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -8013,6 +8013,26 @@ static void clif_autospell(struct map_session_data *sd, uint16 skill_lv)
 	p->packetType = HEADER_ZC_AUTOSPELLLIST;
 	int index = 0;
 
+#ifdef RENEWAL
+	if (skill_lv > 0 && pc->checkskill(sd, MG_COLDBOLT) > 0)
+		p->skills[index++] = MG_COLDBOLT;
+	if (skill_lv > 0 && pc->checkskill(sd, MG_FIREBOLT) > 0)
+		p->skills[index++] = MG_FIREBOLT;
+	if (skill_lv > 0 && pc->checkskill(sd, MG_LIGHTNINGBOLT) > 0)
+		p->skills[index++] = MG_LIGHTNINGBOLT;
+	if (skill_lv > 3 && pc->checkskill(sd, MG_SOULSTRIKE) > 0)
+		p->skills[index++] = MG_SOULSTRIKE;
+	if (skill_lv > 3 && pc->checkskill(sd, MG_FIREBALL) > 0)
+		p->skills[index++] = MG_FIREBALL;
+	if (skill_lv > 6 && pc->checkskill(sd, MG_FROSTDIVER) > 0)
+		p->skills[index++] = MG_FROSTDIVER;
+	if (skill_lv > 6 && pc->checkskill(sd, WZ_EARTHSPIKE) > 0)
+		p->skills[index++] = WZ_EARTHSPIKE;
+	if (skill_lv > 9 && pc->checkskill(sd, MG_THUNDERSTORM) > 0)
+		p->skills[index++] = MG_THUNDERSTORM;
+	if (skill_lv > 9 && pc->checkskill(sd, WZ_HEAVENDRIVE) > 0)
+		p->skills[index++] = WZ_HEAVENDRIVE;
+#else
 	if (skill_lv > 0 && pc->checkskill(sd, MG_NAPALMBEAT) > 0)
 		p->skills[index++] = MG_NAPALMBEAT;
 	if (skill_lv > 1 && pc->checkskill(sd, MG_COLDBOLT) > 0)
@@ -8027,6 +8047,7 @@ static void clif_autospell(struct map_session_data *sd, uint16 skill_lv)
 		p->skills[index++] = MG_FIREBALL;
 	if (skill_lv > 9 && pc->checkskill(sd, MG_FROSTDIVER) > 0)
 		p->skills[index++] = MG_FROSTDIVER;
+#endif
 
 #if PACKETVER_MAIN_NUM >= 20181128 || PACKETVER_RE_NUM >= 20181031
 	const int len = sizeof(struct PACKET_ZC_AUTOSPELLLIST) + index * 4;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1124,6 +1124,7 @@ static sc_type skill_get_sc_type(int skill_id)
 static int skill_calc_heal(struct block_list *src, struct block_list *target, uint16 skill_id, uint16 skill_lv, bool heal)
 {
 	int skill2_lv, hp;
+
 	struct map_session_data *sd = BL_CAST(BL_PC, src);
 	struct map_session_data *tsd = BL_CAST(BL_PC, target);
 	struct status_change* sc;
@@ -1134,14 +1135,12 @@ static int skill_calc_heal(struct block_list *src, struct block_list *target, ui
 		case SU_TUNABELLY:
 			hp = status_get_max_hp(target) * ((20 * skill_lv) - 10) / 100;
 			break;
+#ifndef RENEWAL //heal removed in RENEWAL, buffs incoming heal
 		case BA_APPLEIDUN:
-#ifdef RENEWAL
-			hp = 100+5*skill_lv+5*(status_get_vit(src)/10); // HP recovery
-#else // not RENEWAL
 			hp = 30+5*skill_lv+5*(status_get_vit(src)/10); // HP recovery
-#endif // RENEWAL
-			if( sd )
+				if( sd )
 				hp += 5*pc->checkskill(sd,BA_MUSICALLESSON);
+#endif
 			break;
 		case PR_SANCTUARY:
 			hp = (skill_lv>6)?777:skill_lv*100;
@@ -1154,7 +1153,7 @@ static int skill_calc_heal(struct block_list *src, struct block_list *target, ui
 				return battle_config.max_heal;
 #ifdef RENEWAL
 			/**
-			 * Renewal Heal Formula
+			 * RENEWAL Heal Formula
 			 * Formula: ( [(Base Level + INT) / 5] ? 30 ) ? (Heal Level / 10) ? (Modifiers) + MATK
 			 **/
 			hp = (status->get_lv(src) + status_get_int(src)) / 5 * 30  * skill_lv / 10;
@@ -1203,6 +1202,12 @@ static int skill_calc_heal(struct block_list *src, struct block_list *target, ui
 			hp = hp * 150 / 100;
 		if (sc->data[SC_NO_RECOVER_STATE])
 			hp = 0;
+#ifdef RENEWAL
+		if(sc->data[SC_ASSUMPTIO])
+			hp += hp * (sc->data[SC_ASSUMPTIO]->val1 * 2) / 100;
+		if(sc->data[SC_APPLEIDUN])
+			hp += hp * (sc->data[SC_APPLEIDUN]->val3) / 100;
+#endif
 	}
 
 #ifdef RENEWAL
@@ -1722,7 +1727,7 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 
 		case WZ_STORMGUST:
 		/**
-		 * Storm Gust counter was dropped in renewal
+		 * Storm Gust counter was dropped in RENEWAL
 		 **/
 		#ifdef RENEWAL
 			sc_start(src, bl, SC_FREEZE, 65 - (5 * skill_lv), skill_lv, skill->get_time2(skill_id, skill_lv), skill_id);
@@ -1800,7 +1805,11 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 			break;
 
 		case AM_DEMONSTRATION:
+#ifdef RENEWAL
+			skill->break_equip(bl, EQP_WEAPON, 300*skill_lv, BCT_ENEMY); //RENEWAL improved chance to break
+#else
 			skill->break_equip(bl, EQP_WEAPON, 100*skill_lv, BCT_ENEMY);
+#endif
 			break;
 
 		case CR_SHIELDCHARGE:
@@ -2368,8 +2377,10 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 					rate += 10;
 				if(sc->data[SC_OVERTHRUST])
 					rate += 10;
-				if(sc->data[SC_OVERTHRUSTMAX])
+#ifndef RENEWAL
+				if(sc->data[SC_OVERTHRUSTMAX])   //RENEWAL removed this chance to break
 					rate += 10;
+#endif
 			}
 			if( rate )
 				skill->break_equip(src, EQP_WEAPON, rate, BCT_SELF);
@@ -3211,12 +3222,14 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 	 //Trick Dead protects you from damage, but not from buffs and the like, hence it's placed here.
 	if (sc && sc->data[SC_TRICKDEAD])
 		return 0;
+#ifndef RENEWAL
 	if ( skill_id != HW_GRAVITATION ) {
 		struct status_change *csc = status->get_sc(src);
 		if(csc && csc->data[SC_GRAVITATION] && csc->data[SC_GRAVITATION]->val3 == BCT_SELF )
 			return 0;
 	}
-
+#endif
+	//Gravitational field was reworked an now it's just a boring damage spell
 	dmg = battle->calc_attack(attack_type,src,bl,skill_id,skill_lv,flag&0xFFF);
 
 	//Skotlex: Adjusted to the new system
@@ -3277,7 +3290,7 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 		#ifdef RENEWAL
 			if( dmg.dmg_lv != ATK_MISS ) // Wiz SL canceled and consumed fragment
 		#else
-			// issue:6415 in pre-renewal Kaite reflected the entire damage received
+			// issue:6415 in pre-RENEWAL Kaite reflected the entire damage received
 			// regardless of caster's equipment (Aegis 11.1)
 			if( dmg.dmg_lv != ATK_MISS && reflecttype == 1 ) //Wiz SL canceled and consumed fragment
 		#endif
@@ -3579,9 +3592,11 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 		case HT_LANDMINE:
 			dmg.dmotion = clif->skill_damage(dsrc,bl,tick, dmg.amotion, dmg.dmotion, damage, dmg.div_, skill_id, -1, type);
 			break;
+#ifndef RENEWAL
 		case HW_GRAVITATION:
 			dmg.dmotion = clif->damage(bl, bl, 0, 0, damage, 1, BDT_ENDURE, 0);
 			break;
+#endif
 		case WZ_SIGHTBLASTER:
 			dmg.dmotion = clif->skill_damage(src,bl,tick, dmg.amotion, dmg.dmotion, damage, dmg.div_, skill_id, (flag&SD_LEVEL) ? -1 : skill_lv, BDT_SPLASH);
 			break;
@@ -4983,6 +4998,32 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 
 		case RG_BACKSTAP:
 			{
+#ifdef RENEWAL //copied code from Asura strike with i=1
+			short x, y, i = 1;
+			struct block_list *mbl = bl;
+			skill->attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag);
+			
+			enum unit_dir dir = map->calc_dir(src, bl->x, bl->y);
+			if (Assert_chk(dir >= UNIT_DIR_FIRST && dir < UNIT_DIR_MAX)) {
+				map->freeblock_unlock(); // unblock before assert-returning
+				return 0;
+			}
+			x = i * dirx[dir];
+			y = i * diry[dir];
+			if ((mbl == src || (!map_flag_gvg2(src->m) && !map->list[src->m].flag.battleground))) {
+				if (unit->move_pos(src, mbl->x + x, mbl->y + y, 1, true) != 0) {
+					// The cell is not reachable (wall, object, ...), move next to the target
+					if (x > 0) x = -1;
+					else if (x < 0) x = 1;
+					if (y > 0) y = -1;
+					else if (y < 0) y = 1;
+
+					unit->move_pos(src, bl->x + x, bl->y + y, 1, true);
+				}
+				clif->slide(src, src->x, src->y);
+				clif->fixpos(src);
+			}	
+#else    //old backstab, PRE-RE
 				enum unit_dir dir = map->calc_dir(src, bl->x, bl->y);
 				enum unit_dir t_dir = unit->getdir(bl);
 				if ((!check_distance_bl(src, bl, 0) && map->check_dir(dir, t_dir) == 0) || bl->type == BL_SKILL) {
@@ -4993,9 +5034,9 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 				}
 				else if (sd)
 					clif->skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0, 0);
+#endif
 			}
 			break;
-
 		case MO_FINGEROFFENSIVE:
 			skill->attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag);
 			if (battle_config.finger_offensive_type && sd) {
@@ -5078,6 +5119,10 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 		// Splash attack skills.
 		case AS_GRIMTOOTH:
 		case MC_CARTREVOLUTION:
+#ifdef RENEWAL
+		case KN_BOWLINGBASH:
+		case MS_BOWLINGBASH:
+#endif
 		case NPC_SPLASHATTACK:
 			flag |= SD_PREAMBLE; // a fake packet will be sent for the first target to be hit
 			FALLTHROUGH
@@ -5237,15 +5282,15 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 				//special case: Venom Splasher uses a different range for searching than for splashing
 				if( flag&SD_LEVEL || skill->get_nk(skill_id)&NK_SPLASHSPLIT )
 					skill->area_temp[0] = map->foreachinrange(skill->area_sub, bl, (skill_id == AS_SPLASHER)?1:skill->get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill->area_sub_count);
-
+				
 				// recursive invocation of skill->castend_damage_id() with flag|1
 				map->foreachinrange(skill->area_sub, bl, skill->get_splash(skill_id, skill_lv), skill->splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill->castend_damage_id);
-
+#ifdef RENEWAL   //RENEWAL removed the gem cost
 				if (skill_id == AS_SPLASHER) {
-					// Prevent double item consumption when the target explodes (item requirements have already been processed in skill_castend_nodamage_id)
-					flag |= 1;
+					// Prevent double item consumption when the target explodes (item requirements have already been processed in skill_castend_nodamage_id).
+						flag |= 1;
 				}
-
+#endif
 				if (sd && skill_id == SU_LUNATICCARROTBEAT) {
 					short item_idx = pc->search_inventory(sd, ITEMID_CARROT);
 
@@ -5273,7 +5318,11 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 			else
 				skill->attack(skill->get_type(skill_id, skill_lv), src, src, bl, skill_id, skill_lv, tick, flag);
 			break;
-
+#ifdef RENEWAL
+			//skill->attack(skill->get_type(skill_id, skill_lv), src, src, bl, skill_id, skill_lv, tick, flag|SD_ANIMATION);
+			//skill->area_temp[0] = map->foreachinrange(skill->area_sub, bl, skill->get_splash(skill_id, skill_lv),skill->splash_target(src), src,skill_id,skill_lv,tick, BCT_ENEMY, skill->area_sub_count);
+			//map->foreachinrange(skill->area_sub, bl, skill->get_splash(skill_id, skill_lv),skill->splash_target(src), src,skill_id,skill_lv,tick,flag | BCT_ENEMY | SD_SPLASH | 1, skill->castend_damage_id);
+#else
 		case KN_BOWLINGBASH:
 		case MS_BOWLINGBASH:
 			{
@@ -5350,8 +5399,8 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 				// Original hit or chain hit depending on flag
 				skill->attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,(flag&0xFFF)>0?SD_ANIMATION:0);
 			}
+#endif
 			break;
-
 		case KN_SPEARSTAB:
 			if(flag&1) {
 				if (bl->id==skill->area_temp[1])
@@ -6373,10 +6422,15 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 		}
 
 		if(ud->skill_id == RG_BACKSTAP) {
+	#ifndef RENEWAL
 			enum unit_dir dir = map->calc_dir(src, target->x, target->y);
 			enum unit_dir t_dir = unit->getdir(target);
-			if (check_distance_bl(src, target, 0) || map->check_dir(dir, t_dir) != 0) {
-				break;
+			if (map->check_dir(dir, t_dir) != 0) {
+			break;
+			}
+	#endif
+			if (check_distance_bl(src, target, 0)) {
+			break;
 			}
 		}
 
@@ -7228,13 +7282,18 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 					break;
 				}
 			}
+#ifdef RENEWAL
+			if (!clif->skill_nodamage(src, bl, skill_id, skill_lv, sc_start(src, bl, type, 100, skill_lv, skill->get_time(skill_id, skill_lv), skill_id))) { //RENEWAL buff never fails
+#else
 			// 100% success rate at lv4 & 5, but lasts longer at lv5
 			if (!clif->skill_nodamage(src, bl, skill_id, skill_lv, sc_start(src, bl, type, (60 + skill_lv * 10), skill_lv, skill->get_time(skill_id, skill_lv), skill_id))) {
+#endif
 				if (sd)
 					clif->skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0, 0);
 				if (skill->break_equip(bl, EQP_WEAPON, 10000, BCT_PARTY) && sd && sd != dstsd)
 					clif->message(sd->fd, msg_sd(sd,869)); // "You broke the target's weapon."
 			}
+
 			break;
 
 		case PR_ASPERSIO:
@@ -7307,9 +7366,11 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 				break;
 			}
 		case PR_SLOWPOISON:
-		case PR_IMPOSITIO:
 		case PR_LEXAETERNA:
+#ifndef RENEWAL
+		case PR_IMPOSITIO:
 		case PR_SUFFRAGIUM:
+#endif
 		case PR_BENEDICTIO:
 		case LK_BERSERK:
 		case MS_BERSERK:
@@ -7872,6 +7933,10 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 			break;
 
 		case AL_ANGELUS:
+#ifdef RENEWAL
+		case PR_SUFFRAGIUM:
+		case PR_IMPOSITIO:
+#endif
 		case PR_MAGNIFICAT:
 		case PR_GLORIA:
 		case SN_WINDWALK:
@@ -8775,18 +8840,20 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 		case SA_AUTOSPELL:
 			clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
 			if(sd){
-				sd->state.workinprogress = 3;
+				sd->state.workinprogress = 0;
 				clif->autospell(sd,skill_lv);
-			}else {
+			}
+#ifndef RENEWAL
+			else {
 				int maxlv=1,spellid=0;
 				static const int spellarray[3] = { MG_COLDBOLT,MG_FIREBOLT,MG_LIGHTNINGBOLT };
 				if(skill_lv >= 10) {
 					spellid = MG_FROSTDIVER;
-#if 0
+	#if 0
 					if (tsc && tsc->data[SC_SOULLINK] && tsc->data[SC_SOULLINK]->val2 == SA_SAGE)
 						maxlv = 10;
 					else
-#endif // 0
+	#endif // 0
 						maxlv = skill_lv - 9;
 				}
 				else if(skill_lv >=8) {
@@ -8810,8 +8877,8 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 					sc_start4(src,src,SC_AUTOSPELL,100,skill_lv,spellid,maxlv,0,
 						skill->get_time(SA_AUTOSPELL, skill_lv), SA_AUTOSPELL);
 			}
+#endif
 			break;
-
 		case BS_GREED:
 			if(sd){
 				clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
@@ -9154,7 +9221,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 		case AS_SPLASHER:
 			if( tstatus->mode&MD_BOSS
 #ifndef RENEWAL
-			  /** Renewal dropped the 3/4 hp requirement **/
+			  /** RENEWAL dropped the 3/4 hp requirement **/
 			 || tstatus-> hp > tstatus->max_hp*3/4
 #endif // RENEWAL
 			) {
@@ -12215,7 +12282,6 @@ static int skill_castend_pos2(struct block_list *src, int x, int y, uint16 skill
 		FALLTHROUGH
 		case MG_FIREWALL:
 		case MG_THUNDERSTORM:
-
 		case AL_PNEUMA:
 		case WZ_FIREPILLAR:
 		case WZ_QUAGMIRE:
@@ -12276,9 +12342,10 @@ static int skill_castend_pos2(struct block_list *src, int x, int y, uint16 skill
 		case NJ_HYOUSYOURAKU:
 		case NJ_RAIGEKISAI:
 		case NJ_KAMAITACHI:
-	#ifdef RENEWAL
+#ifdef RENEWAL
 		case NJ_HUUMA:
-	#endif
+		case HW_GRAVITATION:
+#endif
 		case NPC_EARTHQUAKE:
 		case NPC_EVILLAND:
 		case WL_COMET:
@@ -12569,13 +12636,13 @@ static int skill_castend_pos2(struct block_list *src, int x, int y, uint16 skill
 				return 1;
 			}
 			break;
-
+#ifndef RENEWAL
 		case HW_GRAVITATION:
 			if ((sg = skill->unitsetting(src,skill_id,skill_lv,x,y,0)))
 				sc_start4(src, src, type, 100, skill_lv, 0, BCT_SELF, sg->group_id, skill->get_time(skill_id, skill_lv), skill_id);
 			flag|=1;
 			break;
-
+#endif
 		// Plant Cultivation [Celest]
 		case CR_CULTIVATION:
 			if (sd) {
@@ -13234,22 +13301,32 @@ static struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16
 			val1 = 10; //FIXME: This value is not used anywhere, what is it for? [Skotlex]
 			break;
 		case BA_WHISTLE:
+#ifdef RENEWAL
+			val1 = 18 + skill_lv*2; // Flee increase
+			val2 = (skill_lv + 1) / 2; // Perfect dodge increase
+#else
 			val1 = skill_lv +st->agi/10; // Flee increase
 			val2 = ((skill_lv+1)/2)+st->luk/10; // Perfect dodge increase
 			if(sd){
 				val1 += pc->checkskill(sd,BA_MUSICALLESSON);
 				val2 += pc->checkskill(sd,BA_MUSICALLESSON);
 			}
+#endif
 			break;
 		case DC_HUMMING:
+#ifdef RENEWAL
+			val1 = 4*skill_lv;
+#else
 			val1 = 2*skill_lv+st->dex/10; // Hit increase
-			#ifdef RENEWAL
-				val1 *= 2;
-			#endif
-			if(sd)
+				if(sd)
 				val1 += pc->checkskill(sd,DC_DANCINGLESSON);
+#endif
 			break;
 		case BA_POEMBRAGI:
+#ifdef RENEWAL
+			val1 = 2 * skill_lv; // Casting time reduction
+			val2 = 3 * skill_lv; // After-cast delay reduction
+#else
 			val1 = 3*skill_lv+st->dex/10; // Casting time reduction
 			//For some reason at level 10 the base delay reduction is 50%.
 			val2 = (skill_lv<10?3*skill_lv:50)+st->int_/5; // After-cast delay reduction
@@ -13257,6 +13334,7 @@ static struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16
 				val1 += 2*pc->checkskill(sd,BA_MUSICALLESSON);
 				val2 += 2*pc->checkskill(sd,BA_MUSICALLESSON);
 			}
+#endif
 			break;
 		case DC_DONTFORGETME:
 #ifdef RENEWAL
@@ -13265,24 +13343,34 @@ static struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16
 #else
 			val1 = st->dex/10 + 3*skill_lv + 5; // ASPD decrease
 			val2 = st->agi/10 + 3*skill_lv + 5; // Movement speed adjustment.
-#endif
 			if(sd){
 				val1 += pc->checkskill(sd,DC_DANCINGLESSON);
 				val2 += pc->checkskill(sd,DC_DANCINGLESSON);
 			}
+#endif
 			break;
 		case BA_APPLEIDUN:
-			val1 = 5+2*skill_lv+st->vit/10; // MaxHP percent increase
+#ifdef RENEWAL
+			val2 = 9 + skill_lv + skill_lv/5; // MaxHP percent increase
+			val3 = skill_lv * 2; //heal buff
+#else
+			val2 = 5+2*skill_lv+st->vit/10; // MaxHP percent increase
 			if(sd)
-				val1 += pc->checkskill(sd,BA_MUSICALLESSON);
+				val2 += pc->checkskill(sd,BA_MUSICALLESSON);
+#endif
 			break;
 		case DC_SERVICEFORYOU:
+#ifdef RENEWAL
+			val1 = 9+skill_lv+(st->int_/10)*2; // MaxSP percent increase
+			val2 = 5*skill_lv; // SP cost reduction
+#else
 			val1 = 15+skill_lv+(st->int_/10); // MaxSP percent increase
 			val2 = 20+3*skill_lv+(st->int_/10); // SP cost reduction
 			if(sd){
 				val1 += pc->checkskill(sd,DC_DANCINGLESSON) / 2;
 				val2 += pc->checkskill(sd,DC_DANCINGLESSON) / 2;
 			}
+#endif
 			break;
 		case BA_ASSASSINCROSS:
 			if(sd)
@@ -13298,15 +13386,20 @@ static struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16
 #endif
 			break;
 		case DC_FORTUNEKISS:
+#ifdef RENEWAL
+			val1 = skill_lv; // Critical increase
+			val1 *= 10;
+#else
 			val1 = 10+skill_lv+(st->luk/10); // Critical increase
 			if(sd)
 				val1 += pc->checkskill(sd,DC_DANCINGLESSON);
-			val1*=10; //Because every 10 crit is an actual cri point.
+				val1 *= 10;
+#endif
 			break;
 		case BD_DRUMBATTLEFIELD:
 		#ifdef RENEWAL
-			val1 = (skill_lv+5)*25; //Watk increase
-			val2 = skill_lv*10; //Def increase
+			val1 = 15 + (skill_lv*5); //Watk increase
+			val2 = skill_lv*15; //Def increase
 		#else
 			val1 = (skill_lv+1)*25; //Watk increase
 			val2 = (skill_lv+1)*2; //Def increase
@@ -13316,11 +13409,20 @@ static struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16
 			val1 = (skill_lv+2)*25; //Watk increase
 			break;
 		case BD_RICHMANKIM:
+#ifdef RENEWAL
+			val1 = 10 + 10*skill_lv; //Exp increase bonus.
+#else
 			val1 = 25 + 11*skill_lv; //Exp increase bonus.
+#endif
 			break;
 		case BD_SIEGFRIED:
+#ifdef RENEWAL
+			val1 = skill_lv*3; //Elemental Resistance RENEWAL reword
+			val2 = skill_lv*5; //Status ailment resistance RENEWAL rework
+#else
 			val1 = 55 + skill_lv*5; //Elemental Resistance
 			val2 = skill_lv*10; //Status ailment resistance
+#endif
 			break;
 		case WE_CALLPARTNER:
 			if (sd) val1 = sd->status.partner_id;
@@ -13919,7 +14021,9 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 		case HT_FREEZINGTRAP:
 		case HT_BLASTMINE:
 		case HT_CLAYMORETRAP:
+#ifndef RENEWAL
 		case HW_GRAVITATION:
+#endif
 		case SA_DELUGE:
 		case SA_VOLCANO:
 		case SA_VIOLENTGALE:
@@ -14027,8 +14131,10 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 			break;
 
 		case UNT_MAGNUS:
+#ifndef RENEWAL
 			if (!battle->check_undead(tstatus->race,tstatus->def_ele) && tstatus->race!=RC_DEMON)
 				break;
+#endif
 			skill->attack(BF_MAGIC,ss,&src->bl,bl,sg->skill_id,sg->skill_lv,tick,0);
 			break;
 
@@ -14061,7 +14167,7 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 				}
 				break;
 		/**
-		 * The storm gust counter was dropped in renewal
+		 * The storm gust counter was dropped in RENEWAL
 		 **/
 		#ifndef RENEWAL
 				case WZ_STORMGUST: //SG counter does not reset per stormgust. IE: One hit from a SG and two hits from another will freeze you.
@@ -14847,7 +14953,9 @@ static int skill_unit_onleft(uint16 skill_id, struct block_list *bl, int64 tick)
 		case SA_DELUGE:
 		case SA_VIOLENTGALE:
 		case CG_HERMODE:
+#ifndef RENEWAL
 		case HW_GRAVITATION:
+#endif
 		case NJ_SUITON:
 		case SC_MAELSTROM:
 		case EL_WATER_BARRIER:
@@ -17046,7 +17154,11 @@ static struct skill_condition skill_get_requirement(struct map_session_data *sd,
 					switch( sc->data[SC_COMBOATTACK]->val1 )
 					{
 						case MO_COMBOFINISH:
+#ifdef RENEWAL
+							req.spiritball = 1; //RENEWAL buff
+#else
 							req.spiritball = 4;
+#endif
 							break;
 						case CH_TIGERFIST:
 							req.spiritball = 3;
@@ -17152,12 +17264,13 @@ static int skill_castfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv
 	//ShowInfo("Castime castfix = %d\n",time);
 	return time;
 }
-
 /*==========================================
  * Does cast-time reductions based on sc data.
  *------------------------------------------*/
+
 static int skill_castfix_sc(struct block_list *bl, int time)
 {
+#ifndef RENEWAL_CAST ///seems like this is only used for pre-RENEWAL cast, there fore it's better to keep it separated.
 	struct status_change *sc = status->get_sc(bl);
 
 	if( time < 0 )
@@ -17185,12 +17298,12 @@ static int skill_castfix_sc(struct block_list *bl, int time)
 			time -= time * sc->data[SC_POEMBRAGI]->val2 / 100;
 		if (sc->data[SC_SKF_CAST] != NULL)
 			time -= time * sc->data[SC_SKF_CAST]->val1 / 100;
-		if (sc->data[SC_IZAYOI])
-			time -= time * 50 / 100;
+
 	}
 	time = max(time, 0);
 
 	//ShowInfo("Castime castfix_sc = %d\n",time);
+#endif
 	return time;
 }
 
@@ -17254,7 +17367,9 @@ static int skill_vfcastfix(struct block_list *bl, double time, uint16 skill_id, 
 		// Variable cast reduction bonuses
 		if (sc->data[SC_SUFFRAGIUM]) {
 			VARCAST_REDUCTION(sc->data[SC_SUFFRAGIUM]->val2);
-			status_change_end(bl, SC_SUFFRAGIUM, INVALID_TIMER);
+	#ifndef RENEWAL
+			status_change_end(bl, SC_SUFFRAGIUM, INVALID_TIMER); //RENEWAL rebalance removed the condition of only 1 cast
+	#endif
 		}
 		if (sc->data[SC_MEMORIZE]) {
 			VARCAST_REDUCTION(50);
@@ -17792,7 +17907,12 @@ static int skill_autospell(struct map_session_data *sd, uint16 skill_id)
 	lv=pc->checkskill(sd,skill_id);
 
 	if(!skill_lv || !lv) return 0; // Player must learn the skill before doing auto-spell [Lance]
-
+#ifdef RENEWAL
+	if((skill_id==MG_COLDBOLT || skill_id==MG_FIREBOLT || skill_id==MG_LIGHTNINGBOLT) && (sd->sc.data[SC_SOULLINK] && sd->sc.data[SC_SOULLINK]->val2 == SL_SAGE))
+		maxlv = 10; //Soul Linker bonus. [Skotlex]
+	else
+		maxlv = skill_lv/2;
+#else
 	if(skill_id==MG_NAPALMBEAT) maxlv=3;
 	else if(skill_id==MG_COLDBOLT || skill_id==MG_FIREBOLT || skill_id==MG_LIGHTNINGBOLT){
 		if (sd->sc.data[SC_SOULLINK] && sd->sc.data[SC_SOULLINK]->val2 == SL_SAGE)
@@ -17812,7 +17932,7 @@ static int skill_autospell(struct map_session_data *sd, uint16 skill_id)
 	}
 	else if(skill_id==MG_FROSTDIVER) maxlv=1;
 	else return 0;
-
+#endif
 	if(maxlv > lv)
 		maxlv = lv;
 

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7520,7 +7520,7 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 				val2 = val1 + 2; //Chance to Poison enemies.
 				val3 = 50 * (val1 + 1); //Damage increase (+50 +50*lv%)
 #endif
-				if( sd && pc->checkskill(sd,GC_RESEARCHNEWPOISON) > 0)//[Ind] - iROwiki says each level increases its duration by 3 seconds >[gbasso] updated in 2022 to researchlvl*15 + 30sec
+				if (sd && pc->checkskill(sd,GC_RESEARCHNEWPOISON) > 0) //[Ind] - iROwiki says each level increases its duration by 3 seconds >[gbasso] updated in 2022 to researchlvl*15 + 30sec
 					total_tick += 30000 + pc->checkskill(sd,GC_RESEARCHNEWPOISON)*15000;
 				break;
 			case SC_POISONREACT:

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -5636,7 +5636,7 @@ static short status_calc_aspd_rate(struct block_list *bl, struct status_change *
 		aspd_rate -= 10 * sc->data[SC_STARSTANCE]->val2;
 #ifdef RENEWAL //just in case people want to use classic aspd with renewal. Not going to add the other buffed skills because they are already very strong in classic.
 	if (sc->data[SC_INC_AGI])
-		aspd_rate -= sc->data[SC_INC_AGI]->val1*10;
+		aspd_rate -= sc->data[SC_INC_AGI]->val1 * 10;
 #endif
 	return (short)cap_value(aspd_rate,0,SHRT_MAX);
 }

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -1927,7 +1927,6 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 		bstatus->max_hp = battle_config.max_hp;
 	else if(!bstatus->max_hp)
 		bstatus->max_hp = 1;
-	
 	// ----- SP MAX CALCULATION -----
 
 	// Basic MaxSP value

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -5454,7 +5454,7 @@ static short status_calc_aspd(struct block_list *bl, struct status_change *sc, s
 	#ifdef RENEWAL
 		if (sc->data[SC_INC_AGI])
 			bonus += sc->data[SC_INC_AGI]->val1;
-		if(sc->data[SC_TWOHANDQUICKEN])
+		if (sc->data[SC_TWOHANDQUICKEN])
 			bonus += sc->data[SC_TWOHANDQUICKEN]->val3;
 		if(sc->data[SC_ADRENALINE])
 			bonus += sc->data[SC_ADRENALINE]->val4;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2012,7 +2012,6 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 	
 	if (pc->checkskill(sd, SU_POWEROFLIFE) > 0)
 		bstatus->cri += 20;
-	
 	if(sd->flee2_rate < 0)
 		sd->flee2_rate = 0;
 	if(sd->flee2_rate != 100)

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -4629,7 +4629,7 @@ static int status_calc_critical(struct block_list *bl, struct status_change *sc,
 #ifdef RENEWAL
 	if (sc->data[SC_SPEARQUICKEN])
 		critical += 3*sc->data[SC_SPEARQUICKEN]->val1 * 10;
-	if(sc->data[SC_TWOHANDQUICKEN])
+	if (sc->data[SC_TWOHANDQUICKEN])
 		critical += sc->data[SC_TWOHANDQUICKEN]->val4 * 10;
 #endif
 	if (sc->data[SC__INVISIBILITY])

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -1950,7 +1950,7 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 		bstatus->max_sp += 100;
 #ifdef RENEWAL
 	if ((skill_lv = pc->checkskill(sd, BA_MUSICALLESSON)) > 0)
-		bstatus->max_sp += (int64)bstatus->max_sp * skill_lv/100;
+		bstatus->max_sp += (int64)bstatus->max_sp * skill_lv / 100;
 	if((skill_lv = pc->checkskill(sd,DC_DANCINGLESSON)) > 0)
 		bstatus->max_sp += (int64)bstatus->max_sp * skill_lv/100;
 #endif

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -5635,7 +5635,7 @@ static short status_calc_aspd_rate(struct block_list *bl, struct status_change *
 	if (sc->data[SC_STARSTANCE] != NULL)
 		aspd_rate -= 10 * sc->data[SC_STARSTANCE]->val2;
 #ifdef RENEWAL //just in case people want to use classic aspd with renewal. Not going to add the other buffed skills because they are already very strong in classic.
-		if (sc->data[SC_INC_AGI])
+	if (sc->data[SC_INC_AGI])
 		aspd_rate -= sc->data[SC_INC_AGI]->val1*10;
 #endif
 	return (short)cap_value(aspd_rate,0,SHRT_MAX);

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3675,7 +3675,7 @@ static int status_base_amotion_pc(struct map_session_data *sd, struct status_dat
 	if ( (skill_lv = pc->checkskill(sd, GS_SINGLEACTION)) > 0 )
 		val += ((skill_lv + 1) / 2);
 #ifdef RENEWAL
-	if ((skill_lv = pc->checkskill(sd,BA_MUSICALLESSON)) > 0)
+	if ((skill_lv = pc->checkskill(sd, BA_MUSICALLESSON)) > 0)
 		val += skill_lv;
 	if ((skill_lv = pc->checkskill(sd,RG_PLAGIARISM)) > 0)
 		val += skill_lv;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -4573,7 +4573,7 @@ static int status_calc_matk(struct block_list *bl, struct status_change *sc, int
 		matk += sc->data[SC_MTF_MATK]->val1;
 	if (sc->data[SC_MYSTICSCROLL])
 		matk += matk * sc->data[SC_MYSTICSCROLL]->val1 / 100;
-	if(sc->data[SC_VOLCANO])
+	if (sc->data[SC_VOLCANO])
 		matk += sc->data[SC_VOLCANO]->val2; //renewal buff
 	
 	// Eden Crystal Synthesis

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7521,7 +7521,7 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 				val3 = 50 * (val1 + 1); //Damage increase (+50 +50*lv%)
 #endif
 				if (sd && pc->checkskill(sd,GC_RESEARCHNEWPOISON) > 0) //[Ind] - iROwiki says each level increases its duration by 3 seconds >[gbasso] updated in 2022 to researchlvl*15 + 30sec
-					total_tick += 30000 + pc->checkskill(sd,GC_RESEARCHNEWPOISON)*15000;
+					total_tick += 30000 + pc->checkskill(sd, GC_RESEARCHNEWPOISON) * 15000;
 				break;
 			case SC_POISONREACT:
 				val2=(val1+1)/2 + val1/10; // Number of counters [Skotlex]

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -1915,7 +1915,6 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 
 	if ((pc->checkskill(sd,SU_SPRITEMABLE)) > 0)
 		bstatus->max_hp += 1000;
-	
 	// Apply relative modifiers from equipment
 	if(sd->hprate < 0)
 		sd->hprate = 0;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2058,7 +2058,7 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 	
 	// ----- CRITICAL CALCULATION -----	
 #ifdef RENEWAL
-	if((skill_lv=pc->checkskill(sd,DC_DANCINGLESSON)) > 0)
+	if ((skill_lv = pc->checkskill(sd, DC_DANCINGLESSON)) > 0)
 		bstatus->cri += skill_lv * 10;
 	if((skill_lv=pc->checkskill(sd,PR_MACEMASTERY)) > 0 && (sd->weapontype == W_MACE || sd->weapontype == W_2HMACE))
 		bstatus->cri += skill_lv * 10;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -1949,7 +1949,7 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 	if ((pc->checkskill(sd,SU_SPRITEMABLE)) > 0)
 		bstatus->max_sp += 100;
 #ifdef RENEWAL
-	if((skill_lv = pc->checkskill(sd,BA_MUSICALLESSON)) > 0)
+	if ((skill_lv = pc->checkskill(sd, BA_MUSICALLESSON)) > 0)
 		bstatus->max_sp += (int64)bstatus->max_sp * skill_lv/100;
 	if((skill_lv = pc->checkskill(sd,DC_DANCINGLESSON)) > 0)
 		bstatus->max_sp += (int64)bstatus->max_sp * skill_lv/100;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2060,7 +2060,7 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 #ifdef RENEWAL
 	if ((skill_lv = pc->checkskill(sd, DC_DANCINGLESSON)) > 0)
 		bstatus->cri += skill_lv * 10;
-	if((skill_lv=pc->checkskill(sd,PR_MACEMASTERY)) > 0 && (sd->weapontype == W_MACE || sd->weapontype == W_2HMACE))
+	if ((skill_lv = pc->checkskill(sd, PR_MACEMASTERY)) > 0 && (sd->weapontype == W_MACE || sd->weapontype == W_2HMACE))
 		bstatus->cri += skill_lv * 10;
 #endif
 	

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3677,7 +3677,7 @@ static int status_base_amotion_pc(struct map_session_data *sd, struct status_dat
 #ifdef RENEWAL
 	if ((skill_lv = pc->checkskill(sd, BA_MUSICALLESSON)) > 0)
 		val += skill_lv;
-	if ((skill_lv = pc->checkskill(sd,RG_PLAGIARISM)) > 0)
+	if ((skill_lv = pc->checkskill(sd, RG_PLAGIARISM)) > 0)
 		val += skill_lv;
 #endif
 	


### PR DESCRIPTION
- [X] I have followed [proper Hercules code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

Implemented the skill changes from this patch: https://www.divine-pride.net/forum/index.php?/topic/3453-kro-mass-skills-balance-1st-2nd-and-transcendent-classes-skills/

All skills that were reworked were tested and seem to be working correctly. If I miss anything let me know

**NOT IMPLEMENTED:**
-Basilica (completely new skill);
-AMP (completely new skill);
-Harmonic Lick (completely new skill);
-Classical Pluck (todo: add CONFUSION to the aoe effect);
-New Falcon Assault formula (IRO formula seems weird/wrong and I couldnt find another source).

Also, Bowling Bash should only have 4 hits on 4 or more targets with 2h sword. Atm I only implemented 4 hits with 2h sword at all instances (which I think it's fair).

Additional content: Some skill were later (2022) adjusted again in kro, I might have already updated them (like songs lasting 180sec).

PS: btw, Hindsight skill from Professor seems very convoluted on skill.c,  large portions of code doesnt seem to do anything, I recommend someone clean it up.



