### PR TITLE
Add more details when char-server fails to connect

### DIFF
--- a/src/char/char.c
+++ b/src/char/char.c
@@ -6096,7 +6096,7 @@ static void char_ensure_online_char_data(struct online_char_data *character)
 {
 	nullpo_retv(character);
 	if (character->data == NULL) {
-		character->data = aCalloc(sizeof(struct online_char_data2), 1);
+		character->data = aCalloc(1, sizeof(struct online_char_data2));
 	}
 }
 

--- a/src/char/char.c
+++ b/src/char/char.c
@@ -2414,7 +2414,7 @@ static int char_parse_fromlogin_connection_state(int fd)
 	case 1: // Invalid username/password
 		ShowError("Can not connect to login-server.\n");
 		ShowError("The server communication passwords (default s1/p1) are probably invalid.\n");
-		ShowError("Also, please make sure your login db has the correct communication username/passwords and the gender of the account is S.\n");
+		ShowError("Also, please make sure your login db has the correct communication username/passwords, the gender of the account is S and its id is between 0 and (MAX_SERVERS - 1).\n");
 		ShowError("The communication passwords are set in /conf/map/map-server.conf and /conf/char/char-server.conf\n");
 		sockt->eof(fd);
 		return 1;

--- a/src/login/login.c
+++ b/src/login/login.c
@@ -1504,11 +1504,14 @@ static void login_parse_request_connection(int fd, struct login_session_data* sd
 	if (!sockt->allowed_ip_check(ipl)) {
 		ShowNotice("Connection of the char-server '%s' REFUSED (IP not allowed).\n", server_name);
 		login->char_server_connection_status(fd, sd, 2);
+	} else if (sd->sex != 'S') {
+		ShowNotice("Connection of the char-server '%s' REFUSED (Account sex must be 'S').\n", server_name);
+		login->char_server_connection_status(fd, sd, 1);
+	} else if (sd->account_id < 0 || sd->account_id >= ARRAYLENGTH(login->dbs->server)) {
+		ShowNotice("Connection of the char-server '%s' REFUSED (Account ID must be between 0 and %d).\n", server_name, ARRAYLENGTH(login->dbs->server) - 1);
+		login->char_server_connection_status(fd, sd, 1);
 	} else if (core->runflag == LOGINSERVER_ST_RUNNING &&
 		result == -1 &&
-		sd->sex == 'S' &&
-		sd->account_id >= 0 &&
-		sd->account_id < ARRAYLENGTH(login->dbs->server) &&
 		!sockt->session_is_valid(login->dbs->server[sd->account_id].fd))
 	{
 		ShowStatus("Connection of the char-server '%s' accepted.\n", server_name);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Add a few more info when char-server fails to connect. This helps users understand what is going on, and may also help with support on forums/discord.

I chose to make this PR after noticing the Account ID check that is never mentioned anywhere and a new user stumbled into an issue in it today.

Those cases are now more detailed:
- login-server now records details for failure due to account ID range and wrong sex
- char-server now informs about the Account ID range. It doesn't detail the maximum value since people may be using 2 different builds, and `MAX_SERVERS` is part of login server, not common/char.


**Issues addressed:** <!-- Write here the issue number, if any. -->
None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
