### PR TITLE
Fix typo in skills 'CoolDown' field

### DIFF
--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -31293,7 +31293,7 @@ skill_db: (
 	NumberOfHits: 1
 	AfterCastActDelay: 1000
 	SkillData1: 600000
-	Cooldown: 3000
+	CoolDown: 3000
 	Requirements: {
 		SpCost: 10
 		ZenyCost: 100
@@ -31315,7 +31315,7 @@ skill_db: (
 	CastTime: 1000
 	AfterCastActDelay: 1000
 	SkillData1: 120000
-	Cooldown: 2000
+	CoolDown: 2000
 	Requirements: {
 		SPCost: {
 			Lv1: 40
@@ -31360,7 +31360,7 @@ skill_db: (
 		Lv4: 1500
 		Lv5: 1000
 	}
-	Cooldown: 2000
+	CoolDown: 2000
 	Requirements: {
 		SPCost: {
 			Lv1: 55
@@ -31415,7 +31415,7 @@ skill_db: (
 		Lv4: 13000
 		Lv5: 14000
 	}
-	Cooldown: 10000
+	CoolDown: 10000
 	Requirements: {
 		SPCost: {
 			Lv1: 30
@@ -31507,7 +31507,7 @@ skill_db: (
 		Lv4: 1500
 		Lv5: 1000
 	}
-	Cooldown: 2000
+	CoolDown: 2000
 	Requirements: {
 		SPCost: {
 			Lv1: 50
@@ -31616,7 +31616,7 @@ skill_db: (
 	}
 	SkillInstances: 3
 	SkillData1: 30000
-	Cooldown: 1000
+	CoolDown: 1000
 	Requirements: {
 		SPCost: 10
 		WeaponTypes: {
@@ -31695,7 +31695,7 @@ skill_db: (
 	AfterCastActDelay: 1000
 	SkillData1: 50000
 	SkillData2: 15000
-	Cooldown: {
+	CoolDown: {
 		Lv1: 5000
 		Lv2: 4500
 		Lv3: 4000
@@ -31825,7 +31825,7 @@ skill_db: (
 	}
 	KnockBackTiles: 3
 	AfterCastActDelay: 1000
-	Cooldown: {
+	CoolDown: {
 		Lv1: 2800
 		Lv2: 2600
 		Lv3: 2400
@@ -31890,7 +31890,7 @@ skill_db: (
 		Lv10: 3000
 	}
 	AfterCastActDelay: 1000
-	Cooldown: 3500
+	CoolDown: 3500
 	Requirements: {
 		SPCost: {
 			Lv1: 60
@@ -31930,7 +31930,7 @@ skill_db: (
 	SplashRange: 1
 	AfterCastActDelay: 1000
 	SkillData1: 100
-	Cooldown: 5000
+	CoolDown: 5000
 	Requirements: {
 		SPCost: 70
 		WeaponTypes: {
@@ -32006,7 +32006,7 @@ skill_db: (
 		Lv4: 9000
 		Lv5: 10000
 	}
-	Cooldown: 5000
+	CoolDown: 5000
 	Requirements: {
 		SPCost: {
 			Lv1: 80
@@ -32048,7 +32048,7 @@ skill_db: (
 	}
 	AfterCastActDelay: 1000
 	SkillData2: 2000
-	Cooldown: 5000
+	CoolDown: 5000
 	Requirements: {
 		SPCost: {
 			Lv1: 80
@@ -32106,7 +32106,7 @@ skill_db: (
 		Lv10: 3
 	}
 	AfterCastActDelay: 500
-	Cooldown: 20000
+	CoolDown: 20000
 	Requirements: {
 		SPCost: {
 			Lv1: 70

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -32091,7 +32091,7 @@ skill_db: (
 	CastTime: 1000
 	AfterCastActDelay: 1000
 	SkillData1: 120000
-	Cooldown: 2000
+	CoolDown: 2000
 	FixedCastTime: 2000
 	Requirements: {
 		SPCost: {
@@ -32138,7 +32138,7 @@ skill_db: (
 		Lv5: 1000
 	}
 	FixedCastTime: 1000
-	Cooldown: 2000
+	CoolDown: 2000
 	Requirements: {
 		SPCost: {
 			Lv1: 55
@@ -32193,7 +32193,7 @@ skill_db: (
 		Lv4: 13000
 		Lv5: 14000
 	}
-	Cooldown: 10000
+	CoolDown: 10000
 	Requirements: {
 		SPCost: {
 			Lv1: 30
@@ -32285,7 +32285,7 @@ skill_db: (
 		Lv4: 1500
 		Lv5: 1000
 	}
-	Cooldown: 2000
+	CoolDown: 2000
 	FixedCastTime: 1000
 	Requirements: {
 		SPCost: {
@@ -32395,7 +32395,7 @@ skill_db: (
 	}
 	SkillInstances: 3
 	SkillData1: 30000
-	Cooldown: 1000
+	CoolDown: 1000
 	Requirements: {
 		SPCost: 10
 		WeaponTypes: {
@@ -32474,7 +32474,7 @@ skill_db: (
 	AfterCastActDelay: 1000
 	SkillData1: 50000
 	SkillData2: 15000
-	Cooldown: {
+	CoolDown: {
 		Lv1: 5000
 		Lv2: 4500
 		Lv3: 4000
@@ -32604,7 +32604,7 @@ skill_db: (
 	}
 	KnockBackTiles: 3
 	AfterCastActDelay: 1000
-	Cooldown: {
+	CoolDown: {
 		Lv1: 2800
 		Lv2: 2600
 		Lv3: 2400
@@ -32669,7 +32669,7 @@ skill_db: (
 		Lv10: 3000
 	}
 	AfterCastActDelay: 1000
-	Cooldown: 3500
+	CoolDown: 3500
 	Requirements: {
 		SPCost: {
 			Lv1: 60
@@ -32709,7 +32709,7 @@ skill_db: (
 	SplashRange: 1
 	AfterCastActDelay: 1000
 	SkillData1: 100
-	Cooldown: 5000
+	CoolDown: 5000
 	Requirements: {
 		SPCost: 70
 		WeaponTypes: {
@@ -32785,7 +32785,7 @@ skill_db: (
 		Lv4: 9000
 		Lv5: 10000
 	}
-	Cooldown: 5000
+	CoolDown: 5000
 	FixedCastTime: 1000
 	Requirements: {
 		SPCost: {
@@ -32828,7 +32828,7 @@ skill_db: (
 	}
 	AfterCastActDelay: 1000
 	SkillData2: 2000
-	Cooldown: 5000
+	CoolDown: 5000
 	FixedCastTime: 1000
 	Requirements: {
 		SPCost: {
@@ -32865,7 +32865,7 @@ skill_db: (
 		Lv9: 15
 		Lv10: 16
 	}
-	
+
 	SkillType: {
 		Enemy: true
 	}
@@ -32887,7 +32887,7 @@ skill_db: (
 		Lv10: 3
 	}
 	AfterCastActDelay: 500
-	Cooldown: 20000
+	CoolDown: 20000
 	Requirements: {
 		SPCost: {
 			Lv1: 70
@@ -33489,7 +33489,7 @@ skill_db: (
 	MaxLevel: 10
 	Hit: "BDT_MULTIHIT"
 	SkillType: {
-		Self: true 
+		Self: true
 	}
 	SkillInfo: {
 		Chorus: true


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Some Rebel skills had a typo in the `CoolDown` field (being called `Cooldown`) and thus were not getting proper cool down. Just fixing it.

I thought about adding some sort of warning when there is a typo, but at a quick glance on how libconfig works, I think we can't really do a case-insensitive lookup to check. If there is any suggestions, I can work on it in a separate PR.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
