### PR TITLE
Fix some printf overflow warnings

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -20939,7 +20939,7 @@ static void clif_cashshop_db(void)
 			struct config_setting_t *cat;
 			char entry_name[15];
 
-			sprintf(entry_name,"cat_%d",i);
+			snprintf(entry_name, sizeof(entry_name), "cat_%d", i);
 
 			if( (cat = libconfig->setting_get_member(cats, entry_name)) != NULL ) {
 				int k, item_count = libconfig->setting_length(cat);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -16453,15 +16453,15 @@ static BUILDIN(getinventorylist)
 			pc->setreg(sd, reference_uid(script->add_variable("@inventorylist_identify"), j), sd->status.inventory[i].identify);
 			pc->setreg(sd, reference_uid(script->add_variable("@inventorylist_attribute"), j), sd->status.inventory[i].attribute);
 			for (k = 0; k < MAX_SLOTS; k++) {
-				sprintf(script_var, "@inventorylist_card%d", k + 1);
+				snprintf(script_var, sizeof(script_var), "@inventorylist_card%d", k + 1);
 				pc->setreg(sd, reference_uid(script->add_variable(script_var), j), sd->status.inventory[i].card[k]);
 			}
 			for (k = 0; k < MAX_ITEM_OPTIONS; k++) {
-				sprintf(script_var, "@inventorylist_opt_id%d", k + 1);
+				snprintf(script_var, sizeof(script_var), "@inventorylist_opt_id%d", k + 1);
 				pc->setreg(sd, reference_uid(script->add_variable(script_var), j), sd->status.inventory[i].option[k].index);
-				sprintf(script_var, "@inventorylist_opt_val%d", k + 1);
+				snprintf(script_var, sizeof(script_var), "@inventorylist_opt_val%d", k + 1);
 				pc->setreg(sd, reference_uid(script->add_variable(script_var), j), sd->status.inventory[i].option[k].value);
-				sprintf(script_var, "@inventorylist_opt_param%d", k + 1);
+				snprintf(script_var, sizeof(script_var), "@inventorylist_opt_param%d", k + 1);
 				pc->setreg(sd, reference_uid(script->add_variable(script_var), j), sd->status.inventory[i].option[k].param);
 			}
 			pc->setreg(sd, reference_uid(script->add_variable("@inventorylist_expire"), j), sd->status.inventory[i].expire_time);
@@ -16493,15 +16493,15 @@ static BUILDIN(getcartinventorylist)
 			pc->setreg(sd,reference_uid(script->add_variable("@cartinventorylist_identify"), j),sd->status.cart[i].identify);
 			pc->setreg(sd,reference_uid(script->add_variable("@cartinventorylist_attribute"), j),sd->status.cart[i].attribute);
 			for (k = 0; k < MAX_SLOTS; k++) {
-				sprintf(card_var, "@cartinventorylist_card%d",k+1);
+				snprintf(card_var, sizeof(card_var), "@cartinventorylist_card%d",k+1);
 				pc->setreg(sd,reference_uid(script->add_variable(card_var), j),sd->status.cart[i].card[k]);
 			}
 			for (k = 0; k < MAX_ITEM_OPTIONS; k++) {
-				sprintf(card_var, "@cartinventorylist_opt_id%d", k + 1);
+				snprintf(card_var, sizeof(card_var), "@cartinventorylist_opt_id%d", k + 1);
 				pc->setreg(sd, reference_uid(script->add_variable(card_var), j), sd->status.cart[i].option[k].index);
-				sprintf(card_var, "@cartinventorylist_opt_val%d", k + 1);
+				snprintf(card_var, sizeof(card_var), "@cartinventorylist_opt_val%d", k + 1);
 				pc->setreg(sd, reference_uid(script->add_variable(card_var), j), sd->status.cart[i].option[k].value);
-				sprintf(card_var, "@cartinventorylist_opt_param%d", k + 1);
+				snprintf(card_var, sizeof(card_var), "@cartinventorylist_opt_param%d", k + 1);
 				pc->setreg(sd, reference_uid(script->add_variable(card_var), j), sd->status.cart[i].option[k].param);
 			}
 			pc->setreg(sd,reference_uid(script->add_variable("@cartinventorylist_expire"), j),sd->status.cart[i].expire_time);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Simply replace some `sprintf` with `snprintf`, keeping their destination array size. This removes a few warnings about possible overflows (which never happens in default configs).

**Issues addressed:** None, I think


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
