### PR TITLE
Disable attaching scripts to characters in autotrade

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -14418,15 +14418,21 @@ static void script_detach_rid(struct script_state *st)
 static BUILDIN(attachrid)
 {
 	int rid = script_getnum(st,2);
+	struct map_session_data *sd = map->id2sd(rid);
 
-	if (map->id2sd(rid) != NULL) {
+	if (sd != NULL) {
+		if (sd->state.autotrade) {
+			ShowError("buildin_attachrid: Cannot attach script to character in autotrade\n");
+			script_pushint(st, 0);
+			return false;
+		}
 		script->detach_rid(st);
 
 		st->rid = rid;
 		script->attach_state(st);
-		script_pushint(st,1);
+		script_pushint(st, 1);
 	} else
-		script_pushint(st,0);
+		script_pushint(st, 0);
 	return true;
 }
 /*==========================================


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Disallow using the command attachrid with RIDs from characters in autotrade, as the stack is empty and may crash the server.
Additionally, inform the user of what went wrong when trying to attach such RID.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#568 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
