### PR TITLE
Add bitcount() script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2245,6 +2245,20 @@ Example:
 
 ---------------------------------------
 
+*bitcount(<number>)
+
+This command returns the number of set bits in an integer.
+Also called popcount in many programming languages.
+Very usefull when working with bitmasks.
+
+Example:
+
+bitcount(3);             // 2
+bitcount(0b10101010);    // 4
+bitcount(0xFF);          // 8
+
+---------------------------------------
+
 *if (<condition>) <statement or block>
 
 This is the basic conditional command.

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18221,18 +18221,18 @@ static BUILDIN(getsavepoint)
 }
 
 /*==========================================
- *     bitcount(<number>)
- *     Return number of set bits in an integer [maqc]
+ *	bitcount(<number>)
+ *	Return number of set bits in an integer [maqc]
  *------------------------------------------*/
 static BUILDIN(bitcount)
 {
-    unsigned int count = 0;
+	unsigned int count = 0;
 	unsigned int value = script_getnum(st,2);
-    while(value > 0) {
-        if((value & 1) == 1)
-            count++;
-        value >>= 1;
-    }
+	while(value > 0) {
+		if((value & 1) == 1)
+			count++;
+		value >>= 1;
+	}
 	script_pushint(st,count);
 	return true;
 }
@@ -29318,7 +29318,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(mobcount,"ss"),
 		BUILDIN_DEF(getlook,"i"),
 		BUILDIN_DEF(getsavepoint,"i"),
-        BUILDIN_DEF(bitcount,"i"), // [maqc]
+		BUILDIN_DEF(bitcount,"i"), // [maqc]
 		BUILDIN_DEF(npcspeed,"i"), // [Valaris]
 		BUILDIN_DEF(npcwalkto,"ii"), // [Valaris]
 		BUILDIN_DEF(npcstop,""), // [Valaris]

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18221,6 +18221,23 @@ static BUILDIN(getsavepoint)
 }
 
 /*==========================================
+ *     bitcount(<number>)
+ *     Return number of set bits in an integer [maqc]
+ *------------------------------------------*/
+static BUILDIN(bitcount)
+{
+    unsigned int count = 0;
+	unsigned int value = script_getnum(st,2);
+    while(value > 0) {
+        if((value & 1) == 1)
+            count++;
+        value >>= 1;
+    }
+	script_pushint(st,count);
+	return true;
+}
+
+/*==========================================
  * Get position for  char/npc/pet/mob objects. Added by Lorky
  *
  *     int getMapXY(MapName$,MapX,MapY,type,[CharName$]);
@@ -29301,6 +29318,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(mobcount,"ss"),
 		BUILDIN_DEF(getlook,"i"),
 		BUILDIN_DEF(getsavepoint,"i"),
+        BUILDIN_DEF(bitcount,"i"), // [maqc]
 		BUILDIN_DEF(npcspeed,"i"), // [Valaris]
 		BUILDIN_DEF(npcwalkto,"ii"), // [Valaris]
 		BUILDIN_DEF(npcstop,""), // [Valaris]

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18220,20 +18220,21 @@ static BUILDIN(getsavepoint)
 	return true;
 }
 
-/*==========================================
- *	bitcount(<number>)
- *	Return number of set bits in an integer [maqc]
- *------------------------------------------*/
+/**
+ * Returns the number of set bits in integer <number>
+ *
+ * bitcount(<number>)
+ */
 static BUILDIN(bitcount)
 {
 	unsigned int count = 0;
-	unsigned int value = script_getnum(st,2);
-	while(value > 0) {
-		if((value & 1) == 1)
+	unsigned int value = script_getnum(st, 2);
+	while (value > 0) {
+		if ((value & 1) == 1)
 			count++;
 		value >>= 1;
 	}
-	script_pushint(st,count);
+	script_pushint(st, count);
 	return true;
 }
 
@@ -29318,7 +29319,7 @@ static void script_parse_builtin(void)
 		BUILDIN_DEF(mobcount,"ss"),
 		BUILDIN_DEF(getlook,"i"),
 		BUILDIN_DEF(getsavepoint,"i"),
-		BUILDIN_DEF(bitcount,"i"), // [maqc]
+		BUILDIN_DEF(bitcount, "i"), // [maqc]
 		BUILDIN_DEF(npcspeed,"i"), // [Valaris]
 		BUILDIN_DEF(npcwalkto,"ii"), // [Valaris]
 		BUILDIN_DEF(npcstop,""), // [Valaris]


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add bitcount() script command to return the number of active bits in an integer. Also commonly called popcount. It is a basic  operation that is usefull when dealing with bitmasks. Now, I know it can be done using functions, but isn't it nice to have a built-in command instead of relying on callfunc() for something that simple?

Script example:

```
NPC 1
if(bitcount(quest) < 2)
    mes "You need to talk to 2 different NPCs.";
else
    mes "Here is your reward!";

NPC 2
if(quest & 1)
    mes "You already talked to me.";
else
    quest |= 1;


NPC 3
if(quest & 2)
    mes "You already talked to me.";
else
    quest |= 2;

NPC 4
if(quest & 4)
    mes "You already talked to me.";
else
    quest |= 4;
```




<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
