### PR TITLE
Fix copying own skills via RG_PLAGIARISM or SC_REPRODUCE causing the skill to be deleted and skills that required it eventually.

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -12609,6 +12609,32 @@ void pc_crimson_marker_clear(struct map_session_data *sd)
 	}
 }
 
+/**
+ * Checks if a skill is a permanent skill that one has prerequisites for or has learned.
+ *
+ * NOTE: Unfortunately even uninitialized skills have the flag SKILL_FLAG_PERMANENT, so we have to distinguish by id as well.
+ *       Ideally a more saner zero value should be used for e_skill_flag.
+ * WARNING: This function relies on the skill tree being already calculated / filled.
+ *
+ * @param sd The player to check for.
+ * @param skill_id The skill to check for.
+ * @return True if the player meets the skill prerequisites or has it, false otherwise.
+ */
+static bool pc_is_own_skill(struct map_session_data *sd, uint16 skill_id)
+{
+	nullpo_retr(false, sd);
+
+	int idx = skill->get_index(skill_id);
+	if (idx <= 0)
+		return false; // skill not found
+	if (sd->status.skill[idx].id != skill_id)
+		return false; // not meeting pre-requisites for skill or skill id to index mapping faulty.
+	if (sd->status.skill[idx].flag != SKILL_FLAG_PERMANENT)
+		return false; // script granted or temporary.
+
+	return true;
+}
+
 static void do_final_pc(void)
 {
 
@@ -13035,4 +13061,6 @@ void pc_defaults(void)
 	pc->auto_exp_insurance = pc_auto_exp_insurance;
 
 	pc->crimson_marker_clear = pc_crimson_marker_clear;
+
+	pc->is_own_skill = pc_is_own_skill;
 }

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -8870,18 +8870,7 @@ static int pc_jobchange(struct map_session_data *sd, int class, int upper)
 		pc_setglobalreg(sd, script->add_variable("jobchange_level_3rd"), sd->change_level_3rd);
 	}
 
