### PR TITLE
Update grfio to work with big grf's on windows

### DIFF
--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -584,6 +584,24 @@ size_t hwrite(const void *ptr, size_t size, size_t count, FILE *stream)
 	return fwrite(ptr, size, count, stream);
 }
 
+int64 htell(FILE *stream)
+{
+#ifdef WIN32
+	return _ftelli64(stream);
+#else
+	return ftell(stream);
+#endif
+}
+
+int hseek(FILE *stream, int64 offset, int origin)
+{
+#ifdef WIN32
+	return _fseeki64(stream, offset, origin);
+#else
+	return fseek(stream, offset, origin);
+#endif
+}
+
 void HCache_defaults(void)
 {
 	HCache = &HCache_s;

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -81,6 +81,8 @@ extern float GetFloat(const unsigned char* buf);
 
 size_t hread(void * ptr, size_t size, size_t count, FILE * stream);
 size_t hwrite(const void * ptr, size_t size, size_t count, FILE * stream);
+int64 htell(FILE *stream);
+int hseek(FILE *stream, int64 offset, int origin);
 #endif // HERCULES_CORE
 
 #ifdef WIN32


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Adding wrappers for some file operation functions to support long offsets on windows.
I tested this by rebuilding the mapcache using kRO's 3.6GB GRF file, worked fine on both win and debian linux.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

#2935 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
