### PR TITLE
Initial support for multi-hit critical damage display

### DIFF
--- a/conf/map/battle/feature.conf
+++ b/conf/map/battle/feature.conf
@@ -101,6 +101,10 @@ features: {
 	// false: disable (Default)
 	replace_refine_npcs: false
 
+	// Enable Multi-Hit-Critical damage
+	// Requires: 2016-12-07 RagexeRE or later
+	enable_multi_critical: false
+
 	// Defines the maximum grade level that can be enchanted using the grade enchant ui
 	// Possible values 0-7 (No Grade - SS Grade)
 	grader_max_used: 4

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4915,7 +4915,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 
 	//Check for critical
 #ifdef RENEWAL
-	if((battle_config.feature_enable_multi_crit == 1 || !(wd.type&BDT_MULTIHIT)) && sstatus->cri &&
+	if ((battle_config.feature_enable_multi_crit == 1 || !(wd.type&BDT_MULTIHIT)) && sstatus->cri &&
 		(!skill_id ||
 		skill_id == KN_AUTOCOUNTER ||
 		skill_id == SN_SHARPSHOOTING || skill_id == MA_SHARPSHOOTING ||

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4915,19 +4915,17 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 	}
 
 	//Check for critical
+	if (
 #ifdef RENEWAL
-	if ((battle_config.feature_enable_multi_crit == 1 || !(wd.type&BDT_MULTIHIT)) && sstatus->cri &&
-		(!skill_id ||
-		skill_id == KN_AUTOCOUNTER ||
-		skill_id == SN_SHARPSHOOTING || skill_id == MA_SHARPSHOOTING ||
-		skill_id == NJ_KIRIKAGE))
+		(battle_config.feature_enable_multi_crit == 1 || (wd.type & BDT_MULTIHIT) != 0) &&
 #else
-	if( !flag.cri && wd.type != BDT_MULTIHIT && sstatus->cri &&
+		!flag.cri && wd.type != BDT_MULTIHIT &&
+#endif
+		sstatus->cri &&
 		(!skill_id ||
 		skill_id == KN_AUTOCOUNTER ||
 		skill_id == SN_SHARPSHOOTING || skill_id == MA_SHARPSHOOTING ||
 		skill_id == NJ_KIRIKAGE))
-#endif
 	{
 		short cri = sstatus->cri;
 		if (sd != NULL) {
@@ -4986,10 +4984,11 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 			flag.cri = 1;
 	}
 	if (flag.cri) {
-		if (battle_config.feature_enable_multi_crit == 1)
-			wd.type = (!(wd.type&BDT_MULTIHIT) ? BDT_CRIT : BDT_MULTICRIT);
+		if (battle_config.feature_enable_multi_crit == 1 && (wd.type & BDT_MULTIHIT) != 0)
+			wd.type = BDT_MULTICRIT;
 		else
 			wd.type = BDT_CRIT;
+
 #ifndef RENEWAL
 		flag.idef = flag.idef2 =
 #endif

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4728,7 +4728,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				break;
 
 			case KN_AUTOCOUNTER:
-				wd.flag = (wd.flag&~BF_SKILLMASK)|BF_NORMAL;
+				wd.flag = (wd.flag & ~BF_SKILLMASK) | BF_NORMAL;
 				break;
 
 			case NPC_CRITICALSLASH:

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4683,7 +4683,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 	)
 		flag.arrow = 1;
 
-	if(skill_id || (skill->get_nk(skill_id) & NK_CRITICAL) == 0) {
+	if (skill_id || (skill->get_nk(skill_id) & NK_CRITICAL) == 0) {
 		wd.flag |= battle->range_type(src, target, skill_id, skill_lv);
 		switch(skill_id) {
 			case MO_FINGEROFFENSIVE:

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4605,8 +4605,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 	short hitpercbonus = 0;
 
 	struct Damage wd;
-	struct map_session_data *sd = BL_CAST(BL_PC, src);
-	struct map_session_data *tsd = BL_CAST(BL_PC, target);
 	struct status_change *sc = status->get_sc(src);
 	struct status_change *tsc = status->get_sc(target);
 	struct status_data *sstatus = status->get_status_data(src);
@@ -4672,6 +4670,9 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 		sc = NULL; //Skip checking as there are no status changes active.
 	if (tsc && !tsc->count)
 		tsc = NULL; //Skip checking as there are no status changes active.
+
+	struct map_session_data *sd = BL_CAST(BL_PC, src);
+	struct map_session_data *tsd = BL_CAST(BL_PC, target);
 
 	if(sd)
 		wd.blewcount += battle->blewcount_bonus(sd, skill_id);

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -114,6 +114,7 @@ enum battle_dmg_type {
 	BDT_CRIT        = 10, // Critical hit
 	BDT_PDODGE      = 11, // Lucky dodge
 	//BDT_TOUCH       = 12, // (touch skill?)
+	BDT_MULTICRIT   = 13, ///< Multi-hit with critical
 };
 
 /**
@@ -606,6 +607,8 @@ struct Battle_Config {
 	int show_tip_window;
 	int enable_refinery_ui;
 	int replace_refine_npcs;
+
+	int feature_enable_multi_crit;
 
 	int batk_min;
 	int batk_max;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3488,6 +3488,7 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 		case TF_DOUBLE:
 		case GS_CHAINACTION:
 #ifdef RENEWAL
+		//Focused Arrow Strike and Shadow Slash now shows a critical bubble display.
 		case SN_SHARPSHOOTING:
 		case MA_SHARPSHOOTING:
 		case NJ_KIRIKAGE:

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3487,6 +3487,11 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 		case NPC_CRITICALSLASH:
 		case TF_DOUBLE:
 		case GS_CHAINACTION:
+#ifdef RENEWAL
+		case SN_SHARPSHOOTING:
+		case MA_SHARPSHOOTING:
+		case NJ_KIRIKAGE:
+#endif
 			dmg.dmotion = clif->damage(src,bl,dmg.amotion,dmg.dmotion,damage,dmg.div_,dmg.type,dmg.damage2);
 			break;
 

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -115,6 +115,7 @@ enum e_skill_nk {
 	NK_IGNORE_DEF     = 0x20,
 	NK_IGNORE_FLEE    = 0x40,
 	NK_NO_CARDFIX_DEF = 0x80,
+	NK_CRITICAL       = 0x100,
 };
 
 /// A skill with 3 would be no damage + splash: area of effect.


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR will make multi-hit attacks like `TF_DOUBLE`, `GS_CHAINACTION` & `SC_FEARBREEZE` do critical damage. 
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#2662

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
