### PR TITLE
Fix Metallic Sound damage multiplier for Sleep/Deep Sleep targets

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -3248,8 +3248,11 @@ static int64 battle_calc_damage(struct block_list *src, struct block_list *bl, s
 
 		if( damage ) {
 			if( sc->data[SC_DEEP_SLEEP] ) {
-				damage += damage / 2; // 1.5 times more damage while in Deep Sleep.
-				status_change_end(bl,SC_DEEP_SLEEP,INVALID_TIMER);
+				damage = damage * 225 / 100; // 2.25x damage while in Deep Sleep
+				status_change_end(bl,SC_DEEP_SLEEP,INVALID_TIMER); 
+			} else if( sc->data[SC_SLEEP] ) {
+				damage = damage * 150 / 100; // 1.5x damage while in Sleep
+				status_change_end(bl,SC_SLEEP,INVALID_TIMER);
 			}
 			if( s_sd && t_sd && sc->data[SC_COLD] && flag&BF_WEAPON ){
 				switch (s_sd->weapontype) {

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -3248,11 +3248,8 @@ static int64 battle_calc_damage(struct block_list *src, struct block_list *bl, s
 
 		if( damage ) {
 			if( sc->data[SC_DEEP_SLEEP] ) {
-				damage = damage * 225 / 100; // 2.25x damage while in Deep Sleep
-				status_change_end(bl,SC_DEEP_SLEEP,INVALID_TIMER); 
-			} else if( sc->data[SC_SLEEP] ) {
-				damage = damage * 150 / 100; // 1.5x damage while in Sleep
-				status_change_end(bl,SC_SLEEP,INVALID_TIMER);
+				damage += damage / 2; // 1.5 times more damage while in Deep Sleep.
+				status_change_end(bl,SC_DEEP_SLEEP,INVALID_TIMER);
 			}
 			if( s_sd && t_sd && sc->data[SC_COLD] && flag&BF_WEAPON ){
 				switch (s_sd->weapontype) {
@@ -4404,6 +4401,8 @@ static struct Damage battle_calc_misc_attack(struct block_list *src, struct bloc
 	case WM_SOUND_OF_DESTRUCTION:
 		md.damage = 1000 * skill_lv + (int64)sstatus->int_ * (sd ? pc->checkskill(sd,WM_LESSON) : 10);
 		md.damage += md.damage * 10 * battle->calc_chorusbonus(sd) / 100;
+		if (tsc != NULL && (tsc->data[SC_SLEEP] != NULL || tsc->data[SC_DEEP_SLEEP] != NULL))
+			md.damage = md.damage * 150 / 100;
 		break;
 	/**
 	 * Mechanic

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -3412,8 +3412,11 @@ static int64 battle_calc_damage(struct block_list *src, struct block_list *bl, s
 
 		if( damage ) {
 			if( sc->data[SC_DEEP_SLEEP] ) {
-				damage += damage / 2; // 1.5 times more damage while in Deep Sleep.
-				status_change_end(bl,SC_DEEP_SLEEP,INVALID_TIMER);
+				damage = damage * 225 / 100; // 2.25x damage while in Deep Sleep
+				status_change_end(bl,SC_DEEP_SLEEP,INVALID_TIMER); 
+			} else if( sc->data[SC_SLEEP] ) {
+				damage = damage * 150 / 100; // 1.5x damage while in Sleep
+				status_change_end(bl,SC_SLEEP,INVALID_TIMER);
 			}
 			if( s_sd && t_sd && sc->data[SC_COLD] && flag&BF_WEAPON ){
 				switch (s_sd->weapontype) {

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -3412,11 +3412,8 @@ static int64 battle_calc_damage(struct block_list *src, struct block_list *bl, s
 
 		if( damage ) {
 			if( sc->data[SC_DEEP_SLEEP] ) {
-				damage = damage * 225 / 100; // 2.25x damage while in Deep Sleep
-				status_change_end(bl,SC_DEEP_SLEEP,INVALID_TIMER); 
-			} else if( sc->data[SC_SLEEP] ) {
-				damage = damage * 150 / 100; // 1.5x damage while in Sleep
-				status_change_end(bl,SC_SLEEP,INVALID_TIMER);
+				damage += damage / 2; // 1.5 times more damage while in Deep Sleep.
+				status_change_end(bl,SC_DEEP_SLEEP,INVALID_TIMER);
 			}
 			if( s_sd && t_sd && sc->data[SC_COLD] && flag&BF_WEAPON ){
 				switch (s_sd->weapontype) {
@@ -4604,6 +4601,8 @@ static struct Damage battle_calc_misc_attack(struct block_list *src, struct bloc
 	case WM_SOUND_OF_DESTRUCTION:
 		md.damage = 1000 * skill_lv + (int64)sstatus->int_ * (sd ? pc->checkskill(sd,WM_LESSON) : 10);
 		md.damage += md.damage * 10 * battle->calc_chorusbonus(sd) / 100;
+		if (tsc != NULL && (tsc->data[SC_SLEEP] != NULL || tsc->data[SC_DEEP_SLEEP] != NULL))
+			md.damage = md.damage * 150 / 100;
 		break;
 	/**
 	 * Mechanic


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Added skill-specific 1.5x damage bonus to `WM_SOUND_OF_DESTRUCTION` when target has `SC_SLEEP` or `SC_DEEP_SLEEP`

## Expected behavior (per iRO Wiki)
| Target status | Damage multiplier |
|---|---|
| `SC_SLEEP` | 1.5x (skill bonus only) |
| `SC_DEEP_SLEEP` | 2.25x (global 1.5x × skill 1.5x) |
| Other skills vs Sleep/Deep Sleep | Unchanged |

**Issues addressed:** <!-- Write here the issue number, if any. --> #609


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
