### PR TITLE
Actions CI adjustments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         # gcc, clang-8, clang-9 removed for reduce number of jobs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,11 @@ jobs:
           MYSQL_USER: 'ragnarok'
           MYSQL_PASSWORD: 'ragnarok'
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=3
     env:
       INSTALL_PACKAGES: ${{ matrix.CC }} mariadb-client libmariadbclient-dev-compat
       SQLHOST: mariadb

--- a/.github/workflows/clang15_test.yml
+++ b/.github/workflows/clang15_test.yml
@@ -35,7 +35,11 @@ jobs:
           MYSQL_USER: 'ragnarok'
           MYSQL_PASSWORD: 'ragnarok'
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=3
     env:
       INSTALL_PACKAGES: ${{ matrix.CC }} mariadb-client libmariadbclient-dev-compat
       SQLHOST: mariadb

--- a/.github/workflows/clang15_test.yml
+++ b/.github/workflows/clang15_test.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         CC: [clang-15]

--- a/.github/workflows/gcc_test.yml
+++ b/.github/workflows/gcc_test.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         CC: [gcc]

--- a/.github/workflows/gcc_test.yml
+++ b/.github/workflows/gcc_test.yml
@@ -35,7 +35,11 @@ jobs:
           MYSQL_USER: 'ragnarok'
           MYSQL_PASSWORD: 'ragnarok'
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=3
     env:
       INSTALL_PACKAGES: ${{ matrix.CC }} mariadb-client libmariadbclient-dev-compat
       SQLHOST: mariadb

--- a/.github/workflows/gccold1.yml
+++ b/.github/workflows/gccold1.yml
@@ -36,7 +36,11 @@ jobs:
           MYSQL_USER: 'ragnarok'
           MYSQL_PASSWORD: 'ragnarok'
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=3
     env:
       INSTALL_PACKAGES: ${{ matrix.CC }} mariadb-client libmariadbclient-dev-compat
       SQLHOST: mariadb

--- a/.github/workflows/gccold1.yml
+++ b/.github/workflows/gccold1.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         CC: ["gcc-10", "gcc-9"]

--- a/.github/workflows/gccold2.yml
+++ b/.github/workflows/gccold2.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         CC: ["gcc-8", "gcc-7"]

--- a/.github/workflows/gccold2.yml
+++ b/.github/workflows/gccold2.yml
@@ -36,7 +36,11 @@ jobs:
           MYSQL_USER: 'ragnarok'
           MYSQL_PASSWORD: 'ragnarok'
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=3
     env:
       INSTALL_PACKAGES: ${{ matrix.CC }} mariadb-client libmariadbclient-dev-compat
       SQLHOST: mariadb

--- a/.github/workflows/gccold3.yml
+++ b/.github/workflows/gccold3.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         CC: ["gcc-6", "gcc-5", "gcc-4.8"]

--- a/.github/workflows/gccold3.yml
+++ b/.github/workflows/gccold3.yml
@@ -37,7 +37,11 @@ jobs:
           MYSQL_USER: 'ragnarok'
           MYSQL_PASSWORD: 'ragnarok'
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=3
     env:
       INSTALL_PACKAGES: ${{ matrix.CC }} mariadb-client libmariadbclient-dev-compat
       SQLHOST: mariadb

--- a/.github/workflows/gccsnapshot_test.yml
+++ b/.github/workflows/gccsnapshot_test.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         CC: [gcc]

--- a/.github/workflows/gccsnapshot_test.yml
+++ b/.github/workflows/gccsnapshot_test.yml
@@ -35,7 +35,11 @@ jobs:
           MYSQL_USER: 'ragnarok'
           MYSQL_PASSWORD: 'ragnarok'
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=3
     env:
       INSTALL_PACKAGES: ${{ matrix.CC }} mariadb-client libmariadbclient-dev-compat
       SQLHOST: mariadb

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         CC: [gcc]

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -33,7 +33,11 @@ jobs:
           MYSQL_USER: 'ragnarok'
           MYSQL_PASSWORD: 'ragnarok'
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=2s
+          --health-retries=3
     env:
       INSTALL_PACKAGES: ${{ matrix.CC }} mariadb-client libmariadbclient-dev-compat
       SQLHOST: mysql

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         CC: [gcc]


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
1. Change healthcheck code for actions using MariaDB container.

the current approach of using `mysqladmin ping` is failing all the time, using the healtcheck script contained in the container image should be enough, since it ensures the instance is reachable

mysql containers still use mysqladmin ping (since healthcheck.sh is not available for them)

from my tests, the issue about failing due to unhealthy MariaDB is fixed. There is still the rare occurrence of one container failing in the overall step, but restarting the specific one works.



2. Add a 1 hour timeout to all jobs that runs hercules

After fixing MariaDB checks, I noticed that tests that starts/stops Hercules sometimes gets frozen and stays running until it reaches GitHub's default timeout (6 hours). Those jobs usually finish in 10 minutes, with a few exceptions that takes about 30 minutes.

I set their timeout to 1 hour, in case any of the tests end up locked they will fail in 1 hour instead of 6, saving a good amount of runner minutes.

Sample of it failling : https://github.com/guilherme-gm/Hercules/actions/runs/5502605147/jobs/10027096701


**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
