### PR TITLE
Add missing EXP reward to Amatsu Dungeon quest

### DIFF
--- a/npc/quests/quests_amatsu.txt
+++ b/npc/quests/quests_amatsu.txt
@@ -1803,6 +1803,8 @@ ama_in02,200,176,4	script	Lord of Palace#ama	8_M_JPNMASTER,{
 			next;
 			event_amatsu = 2;
 			changequest 8131,8132;
+			if (RENEWAL_EXP)
+				getexp(50000, 50000); // Renewal: reward 1/4
 			mes "[Ishida Yoshinaga]";
 			mes "I beg you...Please.";
 			mes "My mother is living in a house outside of the palace.";
@@ -1863,6 +1865,10 @@ ama_in02,200,176,4	script	Lord of Palace#ama	8_M_JPNMASTER,{
 			completequest 8135;
 			delitem Fox_Tail,1;
 			getitem Lords_Passable_Ticket,1;
+			if (RENEWAL_EXP)
+				getexp(50000, 50000); // Renewal: reward 4/4
+			else
+				getexp(200000, 120000); // Pre-Renewal: full reward is given at the end.
 			mes "[Ishida Yoshinaga]";
 			mes "This isn't a big reward but";
 			mes "someday it will be useful for you.";
@@ -1948,6 +1954,8 @@ ama_in01,22,111,0	script	Grandma#ama2	4_F_JPNOBA,{
 			event_amatsu = 5;
 			changequest 8134,8135;
 			getitem Fox_Tail,1;
+			if (RENEWAL_EXP)
+				getexp(50000, 50000); // Renewal: reward 3/4
 			mes "[....]";
 			mes "^FF6060Everything that";
 			mes "Yoshinaga does will cause you";
@@ -2172,6 +2180,8 @@ ama_in01,180,173,3	script	Kitsune Mask#ama	4_M_JPN2,{
 		mes "energy to the fox several times.";
 		mes "Sooner or later, you'll be successful.";
 		changequest 8133,8134;
+		if (RENEWAL_EXP)
+			getexp(50000, 50000); // Renewal: reward 2/4
 		close;
 	}
 	else if (event_amatsu == 4) {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Experience rewards for both Pre-Re and Re were added. However, there isn't documentation for the exact four instances where Renewal rewards the player, so they were added in key moments of the quest (due to no multi-leveling, the separated instances are important for low level characters).

**Issues addressed:** <!-- Write here the issue number, if any. -->

Missing experience reward in Amatsu Dungeon Quest for both Pre-RE and RE.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
