### PR TITLE
Fixed attack/chase regression when walking towards enemy

### DIFF
--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -526,7 +526,7 @@ static int unit_walk_toxy_timer(int tid, int64 tick, int id, intptr_t data)
 				unit->attack(bl, tbl->id, ud->state.attack_continue);
 			}
 		} else { // Update chase-path
-			unit->walk_tobl(bl, tbl, ud->chaserange, ud->state.walk_easy | ud->state.attack_continue);
+			unit->walk_tobl(bl, tbl, ud->chaserange, ud->state.walk_easy | (ud->state.attack_continue ? 2 : 0));
 			return 0;
 		}
 	} else {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Reverts changes made to unit.c in https://github.com/HerculesWS/Hercules/commit/964b47351ef2156423f6e0a68bfd3361283936c1

Credits for discovering the bug and its solution to @skyleo , as well as the following explanation:
> I think it affects for example moments where you use a skill out of range on a mob and you think you reached in range
and then it walks out of range
probably more like auto-attack though
But yeah chasing and atk behavior failing under certain situations.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
