### PR TITLE
Fix hit bonus from BS_WEAPONRESEARCH being applied twice in pre-renewal

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -5108,9 +5108,12 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 
 		if( sd ) {
 			// Weaponry Research hidden bonus
+			// This condition is for renewal
+			// For pre-renewal hit rate bonus is in status.c
+#ifdef RENEWAL
 			if ((temp = pc->checkskill(sd,BS_WEAPONRESEARCH)) > 0)
 				hitrate += hitrate * ( 2 * temp ) / 100;
-
+#endif
 			if ((sd->weapontype == W_1HSWORD || sd->weapontype == W_DAGGER) && (temp = pc->checkskill(sd, GN_TRAINING_SWORD)) > 0)
 				hitrate += 3 * temp;
 		}

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2044,7 +2044,7 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 
 	// Absolute modifiers from passive skills
 #ifndef RENEWAL
-	if((skill_lv=pc->checkskill(sd,BS_WEAPONRESEARCH))>0) // is this correct in pre? there is already hitrate bonus in battle.c
+	if((skill_lv=pc->checkskill(sd,BS_WEAPONRESEARCH))>0)
 		bstatus->hit += skill_lv*2;
 #endif
 	if((skill_lv=pc->checkskill(sd,AC_VULTURE))>0) {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

This condition is for renewal

For the pre-renewal bonus hit, the rate bonus is already calculated in status.c

If both are active (battle.c and status.c), in pre-renewal it will give +20 HIT (this is BS_WEAPONRESEARCH pre-renewal behavior) first and then add +20% accuracy after the hit rate is determined (this is BS_WEAPONRESEARCH renewal behavior).

For the pre-renewal bonus hit, just use the bonus from status.c

Note: Sorry for the previous commit, I made a mess. That was my first commit to other people's project.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

- Add renewal if condition for BS_WEAPONRESEARCH HIT bonus in battle.c since it's for renewal

Based on this wiki
https://irowiki.org/classic/Weaponry_Research
https://irowiki.org/wiki/Weaponry_Research

The renewal uses a percentage (+20% accuracy after the hit rate determine) while the pre-renewal use fix HIT number (+20 HIT)

**Issues addressed:** <!-- Write here the issue number, if any. -->

- Fix hit bonus from BS_WEAPONRESEARCH being applied twice in pre-renewal

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
