### PR TITLE
Add date checks and warns to RoDEX mail box and enable it by default

### DIFF
--- a/conf/map/battle/feature.conf
+++ b/conf/map/battle/feature.conf
@@ -61,10 +61,9 @@ features: {
 	rodex: true
 
 	// Allow usage of "Account Mail" box in RoDEX?
-	// Requires: 2016-03-16aRagexeRE or later
-	// This is disabled in client-side in some client versions
-	// Disabled by default
-	rodex_use_accountmail: false
+	// Requires: 2016-03-16aRagexeRE (+ patch) or later, 2016-03-23aRagexe or later, any zero client
+	// For RE clients, it requires client patching and you must also uncomment ENABLE_RODEX_ACCOUNT_MAIL_RE_PATCH in src/config/core.h
+	rodex_use_accountmail: true
 
 	// Allow Homunculus autofeeding
 	// true:  enable (Default)

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9718,6 +9718,9 @@ For examples of usage, see /doc/sample/npc_rodex.txt
 rodex_sendmail2 and rodex_sendmail_acc2 are more flexible versions.
 Check getitem2 command for more information of the extra parameters.
 
+Important: rodex_sendmail_acc (and rodex_sendmail_acc2) requires clients from 2016-03-23 or newer.
+  Additionally, it requires enabling "rodex_use_accountmail" on conf/map/battle/feature.conf.
+
 ---------------------------------------
 //=====================================
 7 - Instance-Related Commands

--- a/src/config/core.h
+++ b/src/config/core.h
@@ -100,6 +100,10 @@
 /// Uncomment for use with Nemo patch ExtendOldCashShopPreview
 //#define ENABLE_OLD_CASHSHOP_PREVIEW_PATCH
 
+/// Uncomment to allow RE clients to enable RoDEX "Account Mail".
+/// RE clients requires Nemo patch for RoDEX Account Mail to work.
+//#define ENABLE_RODEX_ACCOUNT_MAIL_RE_PATCH
+
 /// Uncomment to allow flinch animation and walk delay to be synced
 /// Reduces positional lag when getting hit
 //#define WALKDELAY_SYNC

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -8014,6 +8014,18 @@ static void battle_adjust_conf(void)
 	}
 #endif
 
+#if !(PACKETVER_MAIN_NUM >= 20160323 || (PACKETVER_RE_NUM >= 20160316 && defined(ENABLE_RODEX_ACCOUNT_MAIL_RE_PATCH)) || defined(PACKETVER_ZERO))
+	if (battle_config.feature_rodex_use_accountmail == 1) {
+#ifndef BUILDBOT /* Don't show these warnings to CI */
+		ShowWarning("conf/map/battle/feature.conf:features/rodex_use_accountmail RoDEX account mail is enabled but it requires 2016-03-16 RagexeRE / 2016-03-23 Ragexe or newer, disabling...\n");
+#ifdef PACKETVER_RE
+		ShowWarning("conf/map/battle/feature.conf:features/rodex_use_accountmail For RE clients, you should also enable ENABLE_RODEX_ACCOUNT_MAIL_RE_PATCH\n");
+#endif // PACKETVER_RE
+#endif // !BUILDBOT
+		battle_config.feature_rodex_use_accountmail = 0;
+	}
+#endif // date check
+
 #if !(PACKETVER_MAIN_NUM >= 20161130 || PACKETVER_RE_NUM >= 20161109 || defined(PACKETVER_ZERO))
 	if (battle_config.enable_refinery_ui == 1) {
 		ShowWarning("conf/map/battle/feature.conf refinery ui is enabled but it requires PACKETVER 2016-11-09 RagexeRE/2016-11-30 Ragexe or newer, disabling...\n");

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -27269,6 +27269,9 @@ static bool buildin_rodex_sendmail_sub(struct script_state *st, struct rodex_mes
 	int receiver_id = script_getnum(st, 2);
 
 	if (strcmp(func_name, "rodex_sendmail_acc") == 0 || strcmp(func_name, "rodex_sendmail_acc2") == 0) {
+		if (battle_config.feature_rodex_use_accountmail == 0)
+			ShowWarning("script:rodex_sendmail_acc: You are sending an account mail while \"feature_rodex_use_accountmail\" is disabled. Players may not be able to view it.\n");
+
 		if (receiver_id < START_ACCOUNT_NUM || receiver_id > END_ACCOUNT_NUM) {
 			ShowError("script:rodex_sendmail: Invalid receiver account ID %d passed!\n", receiver_id);
 			return false;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add safety checks to prevent users from enabling RoDEX account box in unsupported clients and improve documentation around it.

Also enables the account box by default. It was disabled back them because herc default packetver didn't support. But since we moved to default to a 2019 main client, account mail has been enabled on the client side, so there is no reason to keep it disabled by default.

With these changes:
1. Enabling the account mail in an unsupported client will give a warning and disable it
2. Users using supported RE versions need to also enable `ENABLE_RODEX_ACCOUNT_MAIL_RE_PATCH` because they must patch their exe ( https://gitlab.com/4144/Nemo/-/merge_requests/83 )
3. Trying to send account mails while the feature is disabled will show a warning, but still send the mail -- This is intentional, I don't want to cause huge issues for someone who is already using it in a broken way, and I see no harm in delivering the mail
4. Account box will be enabled by default in a fresh Hercules


**Issues addressed:** <!-- Write here the issue number, if any. -->
"Solves" #2749 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
