### PR TITLE
Allow call openlapineupgradeui() and openlapineddukddakboxui() without itemid

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -10998,12 +10998,14 @@ returns true on success and false on failure
 
 ---------------------------------------
 *openlapineddukddakboxui({<item_id>})
+*openlapineddukddakboxui({<item_name>})
 
 Opens lapine ddukddak user interface for the player
 returns true on success and false on failure
 
 ---------------------------------------
 *openlapineupgradeui({<item_id>})
+*openlapineupgradeui({<item_name>})
 
 Opens lapine ddukddak upgrade user interface for the player
 returns true on success and false on failure

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -10997,13 +10997,13 @@ Opens refinery user interface for the player
 returns true on success and false on failure
 
 ---------------------------------------
-*openlapineddukddakboxui(<item_id>)
+*openlapineddukddakboxui({<item_id>})
 
 Opens lapine ddukddak user interface for the player
 returns true on success and false on failure
 
 ---------------------------------------
-*openlapineupgradeui(<item_id>)
+*openlapineupgradeui({<item_id>})
 
 Opens lapine ddukddak upgrade user interface for the player
 returns true on success and false on failure

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -27941,7 +27941,7 @@ static BUILDIN(openlapineddukddakboxui)
 	struct map_session_data *sd = script_rid2sd(st);
 	if (sd == NULL)
 		return false;
