### PR TITLE
Fix clif->pLoadEndAck being called in pc->scdata_received before receiving client's loadendack

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11163,6 +11163,7 @@ static void clif_parse_LoadEndAck(int fd, struct map_session_data *sd)
 	}
 
 	if (sd->state.scloaded == 0) { // SC data was not received yet. pc->scdata_received will reinvoke
+		sd->state.loadendack_before_scloaded = 1;
 		return;
 	}
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -12016,10 +12016,10 @@ static void pc_scdata_received(struct map_session_data *sd)
 		clif->pLoadEndAck(0,sd);
 		pc->autotrade_populate(sd);
 		pc->autotrade_start(sd);
-	} else {
+	} else if (sd->state.loadendack_before_scloaded != 0) {
 		clif->pLoadEndAck(sd->fd, sd);
+		sd->state.loadendack_before_scloaded = 0;
 	}
-	
 }
 static int pc_expiration_timer(int tid, int64 tick, int id, intptr_t data)
 {

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -210,6 +210,7 @@ struct map_session_data {
 	struct {
 		unsigned int active : 1; //Marks active player (not active is logging in/out, or changing map servers)
 		unsigned int scloaded : 1; // Marks sc related data has been loaded for player
+		unsigned int loadendack_before_scloaded : 1; // Marks that the LoadEndAck packet was received before scloaded
 		unsigned int menu_or_input : 1;// if a script is waiting for feedback from the player
 		unsigned int dead_sit : 2;
 		unsigned int lr_flag : 3;//1: left h. weapon; 2: arrow; 3: shield


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Don't unnecessarily call clif->pLoadEndAck, when we're receiving scdata and everything else from char to map in time.


in the following part I will talk about behavior before the changes this PR introduces:

As in don't call clif->pLoadEndAck manually if you haven't even received it from the client yet aka client didn't finish loading

Also yes we will get past the various checks if everything happened in time on server-side (as in the stuff we waiting from char-server to receive).

If we login fresh sd->bl.prev will be NULL for example.

So if we call clif->pLoadEndAck in this scenario, we will send data to the client and set data before the client actually finished loading.

**Issues addressed:** None?


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
