### PR TITLE
Don't use SSL for MariaDB CI runs (Fixes CI)

### DIFF
--- a/tools/ci/travis.sh
+++ b/tools/ci/travis.sh
@@ -144,27 +144,32 @@ case "$MODE" in
 		;;
 esac
 
+SSL_ARG=""
+if [[ $(mysql --version) =~ "MariaDB" ]]; then
+	SSL_ARG="--ssl=0"
+fi
+
 case "$MODE" in
 	createdb)
 		echo "Creating database $DBNAME as $DBUSER..."
-		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG --execute="CREATE DATABASE $DBNAME;" || aborterror "Unable to create database."
+		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG $SSL_ARG --execute="CREATE DATABASE $DBNAME;" || aborterror "Unable to create database."
 		;;
 	importdb)
 		echo "Importing tables into $DBNAME as $DBUSER..."
-		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG --database=$DBNAME < sql-files/main.sql || aborterror "Unable to import main database."
-		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG --database=$DBNAME < sql-files/logs.sql || aborterror "Unable to import logs database."
+		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG $SSL_ARG --database=$DBNAME < sql-files/main.sql || aborterror "Unable to import main database."
+		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG $SSL_ARG --database=$DBNAME < sql-files/logs.sql || aborterror "Unable to import logs database."
 		;;
 	adduser)
 		echo "Adding user $NEWUSER as $DBUSER, with access to database $DBNAME..."
-		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG --execute="GRANT SELECT,INSERT,UPDATE,DELETE ON $DBNAME.* TO '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
-		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG --execute="CREATE USER '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
-		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG --execute="GRANT SELECT,INSERT,UPDATE,DELETE ON $DBNAME.* TO '$NEWUSER'@'$DBHOST';" || true
-		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG --execute="ALTER USER '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
+		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG $SSL_ARG --execute="GRANT SELECT,INSERT,UPDATE,DELETE ON $DBNAME.* TO '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
+		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG $SSL_ARG --execute="CREATE USER '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
+		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG $SSL_ARG --execute="GRANT SELECT,INSERT,UPDATE,DELETE ON $DBNAME.* TO '$NEWUSER'@'$DBHOST';" || true
+		mysql $DBUSER_ARG $DBPASS_ARG $DBHOST_ARG $SSL_ARG --execute="ALTER USER '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
 
 		if [[ -n "$(uname -a | grep -i linux)" ]]; then
-			mysql --defaults-file=/etc/mysql/debian.cnf $DBPASS_ARG $DBHOST_ARG --execute="CREATE USER '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
-			mysql --defaults-file=/etc/mysql/debian.cnf $DBPASS_ARG $DBHOST_ARG --execute="GRANT SELECT,INSERT,UPDATE,DELETE ON $DBNAME.* TO '$NEWUSER'@'$DBHOST';" || true
-			mysql --defaults-file=/etc/mysql/debian.cnf $DBPASS_ARG $DBHOST_ARG --execute="ALTER USER '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
+			mysql --defaults-file=/etc/mysql/debian.cnf $DBPASS_ARG $DBHOST_ARG $SSL_ARG --execute="CREATE USER '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
+			mysql --defaults-file=/etc/mysql/debian.cnf $DBPASS_ARG $DBHOST_ARG $SSL_ARG --execute="GRANT SELECT,INSERT,UPDATE,DELETE ON $DBNAME.* TO '$NEWUSER'@'$DBHOST';" || true
+			mysql --defaults-file=/etc/mysql/debian.cnf $DBPASS_ARG $DBHOST_ARG $SSL_ARG --execute="ALTER USER '$NEWUSER'@'$DBHOST' IDENTIFIED BY '$NEWPASS';" || true
 		fi
 		;;
 	build)


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The mysql client currently being used for MariaDB CI runs tries to connect with SSL to the test db. But our test db does not run in SSL (and doesn't have to).

This PR disables the SSL connection for MariaDB tests.

I had to limit to MariaDB v11 as some other tests (specially using MySQL) would fail because `--ssl` is not recognized by them.

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
