### PR TITLE
Fixed foods and cash foods being applied simultaneously

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7203,28 +7203,59 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 			if( bl->type != BL_MER )
 				return 0; // Stats only for Mercenaries
 			break;
+		// Normal foods can't overwrite cash foods, and cash foods only overwrite those of equal or lower level
 		case SC_FOOD_STR:
-			if (sc->data[SC_FOOD_STR_CASH] && sc->data[SC_FOOD_STR_CASH]->val1 > val1)
+			if (sc->data[SC_FOOD_STR_CASH] != NULL)
+				return 0;
+			FALLTHROUGH
+		case SC_FOOD_STR_CASH:
+			if ((sc->data[SC_FOOD_STR_CASH] != NULL && sc->data[SC_FOOD_STR_CASH]->val1 > val1)
+				|| (sc->data[SC_FOOD_STR] != NULL && sc->data[SC_FOOD_STR]->val1 > val1))
 				return 0;
 			break;
 		case SC_FOOD_AGI:
-			if (sc->data[SC_FOOD_AGI_CASH] && sc->data[SC_FOOD_AGI_CASH]->val1 > val1)
+			if (sc->data[SC_FOOD_AGI_CASH] != NULL)
+				return 0;
+			FALLTHROUGH
+		case SC_FOOD_AGI_CASH:
+			if ((sc->data[SC_FOOD_AGI_CASH] != NULL && sc->data[SC_FOOD_AGI_CASH]->val1 > val1)
+				|| (sc->data[SC_FOOD_AGI] != NULL && sc->data[SC_FOOD_AGI]->val1 > val1))
 				return 0;
 			break;
 		case SC_FOOD_VIT:
-			if (sc->data[SC_FOOD_VIT_CASH] && sc->data[SC_FOOD_VIT_CASH]->val1 > val1)
+			if (sc->data[SC_FOOD_VIT_CASH] != NULL)
+				return 0;
+			FALLTHROUGH
+		case SC_FOOD_VIT_CASH:
+			if ((sc->data[SC_FOOD_VIT_CASH] != NULL && sc->data[SC_FOOD_VIT_CASH]->val1 > val1)
+				|| (sc->data[SC_FOOD_VIT] != NULL && sc->data[SC_FOOD_VIT]->val1 > val1))
 				return 0;
 			break;
 		case SC_FOOD_INT:
-			if (sc->data[SC_FOOD_INT_CASH] && sc->data[SC_FOOD_INT_CASH]->val1 > val1)
+			if (sc->data[SC_FOOD_INT_CASH] != NULL)
+				return 0;
+			FALLTHROUGH
+		case SC_FOOD_INT_CASH:
+			if ((sc->data[SC_FOOD_INT_CASH] != NULL && sc->data[SC_FOOD_INT_CASH]->val1 > val1)
+				|| (sc->data[SC_FOOD_INT] != NULL && sc->data[SC_FOOD_INT]->val1 > val1))
 				return 0;
 			break;
 		case SC_FOOD_DEX:
-			if (sc->data[SC_FOOD_DEX_CASH] && sc->data[SC_FOOD_DEX_CASH]->val1 > val1)
+			if (sc->data[SC_FOOD_DEX_CASH] != NULL)
+				return 0;
+			FALLTHROUGH
+		case SC_FOOD_DEX_CASH:
+			if ((sc->data[SC_FOOD_DEX_CASH] != NULL && sc->data[SC_FOOD_DEX_CASH]->val1 > val1)
+				|| (sc->data[SC_FOOD_DEX] != NULL && sc->data[SC_FOOD_DEX]->val1 > val1))
 				return 0;
 			break;
 		case SC_FOOD_LUK:
-			if (sc->data[SC_FOOD_LUK_CASH] && sc->data[SC_FOOD_LUK_CASH]->val1 > val1)
+			if (sc->data[SC_FOOD_LUK_CASH] != NULL)
+				return 0;
+			FALLTHROUGH
+		case SC_FOOD_LUK_CASH:
+			if ((sc->data[SC_FOOD_LUK_CASH] != NULL && sc->data[SC_FOOD_LUK_CASH]->val1 > val1)
+				|| (sc->data[SC_FOOD_LUK] != NULL && sc->data[SC_FOOD_LUK]->val1 > val1))
 				return 0;
 			break;
 		case SC_CAMOUFLAGE:


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Fixes stat foods and stat cash foods being applied simultaneously and stacked one in top of the other. Also, only cash foods can overwrite normal foods (and not the other way around) according to @Kenpachi2k13 in this old PR #2741 

In addition, being the lesser evil, in this PR cash foods will overwrite the same type of food if the level is also the same. However, according to this comment in the aforementioned PR, cash foods should only overwrite stat foods if the effect is stronger, not equal. **Please, let me know if I should respect the quoted behavior and not let foods be overwriten by foods of equal level.**
> Also the the old effect will only be canceled if the new one is stronger. Using +1 STR cash food won't cancel +1 STR normal food.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#2489

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
