### PR TITLE
Fix costumes blocking itemskills execution

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -13568,7 +13568,7 @@ static void clif_useSkillToIdReal(int fd, struct map_session_data *sd, int skill
 		}
 	}
 
-	if (sd->sc.option & OPTION_COSTUME)
+	if (sd->sc.option & OPTION_COSTUME && sd->auto_cast_current.type != AUTOCAST_ITEM) // Item skills can be used with costumes
 		return;
 
 	if (sd->sc.data[SC_BASILICA] && (skill_id != HP_BASILICA || sd->sc.data[SC_BASILICA]->val4 != sd->bl.id))


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes costumes blocking itemskills execution, even when items are being consumed.

Thanks to @skyleo and @guilherme-gm for the info regarding how costumes work in officials.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#2925 Partially, as there're two different issues being described in the comments.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
