### PR TITLE
Fix AutoSpell not replacing selected skill in some cases

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -17922,7 +17922,7 @@ static int skill_autospell_spell_selected(struct map_session_data *sd, uint16 sk
 	if (max_lv > skill_lv)
 		max_lv = skill_lv;
 
-	sc_start4(&sd->bl, &sd->bl, SC_AUTOSPELL, 100, skill_lv, skill_id, max_lv, 0,
+	sc_start4(&sd->bl, &sd->bl, SC_AUTOSPELL, 100, autospell_lv, skill_id, max_lv, 0,
 		skill->get_time(SA_AUTOSPELL, skill_lv), SA_AUTOSPELL);
 	return 0;
 }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

SC_AUTOSPELL val1 should be the AutoSpell skill level, not the selected skill learned level. This was broken during the refactor (#3237) and is now fixed.

Thanks to @violent01 for spotting the issue in the rebalance PR ( https://github.com/HerculesWS/Hercules/pull/3230#issuecomment-1941227650 )

Since it was now using the learned level of the selected skill, this lead to cases where switching the selected skill wouldn't work. For example, if you had Fire Bolt Lv10 and Earth Spikes Lv5 (their max), Lv5 would always be less than Lv10, and would be blocked by the default block of every SC (in status.c, which prevents a lower val1 from overriding a higher val1).

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
