### PR TITLE
Fixed AM_ACIDTERROR not ignoring def on units other than players

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1467,15 +1467,17 @@ static int64 battle_calc_defense(int attack_type, struct block_list *src, struct
 						def2 -= penalty;
 					}
 				}
-#ifndef RENEWAL
-				if (skill_id == AM_ACIDTERROR)
-					def1 = 0; // Acid Terror ignores only armor defense. [Skotlex]
-#endif
-				if (def1 < 0)
-					def1 = 0;
-				if (def2 < 1)
-					def2 = 1;
 			}
+
+#ifndef RENEWAL
+			if (skill_id == AM_ACIDTERROR)
+				def1 = 0; // Acid Terror ignores only armor defense. [Skotlex]
+#endif
+			if (def1 < 0)
+				def1 = 0;
+			if (def2 < 1)
+				def2 = 1;
+			
 			//Vitality reduction from rodatazone: http://rodatazone.simgaming.net/mechanics/substats.php#def
 			if (tsd) {
 				//Sd vit-eq


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Due to a coding bug in eathena, AM_ACIDTERROR only ignores defense on those target types defined in battle_config.vit_penalty_target.
This change makes AM_ACIDTERROR ignore defense regardless of this setting and target type.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
