### PR TITLE
Fix sc statuses not loaded on time when under heavy load

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11161,6 +11161,10 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 		return;
 	}
 
+	if (sd->state.scloaded == 0) { // SC data was not received yet. pc->scdata_received will reinvoke
+		return;
+	}
+
 	if (sd->state.rewarp != 0) { // Rewarp character.
 		sd->state.rewarp = 0;
 		clif->changemap(sd, sd->bl.m, sd->bl.x, sd->bl.y);

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -12260,14 +12260,19 @@ static void pc_scdata_received(struct map_session_data *sd)
 		pc->expire_check(sd);
 	}
 
-	if( sd->state.standalone ) {
-		clif->pLoadEndAck(0,sd);
-		pc->autotrade_populate(sd);
-		pc->autotrade_start(sd);
-	}
 
 	if (sd->sc.data[SC_SOULENERGY] != NULL)
 		sd->soulball = sd->sc.data[SC_SOULENERGY]->val1;
+
+	sd->state.scloaded = 1;
+	if (sd->state.standalone) {
+		clif->pLoadEndAck(0,sd);
+		pc->autotrade_populate(sd);
+		pc->autotrade_start(sd);
+	} else {
+		clif->pLoadEndAck(sd->fd, sd);
+	}
+	
 }
 static int pc_expiration_timer(int tid, int64 tick, int id, intptr_t data)
 {

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -209,6 +209,7 @@ struct map_session_data {
 	//status_calc_pc, while special_state is recalculated in each call. [Skotlex]
 	struct {
 		unsigned int active : 1; //Marks active player (not active is logging in/out, or changing map servers)
+		unsigned int scloaded : 1; // Marks sc related data has been loaded for player
 		unsigned int menu_or_input : 1;// if a script is waiting for feedback from the player
 		unsigned int dead_sit : 2;
 		unsigned int lr_flag : 3;//1: left h. weapon; 2: arrow; 3: shield


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Added a new flag to indicate sc data has been loaded and postpone clif->parse_LoadEndAck until all requirements are met.

When under heavy load, pc->reg_received runs before pc->scdata_received, thus invoking character calculation without taking any sc statuses like SC_PUSH_CART into consideration.

Along with incorrect character stats or substats, this issue makes the player not able to see visual effects or elements related to statuses, as well as the cart, until the player changes maps or uses a fly wing.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
