### PR TITLE
Add script function to work with item_group

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11142,14 +11142,17 @@ Check out some examples in `doc/sample/goldpc.txt`.
 
 *getitemgroupitems(<item_id_array>, <item_group_id>)
 
-Return boolean if success otherwise false.
-Will allocate Without duplicated item at <item_id_array> with all items in <item_group_id>.
+Fills the array <item_id_array> with the IDs of the items from the <item_group_id> item group, without duplicates.
 
-<item_group_id> can be defined on `db/(pre-)re/item_group_db.conf`
+Returns the amount of items inserted into the array.
+
+Note: The array will not be automatically cleared. It's recommended to use the returned value to loop over the array instead of relying on getarraysize.
+
+The possible values for <item_group_id> can be found in `db/(pre-)re/item_group.conf`
 
 Example:
 
-	getitemgroupitems(.@item_list[0], "Old_Card_Album");
-	for (.@i = 0; .@i < getarraysize(.@item_list); .@i++) {
-		mes "^1E56BD\t"+getitemname(.@item_list[.@i])+" ^000000";
+	.@count = getitemgroupitems(.@item_list[0], Old_Card_Album);
+	for (.@i = 0; .@i < .@count; ++.@i) {
+		mesf("^1E56BD\t%s^000000", getitemname(.@item_list[.@i]));
 	}

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11149,7 +11149,7 @@ Will allocate Without duplicated item at <item_id_array> with all itens in <item
 
 Example:
 
-	getitemlistbygroup(.@item_list[0], "Old_Card_Album");
+	getitemgroupitems(.@item_list[0], "Old_Card_Album");
 	for ( .@i = 0; .@i < getarraysize(.@item_list); .@i++ ) {
 		mes "^1E56BD\t"+getitemname(.@item_list[.@i])+" ^000000";
 	}

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8037,7 +8037,7 @@ false means OFF, and true means ON. See setmapflag() for examples of mapflags.
 *getbattleflag("<battle flag>")
 
 Sets or gets the value of the given battle flag.
-Battle flags are the flags found in the conf/map/battle/*.conf files and is
+Battle flags are the flags found in the conf/map/battle/\*.conf files and is
 also used in Lupus' variable rates script.
 
 Examples:
@@ -11136,3 +11136,20 @@ When <played_time> is not provided, it defaults to -1, and the current played ti
           If keeping the GoldPC mode between sessions is desired, you may use OnPCLoginEvent.
 
 Check out some examples in `doc/sample/goldpc.txt`.
+
+
+---------------------------------------
+
+*getitemgroupitems(<item_id_array>, <item_group_id>)
+
+Return boolean if success otherwise false.
+Will allocate Without duplicated item at <item_id_array> with all itens in <item_group_id>.
+
+<item_group_id> can be defined on `db/(pre-)re/item_group_db.conf`
+
+Example:
+
+	getitemlistbygroup(.@item_list[0], "Old_Card_Album");
+	for ( .@i = 0; .@i < getarraysize(.@item_list); .@i++ ) {
+		mes "^1E56BD\t"+getitemname(.@item_list[.@i])+" ^000000";
+	}

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8037,7 +8037,7 @@ false means OFF, and true means ON. See setmapflag() for examples of mapflags.
 *getbattleflag("<battle flag>")
 
 Sets or gets the value of the given battle flag.
-Battle flags are the flags found in the conf/map/battle/\*.conf files and is
+Battle flags are the flags found in the conf/map/battle/*.conf files and is
 also used in Lupus' variable rates script.
 
 Examples:
@@ -11143,13 +11143,13 @@ Check out some examples in `doc/sample/goldpc.txt`.
 *getitemgroupitems(<item_id_array>, <item_group_id>)
 
 Return boolean if success otherwise false.
-Will allocate Without duplicated item at <item_id_array> with all itens in <item_group_id>.
+Will allocate Without duplicated item at <item_id_array> with all items in <item_group_id>.
 
 <item_group_id> can be defined on `db/(pre-)re/item_group_db.conf`
 
 Example:
 
 	getitemgroupitems(.@item_list[0], "Old_Card_Album");
-	for ( .@i = 0; .@i < getarraysize(.@item_list); .@i++ ) {
+	for (.@i = 0; .@i < getarraysize(.@item_list); .@i++) {
 		mes "^1E56BD\t"+getitemname(.@item_list[.@i])+" ^000000";
 	}

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -347,6 +347,26 @@ static bool itemdb_in_group(struct item_group *group, int nameid)
 	return false;
 }
 
+/**
+ * Search for a group of item
+ * @param group return information about group
+ * @param nameid item group id to search
+ * @return bool true if found, false otherwise
+ */
+static bool itemdb_search_group(struct item_group *group, int nameid)
+{
+	for(int i = 0; i < itemdb->group_count; i++ ) {
+		struct item_group g = itemdb->groups[i];
+		
+		if( g.id == nameid ) {
+			*group = g;
+			return true;
+		}
+	}
+
+	return false;
+}
+
 /// Searches for the item_data.
 /// Returns the item_data or NULL if it does not exist.
 static struct item_data *itemdb_exists(int nameid)
@@ -3357,6 +3377,7 @@ void itemdb_defaults(void)
 	itemdb->option_exists = itemdb_option_exists;
 	itemdb->reform_exists = itemdb_reform_exists;
 	itemdb->in_group = itemdb_in_group;
+	itemdb->search_group = itemdb_search_group;
 	itemdb->group_item = itemdb_searchrandomid;
 	itemdb->chain_item = itemdb_chain_item;
 	itemdb->package_item = itemdb_package_item;

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -348,23 +348,19 @@ static bool itemdb_in_group(struct item_group *group, int nameid)
 }
 
 /**
- * Search for a group of item
- * @param group return information about group
+ * Search for an item group.
+ *
  * @param nameid item group id to search
- * @return bool true if found, false otherwise
+ * @return A pointer to the group
+ * @retval NULL if the group was not found
  */
