### PR TITLE
Fix snap_dodge setting not working for MO_EXTREMITYFIST

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -269,11 +269,10 @@ static int battle_delay_damage_sub(int tid, int64 tick, int id, intptr_t data)
 		if (target != NULL && !status->isdead(target)) {
 			//Check to see if you haven't teleported. [Skotlex]
 			if (src != NULL && (
-			    battle_config.fix_warp_hit_delay_abuse ?
-			    (dat->skill_id == MO_EXTREMITYFIST || target->m != src->m || check_distance_bl(src, target, dat->distance))
-			    :
-			    ((target->type != BL_PC || BL_UCAST(BL_PC, target)->invincible_timer == INVALID_TIMER)
-			    && (dat->skill_id == MO_EXTREMITYFIST || (target->m == src->m && check_distance_bl(src, target, dat->distance))))
+				(dat->skill_id == MO_EXTREMITYFIST && (target->m != src->m || !battle_config.snap_dodge)) // Extremity fist always hits
+				|| (battle_config.fix_warp_hit_delay_abuse && target->m != src->m)
+				|| ((target->type != BL_PC || BL_UCAST(BL_PC, target)->invincible_timer == INVALID_TIMER)
+					&& (target->m == src->m && check_distance_bl(src, target, dat->distance)))
 			)) {
 				map->freeblock_lock();
 				status_fix_damage(src, target, dat->damage, dat->delay);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Restore snap_dodge functionality when dealing with extremity fist.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#638 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
