### PR TITLE
Fix all aCalloc calls that had their parameters in the wrong order

### DIFF
--- a/src/char/int_party.c
+++ b/src/char/int_party.c
@@ -363,7 +363,7 @@ static int inter_party_sql_init(void)
 {
 	//memory alloc
 	inter_party->db = idb_alloc(DB_OPT_RELEASE_DATA);
-	inter_party->pt = (struct party_data*)aCalloc(sizeof(struct party_data), 1);
+	inter_party->pt = (struct party_data*)aCalloc(1, sizeof(struct party_data));
 	if (!inter_party->pt) {
 		ShowFatalError("inter_party->sql_init: Out of Memory!\n");
 		exit(EXIT_FAILURE);

--- a/src/char/int_pet.c
+++ b/src/char/int_pet.c
@@ -206,7 +206,7 @@ static int inter_pet_fromsql(int pet_id, struct s_pet *p)
 static int inter_pet_sql_init(void)
 {
 	//memory alloc
-	inter_pet->pt = (struct s_pet*)aCalloc(sizeof(struct s_pet), 1);
+	inter_pet->pt = (struct s_pet*)aCalloc(1, sizeof(struct s_pet));
 	return 0;
 }
 

--- a/src/common/memmgr.h
+++ b/src/common/memmgr.h
@@ -42,13 +42,13 @@
 // Enable memory manager logging by default
 #define LOG_MEMMGR
 
-#define aMalloc(n)    (malloc_proxy((n), ALC_MARK))
-#define aCalloc(m, n) (calloc_proxy((m), (n),ALC_MARK))
-#define aFree(p)      (free_proxy((p), ALC_MARK))
-#define aStrdup(p)    (strdup_proxy((p),ALC_MARK))
-#define aStrndup(p,n) (strndup_proxy((p),(n),ALC_MARK))
-#define aRealloc(p,n) (iMalloc->realloc((p),(n),ALC_MARK))
-#define aReallocz(p,n) (iMalloc->reallocz((p),(n),ALC_MARK))
+#define aMalloc(size)      (malloc_proxy((size), ALC_MARK))
+#define aCalloc(num, size) (calloc_proxy((num), (size), ALC_MARK))
+#define aFree(p)           (free_proxy((p), ALC_MARK))
+#define aStrdup(p)         (strdup_proxy((p), ALC_MARK))
+#define aStrndup(p, size)  (strndup_proxy((p), (size), ALC_MARK))
+#define aRealloc(p, size)  (iMalloc->realloc((p), (size), ALC_MARK))
+#define aReallocz(p, size) (iMalloc->reallocz((p), (size), ALC_MARK))
 
 /////////////// Buffer Creation /////////////////
 // Full credit for this goes to Shinomori [Ajarn]

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -259,8 +259,8 @@ static int instance_add_map(const char *name, int instance_id, bool usebasename,
 	}
 
 	size = map->list[im].bxs * map->list[im].bys * sizeof(struct block_list*);
-	map->list[im].block = (struct block_list**)aCalloc(size, 1);
-	map->list[im].block_mob = (struct block_list**)aCalloc(size, 1);
+	map->list[im].block = (struct block_list**)aCalloc(1, size);
+	map->list[im].block_mob = (struct block_list**)aCalloc(1, size);
 
 	memset(map->list[im].npc, 0x00, sizeof(map->list[i].npc));
 	map->list[im].npc_num = 0;
@@ -670,7 +670,7 @@ static void instance_check_idle(int instance_id)
 		timer->delete(instance->list[instance_id].idle_timer, instance->destroy_timer);
 		instance->list[instance_id].idle_timer = INVALID_TIMER;
 		instance->list[instance_id].idle_timeout = 0;
-		
+
 		// Notify instance users normal instance expiration
 		clif->instance(instance_id, INSTANCE_WND_INFO_PROGRESS_TIME, 0);
 	} else if (instance->list[instance_id].idle_timer == INVALID_TIMER && idle) {
@@ -678,7 +678,7 @@ static void instance_check_idle(int instance_id)
 		int64 destroy_tick = timer->gettick() + instance->list[instance_id].idle_timeoutval * 1000;
 		instance->list[instance_id].idle_timeout = now + instance->list[instance_id].idle_timeoutval;
 		instance->list[instance_id].idle_timer = timer->add(destroy_tick, instance->destroy_timer, instance_id, 0);
-		
+
 		// Notify instance users it will be destroyed if no user join it again in "X" time
 		clif->instance(instance_id, INSTANCE_WND_INFO_IDLE_TIME, 0);
 	}

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -4031,8 +4031,8 @@ static int map_readallmaps(void)
 		map->list[i].bys = (map->list[i].ys + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
 		size = map->list[i].bxs * map->list[i].bys * sizeof(struct block_list*);
-		map->list[i].block = (struct block_list**)aCalloc(size, 1);
-		map->list[i].block_mob = (struct block_list**)aCalloc(size, 1);
+		map->list[i].block = (struct block_list**)aCalloc(1, size);
+		map->list[i].block_mob = (struct block_list**)aCalloc(1, size);
 
 		map->list[i].getcellp = map->sub_getcellp;
 		map->list[i].setcell  = map->sub_setcell;
@@ -4585,7 +4585,7 @@ static bool inter_config_read_database_names(const char *filename, const struct 
 
 /**
  * Looks up configuration "name" which is expect to have a final value of int, but may be specified by a string constant.
- * 
+ *
  * If the config is a string, it will be looked up using script->get_constant function to find the actual integer value.
  *
  * @param[in]  setting        The setting to read.
@@ -4616,7 +4616,7 @@ static bool map_setting_lookup_const(const struct config_setting_t *setting, con
 /**
  * Looks up configuration "name" which is expect to have a final value of int,
  * but may be specified by a string constant or an array of bitflag constants.
- * 
+ *
  * If the config is a string, it will be looked up using script->get_constant function to find the actual integer value.
  * If the config is an array, each value will be read and added to the final bitmask.
  *

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -4377,7 +4377,7 @@ static bool mob_read_optdrops_optslot(struct config_setting_t *optslot, int n, i
 	}
 
 	struct optdrop_group_optslot *entry = &(mob->opt_drop_groups[group_id].optslot[n]);
-	entry->options = aCalloc(sizeof(struct optdrop_group_option), count);
+	entry->options = aCalloc(count, sizeof(struct optdrop_group_option));
 
 	int idx = 0;
 	int i = 0;
@@ -4458,7 +4458,7 @@ static bool mob_read_optdrops_db(void)
 	int i = 0;
 	if (its != NULL && (groups = libconfig->setting_get_elem(its, 0)) != NULL) {
 		int count = libconfig->setting_length(groups);
-		mob->opt_drop_groups = aCalloc(sizeof(struct optdrop_group), count);
+		mob->opt_drop_groups = aCalloc(count, sizeof(struct optdrop_group));
 		mob->opt_drop_groups_count = count; // maximum size (used by assertions)
 
 		struct config_setting_t *group = NULL;

--- a/src/map/npc_chat.c
+++ b/src/map/npc_chat.c
@@ -118,7 +118,7 @@ static struct pcrematch_set *lookup_pcreset(struct npc_data *nd, int setid)
 	nullpo_retr(NULL, nd);
 	npcParse = nd->chatdb;
 	if (npcParse == NULL)
-		nd->chatdb = npcParse = (struct npc_parse *)aCalloc(sizeof(struct npc_parse), 1);
+		nd->chatdb = npcParse = (struct npc_parse *) aCalloc(1, sizeof(struct npc_parse));
 
 	pcreset = npcParse->active;
 
@@ -137,7 +137,7 @@ static struct pcrematch_set *lookup_pcreset(struct npc_data *nd, int setid)
 	}
 
 	if (pcreset == NULL) {
-		pcreset = (struct pcrematch_set *)aCalloc(sizeof(struct pcrematch_set), 1);
+		pcreset = (struct pcrematch_set *) aCalloc(1, sizeof(struct pcrematch_set));
 		pcreset->next = npcParse->inactive;
 		if (pcreset->next != NULL)
 			pcreset->next->prev = pcreset;
@@ -284,7 +284,7 @@ static struct pcrematch_entry *create_pcrematch_entry(struct pcrematch_set *set)
 	struct pcrematch_entry *last;
 
 	nullpo_retr(NULL, set);
-	e = (struct pcrematch_entry *)aCalloc(sizeof(struct pcrematch_entry), 1);
+	e = (struct pcrematch_entry *) aCalloc(1, sizeof(struct pcrematch_entry));
 	last = set->head;
 
 	// Normally we would have just stuck it at the end of the list but

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -7050,7 +7050,7 @@ static BUILDIN(callfunc)
 		return false;
 	}
 
-	ref = (struct reg_db *)aCalloc(sizeof(struct reg_db), 2);
+	ref = (struct reg_db *)aCalloc(2, sizeof(struct reg_db));
 	ref[0].vars = st->stack->scope.vars;
 	if (!st->stack->scope.arrays)
 		st->stack->scope.arrays = idb_alloc(DB_OPT_BASE); // TODO: Can this happen? when?
@@ -7145,7 +7145,7 @@ static BUILDIN(callfunctionofnpc) {
 	}
 
 	// alloc a reg_db reference of the current scope for the new scope
-	struct reg_db *ref = (struct reg_db *)aCalloc(sizeof(struct reg_db), 2);
+	struct reg_db *ref = (struct reg_db *)aCalloc(2, sizeof(struct reg_db));
 	// scope variables (.@var)
 	ref[0].vars = st->stack->scope.vars;
 	ref[0].arrays = st->stack->scope.arrays;
@@ -7214,7 +7214,7 @@ static BUILDIN(callsub)
 		return false;
 	}
 
-	ref = (struct reg_db *)aCalloc(sizeof(struct reg_db), 1);
+	ref = (struct reg_db *) aCalloc(1, sizeof(struct reg_db));
 	ref[0].vars = st->stack->scope.vars;
 	if (!st->stack->scope.arrays)
 		st->stack->scope.arrays = idb_alloc(DB_OPT_BASE); // TODO: Can this happen? when?
@@ -7312,7 +7312,7 @@ static BUILDIN(return)
 				// npc variable
 				if( !data->ref ) {
 					// npc variable without a reference set, link to current script
-					data->ref = (struct reg_db *)aCalloc(sizeof(struct reg_db), 1);
+					data->ref = (struct reg_db *) aCalloc(1, sizeof(struct reg_db));
 					script->add_pending_ref(st, data->ref);
 					data->ref->vars = st->script->local.vars;
 					if( !st->script->local.arrays )

--- a/src/map/storage.c
+++ b/src/map/storage.c
@@ -457,7 +457,7 @@ static void storage_storage_quit(struct map_session_data *sd, int flag)
 static struct DBData create_guildstorage(union DBKey key, va_list args)
 {
 	struct guild_storage *gs = NULL;
-	gs = (struct guild_storage *) aCalloc(sizeof(struct guild_storage), 1);
+	gs = (struct guild_storage *) aCalloc(1, sizeof(struct guild_storage));
 	gs->guild_id=key.i;
 	return DB->ptr2data(gs);
 }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Since gcc-14 began running in our CI, we had been having random failures in `aCalloc` due to wrong order of parameters. For some reason, fixing one place doesn't necessarily triggers the error to the other one...

In this PR I looked through every place we use `aCalloc` and fixed the order to match the function expectations: `(number of elements, size of each element)`. While using in the reverse order works for the language, it fails in gcc-14 validation.

I also renamed the macro parameters to be num / size instead of m/n (which always makes me ask what each one is supposed to receive).


**Issues addressed:** <!-- Write here the issue number, if any. -->
None, I think

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
