### PR TITLE
`getpartymember` upgrade

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9938,6 +9938,13 @@ static BUILDIN(getpartymember)
 		st->state = END;
 		return false;
 	}
+
+	if (type < PT_MEMBER_NAME || type > PT_MEMBER_ACCID) {
+		ShowError("buildin_getpartymember: Invalid type argument\n");
+		script->reportdata(data);
+		st->state = END;
+		return false;
+	}
 	
 	if (!is_int_variable(varname) && (type == PT_MEMBER_CHARID || type == PT_MEMBER_ACCID)) {
 		ShowError("buildin_getpartymember: Target argument is not an int variable\n");

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9920,41 +9920,68 @@ static BUILDIN(getpartyname)
 
 /*==========================================
  * Get the information of the members of a party by type
- * @party_id, @type
- * return by @type :
- * - : nom des membres
- * 1 : char_id des membres
- * 2 : account_id des membres
+ * getpartymember(<party_id>, <type>, <array>);
  *------------------------------------------*/
 static BUILDIN(getpartymember)
 {
-	struct party_data *p;
-	int j=0,type=0;
+	struct map_session_data *sd = NULL;
+	struct party_data *p = party->search(script_getnum(st, 2));
+	enum partymember_type type = script_getnum(st, 3);
+	struct script_data *data = script_getdata(st, 4);
+	const char *varname = reference_getname(data);
+	int id = reference_getid(data);
+	int num = 0;
 
-	p=party->search(script_getnum(st,2));
+	if (!data_isreference(data) || reference_toconstant(data)) {
+		ShowError("buildin_getpartymember: Target argument is not a variable\n");
+		script->reportdata(data);
+		st->state = END;
+		return false;
+	}
+	
+	if (!is_int_variable(varname) && (type == PT_MEMBER_CHARID || type == PT_MEMBER_ACCID)) {
+		ShowError("buildin_getpartymember: Target argument is not an int variable\n");
+		script->reportdata(data);
+		st->state = END;
+		return false;
+	}
 
-	if (script_hasdata(st,3))
-		type=script_getnum(st,3);
+	if (!is_string_variable(varname) && type == PT_MEMBER_NAME) {
+		ShowError("buildin_getpartymember: Target argument is not a string variable\n");
+		script->reportdata(data);
+		st->state = END;
+		return false;
+	}
 
-	if ( p != NULL) {
-		int i;
-		for (i = 0; i < MAX_PARTY; i++) {
-			if(p->party.member[i].account_id) {
+	if (not_server_variable(*varname)) {
+		sd = script->rid2sd(st);
+
+		if (sd == NULL) {
+			script_pushint(st, 0);
+			return true; // player variable but no player attached
+		}
+	}
+
+	if (p) {
+		for (int i = 0; i < MAX_PARTY; i++) {
+			if (p->party.member[i].account_id) {
 				switch (type) {
-					case 2:
-						mapreg->setreg(reference_uid(script->add_variable("$@partymemberaid"), j),p->party.member[i].account_id);
-						break;
-					case 1:
-						mapreg->setreg(reference_uid(script->add_variable("$@partymembercid"), j),p->party.member[i].char_id);
-						break;
-					default:
-						mapreg->setregstr(reference_uid(script->add_variable("$@partymembername$"), j),p->party.member[i].name);
+				case PT_MEMBER_NAME:
+					script->set_reg(st, sd, reference_uid(id, num), varname, (const void *)h64BPTRSIZE(p->party.member[i].name), reference_getref(data));
+					break;
+				case PT_MEMBER_CHARID:
+					script->set_reg(st, sd, reference_uid(id, num), varname, (const void *)h64BPTRSIZE(p->party.member[i].char_id), reference_getref(data));
+					break;
+				case PT_MEMBER_ACCID:
+					script->set_reg(st, sd, reference_uid(id, num), varname, (const void *)h64BPTRSIZE(p->party.member[i].account_id), reference_getref(data));
+					break;
 				}
-				j++;
+				num++;
 			}
 		}
 	}
-	mapreg->setreg(script->add_variable("$@partymembercount"),j);
+
+	script_pushint(st, num);
 
 	return true;
 }
@@ -28867,7 +28894,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(setdialogpos, "ii"),
 		BUILDIN_DEF(setdialogpospercent, "ii"),
 		BUILDIN_DEF(getpartyname,"i"),
-		BUILDIN_DEF(getpartymember,"i?"),
+		BUILDIN_DEF(getpartymember,"iir"),
 		BUILDIN_DEF(getpartyleader,"i?"),
 		BUILDIN_DEF(getguildmember,"i?"),
 		BUILDIN_DEF(getguildinfo,"i?"),
@@ -30120,6 +30147,11 @@ static void script_hardcoded_constants(void)
 	script->set_constant("SIEGE_TYPE_FE", SIEGE_TYPE_FE, false, false);
 	script->set_constant("SIEGE_TYPE_SE", SIEGE_TYPE_SE, false, false);
 	script->set_constant("SIEGE_TYPE_TE", SIEGE_TYPE_TE, false, false);
+
+	script->constdb_comment("partymember types");
+	script->set_constant("PT_MEMBER_NAME", PT_MEMBER_NAME, false, false);
+	script->set_constant("PT_MEMBER_CHARID", PT_MEMBER_CHARID, false, false);
+	script->set_constant("PT_MEMBER_ACCID", PT_MEMBER_ACCID, false, false);
 
 	script->constdb_comment("guildinfo types");
 	script->set_constant("GUILDINFO_NAME", GUILDINFO_NAME, false, false);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9969,7 +9969,7 @@ static BUILDIN(getpartymember)
 		}
 	}
 
-	if (p) {
+	if (p != NULL) {
 		for (int i = 0; i < MAX_PARTY; i++) {
 			if (p->party.member[i].account_id) {
 				switch (type) {

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9971,7 +9971,7 @@ static BUILDIN(getpartymember)
 
 	if (p != NULL) {
 		for (int i = 0; i < MAX_PARTY; i++) {
-			if (p->party.member[i].account_id) {
+			if (p->party.member[i].account_id != 0) {
 				switch (type) {
 				case PT_MEMBER_NAME:
 					script->set_reg(st, sd, reference_uid(id, num), varname, (const void *)h64BPTRSIZE(p->party.member[i].name), reference_getref(data));

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -619,6 +619,12 @@ enum script_hominfo_types {
 	HOMINFO_MAX
 };
 
+enum partymember_type {
+	PT_MEMBER_NAME,
+	PT_MEMBER_CHARID,
+	PT_MEMBER_ACCID,
+};
+
 /**
  * Structures
  **/


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x ] I have followed [proper Hercules code styling][code].
- [x ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Hi, I'd like to share my version of the `getpartymember` script command, similar to `getunits`.

This updated version no longer uses global temporary variables, which are prone to being overwritten, especially when multiple players call the function simultaneously. Instead, it requires the scripter to declare an array as an argument in the 3rd parameter of the command.

Additionally, this change introduces the following constants: `PT_MEMBER_NAME`, `PT_MEMBER_CHARID`, and `PT_MEMBER_ACCID`. The function now also returns the size of the party.

Sample usage:
```
.@count = getpartymember(getcharid(CHAR_ID_PARTY), PT_MEMBER_NAME, .@name$);
for (.@i = 0; .@i < .@count; .@i++) {
	consolemes(CONSOLEMES_DEBUG, ""+.@name$[.@i]+"");
}
```
<!-- Describe the changes that this pull request makes. -->

The existing script will be deprecated, but I will gladly update all current NPC scripts to use this new version if approved. I can apply similar updates to `getguildmember` and `getmobdrops` as well.

I think this approach aligns more closely with Herc's style.

**Issues addressed:** <!-- Write here the issue number, if any. -->
Wrong data when multiple players call the command.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
