### PR TITLE
Added config option to keep direction for free cells

### DIFF
--- a/conf/map/battle/misc.conf
+++ b/conf/map/battle/misc.conf
@@ -117,6 +117,12 @@ duel_only_on_same_map: false
 official_cell_stack_limit: 1
 custom_cell_stack_limit: 1
 
+// Take into consideration the character's walking direction when searching for free cells?
+// Set this to "true" to start searching for free cells in the same direction as the character came from
+// Set this to "false" to always start searching from EAST (official behavior)
+// Note: This setting also makes groups of mobs disperse in circular fashion instead of linear
+keep_dir_free_cell: false
+
 // Check occupied cells while walking? (Note 1)
 check_occupied_cells: true
 

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7573,6 +7573,7 @@ static const struct config_data_old battle_data[] = {
 	{ "official_cell_stack_limit",          &battle_config.official_cell_stack_limit,       1,      0,      255,            },
 	{ "custom_cell_stack_limit",            &battle_config.custom_cell_stack_limit,         1,      1,      255,            },
 	{ "dancing_weaponswitch_fix",           &battle_config.dancing_weaponswitch_fix,        1,      0,      1,              },
+	{ "keep_dir_free_cell",                 &battle_config.keep_dir_free_cell,              0,      0,      1,              },
 	{ "check_occupied_cells",               &battle_config.check_occupied_cells,            1,      0,      1,              },
 
 // eAthena additions

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -359,6 +359,7 @@ struct Battle_Config {
 	int bone_drop;
 	int buyer_name;
 	int dancing_weaponswitch_fix;
+	int keep_dir_free_cell;
 
 	// eAthena additions
 	int night_at_start; // added by [Yor]

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11831,9 +11831,14 @@ static void clif_parse_WalkToXY(int fd, struct map_session_data *sd)
 	if(sd->sc.data[SC_RUN] || sd->sc.data[SC_WUGDASH])
 		return;
 
-	pc->delinvincibletimer(sd);
+	RFIFOPOS(fd, packet_db[RFIFOW(fd, 0)].pos[0], &x, &y, NULL);
 
-	RFIFOPOS(fd, packet_db[RFIFOW(fd,0)].pos[0], &x, &y, NULL);
+	// Do not allow one cell move commands if the target cell is not free
+	if (battle_config.official_cell_stack_limit > 0
+		&& check_distance_blxy(&sd->bl, x, y, 1) && map->count_oncell(sd->bl.m, x, y, BL_CHAR | BL_NPC, 1))
+		return;
+
+	pc->delinvincibletimer(sd);
 
 	//Set last idle time... [Skotlex]
 	pc->update_idle_time(sd, BCIDLE_WALK);

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -1749,7 +1749,7 @@ static int map_search_free_cell(struct block_list *src, int16 m, int16 *x, int16
  *------------------------------------------*/
 static bool map_closest_freecell(int16 m, const struct block_list *bl, int16 *x, int16 *y, int type, int flag)
 {
-	enum unit_dir dir = UNIT_DIR_EAST;
+	enum unit_dir dir = battle_config.keep_dir_free_cell ? unit->getdir(bl) : UNIT_DIR_EAST;
 	int16 tx;
 	int16 ty;
 	int costrange = 10;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Added configuration option `keep_dir_free_cell`. Although it is set to false, I would like it to be enabled by default in Hercules.
This option allows discovery of free cells based on the unit's current facing direction instead of always using EAST, which have the following advantages:
- Improves distribution of mobs when dispersing after being grouped. This setting allows monsters to spread in a circular fashion instead of forming a long horizontal line.
- Allows characters to move more naturally if they came from the east, instead of walking back.
- In some instances, fixes issue #1241 allowing the user to obtain the item.

This commit also fixes #1241 in all scenarios not allowing the character to enter a walk loop. Fix based on rAthena's.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#1241 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