-static bool itemdb_search_group(struct item_group *group, int nameid)
+static const struct item_group *itemdb_search_group(int nameid)
 {
-	for (int i = 0; i < itemdb->group_count; i++) {
-		struct item_group g = itemdb->groups[i];
-		
-		if (g.id == nameid) {
-			*group = g;
-			return true;
-		}
-	}
-
-	return false;
+	int i;
+	ARR_FIND(0, itemdb->group_count, i, itemdb->groups[i].id == nameid);
+	if (i != itemdb->group_count)
+		return &itemdb->groups[i];
+	return NULL;
 }
 
 /// Searches for the item_data.

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -355,10 +355,10 @@ static bool itemdb_in_group(struct item_group *group, int nameid)
  */
 static bool itemdb_search_group(struct item_group *group, int nameid)
 {
-	for(int i = 0; i < itemdb->group_count; i++ ) {
+	for (int i = 0; i < itemdb->group_count; i++) {
 		struct item_group g = itemdb->groups[i];
 		
-		if( g.id == nameid ) {
+		if (g.id == nameid) {
 			*group = g;
 			return true;
 		}

--- a/src/map/itemdb.h
+++ b/src/map/itemdb.h
@@ -708,6 +708,7 @@ struct itemdb_interface {
 	struct itemdb_option* (*option_exists) (int idx);
 	struct item_reform* (*reform_exists) (int idx);
 	bool (*in_group) (struct item_group *group, int nameid);
+	bool (*search_group) (struct item_group *group, int nameid);
 	int (*group_item) (struct item_group *group);
 	int (*chain_item) (unsigned short chain_id, int *rate);
 	void (*package_item) (struct map_session_data *sd, struct item_package *package);

--- a/src/map/itemdb.h
+++ b/src/map/itemdb.h
@@ -708,7 +708,7 @@ struct itemdb_interface {
 	struct itemdb_option* (*option_exists) (int idx);
 	struct item_reform* (*reform_exists) (int idx);
 	bool (*in_group) (struct item_group *group, int nameid);
-	bool (*search_group) (struct item_group *group, int nameid);
+	const struct item_group *(*search_group) (int nameid);
 	int (*group_item) (struct item_group *group);
 	int (*chain_item) (unsigned short chain_id, int *rate);
 	void (*package_item) (struct map_session_data *sd, struct item_package *package);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9202,7 +9202,7 @@ static BUILDIN(getitemgroupitems)
 		return false;
 	}
 
-	if(!utils_itemgroup_remove_duplicate(&group)) {
+	if (!utils_itemgroup_remove_duplicate(&group)) {
 		ShowError("buildin_getitemgroupitems: fail to remove duplicates\n");
 		return false;
 	}

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9212,6 +9212,22 @@ static BUILDIN(getitemgroupitems)
 	int32 idata = reference_getindex(data);
 	int32 dataid = reference_getid(data);
 	const char *data_name = reference_getname(data);
+
+	if (not_server_variable(*data_name)) {
+		if (script->rid2sd(st) == NULL) {
+			// no player attached
+			script_pushint(st, 0);
+			return false;
+		}
+	}
+
+	if (is_string_variable(data_name)) {
+		// string array
+		ShowError("buildin_getitemgroupitems: not an integer array reference\n");
+		script->reportdata(data);
+		st->state = END;
+		return false;
+	}
 	
 	int count = 0;
 	for (int i = 0; i < group.qty; i++) {


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR aims to create a script function to get all items without duplicated from a specific `group_id`. The idea behind this is be able to get all items and be capable to create more complex NPC with it. Ideal for this is: use more groups feature to handle with a list of group in a easiest way without needed to create arrays of a item listing all itens you need, and instead of it, use groups list as resource in NPC.

In same PR i create an utilities tool set to clean duplicated from group in order to get only unique list from group.


Note: I add script command on `docs/script_commands.txt`  

Example:
```c++
getitemgroupitems(.@item_list[0], "Old_Card_Album");
for ( .@i = 0; .@i < getarraysize(.@item_list); .@i++ ) {
    mes "^1E56BD\t"+getitemname(.@item_list[.@i])+" ^000000";
}
```
