### PR TITLE
High Wizard skill rebalance - 2018 patch/renewal

### DIFF
--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -14967,59 +14967,48 @@ skill_db: (
 	Description: "Gravitation Field"
 	MaxLevel: 5
 	Range: 18
-	Hit: "BDT_SKILL"
+	Hit: "BDT_MULTIHIT"
 	SkillType: {
 		Place: true
 	}
 	SkillInfo: {
 		BlockedByStasis: true
 	}
-	AttackType: "Misc"
-	Element: "Ele_Earth"
+	AttackType: "Magic"
+	Element: "Ele_Neutral"
 	DamageType: {
-		NoDamage: true
-		IgnoreElement: true
-		IgnoreDefCards: true
+		SplashArea: true
+	}
+	SplashRange: 2
+	NumberOfHits: {
+		Lv1: 10
+		Lv2: 12
+		Lv3: 14
+		Lv4: 16
+		Lv5: 18
+		Lv6: 20
+		Lv7: 22
+		Lv8: 24
+		Lv9: 26
+		Lv10: 28
 	}
 	InterruptCast: true
-	SkillData1: {
-		Lv1: 5000
-		Lv2: 6000
-		Lv3: 7000
-		Lv4: 8000
-		Lv5: 9000
-		Lv6: 10000
-		Lv7: 11000
-		Lv8: 12000
-		Lv9: 13000
-		Lv10: 14000
-	}
-	FixedCastTime: 5000
+	FixedCastTime: 1_000
+	CastTime: 5_000
+	AfterCastActDelay: 1_000
+	CoolDown: 5_000
 	Requirements: {
 		SPCost: {
-			Lv1: 20
-			Lv2: 40
-			Lv3: 60
-			Lv4: 80
+			Lv1: 60
+			Lv2: 70
+			Lv3: 80
+			Lv4: 90
 			Lv5: 100
-			Lv6: 120
-			Lv7: 140
-			Lv8: 160
-			Lv9: 180
-			Lv10: 200
-		}
-		Items: {
-			Blue_Gemstone: 1
-		}
-	}
-	Unit: {
-		Id: 0xb8
-		Layout: 2
-		Interval: 500
-		Target: "Enemy"
-		Flag: {
-			UF_NOOVERLAP: true
-			UF_DUALMODE: true
+			Lv6: 110
+			Lv7: 120
+			Lv8: 130
+			Lv9: 140
+			Lv10: 150
 		}
 	}
 },

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -12243,7 +12243,6 @@ skill_db: (
 	Element: "Ele_Ghost"
 	DamageType: {
 		SplashArea: true
-		SplitDamage: true
 	}
 	SplashRange: 1
 	NumberOfHits: {
@@ -12260,7 +12259,8 @@ skill_db: (
 	}
 	InterruptCast: true
 	CastTime: 800
-	AfterCastActDelay: 1000
+	AfterCastActDelay: 500
+	CoolDown: 1_000
 	SkillData2: 45000
 	FixedCastTime: 200
 	Requirements: {

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1724,7 +1724,12 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 #endif
 					break;
 				case HW_NAPALMVULCAN:
+#ifndef RENEWAL
 					skillratio += 10 * skill_lv - 30;
+#else
+					skillratio += -100 + 70 * skill_lv;
+					RE_LVL_DMOD(100);
+#endif
 					break;
 
 #ifdef RENEWAL

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1728,6 +1728,11 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					break;
 
 #ifdef RENEWAL
+				case HW_GRAVITATION:
+					skillratio += -100 + 50 * skill_lv;
+					RE_LVL_DMOD(100);
+					break;
+
 				case PA_PRESSURE:
 					skillratio += -100 + 500 + 150 * skill_lv;
 					RE_LVL_DMOD(100);
@@ -3777,7 +3782,9 @@ static int64 battle_calc_pc_damage(struct block_list *src, struct block_list *bl
 
 	switch (skill_id) {
 		//case PA_PRESSURE: /* pressure also belongs to this list but it doesn't reach this area -- so don't worry about it */
+#ifndef RENEWAL // 2018.10 rebalance - HW_GRAVITATION is a basic magic damage skill now
 		case HW_GRAVITATION:
+#endif
 		case NJ_ZENYNAGE:
 		case KO_MUCHANAGE:
 			break;
@@ -4563,10 +4570,14 @@ static struct Damage battle_calc_misc_attack(struct block_list *src, struct bloc
 #endif
 		}
 		break;
+
+#ifndef RENEWAL // 2018.10 rebalance - HW_GRAVITATION is a basic magic damage skill now
 	case HW_GRAVITATION:
 		md.damage = 200+200*skill_lv;
 		md.dmotion = 0; //No flinch animation.
 		break;
+#endif
+
 	case NPC_EVILLAND:
 		md.damage = skill->calc_heal(src,target,skill_id,skill_lv,false);
 		break;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3257,11 +3257,14 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 	 //Trick Dead protects you from damage, but not from buffs and the like, hence it's placed here.
 	if (sc && sc->data[SC_TRICKDEAD])
 		return 0;
+
+#ifndef RENEWAL // 2018.10 rebalance - HW_GRAVITATION is a basic magic damage skill now
 	if ( skill_id != HW_GRAVITATION ) {
 		struct status_change *csc = status->get_sc(src);
 		if(csc && csc->data[SC_GRAVITATION] && csc->data[SC_GRAVITATION]->val3 == BCT_SELF )
 			return 0;
 	}
+#endif
 
 	dmg = battle->calc_attack(attack_type,src,bl,skill_id,skill_lv,flag&0xFFF);
 
@@ -3632,9 +3635,13 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 		case HT_LANDMINE:
 			dmg.dmotion = clif->skill_damage(dsrc,bl,tick, dmg.amotion, dmg.dmotion, damage, dmg.div_, skill_id, -1, type);
 			break;
+
+#ifndef RENEWAL // 2018.10 rebalance - HW_GRAVITATION is a basic magic damage skill now
 		case HW_GRAVITATION:
 			dmg.dmotion = clif->damage(bl, bl, 0, 0, damage, 1, BDT_ENDURE, 0);
 			break;
+#endif
+
 		case WZ_SIGHTBLASTER:
 			dmg.dmotion = clif->skill_damage(src,bl,tick, dmg.amotion, dmg.dmotion, damage, dmg.div_, skill_id, (flag&SD_LEVEL) ? -1 : skill_lv, BDT_SPLASH);
 			break;
@@ -4937,6 +4944,7 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 
 #ifdef RENEWAL
 		case BA_DISSONANCE:
+		case HW_GRAVITATION: // 2018.10 rebalance - HW_GRAVITATION is a basic magic damage skill now
 			skill->attack(BF_MAGIC, src, src, bl, skill_id, skill_lv, tick, flag);
 			break;
 #endif
@@ -12852,9 +12860,15 @@ static int skill_castend_pos2(struct block_list *src, int x, int y, uint16 skill
 			break;
 
 		case HW_GRAVITATION:
+#ifndef RENEWAL // 2018.10 rebalance - HW_GRAVITATION is a basic magic damage skill now
 			if ((sg = skill->unitsetting(src,skill_id,skill_lv,x,y,0)))
 				sc_start4(src, src, type, 100, skill_lv, 0, BCT_SELF, sg->group_id, skill->get_time(skill_id, skill_lv), skill_id);
-			flag|=1;
+				flag|=1;
+#else
+			r = skill->get_splash(skill_id,skill_lv);
+			map->foreachinarea(skill->area_sub, src->m, x - r, y - r, x + r, y + r, skill->splash_target(src),
+			                    src, skill_id, skill_lv, tick, flag | BCT_ENEMY | 1, skill->castend_damage_id);
+#endif
 			break;
 
 		// Plant Cultivation [Celest]
@@ -14206,7 +14220,9 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 		case HT_FREEZINGTRAP:
 		case HT_BLASTMINE:
 		case HT_CLAYMORETRAP:
+#ifndef RENEWAL // 2018.10 rebalance - HW_GRAVITATION is a basic magic damage skill now
 		case HW_GRAVITATION:
+#endif
 		case SA_DELUGE:
 		case SA_VOLCANO:
 		case SA_VIOLENTGALE:
@@ -15138,7 +15154,9 @@ static int skill_unit_onleft(uint16 skill_id, struct block_list *bl, int64 tick)
 		case SA_DELUGE:
 		case SA_VIOLENTGALE:
 		case CG_HERMODE:
+#ifndef RENEWAL // 2018.10 rebalance - HW_GRAVITATION is a basic magic damage skill now
 		case HW_GRAVITATION:
+#endif
 		case NJ_SUITON:
 		case SC_MAELSTROM:
 		case EL_WATER_BARRIER:


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR introduces the rebalance of High Wizard job skills and some fixes on those skills to match the rebalance. This change affects Renewal-only.

I can't say everything is 100% accurate because they are based on sources and very few in-game tests, but should be close enough.

Check the commit messages for details of the changes (or the references below)

**Affected skills**
- HW_GRAVITATION (Gravitational Field)
- HW_NAPALMVULCAN (Napalm Vulcan)


References:
- [kRO 2018.10.31 patch note](https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=7033&curpage=21)
- [kRO 2018.11.28 patch note / translated](https://board.herc.ws/topic/17043-kro-patch-2018-11-28/)
- [Divine Pride](https://www.divine-pride.net/forum/index.php?/topic/3453-kro-mass-skills-balance-1st-2nd-and-transcendent-classes-skills/)

**Issues addressed:** <!-- Write here the issue number, if any. -->
Part of #2735 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
