### PR TITLE
`getmobdrops` refactor

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -4333,54 +4333,25 @@ Example:
 
 ---------------------------------------
 
-*getmobdrops(<mob id>)
+*getmobdrops(<mob_id>, <item_id_array>{, <drop_rate_array>});
 
-This command will find all drops of the specified mob and return the item
-IDs and drop percentages into arrays of temporary global variables.
-getmobdrops() returns true if successful and false if the mob ID doesn't
-exist.
-
-Upon executing this,
-
-$@MobDrop_item[] is a global temporary number array which contains the
-                 item IDs of the monster's drops.
-
-$@MobDrop_rate[] is a global temporary number array which contains the
-                 drop percentages of each item. (1 = .01%)
-
-$@MobDrop_count  is the number of item drops found.
-
-Be sure to use $@MobDrop_count to go through the arrays, and not
-'getarraysize', because the temporary global arrays are not cleared
-between runs of 'getmobdrops'. If a mob with 7 item drops is looked up,
-the arrays would have 7 elements. But if another mob is looked up and it
-only has 5 item drops, the server will not clear the arrays for you,
-overwriting the values instead. So in addition to returning the 5 item
-drops, the 6th and 7th elements from the last call remain, and you will
-get 5+2 item drops, of which the last 2 don't belong to the new mob.
-$@MobDrop_count will always contain the correct number (5), unlike
-getarraysize() which would return 7 in this case.
+This command will find drops information of the specified <mob_id>, copy the
+item ids on to <item_id_array> and drop rate on to <drop_rate_array> if provided.
+Returns the number of items found. Will return 0 if <mob_id> is invalid.
 
 Example:
-
 	// get a Mob ID from the user
 	input(.@mob_id);
 
-	if (getmobdrops(.@mob_id)) { // getmobdrops() returns true on success
-		// immediately copy global temporary variables into scope
-		// variables, since we don't know when getmobdrops() will get
-		// called again for another mob, overwriting your global temporary
-		// variables.
-		.@count = $@MobDrop_count;
-		copyarray(.@item[0], $@MobDrop_item[0], .@count);
-		copyarray(.@rate[0], $@MobDrop_rate[0], .@count);
-
+	.@count = getmobdrops(.@mob_id, .@item, .@rate);
+	
+	if (.@count == 0) {
+		mes("No drops found.");
+	} else {
 		mes(getmonsterinfo(.@mob_id, MOB_NAME) + " - " + .@count + " drops found:");
 		for (.@i = 0; .@i < .@count; ++.@i) {
 			mes(.@item[.@i] + " (" + getitemname(.@item[.@i]) + ") " + .@rate[.@i]/100 + ((.@rate[.@i]%100 < 10) ? ".0":".") + .@rate[.@i]%100 + "%");
 		}
-	} else {
-		mes("Unknown monster ID.");
 	}
 	close();
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Avoid use of global variables that tend to get overwritten when command is called by 2 or more players simultaneously.
The command now requires an array as the second or third argument.
The third argument is optional and, if provided, will copy the drop rates into the array.
Updated documentation to reflect these changes.

<!-- Describe the changes that this pull request makes. -->
Usage:
```
.@count = getmobdrops(.@mob_id, .@item, .@rate);
if (.@count) {
	mes(getmonsterinfo(.@mob_id, MOB_NAME) + " - " + .@count + " drops found:");
	for (.@i = 0; .@i < .@count; ++.@i) {
		mes(.@item[.@i] + " (" + getitemname(.@item[.@i]) + ") " + .@rate[.@i]/100 + ((.@rate[.@i]%100 < 10) ? ".0":".") + .@rate[.@i]%100 + "%");
	}
} else {
	mes("No drops found.");
}
close();
```

**Issues addressed:** <!-- Write here the issue number, if any. -->
Wrong data when multiple players call the command.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
