### PR TITLE
Individually delete unavailable skills on status refresh

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -3475,7 +3475,7 @@ ACMD(lostskill)
 
 	sd->status.skill[index].lv = 0;
 	sd->status.skill[index].flag = 0;
-	clif->deleteskill(sd,skill_id);
+	clif->deleteskill(sd, skill_id, false);
 	clif->message(fd, msg_fd(fd,71)); // You have forgotten the skill.
 
 	return true;

--- a/src/map/chrif.c
+++ b/src/map/chrif.c
@@ -870,7 +870,7 @@ static void chrif_deadopt(int father_id, int mother_id, int child_id)
 		sd->status.skill[idx].id = 0;
 		sd->status.skill[idx].lv = 0;
 		sd->status.skill[idx].flag = 0;
-		clif->deleteskill(sd,WE_CALLBABY);
+		clif->deleteskill(sd, WE_CALLBABY, false);
 	}
 
 	if( mother_id && ( sd = map->charid2sd(mother_id) ) != NULL && sd->status.child == child_id ) {
@@ -878,7 +878,7 @@ static void chrif_deadopt(int father_id, int mother_id, int child_id)
 		sd->status.skill[idx].id = 0;
 		sd->status.skill[idx].lv = 0;
 		sd->status.skill[idx].flag = 0;
-		clif->deleteskill(sd,WE_CALLBABY);
+		clif->deleteskill(sd, WE_CALLBABY, false);
 	}
 
 }

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -5681,7 +5681,7 @@ static void clif_addskill(struct map_session_data *sd, int id)
 
 /// Deletes a skill from the skill tree (ZC_SKILLINFO_DELETE).
 /// 0441 <skill id>.W
-static void clif_deleteskill(struct map_session_data *sd, int id)
+static void clif_deleteskill(struct map_session_data *sd, int id, bool skip_infoblock)
 {
 #if PACKETVER >= 20081217
 	int fd;
@@ -5695,7 +5695,11 @@ static void clif_deleteskill(struct map_session_data *sd, int id)
 	WFIFOW(fd,2) = id;
 	WFIFOSET(fd,packet_len(0x441));
 #endif
-	clif->skillinfoblock(sd);
+
+#if PACKETVER_MAIN_NUM >= 20190807 || PACKETVER_RE_NUM >= 20190807 || PACKETVER_ZERO_NUM >= 20190918
+	if (!skip_infoblock)
+#endif
+		clif->skillinfoblock(sd);
 }
 
 /// Updates a skill in the skill tree (ZC_SKILLINFO_UPDATE).

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -1300,7 +1300,7 @@ struct clif_interface {
 	void (*skillup) (struct map_session_data *sd, uint16 skill_id, int skill_lv, int flag);
 	void (*skillinfo) (struct map_session_data *sd,int skill_id, int inf);
 	void (*addskill) (struct map_session_data *sd, int id);
-	void (*deleteskill) (struct map_session_data *sd, int id);
+	void (*deleteskill) (struct map_session_data *sd, int id, bool skip_infoblock);
 	void (*playerSkillToPacket) (struct map_session_data *sd, struct SKILLDATA *skillData, int skillId, int idx, bool newSkill);
 	/* party-specific */
 	void (*party_created) (struct map_session_data *sd,int result);

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -4323,7 +4323,7 @@ static int pc_skill(struct map_session_data *sd, int id, int level, int flag)
 			sd->status.skill[index].flag = SKILL_FLAG_PERMANENT;
 			if( level == 0 ) { //Remove skill.
 				sd->status.skill[index].id = 0;
-				clif->deleteskill(sd,id);
+				clif->deleteskill(sd, id, false);
 			} else
 				clif->addskill(sd,id);
 			if( !skill->dbs->db[index].inf ) //Only recalculate for passive skills.
@@ -4357,7 +4357,7 @@ static int pc_skill(struct map_session_data *sd, int id, int level, int flag)
 			sd->status.skill[index].flag = SKILL_FLAG_PERM_GRANTED;
 			if( level == 0 ) { //Remove skill.
 				sd->status.skill[index].id = 0;
-				clif->deleteskill(sd,id);
+				clif->deleteskill(sd, id, false);
 			} else
 				clif->addskill(sd,id);
 			if( !skill->dbs->db[index].inf ) //Only recalculate for passive skills.
@@ -9121,7 +9121,7 @@ static int pc_jobchange(struct map_session_data *sd, int class, int upper)
 			sd->status.skill[idx].id = 0;
 			sd->status.skill[idx].lv = 0;
 			sd->status.skill[idx].flag = 0;
-			clif->deleteskill(sd,sd->cloneskill_id);
+			clif->deleteskill(sd, sd->cloneskill_id, false);
 		}
 		sd->cloneskill_id = 0;
 		pc_setglobalreg(sd, script->add_variable("CLONE_SKILL"), 0);
@@ -9134,7 +9134,7 @@ static int pc_jobchange(struct map_session_data *sd, int class, int upper)
 			sd->status.skill[idx].id = 0;
 			sd->status.skill[idx].lv = 0;
 			sd->status.skill[idx].flag = 0;
-			clif->deleteskill(sd,sd->reproduceskill_id);
+			clif->deleteskill(sd, sd->reproduceskill_id, false);
 		}
 		sd->reproduceskill_id = 0;
 		pc_setglobalreg(sd, script->add_variable("REPRODUCE_SKILL"),0);
