### PR TITLE
Fixed MO_TRIPLEATTACK animation being suddenly reset

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -6582,11 +6582,11 @@ static enum damage_lv battle_weapon_attack(struct block_list *src, struct block_
 	if(sd && (skillv = pc->checkskill(sd,MO_TRIPLEATTACK)) > 0) {
 		int triple_rate= 30 - skillv; //Base Rate
 		if (sc && sc->data[SC_SKILLRATE_UP] && sc->data[SC_SKILLRATE_UP]->val1 == MO_TRIPLEATTACK) {
-			triple_rate+= triple_rate*(sc->data[SC_SKILLRATE_UP]->val2)/100;
+			triple_rate += triple_rate * (sc->data[SC_SKILLRATE_UP]->val2) /100;
 			status_change_end(src, SC_SKILLRATE_UP, INVALID_TIMER);
 		}
-		if (rnd()%100 < triple_rate) {
-			if( skill->attack(BF_WEAPON,src,src,target,MO_TRIPLEATTACK,skillv,tick,0) )
+		if (rnd() % 100 < triple_rate) {
+			if (skill->attack(BF_WEAPON, src, src, target, MO_TRIPLEATTACK, skillv, tick, 0))
 				return ATK_DEF;
 			return ATK_MISS;
 		}


### PR DESCRIPTION
Fixed MO_TRIPLEATTACK not applying delay
Fixed Monk combo's delay formula

<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
This PR fixes the following incorrect behavior:
- Monk's triple attack not displaying the attack animation correctly.
- Monk's triple attack not applying any kind of delay.
- Monk's combo delay formula increasing delay with dex instead of decreasing it.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
