### PR TITLE
Fix unit-specifc damage taken rate

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -5647,7 +5647,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				&& skill_id != NPC_GRANDDARKNESS
 				&& skill_id != PA_SHIELDCHAIN
 				&& skill_id != KO_HAPPOKUNAI
-#ifndef RENEWAL			
+#ifndef RENEWAL
 				&& !flag.cri
 #endif
 			) {
@@ -6641,11 +6641,11 @@ static enum damage_lv battle_weapon_attack(struct block_list *src, struct block_
 	if (target->type == BL_MOB) {
 		struct mob_data *md = BL_CAST(BL_MOB, target);
 		if (md != NULL) {
-			if (md->db->dmg_taken_rate != 100) {
+			if (md->dmg_taken_rate != 100) {
 				if (wd.damage > 0)
-					wd.damage = apply_percentrate64(wd.damage, md->db->dmg_taken_rate, 100);
+					wd.damage = apply_percentrate64(wd.damage, md->dmg_taken_rate, 100);
 				if (wd.damage2 > 0)
-					wd.damage2 = apply_percentrate64(wd.damage2, md->db->dmg_taken_rate, 100);
+					wd.damage2 = apply_percentrate64(wd.damage2, md->dmg_taken_rate, 100);
 			}
 		}
 	}

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -1192,6 +1192,7 @@ static int mob_spawn(struct mob_data *md)
 		memset(md->lootitem, 0, sizeof(*md->lootitem));
 
 	md->lootitem_count = 0;
+	md->dmg_taken_rate = md->db->dmg_taken_rate;
 
 	if(md->db->option)
 		// Added for carts, falcons and pecos for cloned monsters. [Valaris]

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3322,11 +3322,11 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 	if (bl->type == BL_MOB) {
 		struct mob_data *md = BL_CAST(BL_MOB, bl);
 		if (md != NULL) {
-			if (md->db->dmg_taken_rate != 100) {
+			if (md->dmg_taken_rate != 100) {
 				if (dmg.damage > 0)
-					dmg.damage = apply_percentrate64(dmg.damage, md->db->dmg_taken_rate, 100);
+					dmg.damage = apply_percentrate64(dmg.damage, md->dmg_taken_rate, 100);
 				if (dmg.damage2 > 0)
-					dmg.damage2 = apply_percentrate64(dmg.damage2, md->db->dmg_taken_rate, 100);
+					dmg.damage2 = apply_percentrate64(dmg.damage2, md->dmg_taken_rate, 100);
 			}
 		}
 	}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This fixes how damage taken rate is controlled at unit level.

Currently, we have a DamageTakenRate for monsters that is configured at db level (via mob_db), but we also have an option in `setunitdata` that allows customizing it for a single GID. The later case (single GID) was not working because every calculation was happening using the `db` field instead of the unit one.

With this change, every calculation will use unit's own rate, which will be initially set to the same as the one defined in `mob_db`

**Issues addressed:** None, I think


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
