### PR TITLE
Fixed server crash via @reloadpcdb

### DIFF
--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -4038,6 +4038,11 @@ ACMD(reloadstatusdb)
 ACMD(reloadpcdb)
 {
 	pc->readdb();
+	// Repopulate class_exp_table, which pc->readdb() just cleared; safe here since the
+	// server has already finished booting and status->read_unit_params_db() has run.
+	// Must NOT be called from pc->readdb() itself, since that also runs during initial
+	// server startup, before status->init() has populated status->dbs->unit_params[].
+	status->read_job_db();
 	clif->message(fd, msg_fd(fd, MSGTBL_RELOAD_PLAYER_RELOADED));
 	return true;
 }

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -11806,8 +11806,12 @@ static int pc_readdb(void)
 	/**
 	 * Read and load into memory, the exp_group_db.conf file.
 	 */
+	pc->clear_class_exp_table();
 	pc->clear_exp_groups();
 	pc->read_exp_db();
+
+	// Repopulate class_exp_table after reloading exp groups
+	status->read_job_db();
 
 	// Reset and read skilltree
 	pc->clear_skill_tree();
@@ -12543,6 +12547,16 @@ static void pc_clear_exp_groups(void)
 	}
 }
 
+static void pc_clear_class_exp_table(void)
+{
+	int i, j;
+	for (i = 0; i < CLASS_COUNT; i++) {
+		for (j = 0; j < 2; j++) {
+			pc->dbs->class_exp_table[i][j] = NULL;
+		}
+	}
+}
+
 static void pc_init_exp_groups(void)
 {
 	int i;
@@ -13079,6 +13093,7 @@ void pc_defaults(void)
 	pc->removecombo = pc_removecombo;
 	pc->update_job_and_level = pc_update_job_and_level;
 	pc->clear_exp_groups = pc_clear_exp_groups;
+	pc->clear_class_exp_table = pc_clear_class_exp_table;
 	pc->init_exp_groups = pc_init_exp_groups;
 	pc->job_is_dummy = pc_job_is_dummy;
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -12004,6 +12004,7 @@ static int pc_readdb(void)
 	/**
 	 * Read and load into memory, the exp_group_db.conf file.
 	 */
+	pc->clear_class_exp_table();
 	pc->clear_exp_groups();
 	pc->read_exp_db();
 
@@ -12729,6 +12730,16 @@ static void pc_clear_exp_groups(void)
 	}
 }
 
+static void pc_clear_class_exp_table(void)
+{
+	int i, j;
+	for (i = 0; i < CLASS_COUNT; i++) {
+		for (j = 0; j < 2; j++) {
+			pc->dbs->class_exp_table[i][j] = NULL;
+		}
+	}
+}
+
 static void pc_init_exp_groups(void)
 {
 	int i;
@@ -13269,6 +13280,7 @@ void pc_defaults(void)
 	pc->removecombo = pc_removecombo;
 	pc->update_job_and_level = pc_update_job_and_level;
 	pc->clear_exp_groups = pc_clear_exp_groups;
+	pc->clear_class_exp_table = pc_clear_class_exp_table;
 	pc->init_exp_groups = pc_init_exp_groups;
 	pc->job_is_dummy = pc_job_is_dummy;
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -1253,6 +1253,7 @@ END_ZEROED_BLOCK; /* End */
 	void (*validate_levels) (void);
 	void (*update_job_and_level) (struct map_session_data *sd);
 	void (*clear_exp_groups) (void);
+	void (*clear_class_exp_table) (void);
 	void (*init_exp_groups) (void);
 	bool (*job_is_dummy) (int job);
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -1268,6 +1268,7 @@ END_ZEROED_BLOCK; /* End */
 	void (*validate_levels) (void);
 	void (*update_job_and_level) (struct map_session_data *sd);
 	void (*clear_exp_groups) (void);
+	void (*clear_class_exp_table) (void);
 	void (*init_exp_groups) (void);
 	bool (*job_is_dummy) (int job);
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Fixes a heap-use-after-free in `pc_readdb()` (`@reloadpcdb`): `pc->clear_exp_groups()` freed the class exp group data before `pc->dbs->class_exp_table` entries pointing into it were cleared, so the table could be dereferenced after free. `pc_readdb()` now clears `pc->dbs->class_exp_table` before rebuilding the exp groups.

Repopulating `class_exp_table` requires calling `status->read_job_db()`. That call is made from `@reloadpcdb` specifically, not from `pc_readdb()` itself — `pc_readdb()` also runs during initial server startup, before `status->init()` has populated `status->dbs->unit_params`, so calling it there crashed the map-server on every boot.

**Issues addressed:** #2811 <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
