### PR TITLE
Fix expandinventory not allowing to return to minimal inventory size

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -12565,7 +12565,7 @@ static bool pc_expandInventory(struct map_session_data *sd, int adjustSize)
 {
 	nullpo_retr(false, sd);
 	const int invSize = sd->status.inventorySize;
-	if (adjustSize > MAX_INVENTORY || invSize + adjustSize <= FIXED_INVENTORY_SIZE || invSize + adjustSize > MAX_INVENTORY) {
+	if (adjustSize > MAX_INVENTORY || invSize + adjustSize < FIXED_INVENTORY_SIZE || invSize + adjustSize > MAX_INVENTORY) {
 		clif->inventoryExpandResult(sd, EXPAND_INVENTORY_RESULT_MAX_SIZE);
 		return false;
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Allow expandinventory to return to original inventory size (minimal one).

See:
```
TehAroil 𝐏𝐋𝐕𝐠𝐠 — 11/01/2024 02:34
>Have 100 Possession Limit
>expandinventory(10);
>Now 110
>expandinventory(-10);
>Refused
>expandinventory(-9);
>Now 101
expandinventory(-1);
>Refused
>Have 101 Possession Limit
```

**Issues addressed:** None?


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
