### PR TITLE
Added option to synchronize flinch animation with walk delay

### DIFF
--- a/src/config/core.h
+++ b/src/config/core.h
@@ -100,6 +100,10 @@
 /// Uncomment for use with Nemo patch ExtendOldCashShopPreview
 //#define ENABLE_OLD_CASHSHOP_PREVIEW_PATCH
 
+/// Uncomment to allow flinch animation and walk delay to be synced
+/// Reduces positional lag when getting hit
+//#define WALKDELAY_SYNC
+
 /**
  * No settings past this point
  **/

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -350,7 +350,9 @@ static int battle_delay_damage(int64 tick, int amotion, struct block_list *src, 
 	if (src->type == BL_PC) {
 		BL_UCAST(BL_PC, src)->delayed_damage++;
 	}
-
+#ifdef WALKDELAY_SYNC
+	timer->add(tick + ddelay, unit->set_walkdelay_timer, target->id, ddelay);
+#endif
 	timer->add(tick+amotion, battle->delay_damage_sub, 0, (intptr_t)dat);
 
 	return 0;

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -5146,6 +5146,10 @@ static int clif_damage(struct block_list *src, struct block_list *dst, int sdela
 #endif
 
 	type = clif_calc_delay(type,div,damage+damage2,ddelay);
+#ifdef WALKDELAY_SYNC
+	// Send adjusted delay to client
+	ddelay = clif->calc_walkdelay(dst, ddelay, type, damage + damage2, div);
+#endif
 
 	p.PacketType = damageType;
 	p.GID = src->id;
@@ -5191,7 +5195,11 @@ static int clif_damage(struct block_list *src, struct block_list *dst, int sdela
 	}
 
 	//Return adjusted can't walk delay for further processing.
-	return clif->calc_walkdelay(dst,ddelay,type,damage+damage2,div);
+#ifdef WALKDELAY_SYNC
+	return ddelay;
+#else
+	return clif->calc_walkdelay(dst, ddelay, type, damage + damage2, div);
+#endif
 }
 
 /*==========================================

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -408,8 +408,10 @@ static int status_damage(struct block_list *src, struct block_list *target, int6
 
 	if (st->hp || (flag&8)) {
 		//Still lives or has been dead before this damage.
+#ifndef WALKDELAY_SYNC
 		if (walkdelay)
 			unit->set_walkdelay(target, timer->gettick(), walkdelay, 0);
+#endif
 		return (int)(hp+sp);
 	}
 

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1345,6 +1345,18 @@ static int unit_resume_running(int tid, int64 tick, int id, intptr_t data)
 
 }
 
+/*==========================================
+ * Apply walk delay timer
+ *------------------------------------------*/
+static int unit_set_walkdelay_timer(int tid, int64 tick, int id, intptr_t data)
+{
+	struct block_list* bl = map->id2bl(id);
+	if (bl == NULL)
+		return 1;
+
+	unit->set_walkdelay(bl, tick, (int)data, 0);
+	return 0;
+}
 
 /*==========================================
  * Applies walk delay to character, considering that
@@ -3236,6 +3248,7 @@ void unit_defaults(void)
 	unit->is_walking = unit_is_walking;
 	unit->can_move = unit_can_move;
 	unit->resume_running = unit_resume_running;
+	unit->set_walkdelay_timer = unit_set_walkdelay_timer;
 	unit->set_walkdelay = unit_set_walkdelay;
 	unit->skilluse_id2 = unit_skilluse_id2;
 	unit->skilluse_pos = unit_skilluse_pos;

--- a/src/map/unit.h
+++ b/src/map/unit.h
@@ -129,6 +129,7 @@ struct unit_interface {
 	int (*is_walking) (struct block_list *bl);
 	int (*can_move) (struct block_list *bl);
 	int (*resume_running) (int tid, int64 tick, int id, intptr_t data);
+	int (*set_walkdelay_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*set_walkdelay) (struct block_list *bl, int64 tick, int delay, int type);
 	int (*skilluse_id2) (struct block_list *src, int target_id, uint16 skill_id, uint16 skill_lv, int casttime, int castcancel);
 	int (*skilluse_pos) (struct block_list *src, short skill_x, short skill_y, uint16 skill_id, uint16 skill_lv);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -9596,6 +9596,8 @@ typedef int (*HPMHOOK_pre_unit_can_move) (struct block_list **bl);
 typedef int (*HPMHOOK_post_unit_can_move) (int retVal___, struct block_list *bl);
 typedef int (*HPMHOOK_pre_unit_resume_running) (int *tid, int64 *tick, int *id, intptr_t *data);
 typedef int (*HPMHOOK_post_unit_resume_running) (int retVal___, int tid, int64 tick, int id, intptr_t data);
+typedef int (*HPMHOOK_pre_unit_set_walkdelay_timer) (int *tid, int64 *tick, int *id, intptr_t *data);
+typedef int (*HPMHOOK_post_unit_set_walkdelay_timer) (int retVal___, int tid, int64 tick, int id, intptr_t data);
 typedef int (*HPMHOOK_pre_unit_set_walkdelay) (struct block_list **bl, int64 *tick, int *delay, int *type);
 typedef int (*HPMHOOK_post_unit_set_walkdelay) (int retVal___, struct block_list *bl, int64 tick, int delay, int type);
 typedef int (*HPMHOOK_pre_unit_skilluse_id2) (struct block_list **src, int *target_id, uint16 *skill_id, uint16 *skill_lv, int *casttime, int *castcancel);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -7494,6 +7494,8 @@ struct {
 	struct HPMHookPoint *HP_unit_can_move_post;
 	struct HPMHookPoint *HP_unit_resume_running_pre;
 	struct HPMHookPoint *HP_unit_resume_running_post;
+	struct HPMHookPoint *HP_unit_set_walkdelay_timer_pre;
+	struct HPMHookPoint *HP_unit_set_walkdelay_timer_post;
 	struct HPMHookPoint *HP_unit_set_walkdelay_pre;
 	struct HPMHookPoint *HP_unit_set_walkdelay_post;
 	struct HPMHookPoint *HP_unit_skilluse_id2_pre;
@@ -15025,6 +15027,8 @@ struct {
 	int HP_unit_can_move_post;
 	int HP_unit_resume_running_pre;
 	int HP_unit_resume_running_post;
+	int HP_unit_set_walkdelay_timer_pre;
+	int HP_unit_set_walkdelay_timer_post;
 	int HP_unit_set_walkdelay_pre;
 	int HP_unit_set_walkdelay_post;
 	int HP_unit_skilluse_id2_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -3835,6 +3835,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(unit->is_walking, HP_unit_is_walking) },
 	{ HP_POP(unit->can_move, HP_unit_can_move) },
 	{ HP_POP(unit->resume_running, HP_unit_resume_running) },
+	{ HP_POP(unit->set_walkdelay_timer, HP_unit_set_walkdelay_timer) },
 	{ HP_POP(unit->set_walkdelay, HP_unit_set_walkdelay) },
 	{ HP_POP(unit->skilluse_id2, HP_unit_skilluse_id2) },
 	{ HP_POP(unit->skilluse_pos, HP_unit_skilluse_pos) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -100199,6 +100199,33 @@ int HP_unit_resume_running(int tid, int64 tick, int id, intptr_t data) {
 	}
 	return retVal___;
 }
+int HP_unit_set_walkdelay_timer(int tid, int64 tick, int id, intptr_t data) {
+	int hIndex = 0;
+	int retVal___ = 0;
+	if (HPMHooks.count.HP_unit_set_walkdelay_timer_pre > 0) {
+		int (*preHookFunc) (int *tid, int64 *tick, int *id, intptr_t *data);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_unit_set_walkdelay_timer_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_unit_set_walkdelay_timer_pre[hIndex].func;
+			retVal___ = preHookFunc(&tid, &tick, &id, &data);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.unit.set_walkdelay_timer(tid, tick, id, data);
+	}
+	if (HPMHooks.count.HP_unit_set_walkdelay_timer_post > 0) {
+		int (*postHookFunc) (int retVal___, int tid, int64 tick, int id, intptr_t data);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_unit_set_walkdelay_timer_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_unit_set_walkdelay_timer_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, tid, tick, id, data);
+		}
+	}
+	return retVal___;
+}
 int HP_unit_set_walkdelay(struct block_list *bl, int64 tick, int delay, int type) {
 	int hIndex = 0;
 	int retVal___ = 0;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Currently, server iteration differs from client behavior when a target receives damage.
As of now, when a character is moving to X/Y and receives damage, clif_damage is invoked and the client reproduces the flinch animation shortly after, locking the character in place without reaching X/Y.
Server side the character is also stopped and a walk delay is applied, however the delay in which this happens is much larger than the one in the client, allowing the character to walk additional cells server side without the client being aware of this, causing positional lag and visual inconsistencies.
This change adds a macro option to apply the walk delay (and stopping the character) at a time relatively similar to the time the flinch animation is displayed client side.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