-	if(sd->cloneskill_id) {
-		idx = skill->get_index(sd->cloneskill_id);
-		if( sd->status.skill[idx].flag == SKILL_FLAG_PLAGIARIZED ) {
-			sd->status.skill[idx].id = 0;
-			sd->status.skill[idx].lv = 0;
-			sd->status.skill[idx].flag = 0;
-			clif->deleteskill(sd, sd->cloneskill_id, false);
-		}
-		sd->cloneskill_id = 0;
-		pc_setglobalreg(sd, script->add_variable("CLONE_SKILL"), 0);
-		pc_setglobalreg(sd, script->add_variable("CLONE_SKILL_LV"), 0);
-	}
+	pc->clear_existing_cloneskill(sd, true);
 
 	if(sd->reproduceskill_id) {
 		idx = skill->get_index(sd->reproduceskill_id);

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1520,11 +1520,17 @@ static int pc_reg_received(struct map_session_data *sd)
 	if ((i = pc->checkskill(sd,RG_PLAGIARISM)) > 0) {
 		sd->cloneskill_id = pc_readglobalreg(sd,script->add_variable("CLONE_SKILL"));
 		if (sd->cloneskill_id > 0 && (idx = skill->get_index(sd->cloneskill_id)) > 0) {
+			int learned_lv = sd->status.skill[idx].lv;
+			bool is_own_skill = pc->is_own_skill(sd, sd->cloneskill_id);
 			sd->status.skill[idx].id = sd->cloneskill_id;
 			sd->status.skill[idx].lv = pc_readglobalreg(sd,script->add_variable("CLONE_SKILL_LV"));
 			if (sd->status.skill[idx].lv > i)
 				sd->status.skill[idx].lv = i;
-			sd->status.skill[idx].flag = SKILL_FLAG_PLAGIARIZED;
+
+			if (is_own_skill)
+				sd->status.skill[idx].flag = learned_lv + SKILL_FLAG_REPLACED_LV_0;
+			else
+				sd->status.skill[idx].flag = SKILL_FLAG_PLAGIARIZED;
 		}
 	}
 	if ((i = pc->checkskill(sd,SC_REPRODUCE)) > 0) {
@@ -1644,7 +1650,8 @@ static void pc_calc_skilltree_clear(struct map_session_data *sd)
 	nullpo_retv(sd);
 
 	for (i = 0; i < MAX_SKILL_DB; i++) {
-		if (sd->status.skill[i].flag != SKILL_FLAG_PLAGIARIZED && sd->status.skill[i].flag != SKILL_FLAG_PERM_GRANTED) //Don't touch these
+		if (sd->status.skill[i].flag != SKILL_FLAG_PLAGIARIZED && sd->status.skill[i].flag != SKILL_FLAG_PERM_GRANTED
+		    && sd->status.skill[i].id != sd->cloneskill_id) //Don't touch these
 			sd->status.skill[i].id = 0; //First clear skills.
 		/* permanent skills that must be re-checked */
 		if (sd->status.skill[i].flag == SKILL_FLAG_PERMANENT) {
@@ -1679,7 +1686,8 @@ static int pc_calc_skilltree(struct map_session_data *sd)
 	pc->calc_skilltree_clear(sd);
 
 	for (int i = 0; i < MAX_SKILL_DB; i++) {
-		if (sd->status.skill[i].flag == SKILL_FLAG_TEMPORARY || sd->status.skill[i].flag >= SKILL_FLAG_REPLACED_LV_0) {
+		if ((sd->status.skill[i].flag >= SKILL_FLAG_REPLACED_LV_0 && sd->status.skill[i].id != sd->cloneskill_id)
+		    || sd->status.skill[i].flag == SKILL_FLAG_TEMPORARY) {
 			// Restore original level of skills after deleting earned skills.
 			sd->status.skill[i].lv = (sd->status.skill[i].flag == SKILL_FLAG_TEMPORARY) ? 0 : sd->status.skill[i].flag - SKILL_FLAG_REPLACED_LV_0;
 			sd->status.skill[i].flag = SKILL_FLAG_PERMANENT;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1536,11 +1536,17 @@ static int pc_reg_received(struct map_session_data *sd)
 	if ((i = pc->checkskill(sd,SC_REPRODUCE)) > 0) {
 		sd->reproduceskill_id = pc_readglobalreg(sd,script->add_variable("REPRODUCE_SKILL"));
 		if( sd->reproduceskill_id > 0 && (idx = skill->get_index(sd->reproduceskill_id)) > 0) {
+			int learned_lv = sd->status.skill[idx].lv;
+			bool is_own_skill = pc->is_own_skill(sd, sd->reproduceskill_id);
 			sd->status.skill[idx].id = sd->reproduceskill_id;
 			sd->status.skill[idx].lv = pc_readglobalreg(sd,script->add_variable("REPRODUCE_SKILL_LV"));
 			if( i < sd->status.skill[idx].lv)
 				sd->status.skill[idx].lv = i;
-			sd->status.skill[idx].flag = SKILL_FLAG_PLAGIARIZED;
+
+			if (is_own_skill)
+				sd->status.skill[idx].flag = learned_lv + SKILL_FLAG_REPLACED_LV_0;
+			else
+				sd->status.skill[idx].flag = SKILL_FLAG_PLAGIARIZED;
 		}
 	}
 
@@ -1650,9 +1656,10 @@ static void pc_calc_skilltree_clear(struct map_session_data *sd)
 	nullpo_retv(sd);
 
 	for (i = 0; i < MAX_SKILL_DB; i++) {
-		if (sd->status.skill[i].flag != SKILL_FLAG_PLAGIARIZED && sd->status.skill[i].flag != SKILL_FLAG_PERM_GRANTED
-		    && sd->status.skill[i].id != sd->cloneskill_id) //Don't touch these
-			sd->status.skill[i].id = 0; //First clear skills.
+		if (sd->status.skill[i].flag == SKILL_FLAG_PLAGIARIZED || sd->status.skill[i].flag == SKILL_FLAG_PERM_GRANTED
+		    || sd->status.skill[i].id == sd->cloneskill_id || sd->status.skill[i].id == sd->reproduceskill_id) //Don't touch these
+			continue;
+		sd->status.skill[i].id = 0; //First clear skills.
 		/* permanent skills that must be re-checked */
 		if (sd->status.skill[i].flag == SKILL_FLAG_PERMANENT) {
 			switch (skill->dbs->db[i].nameid) {
@@ -1686,7 +1693,7 @@ static int pc_calc_skilltree(struct map_session_data *sd)
 	pc->calc_skilltree_clear(sd);
 
 	for (int i = 0; i < MAX_SKILL_DB; i++) {
-		if ((sd->status.skill[i].flag >= SKILL_FLAG_REPLACED_LV_0 && sd->status.skill[i].id != sd->cloneskill_id)
+		if ((sd->status.skill[i].flag >= SKILL_FLAG_REPLACED_LV_0 && sd->status.skill[i].id != sd->cloneskill_id && sd->status.skill[i].id != sd->reproduceskill_id)
 		    || sd->status.skill[i].flag == SKILL_FLAG_TEMPORARY) {
 			// Restore original level of skills after deleting earned skills.
 			sd->status.skill[i].lv = (sd->status.skill[i].flag == SKILL_FLAG_TEMPORARY) ? 0 : sd->status.skill[i].flag - SKILL_FLAG_REPLACED_LV_0;
@@ -8871,7 +8878,6 @@ static int pc_jobchange(struct map_session_data *sd, int class, int upper)
 	}
 
 	pc->clear_existing_cloneskill(sd, true);
-
 	pc->clear_existing_reproduceskill(sd, true);
 
 	if ((job & MAPID_UPPERMASK) != (sd->job & MAPID_UPPERMASK)) { //Things to remove when changing class tree.
@@ -12670,6 +12676,11 @@ static void pc_clear_existing_reproduceskill(struct map_session_data *sd, bool c
 			sd->status.skill[idx].lv = 0;
 			sd->status.skill[idx].flag = 0;
 			clif->deleteskill(sd, sd->reproduceskill_id, false);
+		} else if (sd->status.skill[idx].flag >= SKILL_FLAG_REPLACED_LV_0) {
+			sd->status.skill[idx].lv = sd->status.skill[idx].flag - SKILL_FLAG_REPLACED_LV_0;
+			sd->status.skill[idx].flag = SKILL_FLAG_PERMANENT;
+			// CAREFUL! This assumes you will only ever use SKILL_FLAG_REPLACED_LV_0 logic when copying SKILL_FLAG_PERMANENT skills!!!
+			clif->addskill(sd, sd->reproduceskill_id);
 		}
 	}
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -1286,6 +1286,7 @@ END_ZEROED_BLOCK; /* End */
 
 	bool (*is_own_skill) (struct map_session_data *sd, uint16 skill_id);
 	void (*clear_existing_cloneskill) (struct map_session_data *sd, bool clear_vars);
+	void (*clear_existing_reproduceskill) (struct map_session_data *sd, bool clear_vars);
 };
 
 #ifdef HERCULES_CORE

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -1283,6 +1283,8 @@ END_ZEROED_BLOCK; /* End */
 	bool (*auto_exp_insurance) (struct map_session_data *sd);
 
 	void (*crimson_marker_clear) (struct map_session_data *sd);
+
+	bool (*is_own_skill) (struct map_session_data *sd, uint16 skill_id);
 };
 
 #ifdef HERCULES_CORE

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -1285,6 +1285,7 @@ END_ZEROED_BLOCK; /* End */
 	void (*crimson_marker_clear) (struct map_session_data *sd);
 
 	bool (*is_own_skill) (struct map_session_data *sd, uint16 skill_id);
+	void (*clear_existing_cloneskill) (struct map_session_data *sd, bool clear_vars);
 };
 
 #ifdef HERCULES_CORE

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3681,7 +3681,7 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 				break;
 		}
 
-		int cidx, idx, lv = 0;
+		int cidx, lv = 0;
 		cidx = skill->get_index(copy_skill);
 		switch(can_copy(tsd, copy_skill)) {
 		case 1: // Plagiarism
@@ -3710,15 +3710,7 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 		case 2: // Reproduce
 		{
 			lv = sc ? sc->data[SC__REPRODUCE]->val1 : 1;
-			if (tsd->reproduceskill_id) {
-				idx = skill->get_index(tsd->reproduceskill_id);
-				if (tsd->status.skill[idx].flag == SKILL_FLAG_PLAGIARIZED) {
-					tsd->status.skill[idx].id = 0;
-					tsd->status.skill[idx].lv = 0;
-					tsd->status.skill[idx].flag = 0;
-					clif->deleteskill(tsd, tsd->reproduceskill_id, false);
-				}
-			}
+			pc->clear_existing_reproduceskill(tsd, false);
 			lv = min(lv, skill->get_max(copy_skill));
 
 			tsd->reproduceskill_id = copy_skill;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1263,7 +1263,8 @@ static int can_copy(struct map_session_data *sd, uint16 skill_id)
 		return 0;
 
 	if (sd->status.skill[cidx].id != 0 && (sd->status.skill[cidx].flag >= SKILL_FLAG_REPLACED_LV_0
-	                                       || sd->status.skill[cidx].flag == SKILL_FLAG_PLAGIARIZED))
+	                                       || sd->status.skill[cidx].flag == SKILL_FLAG_PLAGIARIZED
+	                                       || sd->status.skill[cidx].flag == SKILL_FLAG_PERM_GRANTED))
 		return 0;
 
 	// Checks if preserve is active and if skill can be copied by Plagiarism

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3686,20 +3686,7 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 		switch(can_copy(tsd, copy_skill)) {
 		case 1: // Plagiarism
 		{
-			if (tsd->cloneskill_id) {
-				idx = skill->get_index(tsd->cloneskill_id);
-				if (tsd->status.skill[idx].flag == SKILL_FLAG_PLAGIARIZED) {
-					tsd->status.skill[idx].id = 0;
-					tsd->status.skill[idx].lv = 0;
-					tsd->status.skill[idx].flag = 0;
-					clif->deleteskill(tsd, tsd->cloneskill_id, false);
-				} else if (tsd->status.skill[idx].flag >= SKILL_FLAG_REPLACED_LV_0) {
-					tsd->status.skill[idx].lv = tsd->status.skill[idx].flag - SKILL_FLAG_REPLACED_LV_0;
-					tsd->status.skill[idx].flag = SKILL_FLAG_PERMANENT;
-					// CAREFUL! This assumes you will only ever use SKILL_FLAG_REPLACED_LV_0 logic when copying SKILL_FLAG_PERMANENT skills!!!
-					clif->addskill(tsd, tsd->cloneskill_id);
-				}
-			}
+			pc->clear_existing_cloneskill(tsd, false);
 			int learned_lv = tsd->status.skill[cidx].lv;
 			bool copying_own_skill = pc->is_own_skill(tsd, copy_skill);
 

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1262,7 +1262,8 @@ static int can_copy(struct map_session_data *sd, uint16 skill_id)
 	if (!cidx)
 		return 0;
 
-	if (sd->status.skill[cidx].id && sd->status.skill[cidx].flag == SKILL_FLAG_PLAGIARIZED)
+	if (sd->status.skill[cidx].id != 0 && (sd->status.skill[cidx].flag >= SKILL_FLAG_REPLACED_LV_0
+	                                       || sd->status.skill[cidx].flag == SKILL_FLAG_PLAGIARIZED))
 		return 0;
 
 	// Checks if preserve is active and if skill can be copied by Plagiarism


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

We address this by implementing logic to use SKILL_FLAG_REPLACED_LV_0 in SC_REPRODUCE and RG_PLAGIARISM.
We also reduced some code-duplication shared with pc_jobchange and skill_attack logic of those two skills.
SKILL_FLAG_PERM_GRANTED skills are no longer copyable as there's no clearly defined implementation for those when copied.

Note: A skill that one has the prerequisites for but one didn't level will appear as SKILL_FLAG_PERMANENT and have it's .id entry set in an `sd`'s status.skill[] entry.
Note: Well skills that you didn't learn, nor can learn, will also appear as SKILL_FLAG_PERMANENT, but can be distinguished via unset id.

Vaguely inspired by https://github.com/HeraclesHub/Heracles/pull/14

**Issues addressed:** #3289

List of commits in my private-fork that this PR is based on:
```  
dfbdbc0335fd05e5317f1efbefb16cac3b7a9050
6e29dc9c1e92453edfe5930d154687200a1e658f
87ba9544695c4e4d332c2f24504d0cb76a6161a3
9d15215176a525ed3aabfcfdbb89ba877b94c60c
a6ecba8539ab3178d8748c098e27bf808e0420cf
a4bd3b1240274da0650cfa2832a82fa2f15f2c3e
4cea95b2391740e9a3f002ac56d0132608bd3f9c
b82d6ca0d7e890a6d25271c7ecf4081d4654e531
```

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
