### PR TITLE
`getguildmember` refactor

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -10094,44 +10094,76 @@ static BUILDIN(getguildinfo)
 
 /*==========================================
  * Get the information of the members of a guild by type.
- * getguildmember <guild_id>{,<type>};
- * @param guild_id: ID of guild
- * @param type:
- * 0 : name (default)
- * 1 : character ID
- * 2 : account ID
+ * getguildmember(<guild_id>, <type>, <array>);
  *------------------------------------------*/
 static BUILDIN(getguildmember)
 {
-	struct guild *g = NULL;
-	int j = 0;
+	struct map_session_data *sd = NULL;
+	struct guild *g = guild->search(script_getnum(st, 2));
+	enum guildmember_type type = script_getnum(st, 3);
+	struct script_data *data = script_getdata(st, 4);
+	const char *varname = reference_getname(data);
+	int id = reference_getid(data);
+	int num = 0;
 
-	g = guild->search(script_getnum(st,2));
+	if (!data_isreference(data) || reference_toconstant(data)) {
+		ShowError("buildin_getguildmember: Target argument is not a variable\n");
+		script->reportdata(data);
+		st->state = END;
+		return false;
+	}
+	
+	if (type < GD_MEMBER_NAME || type > GD_MEMBER_ACCID) {
+		ShowError("buildin_getguildmember: Invalid type argument\n");
+		script->reportdata(data);
+		st->state = END;
+		return false;
+	}
 
-	if (g) {
-		int i, type = 0;
+	if (!is_int_variable(varname) && (type == GD_MEMBER_CHARID || type == GD_MEMBER_ACCID)) {
+		ShowError("buildin_getguildmember: Target argument is not an int variable\n");
+		script->reportdata(data);
+		st->state = END;
+		return false;
+	}
 
-		if (script_hasdata(st,3))
-			type = script_getnum(st,3);
+	if (!is_string_variable(varname) && type == GD_MEMBER_NAME) {
+		ShowError("buildin_getguildmember: Target argument is not a string variable\n");
+		script->reportdata(data);
+		st->state = END;
+		return false;
+	}
 
-		for ( i = 0; i < MAX_GUILD; i++ ) {
-			if ( g->member[i].account_id ) {
+	if (not_server_variable(*varname)) {
+		sd = script->rid2sd(st);
+
+		if (sd == NULL) {
+			script_pushint(st, 0);
+			return true; // player variable but no player attached
+		}
+	}
+
+	if (g != NULL) {
+		for (int i = 0; i < MAX_GUILD; i++) {
+			if (g->member[i].account_id != 0) {
 				switch (type) {
-				case 2:
-					mapreg->setreg(reference_uid(script->add_variable("$@guildmemberaid"), j),g->member[i].account_id);
+				case GD_MEMBER_NAME:
+					script->set_reg(st, sd, reference_uid(id, num), varname, (const void *)h64BPTRSIZE(g->member[i].name), reference_getref(data));
 					break;
-				case 1:
-					mapreg->setreg(reference_uid(script->add_variable("$@guildmembercid"), j), g->member[i].char_id);
+				case GD_MEMBER_CHARID:
+					script->set_reg(st, sd, reference_uid(id, num), varname, (const void *)h64BPTRSIZE(g->member[i].char_id), reference_getref(data));
 					break;
-				default:
-					mapreg->setregstr(reference_uid(script->add_variable("$@guildmembername$"), j), g->member[i].name);
+				case GD_MEMBER_ACCID:
+					script->set_reg(st, sd, reference_uid(id, num), varname, (const void *)h64BPTRSIZE(g->member[i].account_id), reference_getref(data));
 					break;
 				}
-				j++;
+				num++;
 			}
 		}
 	}
-	mapreg->setreg(script->add_variable("$@guildmembercount"), j);
+
+	script_pushint(st, num);
+
 	return true;
 }
 
@@ -28869,7 +28901,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(getpartyname,"i"),
 		BUILDIN_DEF(getpartymember,"i?"),
 		BUILDIN_DEF(getpartyleader,"i?"),
-		BUILDIN_DEF(getguildmember,"i?"),
+		BUILDIN_DEF(getguildmember,"iir"),
 		BUILDIN_DEF(getguildinfo,"i?"),
 		BUILDIN_DEF(getguildonline, "i?"),
 		BUILDIN_DEF(strcharinfo,"i??"),
@@ -30120,6 +30152,11 @@ static void script_hardcoded_constants(void)
 	script->set_constant("SIEGE_TYPE_FE", SIEGE_TYPE_FE, false, false);
 	script->set_constant("SIEGE_TYPE_SE", SIEGE_TYPE_SE, false, false);
 	script->set_constant("SIEGE_TYPE_TE", SIEGE_TYPE_TE, false, false);
+
+	script->constdb_comment("guildmember types");
+	script->set_constant("GD_MEMBER_NAME", GD_MEMBER_NAME, false, false);
+	script->set_constant("GD_MEMBER_CHARID", GD_MEMBER_CHARID, false, false);
+	script->set_constant("GD_MEMBER_ACCID", GD_MEMBER_ACCID, false, false);
 
 	script->constdb_comment("guildinfo types");
 	script->set_constant("GUILDINFO_NAME", GUILDINFO_NAME, false, false);

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -619,6 +619,12 @@ enum script_hominfo_types {
 	HOMINFO_MAX
 };
 
+enum guildmember_type {
+	GD_MEMBER_NAME,
+	GD_MEMBER_CHARID,
+	GD_MEMBER_ACCID,
+};
+
 /**
  * Structures
  **/


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ x ] I have followed [proper Hercules code styling][code].
- [ x ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ x ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Similar updates to `getpartymember` #3305 where global variables get overwritten by calling the command by 2 or more players simultaneously.
This update makes the command require an array as its argument and will return the size of the guild.

Constants are `GD_MEMBER_NAME`, `GD_MEMBER_CHARID`, and `GD_MEMBER_ACCID`.

Usage:
```
.@count = getguildmember(getcharid(CHAR_ID_GUILD), GD_MEMBER_NAME, .@name$);
for (.@i = 0; .@i < .@count; .@i++) {
	consolemes(CONSOLEMES_DEBUG, ""+.@name$[.@i]+"");
}
```

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Wrong data when multiple players call the command.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
