### PR TITLE
Fix combo_cache_skill checking current skill delay instead of last one

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -13562,13 +13562,13 @@ static void clif_useSkillToIdReal(int fd, struct map_session_data *sd, int skill
 		if (skill_id != SA_CASTCANCEL && skill_id != SO_SPELLFIST && sd->auto_cast_current.type == AUTOCAST_NONE)
 			return;
 	} else if (DIFF_TICK(tick, sd->ud.canact_tick) < 0) {
-		// Cannot perform skill yet, delay execution until canact_tick allows it
-		// Only for combo skills with implicit delays, otherwise we create a speedhack that bypasses client's animation delay		
+		// Delay execution of combo skill until canact_tick allows it
+		// Only for combo skills whose prerequisite induced delay
 		if (battle_config.combo_cache_skill
 			&& !skip_combo_check
 			&& sd->sc.data[SC_COMBOATTACK] != NULL
 			&& skill->is_combo(skill_id)
-			&& skill->get_delaynodex(skill_id, skill_lv) != 0
+			&& skill->delay_fix(&sd->bl, sd->sc.data[SC_COMBOATTACK]->val1, pc->checkskill(sd, sd->sc.data[SC_COMBOATTACK]->val1)) > 0
 		) {
 			timer->add(sd->ud.canact_tick, clif->combo_delay_timer, sd->bl.id, (intptr_t)MakeDWord((uint16)skill_id, (uint16)skill_lv));
 			return;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Setting combo_cache_skill was checking current skill's delay instead of checking for the last combo skill that produced the current delay.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
