### PR TITLE
Add validations/alerts for packet ranges

### DIFF
--- a/src/common/HPM.c
+++ b/src/common/HPM.c
@@ -190,6 +190,10 @@ static bool hplugins_addpacket(unsigned short cmd, unsigned short length, void (
 
 	if (cmd <= MAX_PACKET_DB && cmd >= MIN_PACKET_DB) {
 		packets->db[cmd] = length;
+	} else if (point != hpProxy_ApiLogin && point != hpProxy_ApiChar && point != hpProxy_ApiMap) {
+		// (About the condition above) API Proxy messages does not need to go into packets->db, so we don't error
+		ShowError("HPM->addPacket:%s: packet 0x%04x is out of range! Packet ID must be between 0x%04x (MIN_PACKET_DB) and 0x%04x (MAX_PACKET_DB). Ignoring it...\n",
+		    HPM->pid2name(pluginID), cmd, (unsigned int) MIN_PACKET_DB, (unsigned int) MAX_PACKET_DB);
 	}
 
 	return true;

--- a/src/common/packets.h
+++ b/src/common/packets.h
@@ -30,6 +30,8 @@
 #define MAX_PACKET_DB 0x0F00
 #endif
 
+STATIC_ASSERT(MAX_PACKET_DB <= USHRT_MAX, "MAX_PACKET_DB must not exceed 2 bytes (USHRT_MAX / 65,535)");
+
 #ifndef MIN_INTIF_PACKET_DB
 #define MIN_INTIF_PACKET_DB 0x3800
 #endif


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Add assert to ensure `MAX_PACKET_DB` is within 2 bytes range (currently `packetType` is 2 bytes long)
- Add error message when HPM plugins declare packets outside of PACKET_DB range. This is currently silently ignored. Making a error message will help users debugging their plugins.


**Issues addressed:** <!-- Write here the issue number, if any. -->
None, discussed in discord; thanks to csnv and dastgirp for bringing these up

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
