### PR TITLE
Add *getunitparam to obtain values set via unit_parameters_db.conf in scripts

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3101,6 +3101,37 @@ Examples:
 
 ---------------------------------------
 
+*getunitparam(<param type>{, <class>{, <maxlv array>, <value array>}})
+
+Thi will return the requested parameter's value or fill the required arrays in
+the case of UNIT_PARAM_MAX_HP.
+
+<param type>:
+- UNIT_PARAM_NAME                       ^= name of unit_parameters_db.conf entry used by class.
+- UNIT_PARAM_NATHEAL_WEIGHT_RATE        ^= NaturalHealWeightRate value
+- UNIT_PARAM_MAX_ASPD                   ^= MaxASPD
+- UNIT_PARAM_MAX_HP                     ^= MaxHP
+- UNIT_PARAM_MAX_STATS                  ^= MaxStats
+
+<class> can be -1 if attached players class is desired, such as in the case of UNIT_PARAM_MAX_HP,
+where <class> is mandatory.
+
+Examples:
+
+// Outputs the possible maximum ASPD of attached player.
+	mesf("MAX_ASPD: %d", getunitparam(UNIT_PARAM_MAX_ASPD));
+
+// Outputs the possible maximum stats of Job_Baby.
+	mesf("MAX_STATS: %d", getunitparam(UNIT_PARAM_MAX_STATS, Job_Baby));
+
+// Saves the entries for MAXHP per level ranges of JOB_SUPER_NOVICE into the given arrays and prints them.
+	.@count = getunitparam(UNIT_PARAM_MAX_ASPD, JOB_SUPER_NOVICE, .@max_lv, .@max_hp);
+	for (.@i = 0; .@i < .@count; ++.@i) {
+		mesf("max_lv: %d, max_hp: %d", .@max_lv[.@i], .@max_hp[.@i]);
+	}
+
+---------------------------------------
+
 *sit({"<character name>"})
 *stand({"<character name>"})
 

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -1323,6 +1323,14 @@ struct s_maxhp_entry {
 	int value; ///< The actual max hp value
 };
 
+enum e_unit_params {
+	UNIT_PARAM_NAME,
+	UNIT_PARAM_NATHEAL_WEIGHT_RATE,
+	UNIT_PARAM_MAX_ASPD,
+	UNIT_PARAM_MAX_HP,
+	UNIT_PARAM_MAX_STATS,
+};
+
 struct s_unit_params {
 	char name[SCRIPT_VARNAME_LENGTH]; ///< group name as defined in conf
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add a new script command named `getunitparam` to obtain the values set via unit_parameters_db.conf which used to be obtainable via getbattleflag(...)

In relation to: https://github.com/HerculesWS/Hercules/pull/3214

NOTE: The deprecation warning of the deprecated keys for the battle flags, is not shown when using getbattleflag(..), but zero (or the default value) is silently returned instead.

**Issues addressed:** None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
