### PR TITLE
Fix sc counters not being reset when a mob unit dies

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -10596,7 +10596,19 @@ static int status_change_clear(struct block_list *bl, int type)
 
 	sc = status->get_sc(bl);
 
-	if (!sc || !sc->count)
+	if (sc == NULL)
+		return 0;
+
+	sc->opt1 = 0;
+	sc->opt2 = 0;
+	sc->opt3 = 0;
+	sc->bs_counter = 0;
+	sc->fv_counter = 0;
+#ifndef RENEWAL
+	sc->sg_counter = 0;
+#endif
+
+	if (sc->count == 0)
 		return 0;
 
 	for(i = 0; i < SC_MAX; i++) {
@@ -10629,15 +10641,6 @@ static int status_change_clear(struct block_list *bl, int type)
 			sc->data[i] = NULL;
 		}
 	}
-
-	sc->opt1 = 0;
-	sc->opt2 = 0;
-	sc->opt3 = 0;
-	sc->bs_counter = 0;
-	sc->fv_counter = 0;
-#ifndef RENEWAL
-	sc->sg_counter = 0;
-#endif
 
 	if( type == 0 || type == 2 )
 		clif->changeoption(bl);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix some status change counters not being set to 0 when a mob unit dies.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3196

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
