### PR TITLE
Fixed guild castle siege type being assigned to castle id

### DIFF
--- a/src/map/guild.c
+++ b/src/map/guild.c
@@ -219,11 +219,12 @@ static bool guild_read_castledb_libconfig_sub(struct config_setting_t *it, int i
 	}
 	safestrncpy(gc->castle_event, name, sizeof(gc->castle_event));
 
-	if (map->setting_lookup_const(it, "SiegeType", &i32) && (i32 >= SIEGE_TYPE_MAX || i32 < 0)) {
-		ShowWarning("guild_read_castledb_libconfig_sub: Invalid SiegeType in \"%s\", entry #%d, defaulting to SIEGE_TYPE_FE.\n", source, idx);
-		gc->siege_type = SIEGE_TYPE_FE;
-	} else {
-		gc->siege_type = i32;
+	gc->siege_type = SIEGE_TYPE_FE;
+	if (map->setting_lookup_const(it, "SiegeType", &i32)) {
+		if (i32 >= SIEGE_TYPE_FE && i32 < SIEGE_TYPE_MAX)
+			gc->siege_type = i32;
+		else
+			ShowWarning("guild_read_castledb_libconfig_sub: Invalid SiegeType in \"%s\", entry #%d, defaulting to SIEGE_TYPE_FE.\n", source, idx);
 	}
 
 	libconfig->setting_lookup_bool_real(it, "EnableClientWarp", &gc->enable_client_warp);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
if `SiegeType` not set in `castle_db.conf`, siege type is being assigned to castle id variable above

**Issues addressed:** <!-- Write here the issue number, if any. -->
n/a

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
