### PR TITLE
2-2 jobs skill rebalance (Part 1) (2018 patch/Renewal) and small skill fixes

### DIFF
--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -6973,7 +6973,7 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: 1000
-	SkillData1: {
+	SkillData1: { // Chance to break target's armor (1 = 1%)
 		Lv1: 3
 		Lv2: 7
 		Lv3: 10
@@ -6985,7 +6985,7 @@ skill_db: (
 		Lv9: 13
 		Lv10: 13
 	}
-	SkillData2: 120000
+	SkillData2: 120000 // Bleeding duration (in milliseconds)
 	CoolDown: 0
 	Requirements: {
 		SPCost: 15

--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -6909,17 +6909,29 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: 1000
-	SkillData1: {
-		Lv1: 40000
-		Lv2: 45000
-		Lv3: 50000
-		Lv4: 55000
-		Lv5: 60000
-		Lv6: 65000
-		Lv7: 70000
-		Lv8: 75000
-		Lv9: 80000
-		Lv10: 85000
+	SkillData1: { // Fire unit duration (in milliseconds)
+		Lv1: 40_000
+		Lv2: 45_000
+		Lv3: 50_000
+		Lv4: 55_000
+		Lv5: 60_000
+		Lv6: 65_000
+		Lv7: 70_000
+		Lv8: 75_000
+		Lv9: 80_000
+		Lv10: 85_000
+	}
+	SkillData2: { // Chance to break enemy weapon (100 = 1%)
+		Lv1: 1_00
+		Lv2: 2_00
+		Lv3: 3_00
+		Lv4: 4_00
+		Lv5: 5_00
+		Lv6: 6_00
+		Lv7: 7_00
+		Lv8: 8_00
+		Lv9: 9_00
+		Lv10: 10_00
 	}
 	CoolDown: 0
 	Requirements: {

--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -6538,8 +6538,8 @@ skill_db: (
 		SplashArea: true
 	}
 	SplashRange: 1
-	SkillData1: 5000
-	SkillData2: 30000
+	SkillData1: 5_000 // Stun duration (in milliseconds)
+	SkillData2: 30_000 // Blind duration (in milliseconds)
 	CoolDown: 0
 	Requirements: {
 		SPCost: 20

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -6625,7 +6625,7 @@ skill_db: (
 	StatusChange: "SC_STUN"
 	Description: "Back Stab"
 	MaxLevel: 10
-	Range: -1
+	Range: 1
 	Hit: "BDT_SKILL"
 	SkillType: {
 		Enemy: true
@@ -6636,14 +6636,12 @@ skill_db: (
 	}
 	AttackType: "Weapon"
 	Element: "Ele_Weapon"
-	DamageType: {
-		IgnoreFlee: true
-	}
 	AfterCastActDelay: 500
-	SkillData1: 5000
+	SkillData1: 5_000 // Stun duration (in milliseconds)
+	CoolDown: 500
 	FixedCastTime: 0
 	Requirements: {
-		SPCost: 16
+		SPCost: 12
 	}
 },
 {

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -7129,17 +7129,29 @@ skill_db: (
 	InterruptCast: true
 	CastTime: 800
 	AfterCastActDelay: 500
-	SkillData1: {
-		Lv1: 40000
-		Lv2: 45000
-		Lv3: 50000
-		Lv4: 55000
-		Lv5: 60000
-		Lv6: 65000
-		Lv7: 70000
-		Lv8: 75000
-		Lv9: 80000
-		Lv10: 85000
+	SkillData1: { // Fire unit duration (in milliseconds)
+		Lv1: 40_000
+		Lv2: 45_000
+		Lv3: 50_000
+		Lv4: 55_000
+		Lv5: 60_000
+		Lv6: 65_000
+		Lv7: 70_000
+		Lv8: 75_000
+		Lv9: 80_000
+		Lv10: 85_000
+	}
+	SkillData2: { // Chance to break enemy weapon (100 = 1%)
+		Lv1: 1_00
+		Lv2: 2_00
+		Lv3: 3_00
+		Lv4: 4_00
+		Lv5: 5_00
+		Lv6: 6_00
+		Lv7: 7_00
+		Lv8: 8_00
+		Lv9: 9_00
+		Lv10: 10_00
 	}
 	FixedCastTime: 200
 	Requirements: {

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -7725,7 +7725,6 @@ skill_db: (
 		Self: true
 	}
 	SkillInfo: {
-		TargetSelf: true
 		AllowReproduce: true
 	}
 	AttackType: "Magic"
@@ -7735,23 +7734,24 @@ skill_db: (
 		IgnoreFlee: true
 	}
 	CastDefRate: 33
-	CastTime: 1500
-	AfterCastActDelay: 1500
+	CastTime: 1_000
+	CoolDown: 1_000
+	AfterCastActDelay: 500
 	AfterCastWalkDelay: 900
-	SkillData1: 900
-	SkillData2: {
-		Lv1: 10000
-		Lv2: 11000
-		Lv3: 12000
-		Lv4: 13000
-		Lv5: 14000
-		Lv6: 15000
-		Lv7: 16000
-		Lv8: 17000
-		Lv9: 18000
-		Lv10: 19000
+	SkillData1: 900 // Ground unit duration/ground effect duration (in milliseconds)
+	SkillData2: { // Duration of the blind effect (in milliseconds)
+		Lv1: 10_000
+		Lv2: 11_000
+		Lv3: 12_000
+		Lv4: 13_000
+		Lv5: 14_000
+		Lv6: 15_000
+		Lv7: 16_000
+		Lv8: 17_000
+		Lv9: 18_000
+		Lv10: 19_000
 	}
-	FixedCastTime: 1500
+	FixedCastTime: 500
 	Requirements: {
 		SPCost: {
 			Lv1: 37
@@ -32750,7 +32750,7 @@ skill_db: (
 		Lv9: 15
 		Lv10: 16
 	}
-	
+
 	SkillType: {
 		Enemy: true
 	}
@@ -33374,7 +33374,7 @@ skill_db: (
 	MaxLevel: 10
 	Hit: "BDT_MULTIHIT"
 	SkillType: {
-		Self: true 
+		Self: true
 	}
 	SkillInfo: {
 		Chorus: true

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -7194,19 +7194,19 @@ skill_db: (
 	InterruptCast: true
 	CastTime: 500
 	AfterCastActDelay: 500
-	SkillData1: {
-		Lv1: 3
-		Lv2: 7
-		Lv3: 10
-		Lv4: 12
-		Lv5: 13
-		Lv6: 13
-		Lv7: 13
-		Lv8: 13
-		Lv9: 13
-		Lv10: 13
+	SkillData1: { // Chance to break target's armor (1 = 1%)
+		Lv1: 5
+		Lv2: 15
+		Lv3: 25
+		Lv4: 35
+		Lv5: 45
+		Lv6: 45
+		Lv7: 45
+		Lv8: 45
+		Lv9: 45
+		Lv10: 45
 	}
-	SkillData2: 120000
+	SkillData2: 120_000 // Bleeding duration (in milliseconds)
 	FixedCastTime: 500
 	Requirements: {
 		SPCost: 15

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -6669,11 +6669,11 @@ skill_db: (
 		SplashArea: true
 	}
 	SplashRange: 3
-	SkillData1: 5000
-	SkillData2: 20000
+	SkillData1: 5_000 // Stun duration (in milliseconds)
+	SkillData2: 20_000 // Blind duration (in milliseconds)
 	FixedCastTime: 0
 	Requirements: {
-		SPCost: 20
+		SPCost: 15
 		State: "Hiding"
 	}
 },

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -7142,16 +7142,16 @@ skill_db: (
 		Lv10: 85_000
 	}
 	SkillData2: { // Chance to break enemy weapon (100 = 1%)
-		Lv1: 1_00
-		Lv2: 2_00
-		Lv3: 3_00
-		Lv4: 4_00
-		Lv5: 5_00
-		Lv6: 6_00
-		Lv7: 7_00
-		Lv8: 8_00
-		Lv9: 9_00
-		Lv10: 10_00
+		Lv1: 3_00
+		Lv2: 6_00
+		Lv3: 9_00
+		Lv4: 12_00
+		Lv5: 15_00
+		Lv6: 18_00
+		Lv7: 21_00
+		Lv8: 24_00
+		Lv9: 27_00
+		Lv10: 30_00
 	}
 	FixedCastTime: 200
 	Requirements: {

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -7178,7 +7178,7 @@ skill_db: (
 	Description: "Acid Terror"
 	MaxLevel: 5
 	Range: 9
-	Hit: "BDT_SKILL"
+	Hit: "BDT_MULTIHIT"
 	SkillType: {
 		Enemy: true
 	}
@@ -7191,6 +7191,7 @@ skill_db: (
 		IgnoreCards: true
 		IgnoreFlee: true
 	}
+	NumberOfHits: -5
 	InterruptCast: true
 	CastTime: 500
 	AfterCastActDelay: 500

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2179,7 +2179,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					break;
 				case RG_BACKSTAP:
 					if (sd != NULL && sd->weapontype == W_BOW && battle_config.backstab_bow_penalty)
-						skillratio += (200 + 40 * skill_lv) / 2;
+						skillratio += -100 + (300 + 40 * skill_lv) / 2;
 					else
 						skillratio += 200 + 40 * skill_lv;
 					break;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2184,7 +2184,11 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 						skillratio += 200 + 40 * skill_lv;
 					break;
 				case RG_RAID:
+#ifndef RENEWAL
 					skillratio += 40 * skill_lv;
+#else
+					skillratio += -50 + 150 * skill_lv;
+#endif
 					break;
 				case RG_INTIMIDATE:
 					skillratio += 30 * skill_lv;
@@ -3294,12 +3298,8 @@ static int64 battle_calc_damage(struct block_list *src, struct block_list *bl, s
 		}
 
 #ifdef RENEWAL
-		if( sc->data[SC_RAID] ) {
-			damage += damage * 20 / 100;
-
-			if (--sc->data[SC_RAID]->val1 == 0)
-				status_change_end(bl, SC_RAID, INVALID_TIMER);
-		}
+		if (sc->data[SC_RAID] != NULL)
+			damage += damage * sc->data[SC_RAID]->val2 / 100;
 #endif
 
 		if( damage ) {

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4799,6 +4799,11 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				break;
 
 #ifdef RENEWAL
+			case RG_BACKSTAP:
+				if (sd != NULL && sd->weapontype == W_DAGGER)
+					wd.div_ = 2;
+				break;
+
 			case KN_BOWLINGBASH:
 				wd.div_ = 2;
 
@@ -5163,6 +5168,11 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				if (sd != NULL && pc->checkskill(sd, AS_SONICACCEL) > 0)
 					hitpercbonus += 50;
 				break;
+#ifdef RENEWAL
+			case RG_BACKSTAP:
+				hitrate += 4 * skill_lv;
+				break;
+#endif
 			case MC_CARTREVOLUTION:
 			case GN_CART_TORNADO:
 			case GN_CARTCANNON:

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2230,7 +2230,10 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					break;
 				case AM_ACIDTERROR:
 #ifdef RENEWAL
-					skillratio += 80 * skill_lv + 100;
+					skillratio += -100 + 200 * skill_lv;
+
+					if (sd != NULL)
+						skillratio += 100 * pc->checkskill(sd, AM_LEARNINGPOTION);
 #else
 					skillratio += 40 * skill_lv;
 #endif
@@ -4848,7 +4851,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 #ifdef RENEWAL
 			case MO_EXTREMITYFIST:
 			case GS_PIERCINGSHOT:
-			case AM_ACIDTERROR:
 			case NJ_ISSEN:
 			case PA_SACRIFICE:
 			case KO_HAPPOKUNAI:
@@ -5490,23 +5492,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				} else
 					ATK_ADD(sstatus->rhw.atk2); //Else use Atk2
 				ATK_RATE(battle->calc_skillratio(BF_WEAPON, src, target, skill_id, skill_lv, skillratio, wflag));
-				break;
-			case AM_ACIDTERROR: // [malufett/Hercules]
-			{
-				int64 matk;
-				int totaldef = status->get_total_def(target) + status->get_total_mdef(target);
-				matk = battle->calc_cardfix(BF_MAGIC, src, target, nk, s_ele, 0, status->get_matk(src, 2), 0, wd.flag);
-				matk = battle->attr_fix(src, target, matk, ELE_NEUTRAL, tstatus->def_ele, tstatus->ele_lv);
-				matk = matk * battle->calc_skillratio(BF_WEAPON, src, target, skill_id, skill_lv, skillratio, wflag) / 100;
-				GET_NORMAL_ATTACK((sc && sc->data[SC_MAXIMIZEPOWER] ? 1 : 0) | (sc && sc->data[SC_WEAPONPERFECT] ? 8 : 0), 0);
-				ATK_RATE(battle->calc_skillratio(BF_WEAPON, src, target, skill_id, skill_lv, skillratio, wflag));
-				ATK_ADD(matk);
-				ATK_ADD(-totaldef);
-				if ( skill_id == AM_ACIDTERROR && is_boss(target) )
-					ATK_RATE(50);
-				if ( skill_id == AM_DEMONSTRATION )
-					wd.damage = max(wd.damage, 1);
-			}
 				break;
 			case GN_CARTCANNON:
 				GET_NORMAL_ATTACK((sc && sc->data[SC_MAXIMIZEPOWER] ? 1 : 0) | (sc && sc->data[SC_WEAPONPERFECT] ? 8 : 0), skill_id);

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2220,7 +2220,13 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					break;
 				}
 				case AM_DEMONSTRATION:
+#ifndef RENEWAL
 					skillratio += 20 * skill_lv;
+#else
+					skillratio += -100 + 60 * skill_lv;
+					if (sd != NULL)
+						skillratio += 10 * pc->checkskill(sd, AM_LEARNINGPOTION);
+#endif
 					break;
 				case AM_ACIDTERROR:
 #ifdef RENEWAL
@@ -4843,7 +4849,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 			case MO_EXTREMITYFIST:
 			case GS_PIERCINGSHOT:
 			case AM_ACIDTERROR:
-			case AM_DEMONSTRATION:
 			case NJ_ISSEN:
 			case PA_SACRIFICE:
 			case KO_HAPPOKUNAI:
@@ -5486,7 +5491,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 					ATK_ADD(sstatus->rhw.atk2); //Else use Atk2
 				ATK_RATE(battle->calc_skillratio(BF_WEAPON, src, target, skill_id, skill_lv, skillratio, wflag));
 				break;
-			case AM_DEMONSTRATION:
 			case AM_ACIDTERROR: // [malufett/Hercules]
 			{
 				int64 matk;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -4996,20 +4996,40 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 			status_change_end(src, SC_BLADESTOP, INVALID_TIMER);
 			break;
 
-		case RG_BACKSTAP:
-			{
-				enum unit_dir dir = map->calc_dir(src, bl->x, bl->y);
-				enum unit_dir t_dir = unit->getdir(bl);
-				if ((!check_distance_bl(src, bl, 0) && map->check_dir(dir, t_dir) == 0) || bl->type == BL_SKILL) {
-					status_change_end(src, SC_HIDING, INVALID_TIMER);
-					skill->attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag);
-					dir = unit_get_opposite_dir(dir); // change direction [Celest]
-					unit->set_dir(bl, dir);
-				}
-				else if (sd)
-					clif->skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0, 0);
+		case RG_BACKSTAP: {
+#ifndef RENEWAL
+			enum unit_dir dir = map->calc_dir(src, bl->x, bl->y);
+			enum unit_dir t_dir = unit->getdir(bl);
+			if ((!check_distance_bl(src, bl, 0) && map->check_dir(dir, t_dir) == 0) || bl->type == BL_SKILL) {
+				status_change_end(src, SC_HIDING, INVALID_TIMER);
+				skill->attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag);
+				dir = unit_get_opposite_dir(dir); // change direction [Celest]
+				unit->set_dir(bl, dir);
 			}
+			else if (sd)
+				clif->skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0, 0);
+#else
+			// Finds out where the unit will be after using the skill
+			enum unit_dir dir = map->calc_dir(src, bl->x, bl->y);
+			if (Assert_chk(dir >= UNIT_DIR_FIRST && dir < UNIT_DIR_MAX)) {
+				map->freeblock_unlock(); // unblock before assert-returning
+				return 0;
+			}
+
+			short x = bl->x + dirx[dir];
+			short y = bl->y + diry[dir];
+			if (unit->move_pos(src, x, y, 1, true) != 0) {
+				clif->skill_fail(sd, skill_id, USESKILL_FAIL_POS, 0, 0);
+				break;
+			}
+
+			clif->slide(src, x, y);
+			clif->fixpos(src);
+
+			skill->attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag);
+#endif
 			break;
+		}
 
 		case MO_FINGEROFFENSIVE:
 			skill->attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag);
@@ -5302,7 +5322,7 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 			} else {
 				sc_start(src, src, SC_NO_SWITCH_WEAPON, 100, 1, skill->get_time(skill_id, skill_lv), skill_id);
 				skill->area_temp[0] = map->foreachinrange(skill->area_sub, bl, skill->get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill->area_sub_count);
-				
+
 				// recursive invocation of skill->castend_damage_id() with flag|1
 				map->foreachinrange(skill->area_sub, bl, skill->get_splash(skill_id, skill_lv), skill->splash_target(src), src, skill_id, skill_lv, tick, flag | BCT_ENEMY | SD_SPLASH | 1, skill->castend_damage_id);
 			}
@@ -6407,13 +6427,15 @@ static int skill_castend_id(int tid, int64 tick, int id, intptr_t data)
 				break;
 		}
 
-		if(ud->skill_id == RG_BACKSTAP) {
+#ifndef RENEWAL
+		if (ud->skill_id == RG_BACKSTAP) {
 			enum unit_dir dir = map->calc_dir(src, target->x, target->y);
 			enum unit_dir t_dir = unit->getdir(target);
 			if (check_distance_bl(src, target, 0) || map->check_dir(dir, t_dir) != 0) {
 				break;
 			}
 		}
+#endif
 
 		if( ud->skill_id == PR_TURNUNDEAD ) {
 			struct status_data *tstatus = status->get_status_data(target);
@@ -10119,7 +10141,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 			int level = 0;
 			if (sd != NULL)
 				level = skill_id == AB_CLEMENTIA ? pc->checkskill(sd, AL_BLESSING) : pc->checkskill(sd, AL_INCAGI);
-			
+
 			if (sd == NULL || sd->status.party_id == 0 || flag & 1) {
 				clif->skill_nodamage(bl, bl, skill_id, skill_lv, sc_start(src, bl, type, 100, level, skill->get_time(skill_id, skill_lv), skill_id));
 			} else if (sd != NULL) {

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1798,7 +1798,7 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 
 		case AM_ACIDTERROR:
 			sc_start2(src, bl, SC_BLOODING, (skill_lv * 3), skill_lv, src->id, skill->get_time2(skill_id, skill_lv), skill_id);
-			if ( bl->type == BL_PC && rnd() % 1000 < 10 * skill->get_time(skill_id, skill_lv) ) {
+			if (bl->type == BL_PC && (rnd() % 1000) < (10 * skill->get_time(skill_id, skill_lv))) {
 				skill->break_equip(bl, EQP_ARMOR, 10000, BCT_ENEMY);
 				clif->emotion(bl, E_OMG); // emote icon still shows even there is no armor equip.
 			}

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1805,7 +1805,7 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 			break;
 
 		case AM_DEMONSTRATION:
-			skill->break_equip(bl, EQP_WEAPON, 100*skill_lv, BCT_ENEMY);
+			skill->break_equip(bl, EQP_WEAPON, skill->get_time2(skill_id, skill_lv), BCT_ENEMY);
 			break;
 
 		case CR_SHIELDCHARGE:

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1820,14 +1820,16 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 			sc_start(src, bl, SC_STUN, (10 + 3 * skill_lv), skill_lv, skill->get_time(skill_id, skill_lv), skill_id);
 			sc_start(src, bl, SC_BLIND, (10 + 3 * skill_lv), skill_lv, skill->get_time2(skill_id, skill_lv), skill_id);
 
-	#ifdef RENEWAL
-			sc_start(src, bl, SC_RAID, 100, 7, 5000, skill_id);
+#ifdef RENEWAL
+			sc_start(src, bl, SC_RAID, 100, 7, 10000, skill_id);
+#endif
 			break;
 
+#ifdef RENEWAL
 		case RG_BACKSTAP:
 			sc_start(src, bl, SC_STUN, (5 + 2 * skill_lv), skill_lv, skill->get_time(skill_id, skill_lv), skill_id);
-	#endif
 			break;
+#endif
 
 		case BA_FROSTJOKE:
 			sc_start(src, bl, SC_FREEZE, (15 + 5 * skill_lv), skill_lv, skill->get_time2(skill_id, skill_lv), skill_id);

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3699,8 +3699,10 @@ static int status_base_amotion_pc(struct map_session_data *sd, struct status_dat
 	temp = (float)(sqrt(temp) * 0.25f) + 0xc4;
 	if (sd->weapontype == W_BOOK && (skill_lv = pc->checkskill(sd, SA_ADVANCEDBOOK)) > 0)
 		val += (skill_lv - 1) / 2 + 1;
-	if ( (skill_lv = pc->checkskill(sd, GS_SINGLEACTION)) > 0 )
+	if ((skill_lv = pc->checkskill(sd, GS_SINGLEACTION)) > 0)
 		val += ((skill_lv + 1) / 2);
+	if ((skill_lv = pc->checkskill(sd, RG_PLAGIARISM)) > 0)
+		val += skill_lv;
 	amotion = ((int)(temp + ((float)(status->calc_aspd(&sd->bl, &sd->sc, 1) + val) * st->agi / 200)) - min(amotion, 200));
 #else
 	// base weapon delay

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -5510,6 +5510,8 @@ static short status_calc_aspd(struct block_list *bl, struct status_change *sc, s
 			bonus += 10;
 		if (sc->data[SC_ADRENALINE] != NULL)
 			bonus += 10;
+		if (sc->data[SC_SPEARQUICKEN] != NULL)
+			bonus += 10;
 #endif
 	}
 

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -989,7 +989,9 @@ static int status_check_skilluse(struct block_list *src, struct block_list *targ
 			switch (skill_id) { //Usable skills while hiding.
 				case TF_HIDING:
 				case AS_GRIMTOOTH:
+#ifndef RENEWAL
 				case RG_BACKSTAP:
+#endif
 				case RG_RAID:
 				case NJ_SHADOWJUMP:
 				case NJ_KIRIKAGE:

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7280,6 +7280,16 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 			}
 			if (total_tick == 1) return 1; //Minimal duration: Only strip without causing the SC
 			break;
+
+#ifdef RENEWAL
+		case SC_RAID:
+			if (bl->type == BL_MOB && is_boss(bl))
+				val2 = 15; // Receives 15% more damage
+			else
+				val2 = 30; // Receives 30% more damage
+			break;
+#endif
+
 		case SC_MER_FLEE:
 		case SC_MER_ATK:
 		case SC_MER_HP:


### PR DESCRIPTION
# Dependency
This PR depends on #3223 , all commits from #3223 are included in this one. The first commit original to this PR is:
> Rebalance of CR_GRANDCROSS (Grand Cross)


### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Draft Reason
This PR by itself is ready and I don't think there will be further changes, unless someone finds an issue or a review asks for some change.

BUT, the rebalance in main official servers came at once, so I believe the right thing to do is to merge this PR together with the rest of the rebalance (that will be in other PRs).

So I will keep this as draft for now, but feel free to give an early review :)


### Changes Proposed
The main purpose of this PR is to introduce the rebalance of part of the 2-2 jobs skills. This change affects Renewal-only.

On official servers this came along with rebalances of 1st, 2nd jobs and transclass too. I am working in additional PRs for the remaining 2-2, including bard/dancer, being in separate PRs in order to keep those PRs in a reasonable size.

The implementation in this PR is based on kRO and kRO zero patch notes, iRO Wiki, rAthena and divine pride info, along with some in-game testing. I can't say everything is 100% accurate because there were discrepancies between different sources, and I could not test everything in kRO, but should be quite close.

I won't list all the rebalance changes in the PR description, but it may be checked in each commit text. Also, the commits are in the same order as they appear in the references below.

**Affected jobs/skills**
- Crusader
  - CR_GRANDCROSS (Grand Cross) 
  - CR_SHIELDBOOMERANG (Shield Boomerang) 
  - CR_SPEARQUICKEN (Spear Quicken) 
- Alchemist
  - AM_DEMONSTRATION (Bomb) 
  - AM_ACIDTERROR (Acid Terror) 
- Rogue
  - RG_RAID (Sightless Mind) 
  - RG_BACKSTAP (Back Stab) 
  - RG_PLAGIARISM (Intimidate) 

References:
- [kRO 2018.10.31 patch note](https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=7033&curpage=21)
- [kRO 2018.11.28 patch note / translated](https://board.herc.ws/topic/17043-kro-patch-2018-11-28/)
- [Divine Pride](https://www.divine-pride.net/forum/index.php?/topic/3453-kro-mass-skills-balance-1st-2nd-and-transcendent-classes-skills/)

---

Additionally, there were 3 changes not related to the rebalance patch that is being applied in this PR (since it just appeared exactly where I was touching 😅 )

- **(Both)** Moved AM_DEMONSTRATION chance of breaking weapon to skill_db.conf
   - this simplified the rebalance patch, which gives new chances for renewal
- **(Both)** Fixed Rogue's Backstab bow damage
   - part of the damage was not being halved because it was in the default 100% ratio, now it properly halves the entire damage
- **(RE)** Fix the damage efect of AM_ACIDTERROR
   - In renewal, it shows a bundle of 5 hits instead of only 1. (I don't have info for pre-re, so I didn't change it)


---

Huge thanks to Asheraf and skyleo for helping me with some tests/validations of how it should work.


**Issues addressed:** <!-- Write here the issue number, if any. -->
Part of #2727 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
