### PR TITLE
Fix clang-15 CI jobs in GitHub Actions

### DIFF
--- a/.github/workflows/clang15_test.yml
+++ b/.github/workflows/clang15_test.yml
@@ -32,7 +32,7 @@ jobs:
       cancel-in-progress: true
 
     container:
-      image: debian:unstable
+      image: debian:stable
     services:
       mariadb:
         image: mariadb:latest


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This switches the clang-15 builds to debian:stable since the package was dropped from debian:unstable.

A complete review of the build matrix adding tests on newer compilers and dropping ones that are no longer relevant, will be part of an upcoming release.

**Issues addressed:** N/A


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
