### PR TITLE
Assassin Cross skill rebalance - 2018 patch/renewal

### DIFF
--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -12547,7 +12547,7 @@ skill_db: (
 	}
 	SplashRange: 2
 	CastTime: 250
-	AfterCastActDelay: 500
+	CoolDown: 500
 	SkillData2: {
 		Lv1: 10000
 		Lv2: 5000

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -11627,30 +11627,30 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 	}
-	AfterCastActDelay: 2000
-	SkillData1: {
-		Lv1: 40000
-		Lv2: 45000
-		Lv3: 50000
-		Lv4: 55000
-		Lv5: 60000
-		Lv6: 65000
-		Lv7: 70000
-		Lv8: 75000
-		Lv9: 80000
-		Lv10: 85000
+	CoolDown: 2_000
+	SkillData1: { // SC_EDP duration (in milliseconds)
+		Lv1: 40_000
+		Lv2: 60_000
+		Lv3: 80_000
+		Lv4: 100_000
+		Lv5: 120_000
+		Lv6: 140_000
+		Lv7: 160_000
+		Lv8: 180_000
+		Lv9: 200_000
+		Lv10: 220_000
 	}
-	SkillData2: {
-		Lv1: 20000
-		Lv2: 30000
-		Lv3: 40000
-		Lv4: 50000
-		Lv5: 60000
-		Lv6: 70000
-		Lv7: 80000
-		Lv8: 90000
-		Lv9: 100000
-		Lv10: 110000
+	SkillData2: { // Duration of inflicted poison (SC_DPOISON) (in milliseconds)
+		Lv1: 20_000
+		Lv2: 30_000
+		Lv3: 40_000
+		Lv4: 50_000
+		Lv5: 60_000
+		Lv6: 70_000
+		Lv7: 80_000
+		Lv8: 90_000
+		Lv9: 100_000
+		Lv10: 110_000
 	}
 	FixedCastTime: 0
 	Requirements: {

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -3026,16 +3026,6 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 			}
 			//Skill damage modifiers that stack linearly
 			if(sc && skill_id != PA_SACRIFICE){
-#ifdef RENEWAL_EDP
-				if( sc->data[SC_EDP] ){
-					if( skill_id == GC_COUNTERSLASH ||
-#ifndef RENEWAL
-						skill_id == AS_SONICBLOW ||
-#endif
-						skill_id == GC_CROSSIMPACT )
-							skillratio >>= 1;
-				}
-#endif
 				if(sc->data[SC_OVERTHRUST])
 					skillratio += sc->data[SC_OVERTHRUST]->val3;
 				if(sc->data[SC_OVERTHRUSTMAX])
@@ -4494,10 +4484,7 @@ static struct Damage battle_calc_misc_attack(struct block_list *src, struct bloc
 		int64 matk = battle->calc_magic_attack(src, target, skill_id, skill_lv, mflag).damage;
 		short totaldef = status->get_total_def(target) + status->get_total_mdef(target);
 		int64 atk = battle->calc_base_damage(src, target, skill_id, skill_lv, nk, false, s_ele, ELE_NEUTRAL, EQI_HAND_R, (sc && sc->data[SC_MAXIMIZEPOWER] ? 1 : 0) | (sc && sc->data[SC_WEAPONPERFECT] ? 8 : 0), md.flag);
-#ifdef RENEWAL_EDP
-		if( sc && sc->data[SC_EDP] )
-			ratio >>= 1;
-#endif
+
 		md.damage = (matk + atk) * ratio / 100;
 		md.damage -= totaldef;
 #endif

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -524,7 +524,8 @@ static int64 battle_calc_weapon_damage(struct block_list *src, struct block_list
 	}
 
 #ifdef RENEWAL_EDP
-	if ( sc && sc->data[SC_EDP] && skill_id != AS_GRIMTOOTH && skill_id != AS_VENOMKNIFE && skill_id != ASC_BREAKER ) {
+	if (sc != NULL && sc->data[SC_EDP] != NULL
+	    && skill_id != AS_GRIMTOOTH && skill_id != AS_VENOMKNIFE && skill_id != ASC_METEORASSAULT) {
 		struct status_data *tstatus;
 		tstatus = status->get_status_data(bl);
 		eatk += damage * 0x19 * battle->attr_fix_table[tstatus->ele_lv - 1][ELE_POISON][tstatus->def_ele] / 10000;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2345,7 +2345,12 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					skillratio += i;
 					break;
 				case ASC_METEORASSAULT:
+#ifdef RENEWAL
+					skillratio += 100 + 120 * skill_lv + 5 * st->str;
+					RE_LVL_DMOD(100);
+#else
 					skillratio += 40 * skill_lv - 60;
+#endif
 					break;
 				case SN_SHARPSHOOTING:
 				case MA_SHARPSHOOTING:

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7889,10 +7889,11 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 				//Chance to Poison enemies.
 #ifdef RENEWAL_EDP
 				val2 = ((val1 + 1) / 2 + 2);
+				val3 = 150 + val1 * 30; // Damage increase (+150 +30 * lv%)
 #else
 				val2 = val1 + 2;
-#endif
 				val3 = 50 * (val1 + 1); //Damage increase (+50 +50*lv%)
+#endif
 				if( sd )//[Ind] - iROwiki says each level increases its duration by 3 seconds
 					total_tick += pc->checkskill(sd,GC_RESEARCHNEWPOISON)*3000;
 				break;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR introduces the rebalance of Assassin Cross job skills and some fixes on those skills to match the rebalance. This change affects Renewal-only. Commits credited to gbasso666 are commits where most changes came from #3200.

I can't say everything is 100% accurate because there are discrepancies between different sources, and I could not test everything in kRO, but should be quite close.

Check the commit messages for details of the changes (or the references below)

**Affected skills**
- ASC_METEORASSAULT (Meteor Assault)
- ASC_EDP (Enchant Deadly Poison)
- ASC_BREAKER (Soul Destroyer)


References:
- [kRO 2018.10.31 patch note](https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=7033&curpage=21)
- [kRO 2018.11.28 patch note / translated](https://board.herc.ws/topic/17043-kro-patch-2018-11-28/)
- [Divine Pride](https://www.divine-pride.net/forum/index.php?/topic/3453-kro-mass-skills-balance-1st-2nd-and-transcendent-classes-skills/)
- [iRO Wiki (old page)](https://irowiki.org/w/index.php?title=Enchant_Deadly_Poison&oldid=70030)

**Issues addressed:** <!-- Write here the issue number, if any. -->
Part of #2735 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
