### PR TITLE
Mastersmith skill rebalance - 2018 patch/renewal

### DIFF
--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -15094,7 +15094,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 180000
+	SkillData1: 180_000 // Duration of SC_OVERTHRUSTMAX (in milliseconds)
 	CoolDown: 0
 	Requirements: {
 		SPCost: 15

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -15238,7 +15238,7 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	SkillData1: 180000
+	SkillData1: 180_000 // Duration of SC_OVERTHRUSTMAX (in milliseconds)
 	FixedCastTime: 0
 	Requirements: {
 		SPCost: 15

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -2405,11 +2405,11 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 				if(sc->data[SC_GIANTGROWTH])
 					rate += 10;
 #ifndef RENEWAL
-				if(sc->data[SC_OVERTHRUST])
+				if(sc->data[SC_OVERTHRUST] != NULL)
+					rate += 10;
+				if(sc->data[SC_OVERTHRUSTMAX] != NULL)
 					rate += 10;
 #endif
-				if(sc->data[SC_OVERTHRUSTMAX])
-					rate += 10;
 			}
 			if( rate )
 				skill->break_equip(src, EQP_WEAPON, rate, BCT_SELF);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR introduces the rebalance of Mastersmith job skills. This change affects Renewal-only.

On official servers this came along with rebalances of 1st, 2nd jobs and transclass too. I am working in additional PRs for the remaining transclasses, being in separate PRs in order to keep those PRs easy to review and in a reasonable size.

This PR simply removes the chance to break weapons when under SC_OVERTHRUSTMAX (from WS_OVERTHRUSTMAX / Maximum Power Thrust)

**Affected skills**
- WS_OVERTHRUSTMAX (Maximum Power Thrust)


References:
- [kRO 2018.10.31 patch note](https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=7033&curpage=21)
- [kRO 2018.11.28 patch note / translated](https://board.herc.ws/topic/17043-kro-patch-2018-11-28/)
- [Divine Pride](https://www.divine-pride.net/forum/index.php?/topic/3453-kro-mass-skills-balance-1st-2nd-and-transcendent-classes-skills/)

**Issues addressed:** <!-- Write here the issue number, if any. -->
Part of #2735 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
