### PR TITLE
Fixes to Blade Stop (Root) trigger

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1479,7 +1479,7 @@ static int64 battle_calc_defense(int attack_type, struct block_list *src, struct
 				def1 = 0;
 			if (def2 < 1)
 				def2 = 1;
-			
+
 			//Vitality reduction from rodatazone: http://rodatazone.simgaming.net/mechanics/substats.php#def
 			if (tsd) {
 				//Sd vit-eq
@@ -6518,19 +6518,18 @@ static bool battle_should_bladestop_attacker(struct block_list *attacker, struct
 	if (is_boss(attacker))
 		return false; // Boss monsters are not affected
 
-	// CHECKME: Is that right?
+#ifndef RENEWAL
 	if (attacker->type == BL_PC)
-		return true; // Player gets into BladeStop regardless of distance
+		return true; // In Pre-RE (Ep 11.2), player attackers are BladeStopped regardless of the distance
+#endif
 
-	struct map_session_data *tsd = BL_CAST(BL_PC, target);
-	if (tsd != NULL) {
-		int max_distance = tsd->weapontype == W_FIST ? 1 : 2;
-		return distance_bl(attacker, target) <= max_distance;
+	if (target->type != BL_PC) {
+		// Non-player targets causes BladeStop regardless of distance (Hercules-custom).
+		// Officially, non-player units does not use Blade Stop.
+		return true;
 	}
 
-	// CHECKME: Is that right?
-	// Target is not a player. BladeStop starts regardless of distance
-	return true;
+	return (distance_bl(attacker, target) <= 2);
 }
 
 /*==========================================

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -707,6 +707,8 @@ struct battle_interface {
 	int64 (*calc_bg_damage) (struct block_list *src, struct block_list *bl, int64 damage, int div_, uint16 skill_id, uint16 skill_lv, int flag);
 	/* normal weapon attack */
 	enum damage_lv (*weapon_attack) (struct block_list *bl, struct block_list *target, int64 tick, int flag);
+	/* returns whether bladestop should start for attacker/target */
+	bool (*should_bladestop_attacker) (struct block_list *src, struct block_list *target);
 	/* check is equipped ammo and this ammo allowed */
 	bool (*check_arrows) (struct map_session_data *sd);
 	/* calculate weapon attack */

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -464,6 +464,8 @@ typedef int64 (*HPMHOOK_pre_battle_calc_bg_damage) (struct block_list **src, str
 typedef int64 (*HPMHOOK_post_battle_calc_bg_damage) (int64 retVal___, struct block_list *src, struct block_list *bl, int64 damage, int div_, uint16 skill_id, uint16 skill_lv, int flag);
 typedef enum damage_lv (*HPMHOOK_pre_battle_weapon_attack) (struct block_list **bl, struct block_list **target, int64 *tick, int *flag);
 typedef enum damage_lv (*HPMHOOK_post_battle_weapon_attack) (enum damage_lv retVal___, struct block_list *bl, struct block_list *target, int64 tick, int flag);
+typedef bool (*HPMHOOK_pre_battle_should_bladestop_attacker) (struct block_list **src, struct block_list **target);
+typedef bool (*HPMHOOK_post_battle_should_bladestop_attacker) (bool retVal___, struct block_list *src, struct block_list *target);
 typedef bool (*HPMHOOK_pre_battle_check_arrows) (struct map_session_data **sd);
 typedef bool (*HPMHOOK_post_battle_check_arrows) (bool retVal___, struct map_session_data *sd);
 typedef struct Damage (*HPMHOOK_pre_battle_calc_weapon_attack) (struct block_list **src, struct block_list **target, uint16 *skill_id, uint16 *skill_lv, int *wflag);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -230,6 +230,8 @@ struct {
 	struct HPMHookPoint *HP_battle_calc_bg_damage_post;
 	struct HPMHookPoint *HP_battle_weapon_attack_pre;
 	struct HPMHookPoint *HP_battle_weapon_attack_post;
+	struct HPMHookPoint *HP_battle_should_bladestop_attacker_pre;
+	struct HPMHookPoint *HP_battle_should_bladestop_attacker_post;
 	struct HPMHookPoint *HP_battle_check_arrows_pre;
 	struct HPMHookPoint *HP_battle_check_arrows_post;
 	struct HPMHookPoint *HP_battle_calc_weapon_attack_pre;
@@ -7783,6 +7785,8 @@ struct {
 	int HP_battle_calc_bg_damage_post;
 	int HP_battle_weapon_attack_pre;
 	int HP_battle_weapon_attack_post;
+	int HP_battle_should_bladestop_attacker_pre;
+	int HP_battle_should_bladestop_attacker_post;
 	int HP_battle_check_arrows_pre;
 	int HP_battle_check_arrows_post;
 	int HP_battle_calc_weapon_attack_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -133,6 +133,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(battle->calc_gvg_damage, HP_battle_calc_gvg_damage) },
 	{ HP_POP(battle->calc_bg_damage, HP_battle_calc_bg_damage) },
 	{ HP_POP(battle->weapon_attack, HP_battle_weapon_attack) },
+	{ HP_POP(battle->should_bladestop_attacker, HP_battle_should_bladestop_attacker) },
 	{ HP_POP(battle->check_arrows, HP_battle_check_arrows) },
 	{ HP_POP(battle->calc_weapon_attack, HP_battle_calc_weapon_attack) },
 	{ HP_POP(battle->delay_damage, HP_battle_delay_damage) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -2780,6 +2780,33 @@ enum damage_lv HP_battle_weapon_attack(struct block_list *bl, struct block_list 
 	}
 	return retVal___;
 }
+bool HP_battle_should_bladestop_attacker(struct block_list *src, struct block_list *target) {
+	int hIndex = 0;
+	bool retVal___ = false;
+	if (HPMHooks.count.HP_battle_should_bladestop_attacker_pre > 0) {
+		bool (*preHookFunc) (struct block_list **src, struct block_list **target);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_battle_should_bladestop_attacker_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_battle_should_bladestop_attacker_pre[hIndex].func;
+			retVal___ = preHookFunc(&src, &target);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.battle.should_bladestop_attacker(src, target);
+	}
+	if (HPMHooks.count.HP_battle_should_bladestop_attacker_post > 0) {
+		bool (*postHookFunc) (bool retVal___, struct block_list *src, struct block_list *target);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_battle_should_bladestop_attacker_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_battle_should_bladestop_attacker_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, src, target);
+		}
+	}
+	return retVal___;
+}
 bool HP_battle_check_arrows(struct map_session_data *sd) {
 	int hIndex = 0;
 	bool retVal___ = false;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Extract the conditions to start SC_BLADESTOP to its own function, since it has several conditions, and with the rebalance (#3253), more RE/Pre-RE differences.

And also fixes some mistakes in the logic, making it closer to official behavior. This affects both Pre-RE and RE.

Changes:
1. The target's equipped weapon no longer affects the range of Blade Stop. This applies for both Pre-RE and RE. In current code, a bare-handed monk would only blade-stop targets 1-cell away
2. Player attackers are only blade stopped from far away (> 2 cells) in Pre-RE -- My tests in renewal showed that a Hunter will only get blade-stopped if they are up to 2 cells away from the Monk.

Discussion here: https://github.com/HerculesWS/Hercules/pull/3253#discussion_r1394281487 . Copying skyleo findings:
```
So yeah, if attacker player and attacking bladestopped player -> no extra range check(still needs to be in attack range of course). if attacking mob -> no bladestop check

If attacker mob or anything else non-player and attacking bladestopped anything -> range check of 2 

In Aegis 11.2 the code is written in a way that it assumes that mobs cannot use Bladestop, so when someone is in Bladestop there is code that assumes that someone is a player, without checking if it's player type.
```

Huge thanks to skyleo for helping with Pre-RE validation.

**This change is NOT related to the rebalance of classes made in RE.**

**Issues addressed:** None, I think


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
