### PR TITLE
Fix sysinfogen.sh get incorrect synctax SYSINFO_CPUCORES

### DIFF
--- a/sysinfogen.sh
+++ b/sysinfogen.sh
@@ -238,7 +238,7 @@ cat >> "$OUTFILE" << EOF
 #define SYSINFO_CPU "$( cleanstring "${HERC_CPU}" )"
 
 // CPU Cores (Platform-dependent)
-#define SYSINFO_CPUCORES ( $( cleanstring "${HERC_CORES}" ) )
+#define SYSINFO_CPUCORES ( "$( cleanstring "${HERC_CORES}" )" )
 
 EOF
 [ $? -eq 0 ] || do_fail
@@ -290,4 +290,3 @@ cat >> "$OUTFILE" << EOF
 
 EOF
 [ $? -eq 0 ] || do_fail
-

--- a/sysinfogen.sh
+++ b/sysinfogen.sh
@@ -190,7 +190,7 @@ case $HERC_PLATFORM in
 			HWDATA="$( system_profiler SPHardwareDataType )"
 			HWDATA_CPU="$( echo "$HWDATA" | grep "Processor Name:" | cut -d: -f2- )"
 			HWDATA_CPUSPEED="$( cleanstring "$( echo "$HWDATA" | grep "Processor Speed:" | cut -d: -f2- )" )"
-			HERC_CORES="$( echo "$HWDATA" | grep "Total Number of Cores:" | cut -d: -f2- )"
+			HERC_CORES="$( echo "$HWDATA" | grep "Total Number of Cores:" | cut -d: -f2- | sed -E 's/ *([0-9]+).*/\1/')"
 			HERC_CPU="${HWDATA_CPU} (${HWDATA_CPUSPEED})"
 		fi
 		;;
@@ -238,7 +238,7 @@ cat >> "$OUTFILE" << EOF
 #define SYSINFO_CPU "$( cleanstring "${HERC_CPU}" )"
 
 // CPU Cores (Platform-dependent)
-#define SYSINFO_CPUCORES ( "$( cleanstring "${HERC_CORES}" )" )
+#define SYSINFO_CPUCORES ( $( cleanstring "${HERC_CORES}" ) )
 
 EOF
 [ $? -eq 0 ] || do_fail


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Issue:
When trying to run `make`. `sysinfo.inc` will be generated.
I'm using Mac M1 the output of `SYSINFO_CPUCORES` is
```
// CPU Cores (Platform-dependent)
#define i ( 10 (8 performance and 2 efficiency) )
```
That will be make error while compile process:
```
sysinfo.c:1020:25: error: expected ')'
        sysinfo->p->cpucores = SYSINFO_CPUCORES;
                               ^
../common/sysinfo.inc:33:34: note: expanded from macro 'SYSINFO_CPUCORES'
#define SYSINFO_CPUCORES ( 10 (8 performance and 2 efficiency) )
                                 ^
sysinfo.c:1020:25: note: to match this '('
../common/sysinfo.inc:33:31: note: expanded from macro 'SYSINFO_CPUCORES'
#define SYSINFO_CPUCORES ( 10 (8 performance and 2 efficiency) )
                              ^
1 error generated.
make[1]: *** [obj_all/sysinfo.o] Error 1
make: *** [common_sql] Error 2
```

### Changes Proposed
Add quotation marks to call `HERC_CORES` in `sysinfogen.sh`
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. --> no


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