-	const int item_id = script_getnum(st, 2);
+	const int item_id = (script_getnum(st, 2) == 0) ? sd->itemid : script_getnum(st, 2);
 	struct item_data *it = itemdb->exists(item_id);
 	if (it == NULL) {
 		ShowError("buildin_openlapineddukddakboxui: Item %d is not valid\n", item_id);
@@ -27962,7 +27962,8 @@ static BUILDIN(openlapineupgradeui)
 	if (sd == NULL)
 		return false;
 
-	const int item_id = script_getnum(st, 2);
+	const int item_id = (script_getnum(st, 2) == 0) ? sd->itemid : script_getnum(st, 2);
+
 	struct item_data *it = itemdb->exists(item_id);
 	if (it == NULL || it->lapineupgrade == NULL) {
 		ShowError("buildin_openlapineupgradeui: Item %d is not valid\n", item_id);
@@ -29183,8 +29184,8 @@ static void script_parse_builtin(void)
 
 		BUILDIN_DEF(identify, "i"),
 		BUILDIN_DEF(identifyidx, "i"),
-		BUILDIN_DEF(openlapineddukddakboxui, "i"),
-		BUILDIN_DEF(openlapineupgradeui, "i"),
+		BUILDIN_DEF(openlapineddukddakboxui, "?"),
+		BUILDIN_DEF(openlapineupgradeui, "?"),
 
 		BUILDIN_DEF(callfunctionofnpc, "vs*"),
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -27941,16 +27941,37 @@ static BUILDIN(openlapineddukddakboxui)
 	struct map_session_data *sd = script_rid2sd(st);
 	if (sd == NULL)
 		return false;
-	const int item_id = (script_getnum(st, 2) == 0) ? sd->itemid : script_getnum(st, 2);
-	struct item_data *it = itemdb->exists(item_id);
-	if (it == NULL) {
-		ShowError("buildin_openlapineddukddakboxui: Item %d is not valid\n", item_id);
+
+	struct item_data *it = NULL;
+	if (script_hasdata(st, 2)) {
+		if (script_isstring(st, 2)) {
+			const char *item_name = script_getstr(st, 2);
+			it = itemdb->search_name(item_name);
+			if (it == NULL) {
+				ShowError("buildin_openlapineddukddakboxui: Item %s is not valid\n", item_name);
+				script->reportfunc(st);
+				script->reportsrc(st);
+				script_pushint(st, false);
+				return true;
+			}
+		} else {
+			it = itemdb->exists(script_getnum(st, 2));
+		}
+	} else {
+		if (sd->itemid > 0) {
+			it = itemdb->exists(sd->itemid);
+		}
+	}
+
+	if (it == NULL || it->lapineddukddak == NULL) {
+		ShowError("buildin_openlapineddukddakboxui: Item Id %d is not valid\n", it->nameid);
 		script->reportfunc(st);
 		script->reportsrc(st);
 		script_pushint(st, false);
 		return true;
 	}
-	clif->lapineDdukDdak_open(sd, item_id);
+
+	clif->lapineDdukDdak_open(sd, it->nameid);
 	script_pushint(st, true);
 	return true;
 }
@@ -27962,18 +27983,36 @@ static BUILDIN(openlapineupgradeui)
 	if (sd == NULL)
 		return false;
 
-	const int item_id = (script_getnum(st, 2) == 0) ? sd->itemid : script_getnum(st, 2);
+	struct item_data *it = NULL;
+	if (script_hasdata(st, 2)) {
+		if (script_isstring(st, 2)) {
+			const char *item_name = script_getstr(st, 2);
+			it = itemdb->search_name(item_name);
+			if (it == NULL) {
+				ShowError("buildin_openlapineupgradeui: Item %s is not valid\n", item_name);
+				script->reportfunc(st);
+				script->reportsrc(st);
+				script_pushint(st, false);
+				return true;
+			}
+		} else {
+			it = itemdb->exists(script_getnum(st, 2));
+		}
+	} else {
+		if (sd->itemid > 0) {
+			it = itemdb->exists(sd->itemid);
+		}
+	}
 
-	struct item_data *it = itemdb->exists(item_id);
 	if (it == NULL || it->lapineupgrade == NULL) {
-		ShowError("buildin_openlapineupgradeui: Item %d is not valid\n", item_id);
+		ShowError("buildin_openlapineupgradeui: Item Id %d is not valid\n", it->nameid);
 		script->reportfunc(st);
 		script->reportsrc(st);
 		script_pushint(st, false);
 		return true;
 	}
 
-	clif->lapineUpgrade_open(sd, item_id);
+	clif->lapineUpgrade_open(sd, it->nameid);
 	script_pushint(st, true);
 	return true;
 }

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -27964,7 +27964,11 @@ static BUILDIN(openlapineddukddakboxui)
 	}
 
 	if (it == NULL || it->lapineddukddak == NULL) {
-		ShowError("buildin_openlapineddukddakboxui: Item Id %d is not valid\n", it->nameid);
+		if (it != NULL) {
+			ShowError("buildin_openlapineddukddakboxui: Item Id %d is not valid\n", it->nameid);
+		} else {
+			ShowError("buildin_openlapineddukddakboxui: Item is NULL\n");
+		}
 		script->reportfunc(st);
 		script->reportsrc(st);
 		script_pushint(st, false);
@@ -28005,7 +28009,11 @@ static BUILDIN(openlapineupgradeui)
 	}
 
 	if (it == NULL || it->lapineupgrade == NULL) {
-		ShowError("buildin_openlapineupgradeui: Item Id %d is not valid\n", it->nameid);
+		if (it != NULL) {
+			ShowError("buildin_openlapineddukddakboxui: Item Id %d is not valid\n", it->nameid);
+		} else {
+			ShowError("buildin_openlapineddukddakboxui: Item is NULL\n");
+		}
 		script->reportfunc(st);
 		script->reportsrc(st);
 		script_pushint(st, false);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Allow call `openlapineupgradeui()` and `openlapineddukddakboxui()` without itemid
Example:
```diff
{
	Id: 23926
	AegisName: "Shadow_9_Refine_Hammer"
	Name: "Shadow_9_Refine_Hammer"
	Type: "IT_DELAYCONSUME"
-	Script: <" openlapineupgradeui(23926); ">
+	Script: <" openlapineupgradeui(); ">
},
```
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
