### PR TITLE
Bug fix: wrong behavior in hateffect when disabling effect

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -27870,6 +27870,9 @@ static BUILDIN(hateffect)
 			}
 		}
 	}
+	
+	if (enabled == 0)
+		return true;
 
 	VECTOR_ENSURE(sd->hatEffectId, 1, 1);
 	VECTOR_PUSH(sd->hatEffectId, effectId);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixes a logical flaw in the `hateffect` script function, where calling it with `enabled = 0` (to remove an effect) would still add the `effectId` to the `hatEffectId` vector if it wasn't already present.

The correct behavior when `enabled = 0` is to remove the effect if present — and **do nothing** if it's not found.

This fix adds a `return true;` right after the `for` loop to prevent unintended addition of the `effectId` when the intent is to remove it.


**Issues addressed:** No related issues.