### PR TITLE
High Priest skill rebalance - 2018 patch/renewal

### DIFF
--- a/db/constants.conf
+++ b/db/constants.conf
@@ -1320,6 +1320,7 @@ constants_db: {
 	SC_ENSEMBLEFATIGUE:               724
 	SC_ADAPTATION:                    725
 	SC_BASILICA_BUFF:                 726
+	SC_ASSUMPTIO_BUFF:                727
 
 	comment__: "Emotes"
 	e_gasp:         0
@@ -4947,6 +4948,7 @@ constants_db: {
 	SI_SP_SHA:                                   1064
 	SI_ENSEMBLEFATIGUE:                          1088
 	SI_ADAPTATION:                               1089
+	SI_ASSUMPTIO_BUFF:                           1121
 	SI_BASILICA_BUFF:                            1122
 	SI_SOULCURSE:                                1125
 	SI_MADOGEAR:                                 1149

--- a/db/constants.conf
+++ b/db/constants.conf
@@ -1319,6 +1319,7 @@ constants_db: {
 
 	SC_ENSEMBLEFATIGUE:               724
 	SC_ADAPTATION:                    725
+	SC_BASILICA_BUFF:                 726
 
 	comment__: "Emotes"
 	e_gasp:         0
@@ -4946,6 +4947,7 @@ constants_db: {
 	SI_SP_SHA:                                   1064
 	SI_ENSEMBLEFATIGUE:                          1088
 	SI_ADAPTATION:                               1089
+	SI_BASILICA_BUFF:                            1122
 	SI_SOULCURSE:                                1125
 	SI_MADOGEAR:                                 1149
 }

--- a/db/re/sc_config.conf
+++ b/db/re/sc_config.conf
@@ -6532,3 +6532,17 @@ SC_ADAPTATION: {
 	Icon: "SI_ADAPTATION"
 	Skills: ["BD_ADAPTATION"]
 }
+
+SC_BASILICA_BUFF: {
+	Visible: true
+	Flags: {
+		Buff: true
+		NoMadoReset: true
+		NoMagicBlocked: true
+	}
+	CalcFlags: {
+		All: true
+	}
+	Icon: "SI_BASILICA_BUFF"
+	Skills: ["HP_BASILICA"]
+}

--- a/db/re/sc_config.conf
+++ b/db/re/sc_config.conf
@@ -853,7 +853,7 @@ SC_ASSUMPTIO: {
 		NoMagicBlocked: true
 	}
 	Icon: "SI_ASSUMPTIO"
-	Skill: "HP_ASSUMPTIO"
+	// Skill: "HP_ASSUMPTIO" // 2018.11 rebalance - HP_ASSUMPTIO now uses SP_ASSUMPTIO_BUFF
 }
 SC_BASILICA: {
 	Flags: {
@@ -6545,4 +6545,14 @@ SC_BASILICA_BUFF: {
 	}
 	Icon: "SI_BASILICA_BUFF"
 	Skills: ["HP_BASILICA"]
+}
+
+SC_ASSUMPTIO_BUFF: {
+	Visible: true
+	Flags: {
+		Buff: true
+		NoMagicBlocked: true
+	}
+	Icon: "SI_ASSUMPTIO_BUFF"
+	Skill: "HP_ASSUMPTIO"
 }

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -11078,10 +11078,9 @@ skill_db: (
 {
 	Id: 362
 	Name: "HP_BASILICA"
-	StatusChange: "SC_BASILICA"
+	StatusChange: "SC_BASILICA_BUFF"
 	Description: "Basilica"
 	MaxLevel: 5
-	Range: 4
 	Hit: "BDT_SKILL"
 	SkillType: {
 		Self: true
@@ -11091,19 +11090,8 @@ skill_db: (
 		NoDamage: true
 	}
 	InterruptCast: true
-	KnockBackTiles: 2
-	AfterCastActDelay: {
-		Lv1: 2000
-		Lv2: 3000
-		Lv3: 4000
-		Lv4: 5000
-		Lv5: 6000
-		Lv6: 7000
-		Lv7: 8000
-		Lv8: 9000
-		Lv9: 10000
-		Lv10: 11000
-	}
+	AfterCastActDelay: 1_000
+	CoolDown: 30_000
 	SkillData1: {
 		Lv1: 20000
 		Lv2: 25000
@@ -11116,55 +11104,21 @@ skill_db: (
 		Lv9: 60000
 		Lv10: 65000
 	}
-	SkillData2: {
-		Lv1: 20000
-		Lv2: 25000
-		Lv3: 30000
-		Lv4: 35000
-		Lv5: 40000
-		Lv6: 45000
-		Lv7: 50000
-		Lv8: 55000
-		Lv9: 60000
-		Lv10: 65000
-	}
-	FixedCastTime: {
-		Lv1: 5000
-		Lv2: 6000
-		Lv3: 7000
-		Lv4: 8000
-		Lv5: 9000
-		Lv6: 10000
-		Lv7: 11000
-		Lv8: 12000
-		Lv9: 13000
-		Lv10: 14000
-	}
+	FixedCastTime: 1_000
+	CastTime: 3_000
 	Requirements: {
 		SPCost: {
-			Lv1: 80
-			Lv2: 90
-			Lv3: 100
-			Lv4: 110
-			Lv5: 120
-			Lv6: 130
-			Lv7: 140
-			Lv8: 150
-			Lv9: 160
-			Lv10: 170
+			Lv1: 40
+			Lv2: 50
+			Lv3: 60
+			Lv4: 70
+			Lv5: 80
+			Lv6: 90
+			Lv7: 100
+			Lv8: 110
+			Lv9: 120
+			Lv10: 130
 		}
-		Items: {
-			Yellow_Gemstone: 1
-			Red_Gemstone: 1
-			Blue_Gemstone: 1
-			Holy_Water: 1
-		}
-	}
-	Unit: {
-		Id: 0xb4
-		Range: 2
-		Interval: 300
-		Target: "All"
 	}
 },
 {

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -10998,7 +10998,7 @@ skill_db: (
 {
 	Id: 361
 	Name: "HP_ASSUMPTIO"
-	StatusChange: "SC_ASSUMPTIO"
+	StatusChange: "SC_ASSUMPTIO_BUFF"
 	Description: "Assumptio"
 	MaxLevel: 5
 	Range: 9
@@ -11024,18 +11024,7 @@ skill_db: (
 		Lv9: 2400
 		Lv10: 2400
 	}
-	AfterCastActDelay: {
-		Lv1: 1100
-		Lv2: 1200
-		Lv3: 1300
-		Lv4: 1400
-		Lv5: 1500
-		Lv6: 1600
-		Lv7: 1700
-		Lv8: 1800
-		Lv9: 1900
-		Lv10: 2000
-	}
+	AfterCastActDelay: 500
 	SkillData1: {
 		Lv1: 20000
 		Lv2: 40000

--- a/npc/events/nguild/nguild_warper.txt
+++ b/npc/events/nguild/nguild_warper.txt
@@ -75,6 +75,7 @@ prontera,146,163,6	script	Novice Castles	4_F_NOVICE,{
 		} else if (select("Warp me to Novice Castles","Cancel") == 1) {
 			// remove several unallowed buffs
 			sc_end SC_ASSUMPTIO;
+			sc_end SC_ASSUMPTIO_BUFF;
 			sc_end SC_IMPOSITIO;
 			sc_end SC_SUFFRAGIUM;
 			sc_end SC_MAGNIFICAT;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -880,6 +880,9 @@ static int64 battle_calc_masteryfix(struct block_list *src, struct block_list *t
 	}
 
 	if( sc ){ // sc considered as masteries
+		enum elements target_ele = status_get_element(target);
+		if (sc->data[SC_BASILICA_BUFF] != NULL && (target_ele == ELE_UNDEAD || target_ele == ELE_DARK))
+			damage += damage * sc->data[SC_BASILICA_BUFF]->val2 / 100;
 		if(sc->data[SC_GN_CARTBOOST])
 			damage += 10 * sc->data[SC_GN_CARTBOOST]->val1;
 		if(sc->data[SC_CAMOUFLAGE])

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1221,6 +1221,8 @@ static int skill_calc_heal(struct block_list *src, struct block_list *target, ui
 			hp += hp * sc->data[SC_VITALIZE_POTION]->val3 / 100;
 		if(sc->data[SC_WATER_INSIGNIA] && sc->data[SC_WATER_INSIGNIA]->val1 == 2)
 			hp += hp / 10;
+		if (sc->data[SC_ASSUMPTIO_BUFF] != NULL)
+			hp += hp * 2 * sc->data[SC_ASSUMPTIO_BUFF]->val1 / 100;
 		if (sc->data[SC_VITALITYACTIVATION])
 			hp = hp * 150 / 100;
 		if (sc->data[SC_NO_RECOVER_STATE])
@@ -2104,6 +2106,7 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 				//Deactivatable Statuses: Kyrie Eleison, Auto Guard, Steel Body, Assumptio, and Millennium Shield
 				status_change_end(bl, SC_KYRIE, INVALID_TIMER);
 				status_change_end(bl, SC_ASSUMPTIO, INVALID_TIMER);
+				status_change_end(bl, SC_ASSUMPTIO_BUFF, INVALID_TIMER);
 				status_change_end(bl, SC_STEELBODY, INVALID_TIMER);
 				status_change_end(bl, SC_GENTLETOUCH_CHANGE, INVALID_TIMER);
 				status_change_end(bl, SC_GENTLETOUCH_REVITALIZE, INVALID_TIMER);
@@ -2347,6 +2350,7 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 							continue;
 						break;
 					case SC_ASSUMPTIO:
+					case SC_ASSUMPTIO_BUFF:
 						if (bl->type == BL_MOB)
 							continue;
 						break;
@@ -8846,6 +8850,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 #endif
 
 						case SC_ASSUMPTIO:
+						case SC_ASSUMPTIO_BUFF:
 							if( bl->type == BL_MOB )
 								continue;
 							break;
@@ -10370,6 +10375,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 					PRAGMA_GCC46(GCC diagnostic ignored "-Wswitch-enum")
 					switch (i) {
 						case SC_ASSUMPTIO:
+						case SC_ASSUMPTIO_BUFF:
 							if( bl->type == BL_MOB )
 								continue;
 							break;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -4108,7 +4108,9 @@ static int skill_check_unit_range_sub(struct block_list *bl, va_list ap)
 		case HT_BLASTMINE:
 		case HT_CLAYMORETRAP:
 		case HT_TALKIEBOX:
+#ifndef RENEWAL // 2018.11 rebalance - Basilica changed to a self buff
 		case HP_BASILICA:
+#endif
 		case RA_ELECTRICSHOCKER:
 		case RA_CLUSTERBOMB:
 		case RA_MAGENTATRAP:
@@ -4161,8 +4163,10 @@ static int skill_check_unit_range2_sub(struct block_list *bl, va_list ap)
 	if( status->isdead(bl) && skill_id != AL_WARP )
 		return 0;
 
+#ifndef RENEWAL // 2018.11 rebalance - Basilica changed to a self buff
 	if( skill_id == HP_BASILICA && bl->type == BL_PC )
 		return 0;
+#endif
 
 	if (skill_id == AM_DEMONSTRATION && bl->type == BL_MOB && BL_UCCAST(BL_MOB, bl)->class_ == MOBID_EMPELIUM)
 		return 0; //Allow casting Bomb/Demonstration Right under emperium [Skotlex]
@@ -7506,6 +7510,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 		case SP_SOULREAPER:
 #ifdef RENEWAL
 		case BD_ADAPTATION:
+		case HP_BASILICA: // 2018.11 rebalance - Basilica changed to a self buff
 #endif
 			clif->skill_nodamage(src,bl,skill_id,skill_lv,
 				sc_start(src, bl, type, 100, skill_lv, skill->get_time(skill_id, skill_lv), skill_id));
@@ -12601,6 +12606,8 @@ static int skill_castend_pos2(struct block_list *src, int x, int y, uint16 skill
 			skill->unitsetting(src,skill_id,skill_lv,x,y,0);
 			flag|=1;
 			break;
+
+#ifndef RENEWAL // 2018.11 rebalance - Basilica changed to a self buff
 		case HP_BASILICA:
 			if( sc && sc->data[SC_BASILICA] )
 				status_change_end(src, SC_BASILICA, INVALID_TIMER); // Cancel Basilica
@@ -12617,6 +12624,8 @@ static int skill_castend_pos2(struct block_list *src, int x, int y, uint16 skill
 				flag|=1;
 			}
 			break;
+#endif
+
 		case CG_HERMODE:
 			skill->clear_unitgroup(src);
 			if ((sg = skill->unitsetting(src,skill_id,skill_lv,x,y,0)))
@@ -13394,9 +13403,12 @@ static struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16
 				val3 = group->val3; //as well as the mapindex to warp to.
 			}
 			break;
+
+#ifndef RENEWAL // 2018.11 rebalance - Basilica changed to a self buff
 		case HP_BASILICA:
 			val1 = src->id; // Store caster id.
 			break;
+#endif
 
 		case PR_SANCTUARY:
 		case NPC_EVILLAND:
@@ -17737,10 +17749,14 @@ static int skill_delay_fix(struct block_list *bl, uint16 skill_id, uint16 skill_
 		case SJ_PROMINENCEKICK:
 			time -= (4 * status_get_agi(bl) + 2 * status_get_dex(bl));
 			break;
+
+#ifndef RENEWAL // 2018.11 rebalance - Basilica changed to a self buff
 		case HP_BASILICA:
 			if( sc && !sc->data[SC_BASILICA] )
 				time = 0; // There is no Delay on Basilica creation, only on cancel
 			break;
+#endif
+
 		default:
 			if (battle_config.delay_dependon_dex && !(delaynodex&1)) {
 				// if skill delay is allowed to be reduced by dex
@@ -18717,7 +18733,9 @@ static int skill_cell_overlap(struct block_list *bl, va_list ap)
 			}
 			break;
 		case WZ_ICEWALL:
+#ifndef RENEWAL // 2018.11 rebalance - Basilica changed to a self buff
 		case HP_BASILICA:
+#endif
 			if (su->group->skill_id == skill_id) {
 				//These can't be placed on top of themselves (duration can't be refreshed)
 				(*alive) = 0;
@@ -19105,9 +19123,13 @@ static struct skill_unit *skill_initunit(struct skill_unit_group *group, int idx
 		case SA_LANDPROTECTOR:
 			skill->unitsetmapcell(su,SA_LANDPROTECTOR,group->skill_lv,CELL_LANDPROTECTOR,true);
 			break;
+
+#ifndef RENEWAL // 2018.11 rebalance - Basilica changed to a self buff
 		case HP_BASILICA:
 			skill->unitsetmapcell(su,HP_BASILICA,group->skill_lv,CELL_BASILICA,true);
 			break;
+#endif
+
 		default:
 			if (group->state.song_dance&0x1) //Check for dissonance.
 				skill->dance_overlap(su, 1);
@@ -19167,9 +19189,13 @@ static int skill_delunit(struct skill_unit *su)
 		case SA_LANDPROTECTOR:
 			skill->unitsetmapcell(su,SA_LANDPROTECTOR,group->skill_lv,CELL_LANDPROTECTOR,false);
 			break;
+
+#ifndef RENEWAL // 2018.11 rebalance - Basilica changed to a self buff
 		case HP_BASILICA:
 			skill->unitsetmapcell(su,HP_BASILICA,group->skill_lv,CELL_BASILICA,false);
 			break;
+#endif
+
 		case RA_ELECTRICSHOCKER: {
 				struct block_list* target = map->id2bl(group->val2);
 				if( target )

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -5245,6 +5245,9 @@ static signed short status_calc_def2(struct block_list *bl, struct status_change
 		if (sc->data[SC_ASSUMPTIO])
 			def2 <<= 1;
 #endif
+		// @TODO: Is is hidden or it should show?
+		if (sc->data[SC_ASSUMPTIO_BUFF] != NULL)
+			def2 += sc->data[SC_ASSUMPTIO_BUFF]->val1 * 50;
 		if (sc->data[SC_CAMOUFLAGE])
 			def2 -= def2 * 5 * (10-sc->data[SC_CAMOUFLAGE]->val4) / 100;
 		if (sc->data[SC_GENTLETOUCH_REVITALIZE])
@@ -10497,6 +10500,7 @@ static int status_change_start_set_option(struct block_list *bl, struct status_c
 			opt_flag = 0;
 			break;
 		case SC_ASSUMPTIO:
+		case SC_ASSUMPTIO_BUFF:
 			sc->opt3 |= OPT3_ASSUMPTIO;
 			opt_flag = 0;
 			break;
@@ -10771,7 +10775,7 @@ static bool status_end_sc_before_start(struct block_list *bl, struct status_data
 		status_change_end(bl, SC_OVERTHRUST, INVALID_TIMER);
 		break;
 	case SC_KYRIE:
-		// Cancels Assumptio
+		// Cancels Assumptio (Non-Renewal version)
 		status_change_end(bl, SC_ASSUMPTIO, INVALID_TIMER);
 		break;
 	case SC_MAGNIFICAT:
@@ -10815,11 +10819,13 @@ static bool status_end_sc_before_start(struct block_list *bl, struct status_data
 
 		break;
 	case SC_ASSUMPTIO:
+	// case SC_ASSUMPTIO_BUFF: // 2018.11 rebalance - New assumptio works together with Kaite/Kyrie
 		status_change_end(bl, SC_KYRIE, INVALID_TIMER);
 		status_change_end(bl, SC_KAITE, INVALID_TIMER);
 		break;
 	case SC_KAITE:
 		status_change_end(bl, SC_ASSUMPTIO, INVALID_TIMER);
+		// status_change_end(bl, SC_ASSUMPTIO_BUFF, INVALID_TIMER); // 2018.11 rebalance - New assumptio works together with Kaite/Kyrie
 		break;
 	case SC_CARTBOOST:
 		if (sc->data[SC_DEC_AGI] != NULL || sc->data[SC_ADORAMUS] != NULL) {

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2361,6 +2361,8 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 		if (sc->data[SC_PROPERTYGROUND] != NULL)
 			sd->magic_atk_ele[ELE_EARTH] += sc->data[SC_PROPERTYGROUND]->val1;
 #endif
+		if (sc->data[SC_BASILICA_BUFF] != NULL)
+			sd->magic_atk_ele[ELE_HOLY] += sc->data[SC_BASILICA_BUFF]->val1;
 
 		// Geffen Scrolls
 		if (sc->data[SC_SKELSCROLL]) {
@@ -9953,6 +9955,12 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 			case SC_SOULDIVISION:
 				val2 = 10 * 1; // Skill Aftercast Increase
 				break;
+
+			case SC_BASILICA_BUFF: // Renewal version of Basilica, where it is a buff.
+				val2 = 3 * val1; // Holy MATK % Increase
+				val3 = 5 * val1; // ATK % Increase
+				break;
+
 			default:
 				if (status->change_start_unknown_sc(src, bl, type, calc_flag, rate, val1, val2, val3, val4, total_tick, flag)) {
 					return 0;

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -927,6 +927,7 @@ typedef enum sc_type {
 
 	// New SCs for High Priest (2018.11 rebalance)
 	SC_BASILICA_BUFF, // Renewal version of Basilica, where it is an ATK/MATK buff.
+	SC_ASSUMPTIO_BUFF, // Renewal version of Assumptio
 
 #ifndef SC_MAX
 	SC_MAX, //Automatically updated max, used in for's to check we are within bounds.

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -925,6 +925,9 @@ typedef enum sc_type {
 	SC_ENSEMBLEFATIGUE,
 	SC_ADAPTATION,
 
+	// New SCs for High Priest (2018.11 rebalance)
+	SC_BASILICA_BUFF, // Renewal version of Basilica, where it is an ATK/MATK buff.
+
 #ifndef SC_MAX
 	SC_MAX, //Automatically updated max, used in for's to check we are within bounds.
 #endif

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1711,10 +1711,14 @@ static int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill
 		if (sc && sc->data[SC_RUN])
 			casttime = -1;
 	break;
+
+#ifndef RENEWAL // 2018.11 rebalance - Basilica changed to a self buff
 	case HP_BASILICA:
 		if( sc && sc->data[SC_BASILICA] )
 			casttime = -1; // No Casting time on basilica cancel
 	break;
+#endif
+
 	case KN_CHARGEATK:
 		{
 		unsigned int k = (distance_bl(src,target)-1)/3; //+100% every 3 cells of distance


### PR DESCRIPTION
> [!NOTE]
> I am still performing a self review/game check on this

### Pull Request Prelude
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR introduces the rebalance of High Priest job skills. This change affects Renewal-only.

I can't say everything is 100% accurate because they are based on sources and very few in-game tests, but should be close enough.

Check the commit messages for details of the changes (or the references below)

**Affected skills**
- HP_BASILICA (Basilica)
- HP_ASSUMPTION (Assumptio)


References:
- [kRO 2018.10.31 patch note](https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=7033&curpage=21)
- [kRO 2018.11.28 patch note / translated](https://board.herc.ws/topic/17043-kro-patch-2018-11-28/)
- [Divine Pride](https://www.divine-pride.net/forum/index.php?/topic/3453-kro-mass-skills-balance-1st-2nd-and-transcendent-classes-skills/)

**Issues addressed:** <!-- Write here the issue number, if any. -->
Part of #2735 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
