### PR TITLE
Increased ASC_BREAKER range from 7 to 9 cells

### DIFF
--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -11592,7 +11592,7 @@ skill_db: (
 	Name: "ASC_BREAKER"
 	Description: "Soul Destroyer"
 	MaxLevel: 10
-	Range: 7
+	Range: 9
 	Hit: "BDT_SKILL"
 	SkillType: {
 		Enemy: true
@@ -11603,7 +11603,7 @@ skill_db: (
 		IgnoreCards: true
 	}
 	InterruptCast: true
-	CastTime: 700
+	CastTime: 500
 	AfterCastActDelay: {
 		Lv1: 1000
 		Lv2: 1200

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -11917,7 +11917,7 @@ skill_db: (
 	Name: "ASC_BREAKER"
 	Description: "Soul Destroyer"
 	MaxLevel: 10
-	Range: 7
+	Range: 9
 	Hit: "BDT_SKILL"
 	SkillType: {
 		Enemy: true


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
<!-- Describe the changes that this pull request makes. -->
As expressed on the linked issue, the correct range for Soul Breaker/Destroyer is 9 cells instead of 7 cells for pre-re.
Gravity with its 2020 skill overhaul reduced this range in renewal to 4 cells. However, Hercules is not at that episode yet, so I've decided it's better to stay at 9 cells for renewal too.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#1104 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
