### PR TITLE
Add missing commit for (m)atk/(m)def percent implementation and one official behavior fix for BS_OVERTHRUST

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -8308,8 +8308,15 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 				val2 = 20*val1; //Power increase
 				break;
 			case SC_OVERTHRUST:
-				//val2 holds if it was casted on self, or is bonus received from others
-				val3 = 5*val1; //Power increase
+#ifndef RENEWAL
+				if (val2 == 1) // cast on self
+					val3 = 5 * val1; //Power increase
+				else // received cast
+					val3 = 5;
+#else
+				// for renewal this is actually wrong for party members since 2020 and will need to be changed.
+				val3 = 5 * val1; // Power increase
+#endif
 				if(sd && pc->checkskill(sd,BS_HILTBINDING)>0)
 					total_tick += total_tick / 10;
 				break;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3884,6 +3884,11 @@ static void status_calc_misc(struct block_list *bl, struct status_data *st, int 
 	st->mdef2 += st->int_ + (st->vit >> 1);
 #endif // RENEWAL
 
+	st->atk_percent = 100;
+	st->matk_percent = 100;
+	st->def_percent = 100;
+	st->mdef_percent = 100;
+
 	if ( bl->type&battle_config.enable_critical )
 		st->cri += 10 + (st->luk * 10 / 3); // (every 1 luk = +0.33 critical -> 3 luk = +1 critical)
 	else


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This ensures that ATK/DEF percent is initialized for all bl-types, which it wasn't so it was defaulted to 0, resulting to no damage or 1 damage.

Also implements correct buff for ATK % (not the one of the atk percent behavior, but in general) of BS_OVERTHRUST for party members.

**Issues addressed:** None.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
