### PR TITLE
Change appveyor config to use new/single VS sln file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,18 +7,24 @@ branches:
   - coverity_scan
 skip_tags: true
 skip_branch_with_pr: true
-image: Visual Studio 2017
+image: Visual Studio 2022
 clone_depth: 5
 environment:
+  HerculesProject: Hercules.sln
+
   matrix:
-  - HerculesProject: Hercules-15.sln
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    PlatformToolset: v141
+    WindowsTargetPlatformVersion: 10.0.14393.0
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    HerculesProject: Hercules-16.sln
+    PlatformToolset: v142
+    WindowsTargetPlatformVersion: 10.0.17763.0
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    HerculesProject: Hercules-17.sln
+    PlatformToolset: v143
+    WindowsTargetPlatformVersion: 10.0
 services: mysql
 build_script:
-- cmd: MSBuild %HerculesProject% /t:map-server,char-server,login-server
+- cmd: MSBuild %HerculesProject% /p:PlatformToolset=%PlatformToolset% /p:WindowsTargetPlatformVersion=%WindowsTargetPlatformVersion% /t:map-server,char-server,login-server
 test: off
 deploy: off
 notifications:


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Looks like appveyor build is breaking after #3262 due to the rename/removal of the old solution names.

Just fixing it to use the single/new name of the solution.

Since we are no longer using multiple sln, I also removed the "matrix" config (which is meant to run several similar jobs with minor changes, in our case, 1 job for each sln)

**Issues addressed:** None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
