### PR TITLE
Sniper skill rebalance - 2018 patch/renewal

### DIFF
--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -11823,9 +11823,9 @@ skill_db: (
 	SplashRange: 1
 	InterruptCast: true
 	SkillInstances: 13
-	CastTime: 1000
-	AfterCastActDelay: 1500
-	FixedCastTime: 1000
+	CastTime: 500
+	AfterCastActDelay: 500
+	FixedCastTime: 500
 	Requirements: {
 		SPCost: {
 			Lv1: 18

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2347,8 +2347,13 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					skillratio += 40 * skill_lv - 60;
 					break;
 				case SN_SHARPSHOOTING:
-				case MA_SHARPSHOOTING:
+				case MA_SHARPSHOOTING: // @TODO: Is mercenary also affected?
+#ifndef RENEWAL
 					skillratio += 100 + 50 * skill_lv;
+#else
+					skillratio += 50 + 200 * skill_lv;
+					RE_LVL_DMOD(100);
+#endif
 					break;
 				case CG_ARROWVULCAN:
 					skillratio += 100 + 100 * skill_lv;
@@ -5125,7 +5130,11 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				break;
 			case SN_SHARPSHOOTING:
 			case MA_SHARPSHOOTING:
+#ifndef RENEWAL
 				cri += 200;
+#else
+				cri += 500; // 2018.11 rebalance - source: iRO Wiki
+#endif
 				break;
 			case NJ_KIRIKAGE:
 				cri += 250 + 50*skill_lv;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4360,7 +4360,9 @@ static struct Damage battle_calc_misc_attack(struct block_list *src, struct bloc
 		break;
 #endif
 	case HT_BLITZBEAT:
+#ifndef RENEWAL
 	case SN_FALCONASSAULT:
+#endif
 		// Blitz-beat Damage.
 		if (sd == NULL || (temp = pc->checkskill(sd,HT_STEELCROW)) <= 0)
 			temp = 0;
@@ -4381,6 +4383,24 @@ static struct Damage battle_calc_misc_attack(struct block_list *src, struct bloc
 			md.damage=md.damage*(150+70*skill_lv)/100;
 		}
 		break;
+
+#ifdef RENEWAL
+	case SN_FALCONASSAULT: {
+		int blitz_lv = 0;
+		int steel_crow_lv = 0;
+
+		if (sd != NULL) {
+			blitz_lv = pc->checkskill(sd, HT_BLITZBEAT);
+			steel_crow_lv = pc->checkskill(sd, HT_STEELCROW);
+		}
+
+		// Formula from iRO Wiki
+		int64 dmg_part1 = ((sstatus->agi / 2 + sstatus->dex / 10) * 2 + blitz_lv * 20 + steel_crow_lv * 6) * skill_lv + steel_crow_lv * 6;
+		md.damage = dmg_part1 * (steel_crow_lv / 20 + skill_lv + status->get_lv(src) / 50);
+	}
+		break;
+#endif
+
 	case TF_THROWSTONE:
 		md.damage=50;
 		break;


### PR DESCRIPTION
> [!NOTE]
> I am still performing a self review/game check on this

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR introduces the rebalance of Sniper job skills. This change affects Renewal-only.

I can't say everything is 100% accurate because they are based on sources and very few in-game tests, but should be close enough.

Check the commit messages for details of the changes (or the references below)

**Affected skills**
- SN_SHARPSHOOTING (Focused Arrow Strike)
- SN_FALCONASSAULT (Falcon Assault)


References:
- [kRO 2018.10.31 patch note](https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=7033&curpage=21)
- [kRO 2018.11.28 patch note / translated](https://board.herc.ws/topic/17043-kro-patch-2018-11-28/)
- [Divine Pride](https://www.divine-pride.net/forum/index.php?/topic/3453-kro-mass-skills-balance-1st-2nd-and-transcendent-classes-skills/)

**Issues addressed:** <!-- Write here the issue number, if any. -->
Part of #2735 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
