### PR TITLE
Fix warning when SECURE_NPCTIMEOUT enabled

### DIFF
--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -313,7 +313,8 @@ static int npc_rr_secure_timeout_timer(int tid, int64 tick, int id, intptr_t dat
 		case NPCT_MENU:
 			timeout = NPC_SECURE_TIMEOUT_MENU;
 			break;
-		//case NPCT_WAIT: var starts with this value
+		case NPCT_WAIT: //var starts with this value
+			break;
 	}
 
 	if( DIFF_TICK(tick,sd->npc_idle_tick) > (timeout*1000) ) {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
include `NPCT_WAIT` in switch enum
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** #3197 <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
