### PR TITLE
Fix issues with Auto Shadow Spell

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -20928,7 +20928,8 @@ static void clif_parse_SkillSelectMenu(int fd, struct map_session_data *sd)
 		return;
 	}
 
-	skill->select_menu(sd,RFIFOW(fd,6));
+	const struct PACKET_CZ_SKILL_SELECT_RESPONSE *p = RP2PTR(fd);
+	skill->select_menu(sd, p->selectedSkillId);
 
 	clif_menuskill_clear(sd);
 }

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -20868,7 +20868,7 @@ static int clif_autoshadowspell_list(struct map_session_data *sd)
 
 		len = c * sizeof(*p->skillIds) + sizeof(*p);
 		p->packetLength = len;
-		p->flag = c;
+		p->flag = 1; // 1 = auto shadow spell
 
 		WFIFOSET(fd, len);
 	} else {

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -20828,32 +20828,49 @@ static int clif_poison_list(struct map_session_data *sd, uint16 skill_lv)
 
 	return 1;
 }
+
 static int clif_autoshadowspell_list(struct map_session_data *sd)
 {
-	int fd, i, c;
 	nullpo_ret(sd);
-	fd = sd->fd;
-	if( !fd ) return 0;
 
-	if( sd->menuskill_id == SC_AUTOSHADOWSPELL )
+	int fd = sd->fd;
+	if (fd == 0)
 		return 0;
 
-	WFIFOHEAD(fd, 2 * 6 + 4);
-	WFIFOW(fd,0) = 0x442;
-	for (i = 0, c = 0; i < MAX_SKILL_DB; i++)
+	if (sd->menuskill_id == SC_AUTOSHADOWSPELL)
+		return 0;
+
+	// Max number of skills shown. This number should never go above 2, but let's leave some space for customization.
+	const int max_count = 10;
+
+	struct PACKET_ZC_SKILL_SELECT_REQUEST *p;
+	int len = max_count * sizeof(*p->skillIds);
+	WFIFOHEAD(fd, len);
+	p = WFIFOP(fd, 0);
+	p->packetType = HEADER_ZC_SKILL_SELECT_REQUEST;
+
+	int c = 0;
+	for (int i = 0; i < MAX_SKILL_DB && c < max_count; i++) {
 		if (sd->status.skill[i].flag == SKILL_FLAG_PLAGIARIZED && sd->status.skill[i].id > 0 && sd->status.skill[i].id < GS_GLITTERING
 		    && skill->get_type(sd->status.skill[i].id, sd->status.skill[i].lv) == BF_MAGIC) {
 			// Can't auto cast both Extended class and 3rd class skills.
-			WFIFOW(fd,8+c*2) = sd->status.skill[i].id;
+			p->skillIds[c] = sd->status.skill[i].id;
 			c++;
 		}
+	}
 
-	if( c > 0 ) {
-		WFIFOW(fd,2) = 8 + c * 2;
-		WFIFOL(fd,4) = c;
-		WFIFOSET(fd,WFIFOW(fd,2));
+	if (c == max_count)
+		ShowError("%s: max_count shadow spells was reached, some skills may not be shown.\n", __func__);
+
+	if (c > 0) {
 		sd->menuskill_id = SC_AUTOSHADOWSPELL;
 		sd->menuskill_val = c;
+
+		len = c * sizeof(*p->skillIds) + sizeof(*p);
+		p->packetLength = len;
+		p->flag = c;
+
+		WFIFOSET(fd, len);
 	} else {
 		status_change_end(&sd->bl,SC_STOP,INVALID_TIMER);
 		clif->skill_fail(sd, SC_AUTOSHADOWSPELL, USESKILL_FAIL_IMITATION_SKILL_NONE, 0, 0);
@@ -20861,6 +20878,7 @@ static int clif_autoshadowspell_list(struct map_session_data *sd)
 
 	return 1;
 }
+
 /*===========================================
  * Skill list for Four Elemental Analysis
  * and Change Material skills.

--- a/src/map/packets_struct.h
+++ b/src/map/packets_struct.h
@@ -3319,6 +3319,14 @@ struct PACKET_ZC_MAKINGARROW_LIST {
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(ZC_MAKINGARROW_LIST, 0x01ad);
 
+struct PACKET_ZC_SKILL_SELECT_REQUEST {
+	int16 packetType;
+	int16 packetLength;
+	int32 flag; //< 0 = old code compatibility; 1 = Auto Shadow Spell; same value is received in CZ_SKILL_SELECT_RESPONSE
+	int16 skillIds[];
+} __attribute__((packed));
+DEFINE_PACKET_HEADER(ZC_SKILL_SELECT_REQUEST, 0x0442);
+
 #if PACKETVER_MAIN_NUM >= 20200916 || PACKETVER_RE_NUM >= 20200723 || PACKETVER_ZERO_NUM >= 20221024
 #define REPAIRITEM_INFO REPAIRITEM_INFO2
 struct PACKET_ZC_REPAIRITEMLIST {
@@ -4768,7 +4776,7 @@ struct PACKET_ZC_NOTIFY_SKILL {
 	int8 action;
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(ZC_NOTIFY_SKILL, 0x01de);
-#endif 
+#endif
 
 #if PACKETVER_MAIN_NUM >= 20130731 || PACKETVER_RE_NUM >= 20130724 || defined(PACKETVER_ZERO)
 struct PACKET_ZC_USE_SKILL {

--- a/src/map/packets_struct.h
+++ b/src/map/packets_struct.h
@@ -3327,6 +3327,12 @@ struct PACKET_ZC_SKILL_SELECT_REQUEST {
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(ZC_SKILL_SELECT_REQUEST, 0x0442);
 
+struct PACKET_CZ_SKILL_SELECT_RESPONSE {
+	int16 packetType;
+	int32 flag; //< currently unused, matches ZC_SKILL_SELECT_REQUEST.flag
+	int16 selectedSkillId;
+} __attribute__((packed));
+
 #if PACKETVER_MAIN_NUM >= 20200916 || PACKETVER_RE_NUM >= 20200723 || PACKETVER_ZERO_NUM >= 20221024
 #define REPAIRITEM_INFO REPAIRITEM_INFO2
 struct PACKET_ZC_REPAIRITEMLIST {

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -10445,15 +10445,19 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 			}
 			break;
 		case SC_AUTOSHADOWSPELL:
-			if( sd ) {
-				int idx1 = skill->get_index(sd->reproduceskill_id), idx2 = skill->get_index(sd->cloneskill_id);
-				if( sd->status.skill[idx1].id || sd->status.skill[idx2].id ) {
+			if (sd != NULL) {
+				int reproduceIdx = sd->reproduceskill_id > 0 ? skill->get_index(sd->reproduceskill_id) : -1;
+				int cloneIdx = sd->cloneskill_id > 0 ? skill->get_index(sd->cloneskill_id) : -1;
+
+				bool hasReproduceSkill = reproduceIdx >= 0 && sd->status.skill[reproduceIdx].id != 0;
+				bool hasCloneSkill = cloneIdx >= 0 && sd->status.skill[cloneIdx].id != 0;
+				if (hasReproduceSkill || hasCloneSkill) {
 					sc_start(src, src, SC_STOP, 100, skill_lv, INFINITE_DURATION, skill_id); // The skill_lv is stored in val1 used in skill_select_menu to determine the used skill lvl [Xazax]
 					clif->autoshadowspell_list(sd);
-					clif->skill_nodamage(src,bl,skill_id,1,1);
-				}
-				else
+					clif->skill_nodamage(src, bl, skill_id, 1, 1);
+				} else {
 					clif->skill_fail(sd, skill_id, USESKILL_FAIL_IMITATION_SKILL_NONE, 0, 0);
+				}
 			}
 			break;
 

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -143,7 +143,7 @@ enum e_skill_inf2 {
 	INF2_HIDDEN_TRAP        = 0x00080000, ///< Traps that are hidden (based on trap_visiblity battle conf)
 	INF2_IS_COMBO_SKILL     = 0x00100000, ///< Sets whether a skill can be used in combos or not
 	INF2_NO_STASIS          = 0x00200000,
-	INF2_NO_KAGEHUMI        = 0x00400000, 
+	INF2_NO_KAGEHUMI        = 0x00400000,
 	INF2_RANGE_VULTURE      = 0x00800000, ///< Range is modified by AC_VULTURE
 	INF2_RANGE_SNAKEEYE     = 0x01000000, ///< Range is modified by GS_SNAKEEYE
 	INF2_RANGE_SHADOWJUMP   = 0x02000000, ///< Range is modified by NJ_SHADOWJUMP
@@ -2067,6 +2067,7 @@ struct skill_interface {
 	int unit_group_newid;
 	/* accesssors */
 	int (*get_index) (int skill_id);
+	int (*get_index_sub) (int skill_id, bool report_errors);
 	int (*get_type) (int skill_id, int skill_lv);
 	int (*get_hit) (int skill_id, int skill_lv);
 	int (*get_inf) (int skill_id);

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7418,6 +7418,7 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 			case SC_RESIST_PROPERTY_WIND:
 			case SC_FLASHKICK:
 			case SC_SOULUNITY:
+			case SC__AUTOSHADOWSPELL: // otherwise you can't change your shadow spell to a lower skill_id
 				break;
 			case SC_GOSPEL:
 				//Must not override a casting gospel char.


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes a few issues with Auto Shadow Spell.

1. When casting Auto Shadow Spell, we now properly check if there are skills copied with Intimidade/Reproduce before trying to get the skill_id
   This prevents assertion failures due to the skill id being "0" (no skill)
   In current code, this would still work, but cause a log about bad skill handling

2. Fixed a check that prevented you from switching an active shadow spell to another when their Skill ID was smaller (due to sc val1)

3. Fix assertion error when clicking "cance" or clicking "ok" in Auto Spell list without selecting a skill
   As far as I could analyze, the client is not cleaning up the field that stores the current selected skill, so when you click "ok" it just sends a garbage id that may (or may not) be a valid skill. We now validate before running the skill code.
   For cancel, it sends id "0", which is also fixed now since 0 is not a valid skill id.


As a bonus, I've converted both packets related to that flow to use structs.


**Issues addressed:** Closes #3286 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
