### PR TITLE
Improved atCommand(iteminfo)

### DIFF
--- a/conf/messages.conf
+++ b/conf/messages.conf
@@ -1323,7 +1323,7 @@
 
 // @iteminfo
 1276: Please enter an item name/ID (usage: @ii/@iteminfo <item name/ID>).
-1277: Item: '%s'/'%s'[%d] (%d) Type: %s | Extra Effect: %s
+1277: Item: '%s'/'%s' (%d) Type: %s | Extra Effect: %s
 1278: None
 1279: With script
 1280: NPC Buy:%dz, Sell:%dz | Weight: %.1f 

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -7717,14 +7717,22 @@ ACMD(iteminfo)
 		clif->message(fd, atcmd_output);
 		count = MAX_SEARCH;
 	}
+	StringBuf buf;
+	StrBuf->Init(&buf);
 	for (i = 0; i < count; i++) {
 		struct item_data *item_data = item_array[i];
 		if (item_data != NULL) {
-			snprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd, MSGTBL_ITEMINFO_DETAILS), // Item: '%s'/'%s'[%d] (%d) Type: %s | Extra Effect: %s
-				item_data->name, item_data->jname, item_data->slot, item_data->nameid,
+
+			struct item link_item = { 0 };
+			link_item.nameid = item_data->nameid;
+			clif->format_itemlink(&buf, &link_item);
+
+			snprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd, MSGTBL_ITEMINFO_DETAILS), // Item: '%s'/'%s' (%d) Type: %s | Extra Effect: %s
+				item_data->name, StrBuf->Value(&buf), item_data->nameid,
 				itemdb->typename(item_data->type),
 				(item_data->script == NULL) ? msg_fd(fd, MSGTBL_ITEMINFO_NONE) : msg_fd(fd, MSGTBL_ITEMINFO_WITH_SCRIPT) // None / With script
 			);
+			StrBuf->Clear(&buf);
 			clif->message(fd, atcmd_output);
 
 			snprintf(atcmd_output, sizeof(atcmd_output), msg_fd(fd, MSGTBL_ITEMINFO_NPC_DETAILS), item_data->value_buy, item_data->value_sell, item_data->weight / 10.); // NPC Buy:%dz, Sell:%dz | Weight: %.1f
@@ -7741,6 +7749,7 @@ ACMD(iteminfo)
 			clif->message(fd, atcmd_output);
 		}
 	}
+	StrBuf->Destroy(&buf);
 	return true;
 }
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ x ] I have followed [proper Hercules code styling][code].
- [ x ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ x ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Uses itemlink on iteminfo atcommand.
No longer list slots on iteminfo, itemlink contains slot information.

![20241029192847108 - ElectricPeruSwan](https://github.com/user-attachments/assets/bbf0ef17-60ad-4b4a-8937-0cca221ba1fd)



<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
