### PR TITLE
Added toggle to allow venom dust to give experience points

### DIFF
--- a/conf/map/battle/battle.conf
+++ b/conf/map/battle/battle.conf
@@ -178,3 +178,7 @@ knockback_left: true
 // Should the target be able of dodging damage by snapping away to the edge of the screen?
 // Official behavior is false
 snap_dodge: false
+
+// Should Venom Dust give experience based on the amount of damage caused by its poison?
+// Official behavior is false
+venom_dust_exp: false

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7850,6 +7850,7 @@ static const struct config_data_old battle_data[] = {
 	{ "dynamic_npc_range",                  &battle_config.dynamic_npc_range,                 0,    0,      INT_MAX,        },
 	{ "features/goldpc/enable",             &battle_config.feature_goldpc_enable,             0,    0,      1,              },
 	{ "features/goldpc/default_mode",       &battle_config.feature_goldpc_default_mode,       1,    0,      INT_MAX,        },
+	{ "venom_dust_exp",                     &battle_config.venom_dust_exp,                    0,    0,      1,              },
 };
 
 static bool battle_set_value_sub(int index, int value)

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -648,6 +648,8 @@ struct Battle_Config {
 
 	int feature_goldpc_enable;
 	int feature_goldpc_default_mode;
+
+	int venom_dust_exp; // Enable exp given by venom dust
 };
 
 /* criteria for battle_config.idletime_criteria */

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -14158,8 +14158,8 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 			break;
 
 		case UNT_VENOMDUST:
-			if(tsc && !tsc->data[type])
-				status->change_start(ss, bl, type, 10000, sg->skill_lv, sg->group_id, 0, 0, skill->get_time2(sg->skill_id, sg->skill_lv), SCFLAG_NONE, skill_id);
+			if (tsc != NULL && tsc->data[type] == NULL)
+				status->change_start(ss, bl, type, 10000, sg->skill_lv, battle_config.venom_dust_exp != 0 ? sg->src_id : sg->group_id, 0, 0, skill->get_time2(sg->skill_id, sg->skill_lv), SCFLAG_NONE, skill_id);
 			break;
 
 		case UNT_MAGENTATRAP:


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Currently, the damage caused by the poison status inflicted by Venom Dust does not return experience points.
This seems to be the official behavior. This PR adds a toggle setting to allow Venom Dust to give experience.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3188 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
