### PR TITLE
Fix crit not always being 0.33 crit per luk but 0.3 in some cases

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3201,7 +3201,9 @@ static void status_calc_bl_main(struct block_list *bl, /*enum scb_flag*/int flag
 		if (st->luk == bst->luk) {
 			st->cri = status->calc_critical(bl, sc, bst->cri, true);
 		} else {
-			st->cri = status->calc_critical(bl, sc, bst->cri + 3*(st->luk - bst->luk), true);
+			// supposedly for Renewal some say it might be 0.3 crit per luk instead of 0.33 crit per luk as here.
+			// The behavior here is also identical to episode 14.0, can't verify this for later versions of Aegis.
+			st->cri = status->calc_critical(bl, sc, bst->cri - (bst->luk * 10 / 3) + (st->luk * 10 / 3), true);
 		}
 		if (battle_config.show_katar_crit_bonus && bl->type == BL_PC && BL_UCAST(BL_PC, bl)->weapontype == W_KATAR) {
 			st->cri *= 2;
@@ -3860,7 +3862,7 @@ static void status_calc_misc(struct block_list *bl, struct status_data *st, int 
 #endif // RENEWAL
 
 	if ( bl->type&battle_config.enable_critical )
-		st->cri += 10 + (st->luk * 10 / 3); //(every 1 luk = +0.3 critical)
+		st->cri += 10 + (st->luk * 10 / 3); // (every 1 luk = +0.33 critical -> 3 luk = +1 critical)
 	else
 		st->cri = 0;
 


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Always let 1 luk be 0.33 crit (meaning 3 luk = 1 crit) just like on officials.

Basically when luk changed due to status effects such as Gloria and other cases, the crit difference was calculated via 0.3 crit per luk instead of 0.33.

Also only adding the difference on top can result in edge cases where integer arithmetic will round down to less than one should get, to prevent this we remove the old luk from our current crit first and recalculate with the new luk.

Verified in pre-re 11.2 and re 14.0

Inspired by https://github.com/rathena/rathena/pull/7938

**Issues addressed:** https://github.com/HerculesWS/Hercules/issues/3094


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
