### PR TITLE
Champion skill rebalance - 2018 patch/renewal

### DIFF
--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -11486,7 +11486,7 @@ skill_db: (
 			Lv9: 20
 			Lv10: 22
 		}
-		SpiritSphereCost: 2
+		SpiritSphereCost: 1
 	}
 },
 {

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -12390,7 +12390,7 @@ skill_db: (
 	}
 	InterruptCast: true
 	SkillData1: 600000
-	FixedCastTime: 2000
+	FixedCastTime: 1_000
 	Requirements: {
 		SPCost: 20
 	}

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2326,7 +2326,12 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 #endif
 					break;
 				case CH_TIGERFIST:
+#ifndef RENEWAL
 					skillratio += 100 * skill_lv - 60;
+#else
+					skillratio += -100 + 500 + 150 * skill_lv;
+					RE_LVL_DMOD(100);
+#endif
 					break;
 				case CH_CHAINCRUSH:
 					skillratio += 300 + 100 * skill_lv;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2332,7 +2332,12 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 					skillratio += 300 + 100 * skill_lv;
 					break;
 				case CH_PALMSTRIKE:
+#ifndef RENEWAL
 					skillratio += 100 + 100 * skill_lv;
+#else
+					skillratio += -100 + 200 + 100 * skill_lv + 5 * st->str;
+					RE_LVL_DMOD(100);
+#endif
 					break;
 				case LK_HEADCRUSH:
 					skillratio += 40 * skill_lv;

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2334,7 +2334,12 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 #endif
 					break;
 				case CH_CHAINCRUSH:
+#ifndef RENEWAL
 					skillratio += 300 + 100 * skill_lv;
+#else
+					skillratio += -100 + 200 * skill_lv;
+					RE_LVL_DMOD(100);
+#endif
 					break;
 				case CH_PALMSTRIKE:
 #ifndef RENEWAL


### PR DESCRIPTION
> [!NOTE]
> I am still performing a self review/game check on this

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR introduces the rebalance of Champion job skills. This change affects Renewal-only.

I can't say everything is 100% accurate because they are based on sources and very few in-game tests, but should be close enough.

Commits authored by gbasso were copied from #3200, which needed commit split/rebase (done here), and were reviewed with minor/no changes by me

Check the commit messages for details of the changes (or the references below)

**Affected skills**
- CH_SOULCOLLECT (Zen)
- CH_PALMSTRIKE (Raging Palm Strike)
- CH_TIGERFIST (Glacier Fist)
- CH_CHAINCRUSH (Chain Crush Combo)


References:
- [kRO 2018.10.31 patch note](https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=7033&curpage=21)
- [kRO 2018.11.28 patch note / translated](https://board.herc.ws/topic/17043-kro-patch-2018-11-28/)
- [Divine Pride](https://www.divine-pride.net/forum/index.php?/topic/3453-kro-mass-skills-balance-1st-2nd-and-transcendent-classes-skills/)

**Issues addressed:** <!-- Write here the issue number, if any. -->
Part of #2735 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
