### PR TITLE
Fix previously plagiarized skill re-appearing after relog, when removed prior

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3690,12 +3690,13 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 		switch(can_copy(tsd, copy_skill)) {
 		case 1: // Plagiarism
 		{
-			pc->clear_existing_cloneskill(tsd, false);
-
 			lv = min(skill_lv, pc->checkskill(tsd, RG_PLAGIARISM));
-			if (learned_lv > lv)
+			if (learned_lv > lv) {
+				pc->clear_existing_cloneskill(tsd, true);
 				break; // [Aegis] can't overwrite skill of higher level, but will still remove previously copied skill.
+			}
 
+			pc->clear_existing_cloneskill(tsd, false);
 			tsd->cloneskill_id = copy_skill;
 			pc_setglobalreg(tsd, script->add_variable("CLONE_SKILL"), copy_skill);
 			pc_setglobalreg(tsd, script->add_variable("CLONE_SKILL_LV"), lv);
@@ -3712,12 +3713,13 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 		case 2: // Reproduce
 		{
 			lv = sc ? sc->data[SC__REPRODUCE]->val1 : 1;
-			pc->clear_existing_reproduceskill(tsd, false);
-
 			lv = min(lv, skill->get_max(copy_skill));
-			if (learned_lv > lv)
+			if (learned_lv > lv) {
+				pc->clear_existing_reproduceskill(tsd, true);
 				break; // unconfirmed, but probably the same behavior as for RG_PLAGIARISM
+			}
 
+			pc->clear_existing_reproduceskill(tsd, false);
 			tsd->reproduceskill_id = copy_skill;
 			pc_setglobalreg(tsd, script->add_variable("REPRODUCE_SKILL"), copy_skill);
 			pc_setglobalreg(tsd, script->add_variable("REPRODUCE_SKILL_LV"), lv);


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Ensure that on relog the previously removed plagiarized skill doesn't get re-added.

This was due to failure to clear the remembered cloneskill script variables and such.

As by the comment `[Aegis] can't overwrite skill of higher level, but will still remove previously copied skill.` this is official behavior, that if you had a plagiarized spell, something would attack you with for example Envenom 3, when you have Envenom 10, you'd then lose the plagiarized spell but not have your higher level Envenom overwritten.

*That being said I may consider changing it so that if it tries to copy the same level nothing happens. Or re-check if in Aegis this really will result in the removal as well, in case I missed the == case.*

**Issues addressed:** None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
