### PR TITLE
Fixed issue with GN_SLINGITEM doesn't work after relog.

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -11274,7 +11274,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 			if( sd ) {
 				int ammo_id;
 				int equip_idx = sd->equip_index[EQI_AMMO];
-				if( equip_idx <= 0 )
+				if( equip_idx < 0 )
 					break; // No ammo.
 				if (sd->inventory_data[equip_idx] == NULL)
 					break;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Seems like GN_SLINGITEM doesn't work on relog due to invalid index.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** #1010  <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
