### PR TITLE
Fix sending clif->updatestatus to non-sd objects for percent-based stuff

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3079,22 +3079,14 @@ static void status_calc_bl_main(struct block_list *bl, e_scb_flag flag)
 			;
 	}
 
-	if ((flag & SCB_ATK_PERC) != 0) {
-		int prev_atk_percent = st->atk_percent;
+	if ((flag & SCB_ATK_PERC) != 0)
 		st->atk_percent = status->calc_atk_percent(bl, sc);
-		if (prev_atk_percent != st->atk_percent)
-			clif->updatestatus(sd, SP_ATK1);
-	}
 
 	if ((flag & SCB_MATK_PERC) != 0)
 		st->matk_percent = status->calc_matk_percent(bl, sc);
 
-	if ((flag & SCB_DEF_PERC) != 0) {
-		int prev_def_percent = st->def_percent;
+	if ((flag & SCB_DEF_PERC) != 0)
 		st->def_percent = status->calc_def_percent(bl, sc);
-		if (prev_def_percent != st->def_percent)
-			clif->updatestatus(sd, SP_DEF2);
-	}
 
 	if ((flag & SCB_MDEF_PERC) != 0) {
 		st->mdef_percent = status->calc_mdef_percent(bl, sc);
@@ -3497,6 +3489,8 @@ static void status_calc_bl_(struct block_list *bl, e_scb_flag flag, enum e_statu
 #endif
 		)
 			clif->updatestatus(sd,SP_ATK1);
+		else if (bst.atk_percent != st->atk_percent)
+			clif->updatestatus(sd, SP_ATK1);
 
 		if(bst.def != st->def) {
 			clif->updatestatus(sd,SP_DEF1);
@@ -3517,7 +3511,10 @@ static void status_calc_bl_(struct block_list *bl, e_scb_flag flag, enum e_statu
 #ifdef RENEWAL
 			clif->updatestatus(sd,SP_DEF1);
 #endif
+		} else if (bst.def_percent != st->def_percent) {
+			clif->updatestatus(sd,SP_DEF2);
 		}
+
 		if(bst.flee2 != st->flee2)
 			clif->updatestatus(sd,SP_FLEE2);
 		if(bst.cri != st->cri)


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Ensure clif->updatestatus is not called for non-player objects in relation to atk/def percent stuff.

*Accidentally pushed this to a branch on the main repo instead of my fork, gomen ne*

Follow-up to  https://github.com/HerculesWS/Hercules/pull/3290

Commit-reference to my private fork:
```
eb1dcf631508f12e92260119098b5712bb11b9a5
```

**Issues addressed:** None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