@@ -9205,10 +9205,6 @@ static int pc_jobchange(struct map_session_data *sd, int class, int upper)
 		clif->changelook(&sd->bl,LOOK_CLOTHES_COLOR,sd->vd.cloth_color);
 	if (sd->vd.body_style)
 		clif->changelook(&sd->bl,LOOK_BODY2,sd->vd.body_style);
-
-	//Update skill tree.
-	pc->calc_skilltree(sd);
-	clif->skillinfoblock(sd);
 
 	if (old_overhealweightrate != pc_overhealweightrate(sd))
 		clif->overweight_percent(sd);

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3661,7 +3661,7 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 					tsd->status.skill[idx].id = 0;
 					tsd->status.skill[idx].lv = 0;
 					tsd->status.skill[idx].flag = 0;
-					clif->deleteskill(tsd, tsd->cloneskill_id);
+					clif->deleteskill(tsd, tsd->cloneskill_id, false);
 				}
 			}
 
@@ -3686,7 +3686,7 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 					tsd->status.skill[idx].id = 0;
 					tsd->status.skill[idx].lv = 0;
 					tsd->status.skill[idx].flag = 0;
-					clif->deleteskill(tsd, tsd->reproduceskill_id);
+					clif->deleteskill(tsd, tsd->reproduceskill_id, false);
 				}
 			}
 			lv = min(lv, skill->get_max(copy_skill));

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2388,8 +2388,18 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 		calculating = 0;
 		return 0;
 	}
-	if(memcmp(b_skill,sd->status.skill,sizeof(sd->status.skill)))
+
+	if (memcmp(b_skill, sd->status.skill, sizeof(sd->status.skill))) {
+#if PACKETVER_MAIN_NUM >= 20190807 || PACKETVER_RE_NUM >= 20190807 || PACKETVER_ZERO_NUM >= 20190918
+		// Client doesn't delete unavailable skills even if we refresh
+		// the skill tree, individually delete them.
+		for (i = 0; i < MAX_SKILL_DB; i++) {
+			if (b_skill[i].id != 0 && sd->status.skill[i].id == 0)
+				clif->deleteskill(sd, b_skill[i].id, true);
+		}
+#endif
 		clif->skillinfoblock(sd);
+	}
 	if(b_weight != sd->weight)
 		clif->updatestatus(sd,SP_WEIGHT);
 	if(b_max_weight != sd->max_weight) {

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -1964,8 +1964,8 @@ typedef void (*HPMHOOK_pre_clif_skillinfo) (struct map_session_data **sd, int *s
 typedef void (*HPMHOOK_post_clif_skillinfo) (struct map_session_data *sd, int skill_id, int inf);
 typedef void (*HPMHOOK_pre_clif_addskill) (struct map_session_data **sd, int *id);
 typedef void (*HPMHOOK_post_clif_addskill) (struct map_session_data *sd, int id);
-typedef void (*HPMHOOK_pre_clif_deleteskill) (struct map_session_data **sd, int *id);
-typedef void (*HPMHOOK_post_clif_deleteskill) (struct map_session_data *sd, int id);
+typedef void (*HPMHOOK_pre_clif_deleteskill) (struct map_session_data **sd, int *id, bool *skip_infoblock);
+typedef void (*HPMHOOK_post_clif_deleteskill) (struct map_session_data *sd, int id, bool skip_infoblock);
 typedef void (*HPMHOOK_pre_clif_playerSkillToPacket) (struct map_session_data **sd, struct SKILLDATA **skillData, int *skillId, int *idx, bool *newSkill);
 typedef void (*HPMHOOK_post_clif_playerSkillToPacket) (struct map_session_data *sd, struct SKILLDATA *skillData, int skillId, int idx, bool newSkill);
 typedef void (*HPMHOOK_pre_clif_party_created) (struct map_session_data **sd, int *result);

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -17265,14 +17265,14 @@ void HP_clif_addskill(struct map_session_data *sd, int id) {
 	}
 	return;
 }
-void HP_clif_deleteskill(struct map_session_data *sd, int id) {
+void HP_clif_deleteskill(struct map_session_data *sd, int id, bool skip_infoblock) {
 	int hIndex = 0;
 	if (HPMHooks.count.HP_clif_deleteskill_pre > 0) {
-		void (*preHookFunc) (struct map_session_data **sd, int *id);
+		void (*preHookFunc) (struct map_session_data **sd, int *id, bool *skip_infoblock);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_deleteskill_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_clif_deleteskill_pre[hIndex].func;
-			preHookFunc(&sd, &id);
+			preHookFunc(&sd, &id, &skip_infoblock);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -17280,13 +17280,13 @@ void HP_clif_deleteskill(struct map_session_data *sd, int id) {
 		}
 	}
 	{
-		HPMHooks.source.clif.deleteskill(sd, id);
+		HPMHooks.source.clif.deleteskill(sd, id, skip_infoblock);
 	}
 	if (HPMHooks.count.HP_clif_deleteskill_post > 0) {
-		void (*postHookFunc) (struct map_session_data *sd, int id);
+		void (*postHookFunc) (struct map_session_data *sd, int id, bool skip_infoblock);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_deleteskill_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_clif_deleteskill_post[hIndex].func;
-			postHookFunc(sd, id);
+			postHookFunc(sd, id, skip_infoblock);
 		}
 	}
 	return;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Individually delete skills that are not available anymore yet the client still displays in the skill tree and the skillbar.
For example, equipping and unequiping a clip with a smokie card that grants the skill `hiding`.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3209


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
