### PR TITLE
Validate length of configuration names from add*Conf HPM commands

### DIFF
--- a/src/common/HPM.c
+++ b/src/common/HPM.c
@@ -451,6 +451,11 @@ static bool hplugins_addconf(unsigned int pluginID, enum HPluginConfType type, c
 		return false;
 	}
 
+	if (strnlen(name, HPM_ADDCONF_LENGTH) >= HPM_ADDCONF_LENGTH) {
+		ShowError("HPM->addConf:%s: config '%s' name/path is too long. Maximum is %d characters (see #define HPM_ADDCONF_LENGTH). Skipping it.\n", HPM->pid2name(pluginID), name, HPM_ADDCONF_LENGTH - 1);
+		return false;
+	}
+
 	ARR_FIND(0, VECTOR_LENGTH(HPM->config_listeners[type]), i, strcmpi(name, VECTOR_INDEX(HPM->config_listeners[type], i).key) == 0);
 	if (i != VECTOR_LENGTH(HPM->config_listeners[type])) {
 		ShowError("HPM->addConf:%s: duplicate '%s', already in use by '%s'!",

--- a/src/common/HPMi.h
+++ b/src/common/HPMi.h
@@ -35,6 +35,8 @@ struct map_session_data;
 struct hplugin_data_store;
 
 #define HPM_VERSION "1.2"
+
+// Maximum length of the configuration path for configs added with add*Conf
 #define HPM_ADDCONF_LENGTH 40
 
 struct hplugin_info {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Adds a validation when configuration registered by HPM are longer than the supported size.

Today it would silently fail because the registered key is shorter than the actual name, it would not work but also not alert because it simply didn't find and the defaults for `add*Conf` macros is to make them not required.

With this change, users would be informed that this configuration won't work so they can provide a shorter name or increase the define.

**Issues addressed:** None, I think


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
