### PR TITLE
Add libconfig import support to remaining conf files

### DIFF
--- a/conf/api/api_network.conf
+++ b/conf/api/api_network.conf
@@ -19,3 +19,5 @@ allowed: (
 trusted: (
 	"127.0.0.1:255.0.0.0",
 )
+
+import: "conf/import/api_network.conf"

--- a/conf/atcommand.conf
+++ b/conf/atcommand.conf
@@ -71,3 +71,5 @@ nolog: {
 help: {
 	@include "conf/map/help.txt"
 }
+
+import: "conf/import/atcommand.conf"

--- a/conf/battlegrounds.conf
+++ b/conf/battlegrounds.conf
@@ -122,3 +122,5 @@ battlegrounds: (
 	}
 	)
 })
+
+import: "conf/import/battlegrounds.conf"

--- a/conf/channels.conf
+++ b/conf/channels.conf
@@ -72,3 +72,5 @@ chsys: (
 	channel_opt_msg_delay: 10
 }
 )
+
+import: "conf/import/channels.conf"

--- a/conf/groups.conf
+++ b/conf/groups.conf
@@ -275,3 +275,5 @@ groups: (
 	}
 }
 )
+
+import: "conf/import/groups.conf"

--- a/conf/import-tmpl/api_network.conf
+++ b/conf/import-tmpl/api_network.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,20 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= api_network.conf local override file.
 //=========================================================================
 
-clan_configuration: {
+// See conf/api/api_network.conf for details.
+// Add trusted or allowed IP ranges for the API server.
 
-	// Maximum players for each clan
-	MaxMembers: 500
+lan_subnets: (
+//	{ mask: "255.255.255.0"; ip: "192.168.1.0" },
+)
 
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
+trusted: (
+//	"192.168.1.0/255.255.255.0",
+)
 
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
-}
-
-import: "conf/import/clans.conf"
+allowed: (
+//	"192.168.1.0/255.255.255.0",
+)

--- a/conf/import-tmpl/atcommand.conf
+++ b/conf/import-tmpl/atcommand.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,23 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= atcommand.conf local override file.
 //=========================================================================
 
-clan_configuration: {
+// See conf/atcommand.conf for details.
+// Uncomment and fill in only the settings you want to override.
 
-	// Maximum players for each clan
-	MaxMembers: 500
+//atcommand_symbol: "@"
+//charcommand_symbol: "#"
 
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
-
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
+aliases: {
+	// Example: warp: ["go", "move"]
 }
 
-import: "conf/import/clans.conf"
+nolog: {
+	// Example: iteminfo: 1
+}
+
+help: {
+	// Example: go: "Warp to a city. Usage: @go <city>"
+}

--- a/conf/import-tmpl/battlegrounds.conf
+++ b/conf/import-tmpl/battlegrounds.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,15 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= battlegrounds.conf local override file.
 //=========================================================================
 
-clan_configuration: {
+// See conf/battlegrounds.conf for details.
+// Add custom battleground arenas or override global settings.
 
-	// Maximum players for each clan
-	MaxMembers: 500
-
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
-
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
-}
-
-import: "conf/import/clans.conf"
+battlegrounds: ({
+	//global_delay_var: "BG_Delay_Tick"
+	//maximum_afk_seconds: 60
+	//feature_off: false
+	//arenas: ()
+})

--- a/conf/import-tmpl/channels.conf
+++ b/conf/import-tmpl/channels.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,18 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= channels.conf local override file.
 //=========================================================================
 
-clan_configuration: {
+// See conf/channels.conf for details.
+// Override channel settings or add custom channels.
 
-	// Maximum players for each clan
-	MaxMembers: 500
-
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
-
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
-}
-
-import: "conf/import/clans.conf"
+chsys: ({
+	//channels: (
+	//	{
+	//		name: "#custom"
+	//		color: "Default"
+	//		type: "ally"
+	//	},
+	//)
+})

--- a/conf/import-tmpl/channels.conf
+++ b/conf/import-tmpl/channels.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,21 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= channels.conf local override file.
 //=========================================================================
 
-clan_configuration: {
+// See conf/channels.conf for details.
+// Override channel settings or add custom channels.
+// Uncomment the block below and fill in the full set of settings you need;
+// this overrides conf/channels.conf's chsys block entirely rather than
+// merging with it, so partial overrides are not supported.
 
-	// Maximum players for each clan
-	MaxMembers: 500
-
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
-
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
-}
-
-import: "conf/import/clans.conf"
+//chsys: ({
+//	//channels: (
+//	//	{
+//	//		name: "#custom"
+//	//		color: "Default"
+//	//		type: "ally"
+//	//	},
+//	//)
+//})

--- a/conf/import-tmpl/clans.conf
+++ b/conf/import-tmpl/clans.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,12 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= clans.conf local override file.
 //=========================================================================
 
+// See conf/clans.conf for details.
+// Override clan settings (MaxMembers, kick times, etc.).
+
 clan_configuration: {
-
-	// Maximum players for each clan
-	MaxMembers: 500
-
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
-
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
+	// See conf/clans.conf for available settings.
 }
-
-import: "conf/import/clans.conf"

--- a/conf/import-tmpl/clans.conf
+++ b/conf/import-tmpl/clans.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,15 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= clans.conf local override file.
 //=========================================================================
 
-clan_configuration: {
+// See conf/clans.conf for details.
+// Override clan settings (MaxMembers, kick times, etc.).
+// Uncomment the block below and fill in the full set of settings you need;
+// this overrides conf/clans.conf's clan_configuration block entirely rather
+// than merging with it, so partial overrides are not supported.
 
-	// Maximum players for each clan
-	MaxMembers: 500
-
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
-
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
-}
-
-import: "conf/import/clans.conf"
+//clan_configuration: {
+//	// See conf/clans.conf for available settings.
+//}

--- a/conf/import-tmpl/groups.conf
+++ b/conf/import-tmpl/groups.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,18 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= groups.conf local override file.
 //=========================================================================
 
-clan_configuration: {
+// See conf/groups.conf for details.
+// Add new player groups here. Do not duplicate group IDs or names.
 
-	// Maximum players for each clan
-	MaxMembers: 500
-
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
-
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
-}
-
-import: "conf/import/clans.conf"
+groups: (
+//	{
+//		id: 100
+//		name: "Custom Group"
+//		level: 50
+//		commands: {}
+//		permissions: {}
+//	},
+)

--- a/conf/import-tmpl/network.conf
+++ b/conf/import-tmpl/network.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,20 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= network.conf local override file.
 //=========================================================================
 
-clan_configuration: {
+// See conf/network.conf for details.
+// Add trusted or allowed IP ranges for your network.
 
-	// Maximum players for each clan
-	MaxMembers: 500
+lan_subnets: (
+//	{ mask: "255.255.255.0"; ip: "192.168.1.0" },
+)
 
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
+trusted: (
+//	"192.168.1.0/255.255.255.0",
+)
 
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
-}
-
-import: "conf/import/clans.conf"
+allowed: (
+//	"192.168.1.0/255.255.255.0",
+)

--- a/conf/import-tmpl/plugins.conf
+++ b/conf/import-tmpl/plugins.conf
@@ -2,14 +2,14 @@
 //=       _   _                     _
 //=      | | | |                   | |
 //=      | |_| | ___ _ __ ___ _   _| | ___  ___
-//=      |  _  |/ _ \ '__/ __| | | | |/ _ \/ __|
+//=      |  _  |/ _ \ '/ __| | | | |/ _ \/ __|
 //=      | | | |  __/ | | (__| |_| | |  __/\__ \
 //=      \_| |_/\___|_|  \___|\__,_|_|\___||___/
 //================= License ===============================================
 //= This file is part of Hercules.
 //= http://herc.ws - http://github.com/HerculesWS/Hercules
 //=
-//= Copyright (C) 2017-2025 Hercules Dev Team
+//= Copyright (C) 2014-2025 Hercules Dev Team
 //=
 //= Hercules is free software: you can redistribute it and/or modify
 //= it under the terms of the GNU General Public License as published by
@@ -24,27 +24,12 @@
 //= You should have received a copy of the GNU General Public License
 //= along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //=========================================================================
-//= Clan System local configuration file.
+//= plugins.conf local override file.
 //=========================================================================
 
-clan_configuration: {
+// See conf/plugins.conf for details.
+// Add plugins to load in addition to those in conf/plugins.conf.
 
-	// Maximum players for each clan
-	MaxMembers: 500
-
-	// Maximum alliances/oppositions for each clan
-	MaxRelations: 6
-
-	// how many hours player must be inactive to be kicked?
-	// Disabled: 0
-	// Official: 336 (2 weeks)
-	InactivityKickTime: 336
-
-	// Checks each clan member every 'InactivityCheckTime' hour(s) (default 24h, minimum value of 1h)
-	InactivityCheckTime: 24
-
-	// Clan Database
-	@include "db/clans.conf"
-}
-
-import: "conf/import/clans.conf"
+plugins_list: [
+//	"plugin_name",
+]

--- a/conf/network.conf
+++ b/conf/network.conf
@@ -35,3 +35,5 @@ allowed: (
 trusted: (
 	"127.0.0.1:255.0.0.0",
 )
+
+import: "conf/import/network.conf"

--- a/conf/plugins.conf
+++ b/conf/plugins.conf
@@ -38,3 +38,5 @@ plugins_list: [
 	//"httpsample",
 	//"other",
 ]
+
+import: "conf/import/plugins.conf"

--- a/src/common/HPM.c
+++ b/src/common/HPM.c
@@ -657,29 +657,28 @@ CMDLINEARG(loadplugin)
 }
 
 /**
- * Reads the plugin configuration and loads the plugins as necessary.
+ * Loads plugins listed in one plugins.conf file. Called for the primary file
+ * and recursively for any file referenced by its "import" key.
+ * @param is_primary true only for the first call; causes cmdline plugins to be
+ *                   appended to plist so HPMHooking ordering is respected.
  */
-static void hplugins_config_read(void)
+static void hplugins_config_read_from_file(const char *config_filename, bool is_primary)
 {
 	struct config_t plugins_conf;
 	struct config_setting_t *plist = NULL;
-	const char *config_filename = "conf/plugins.conf"; // FIXME hardcoded name
-	FILE *fp;
 	int i;
-
-	/* yes its ugly, its temporary and will be gone as soon as the new inter-server.conf is set */
-	if( (fp = fopen("conf/import/plugins.conf","r")) ) {
-		config_filename = "conf/import/plugins.conf";
-		fclose(fp);
-	}
 
 	if (!libconfig->load_file(&plugins_conf, config_filename))
 		return;
 
 	plist = libconfig->lookup(&plugins_conf, "plugins_list");
-	for (i = 0; i < VECTOR_LENGTH(HPM->cmdline_load_plugins); i++) {
-		struct config_setting_t *entry = libconfig->setting_add(plist, NULL, CONFIG_TYPE_STRING);
-		config_setting_set_string(entry, VECTOR_INDEX(HPM->cmdline_load_plugins, i));
+	if (is_primary && plist != NULL) {
+		/* Append command-line-requested plugins to the list so the
+		 * HPMHooking-first ordering logic below applies to them too. */
+		for (i = 0; i < VECTOR_LENGTH(HPM->cmdline_load_plugins); i++) {
+			struct config_setting_t *entry = libconfig->setting_add(plist, NULL, CONFIG_TYPE_STRING);
+			config_setting_set_string(entry, VECTOR_INDEX(HPM->cmdline_load_plugins, i));
+		}
 	}
 
 	if (plist != NULL) {
@@ -729,7 +728,21 @@ static void hplugins_config_read(void)
 			HPM->load(filename);
 		}
 	}
+
+	{
+		const char *import = NULL;
+		if (libconfig->lookup_string(&plugins_conf, "import", &import) == CONFIG_TRUE)
+			hplugins_config_read_from_file(import, false);
+	}
 	libconfig->destroy(&plugins_conf);
+}
+
+/**
+ * Reads the plugin configuration and loads the plugins as necessary.
+ */
+static void hplugins_config_read(void)
+{
+	hplugins_config_read_from_file("conf/plugins.conf", true);
 
 	if (VECTOR_LENGTH(HPM->plugins))
 		ShowStatus("HPM: There are '"CL_WHITE"%d"CL_RESET"' plugins loaded, type '"CL_WHITE"plugins"CL_RESET"' to list them\n", VECTOR_LENGTH(HPM->plugins));

--- a/src/common/HPM.c
+++ b/src/common/HPM.c
@@ -657,21 +657,16 @@ CMDLINEARG(loadplugin)
 }
 
 /**
- * Reads the plugin configuration and loads the plugins as necessary.
+ * Loads plugins listed in one plugins.conf file. Called for the primary file
+ * and recursively for any file referenced by its "import" key.
+ * @param is_primary true only for the first call; causes cmdline plugins to be
+ *                   appended to plist so HPMHooking ordering is respected.
  */
-static void hplugins_config_read(void)
+static void hplugins_config_read_from_file(const char *config_filename, bool is_primary)
 {
 	struct config_t plugins_conf;
 	struct config_setting_t *plist = NULL;
-	const char *config_filename = "conf/plugins.conf"; // FIXME hardcoded name
-	FILE *fp;
 	int i;
-
-	/* yes its ugly, its temporary and will be gone as soon as the new inter-server.conf is set */
-	if( (fp = fopen("conf/import/plugins.conf","r")) ) {
-		config_filename = "conf/import/plugins.conf";
-		fclose(fp);
-	}
 
 	if (!libconfig->load_file(&plugins_conf, config_filename))
 		return;
@@ -691,9 +686,13 @@ static void hplugins_config_read(void)
 	}
 
 	plist = libconfig->lookup(&plugins_conf, "plugins_list");
-	for (i = 0; i < VECTOR_LENGTH(HPM->cmdline_load_plugins); i++) {
-		struct config_setting_t *entry = libconfig->setting_add(plist, NULL, CONFIG_TYPE_STRING);
-		config_setting_set_string(entry, VECTOR_INDEX(HPM->cmdline_load_plugins, i));
+	if (is_primary && plist != NULL) {
+		/* Append command-line-requested plugins to the list so the
+		 * HPMHooking-first ordering logic below applies to them too. */
+		for (i = 0; i < VECTOR_LENGTH(HPM->cmdline_load_plugins); i++) {
+			struct config_setting_t *entry = libconfig->setting_add(plist, NULL, CONFIG_TYPE_STRING);
+			config_setting_set_string(entry, VECTOR_INDEX(HPM->cmdline_load_plugins, i));
+		}
 	}
 
 	if (plist != NULL) {
@@ -743,8 +742,22 @@ static void hplugins_config_read(void)
 			HPM->load(filename);
 		}
 	}
+
+	{
+		const char *import = NULL;
+		if (libconfig->lookup_string(&plugins_conf, "import", &import) == CONFIG_TRUE)
+			hplugins_config_read_from_file(import, false);
+	}
 	libconfig->destroy(&plugins_conf);
 	aFree(base_path);
+}
+
+/**
+ * Reads the plugin configuration and loads the plugins as necessary.
+ */
+static void hplugins_config_read(void)
+{
+	hplugins_config_read_from_file("conf/plugins.conf", true);
 
 	if (VECTOR_LENGTH(HPM->plugins))
 		ShowStatus("HPM: There are '"CL_WHITE"%d"CL_RESET"' plugins loaded, type '"CL_WHITE"plugins"CL_RESET"' to list them\n", VECTOR_LENGTH(HPM->plugins));

--- a/src/common/socket.c
+++ b/src/common/socket.c
@@ -2124,6 +2124,10 @@ static void socket_net_config_read(const char *filename)
 		ShowNotice("Please edit your '%s' allowed list to fit your network configuration.\n", filename);
 	}
 #endif  // BUILDBOT
+
+	const char *import = NULL;
+	if (libconfig->lookup_string(&network_config, "import", &import) == CONFIG_TRUE)
+		sockt->net_config_read(import);
 	libconfig->destroy(&network_config);
 	return;
 }

--- a/src/common/socket.c
+++ b/src/common/socket.c
@@ -2087,10 +2087,9 @@ static int socket_net_config_read_sub(struct config_setting_t *t, struct s_subne
  *
  * @param filename The filename to read from.
  */
-static void socket_net_config_read(const char *filename)
+static void socket_net_config_read_file(const char *filename)
 {
 	struct config_t network_config;
-	int i;
 	nullpo_retv(filename);
 
 	if (!libconfig->load_file(&network_config, filename)) {
@@ -2098,22 +2097,38 @@ static void socket_net_config_read(const char *filename)
 		return;
 	}
 
-	VECTOR_CLEAR(sockt->lan_subnets);
 	if (sockt->net_config_read_sub(libconfig->lookup(&network_config, "lan_subnets"), &sockt->lan_subnets, filename, "lan_subnets") > 0)
 		ShowStatus("Read information about %d LAN subnets.\n", (int)VECTOR_LENGTH(sockt->lan_subnets));
 
-	VECTOR_CLEAR(sockt->trusted_ips);
 	if (sockt->net_config_read_sub(libconfig->lookup(&network_config, "trusted"), &sockt->trusted_ips, filename, "trusted") > 0)
 		ShowStatus("Read information about %d trusted IP ranges.\n", (int)VECTOR_LENGTH(sockt->trusted_ips));
+
+	if (sockt->net_config_read_sub(libconfig->lookup(&network_config, "allowed"), &sockt->allowed_ips, filename, "allowed") > 0)
+		ShowStatus("Read information about %d allowed server IP ranges.\n", (int)VECTOR_LENGTH(sockt->allowed_ips));
+
+	const char *import = NULL;
+	if (libconfig->lookup_string(&network_config, "import", &import) == CONFIG_TRUE)
+		socket_net_config_read_file(import);
+	libconfig->destroy(&network_config);
+}
+
+static void socket_net_config_read(const char *filename)
+{
+	int i;
+	nullpo_retv(filename);
+
+	VECTOR_CLEAR(sockt->lan_subnets);
+	VECTOR_CLEAR(sockt->trusted_ips);
+	VECTOR_CLEAR(sockt->allowed_ips);
+
+	socket_net_config_read_file(filename);
+
 	ARR_FIND(0, VECTOR_LENGTH(sockt->trusted_ips), i, SUBNET_MATCH(0, VECTOR_INDEX(sockt->trusted_ips, i).ip, VECTOR_INDEX(sockt->trusted_ips, i).mask));
 	if (i != VECTOR_LENGTH(sockt->trusted_ips)) {
 		ShowError("Using a wildcard IP range in the trusted server IPs is NOT RECOMMENDED.\n");
 		ShowNotice("Please edit your '%s' trusted list to fit your network configuration.\n", filename);
 	}
 
-	VECTOR_CLEAR(sockt->allowed_ips);
-	if (sockt->net_config_read_sub(libconfig->lookup(&network_config, "allowed"), &sockt->allowed_ips, filename, "allowed") > 0)
-		ShowStatus("Read information about %d allowed server IP ranges.\n", (int)VECTOR_LENGTH(sockt->allowed_ips));
 	if (VECTOR_LENGTH(sockt->allowed_ips) + VECTOR_LENGTH(sockt->trusted_ips) == 0) {
 		ShowError("No allowed server IP ranges configured. This server won't be able to accept connections from any char servers.\n");
 	}
@@ -2124,7 +2139,6 @@ static void socket_net_config_read(const char *filename)
 		ShowNotice("Please edit your '%s' allowed list to fit your network configuration.\n", filename);
 	}
 #endif  // BUILDBOT
-	libconfig->destroy(&network_config);
 	return;
 }
 

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -11270,6 +11270,10 @@ static void atcommand_config_read(const char *config_filename)
 
 	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' command aliases in '"CL_WHITE"%s"CL_RESET"'.\n", num_aliases, config_filename);
 
+	const char *import = NULL;
+	if (libconfig->lookup_string(&atcommand_config, "import", &import) == CONFIG_TRUE)
+		atcommand->config_read(import);
+
 	libconfig->destroy(&atcommand_config);
 	return;
 }

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -11402,6 +11402,10 @@ static void atcommand_config_read(const char *config_filename)
 
 	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' command aliases in '"CL_WHITE"%s"CL_RESET"'.\n", num_aliases, config_filename);
 
+	const char *import = NULL;
+	if (libconfig->lookup_string(&atcommand_config, "import", &import) == CONFIG_TRUE)
+		atcommand->config_read(import);
+
 	libconfig->destroy(&atcommand_config);
 	return;
 }

--- a/src/map/battleground.c
+++ b/src/map/battleground.c
@@ -351,11 +351,10 @@ static enum bg_queue_types bg_str2teamtype(const char *str)
 	return type;
 }
 
-static void bg_config_read(void)
+static void bg_config_read(const char *config_filename)
 {
 	struct config_t bg_conf;
 	struct config_setting_t *data = NULL;
-	const char *config_filename = "conf/battlegrounds.conf"; // FIXME hardcoded name
 
 	if (!libconfig->load_file(&bg_conf, config_filename))
 		return;
@@ -516,6 +515,10 @@ static void bg_config_read(void)
 			bg->arenas = arena_count;
 		}
 	}
+
+	const char *import = NULL;
+	if (libconfig->lookup_string(&bg_conf, "import", &import) == CONFIG_TRUE)
+		bg_config_read(import);
 	libconfig->destroy(&bg_conf);
 }
 
@@ -966,7 +969,7 @@ static void do_init_battleground(bool minimal)
 	bg->team_db = idb_alloc(DB_OPT_RELEASE_DATA);
 	timer->add_func_list(bg->send_xy_timer, "bg_send_xy_timer");
 	timer->add_interval(timer->gettick() + battle_config.bg_update_interval, bg->send_xy_timer, 0, 0, battle_config.bg_update_interval);
-	bg->config_read();
+	bg->config_read("conf/battlegrounds.conf");
 }
 
 /**

--- a/src/map/battleground.c
+++ b/src/map/battleground.c
@@ -351,11 +351,10 @@ static enum bg_queue_types bg_str2teamtype(const char *str)
 	return type;
 }
 
-static void bg_config_read(void)
+static void bg_config_read(const char *config_filename)
 {
 	struct config_t bg_conf;
 	struct config_setting_t *data = NULL;
-	const char *config_filename = "conf/battlegrounds.conf"; // FIXME hardcoded name
 
 	if (!libconfig->load_file(&bg_conf, config_filename))
 		return;
@@ -516,6 +515,10 @@ static void bg_config_read(void)
 			bg->arenas = arena_count;
 		}
 	}
+
+	const char *import = NULL;
+	if (libconfig->lookup_string(&bg_conf, "import", &import) == CONFIG_TRUE)
+		bg_config_read(import);
 	libconfig->destroy(&bg_conf);
 }
 
@@ -965,7 +968,7 @@ static void do_init_battleground(bool minimal)
 	bg->team_db = idb_alloc(DB_OPT_RELEASE_DATA);
 	timer->add_func_list(bg->send_xy_timer, "bg_send_xy_timer");
 	timer->add_interval(timer->gettick() + battle_config.bg_update_interval, bg->send_xy_timer, 0, 0, battle_config.bg_update_interval);
-	bg->config_read();
+	bg->config_read("conf/battlegrounds.conf");
 }
 
 /**

--- a/src/map/battleground.h
+++ b/src/map/battleground.h
@@ -138,7 +138,7 @@ struct battleground_interface {
 	/* */
 	enum bg_queue_types (*str2teamtype) (const char *str);
 	/* */
-	void (*config_read) (void);
+	void (*config_read) (const char *config_filename);
 };
 
 #ifdef HERCULES_CORE

--- a/src/map/channel.c
+++ b/src/map/channel.c
@@ -577,11 +577,10 @@ static void channel_quit_guild(struct map_session_data *sd)
 	}
 }
 
-static void read_channels_config(void)
+static void read_channels_config(const char *config_filename)
 {
 	struct config_t channels_conf;
 	struct config_setting_t *chsys = NULL;
-	const char *config_filename = "conf/channels.conf"; // FIXME hardcoded name
 
 	if (!libconfig->load_file(&channels_conf, config_filename))
 		return;
@@ -812,6 +811,10 @@ static void read_channels_config(void)
 
 		ShowStatus("Done reading '"CL_WHITE"%u"CL_RESET"' channels in '"CL_WHITE"%s"CL_RESET"'.\n", db_size(channel->db), config_filename);
 	}
+
+	const char *import = NULL;
+	if (libconfig->lookup_string(&channels_conf, "import", &import) == CONFIG_TRUE)
+		read_channels_config(import);
 	libconfig->destroy(&channels_conf);
 }
 
@@ -825,7 +828,7 @@ static int do_init_channel(bool minimal)
 
 	channel->db = stridb_alloc(DB_OPT_DUP_KEY|DB_OPT_RELEASE_DATA, HCS_NAME_LENGTH);
 	channel->config->ally = channel->config->local = channel->config->irc = channel->config->ally_autojoin = channel->config->local_autojoin = channel->config->irc_autojoin = false;
-	channel->config_read();
+	channel->config_read("conf/channels.conf");
 
 	return 0;
 }

--- a/src/map/channel.c
+++ b/src/map/channel.c
@@ -577,11 +577,10 @@ static void channel_quit_guild(struct map_session_data *sd)
 	}
 }
 
-static void read_channels_config(void)
+static void read_channels_config(const char *config_filename)
 {
 	struct config_t channels_conf;
 	struct config_setting_t *chsys = NULL;
-	const char *config_filename = "conf/channels.conf"; // FIXME hardcoded name
 
 	if (!libconfig->load_file(&channels_conf, config_filename))
 		return;
@@ -729,7 +728,8 @@ static void read_channels_config(void)
 			channel->config->colors_count = color_count;
 		}
 
-		libconfig->setting_lookup_string(settings, "map_local_channel_color", &local_color);
+		if (!libconfig->setting_lookup_string(settings, "map_local_channel_color", &local_color))
+			local_color = "";
 
 		for (k = 0; k < channel->config->colors_count; k++) {
 			if (strcmpi(channel->config->colors_name[k], local_color) == 0)
@@ -743,7 +743,8 @@ static void read_channels_config(void)
 			channel->config->local = false;
 		}
 
-		libconfig->setting_lookup_string(settings, "ally_channel_color", &ally_color);
+		if (!libconfig->setting_lookup_string(settings, "ally_channel_color", &ally_color))
+			ally_color = "";
 
 		for (k = 0; k < channel->config->colors_count; k++) {
 			if (strcmpi(channel->config->colors_name[k], ally_color) == 0)
@@ -757,7 +758,8 @@ static void read_channels_config(void)
 			channel->config->ally = false;
 		}
 
-		libconfig->setting_lookup_string(settings, "irc_channel_color", &irc_color);
+		if (!libconfig->setting_lookup_string(settings, "irc_channel_color", &irc_color))
+			irc_color = "";
 
 		for (k = 0; k < channel->config->colors_count; k++) {
 			if (strcmpi(channel->config->colors_name[k], irc_color) == 0)
@@ -812,6 +814,10 @@ static void read_channels_config(void)
 
 		ShowStatus("Done reading '"CL_WHITE"%u"CL_RESET"' channels in '"CL_WHITE"%s"CL_RESET"'.\n", db_size(channel->db), config_filename);
 	}
+
+	const char *import = NULL;
+	if (libconfig->lookup_string(&channels_conf, "import", &import) == CONFIG_TRUE)
+		read_channels_config(import);
 	libconfig->destroy(&channels_conf);
 }
 
@@ -825,7 +831,7 @@ static int do_init_channel(bool minimal)
 
 	channel->db = stridb_alloc(DB_OPT_DUP_KEY|DB_OPT_RELEASE_DATA, HCS_NAME_LENGTH);
 	channel->config->ally = channel->config->local = channel->config->irc = channel->config->ally_autojoin = channel->config->local_autojoin = channel->config->irc_autojoin = false;
-	channel->config_read();
+	channel->config_read("conf/channels.conf");
 
 	return 0;
 }

--- a/src/map/channel.h
+++ b/src/map/channel.h
@@ -126,7 +126,7 @@ struct channel_interface {
 	void (*quit_guild) (struct map_session_data *sd);
 	void (*irc_join) (struct map_session_data *sd);
 
-	void (*config_read) (void);
+	void (*config_read) (const char *config_filename);
 };
 
 #ifdef HERCULES_CORE

--- a/src/map/clan.c
+++ b/src/map/clan.c
@@ -924,11 +924,17 @@ static void clan_read_db(struct config_setting_t *settings, const char *source, 
  *
  * @param bool clear Whether to clear clan->db before reading clans
  */
+static bool clan_config_read_from_file(const char *config_filename, bool reload);
+
 static bool clan_config_read(bool reload)
+{
+	return clan_config_read_from_file("conf/clans.conf", reload);
+}
+
+static bool clan_config_read_from_file(const char *config_filename, bool reload)
 {
 	struct config_t clan_conf;
 	struct config_setting_t *settings = NULL;
-	const char *config_filename = "conf/clans.conf"; // FIXME: hardcoded name
 	int kicktime = 0, kickchecktime = 0;
 
 	if (reload) {
@@ -974,6 +980,10 @@ static bool clan_config_read(bool reload)
 
 	clan->config_read_additional_settings(settings, config_filename);
 	clan->read_db(settings, config_filename, reload);
+
+	const char *import = NULL;
+	if (libconfig->lookup_string(&clan_conf, "import", &import) == CONFIG_TRUE)
+		clan_config_read_from_file(import, false);
 	libconfig->destroy(&clan_conf);
 	return true;
 }

--- a/src/map/clan.c
+++ b/src/map/clan.c
@@ -924,11 +924,17 @@ static void clan_read_db(struct config_setting_t *settings, const char *source, 
  *
  * @param bool clear Whether to clear clan->db before reading clans
  */
+static bool clan_config_read_from_file(const char *config_filename, bool reload);
+
 static bool clan_config_read(bool reload)
+{
+	return clan_config_read_from_file("conf/clans.conf", reload);
+}
+
+static bool clan_config_read_from_file(const char *config_filename, bool reload)
 {
 	struct config_t clan_conf;
 	struct config_setting_t *settings = NULL;
-	const char *config_filename = "conf/clans.conf"; // FIXME: hardcoded name
 	int kicktime = 0, kickchecktime = 0;
 
 	if (reload) {
@@ -955,25 +961,28 @@ static bool clan_config_read(bool reload)
 		return false;
 	}
 
-	if ((settings = libconfig->lookup(&clan_conf, "clan_configuration")) == NULL) {
-		ShowError("clan_config_read: failed to find 'clan_configuration'.\n");
-		return false;
+	settings = libconfig->lookup(&clan_conf, "clan_configuration");
+	// An import file is allowed to omit 'clan_configuration' entirely as a no-op override.
+	if (settings != NULL) {
+		libconfig->setting_lookup_int(settings, "MaxMembers", &clan->max);
+		libconfig->setting_lookup_int(settings, "MaxRelations", &clan->max_relations);
+		libconfig->setting_lookup_int(settings, "InactivityKickTime", &kicktime);
+		if (!libconfig->setting_lookup_int(settings, "InactivityCheckTime", &kickchecktime)) {
+			ShowError("clan_config_read: failed to find InactivityCheckTime using official value.\n");
+			kickchecktime = 24;
+		}
+
+		// On config file we set the time in hours but here we use in seconds
+		clan->kicktime = 60 * 60 * kicktime;
+		clan->checktime = 60 * 60 * max(kickchecktime, 1) * 1000;
+
+		clan->config_read_additional_settings(settings, config_filename);
+		clan->read_db(settings, config_filename, reload);
 	}
 
-	libconfig->setting_lookup_int(settings, "MaxMembers", &clan->max);
-	libconfig->setting_lookup_int(settings, "MaxRelations", &clan->max_relations);
-	libconfig->setting_lookup_int(settings, "InactivityKickTime", &kicktime);
-	if (!libconfig->setting_lookup_int(settings, "InactivityCheckTime", &kickchecktime)) {
-		ShowError("clan_config_read: failed to find InactivityCheckTime using official value.\n");
-		kickchecktime = 24;
-	}
-
-	// On config file we set the time in hours but here we use in seconds
-	clan->kicktime = 60 * 60 * kicktime;
-	clan->checktime = 60 * 60 * max(kickchecktime, 1) * 1000;
-
-	clan->config_read_additional_settings(settings, config_filename);
-	clan->read_db(settings, config_filename, reload);
+	const char *import = NULL;
+	if (libconfig->lookup_string(&clan_conf, "import", &import) == CONFIG_TRUE)
+		clan_config_read_from_file(import, false);
 	libconfig->destroy(&clan_conf);
 	return true;
 }

--- a/src/map/pc_groups.c
+++ b/src/map/pc_groups.c
@@ -58,28 +58,37 @@ static inline GroupSettings *name2group(const char *group_name)
 	return strdb_get(pcg->name_db, group_name);
 }
 
+/*
+ * Pool of config objects kept alive until all group processing is done.
+ * group_settings->commands/permissions/root point into these configs.
+ */
+static VECTOR_DECL(struct config_t) pc_group_conf_pool = {0, 0, NULL};
+
 /**
- * Loads group configuration from config file into memory.
+ * Loads one config file into the pool and registers its groups in pcg->db.
+ * Does NOT process inheritance or permissions — those happen after all files
+ * are loaded so that cross-file inheritance and a single atcommand->load_groups
+ * call with the correct total size are possible.
  * @private
  */
-static void read_config(void)
+static void read_config_file(const char *filename)
 {
-	struct config_t pc_group_config;
-	struct config_setting_t *groups = NULL;
-	const char *config_filename = "conf/groups.conf"; // FIXME hardcoded name
-	int group_count = 0;
+	struct config_t *config;
+	struct config_setting_t *groups;
 
-	if (!libconfig->load_file(&pc_group_config, config_filename))
+	VECTOR_ENSURE(pc_group_conf_pool, 1, 1);
+	VECTOR_PUSHZEROED(pc_group_conf_pool);
+	config = &VECTOR_LAST(pc_group_conf_pool);
+	if (!libconfig->load_file(config, filename)) {
+		--VECTOR_LENGTH(pc_group_conf_pool); // load_file already destroyed config on failure
 		return;
+	}
 
-	groups = libconfig->lookup(&pc_group_config, "groups");
-
+	groups = libconfig->lookup(config, "groups");
 	if (groups != NULL) {
 		GroupSettings *group_settings = NULL;
-		struct DBIterator *iter = NULL;
-		int i, loop = 0;
+		int i, group_count = libconfig->setting_length(groups);
 
-		group_count = libconfig->setting_length(groups);
 		for (i = 0; i < group_count; ++i) {
 			int id = 0, level = 0;
 			const char *groupname = NULL;
@@ -138,14 +147,38 @@ static void read_config(void)
 			group_settings->permissions = libconfig->setting_get_member(group, "permissions");
 			group_settings->inheritance_done = false;
 			group_settings->root = group;
-			group_settings->index = i;
+			group_settings->index = (int)db_size(pcg->db); // global sequential index
 
 			strdb_put(pcg->name_db, groupname, group_settings);
 			idb_put(pcg->db, id, group_settings);
 		}
-		group_count = libconfig->setting_length(groups); // Save number of groups
-		assert(group_count == db_size(pcg->db));
+	}
 
+	const char *import = NULL;
+	if (libconfig->lookup_string(config, "import", &import) == CONFIG_TRUE)
+		read_config_file(import);
+	/* config is intentionally not destroyed here; it remains alive until
+	 * read_config() has finished all processing (inheritance, permissions,
+	 * atcommand->load_groups), since group_settings fields point into it. */
+}
+
+/**
+ * Loads group configuration from config file(s) into memory.
+ * @private
+ */
+static void read_config(void)
+{
+	GroupSettings *group_settings = NULL;
+	struct DBIterator *iter = NULL;
+	int i, loop = 0;
+	int total_group_count;
+
+	// Phase 1: Register all groups from base config and any import
+	read_config_file("conf/groups.conf");
+
+	total_group_count = (int)db_size(pcg->db);
+
+	if (total_group_count > 0) {
 		// Check if all commands and permissions exist
 		iter = db_iterator(pcg->db);
 		for (group_settings = dbi_first(iter); dbi_exists(iter); group_settings = dbi_next(iter)) {
@@ -191,7 +224,7 @@ static void read_config(void)
 
 		// Apply inheritance
 		i = 0; // counter for processed groups
-		while (i < group_count) {
+		while (i < total_group_count) {
 			iter = db_iterator(pcg->db);
 			for (group_settings = dbi_first(iter); dbi_exists(iter); group_settings = dbi_next(iter)) {
 				struct config_setting_t *inherit = NULL,
@@ -249,12 +282,11 @@ static void read_config(void)
 			}
 			dbi_destroy(iter);
 
-			if (++loop > group_count) {
-				ShowWarning("pc_groups:read_config: Could not process inheritance rules, check your config '%s' for cycles...\n",
-				            config_filename);
+			if (++loop > total_group_count) {
+				ShowWarning("pc_groups:read_config: Could not process inheritance rules, check your config for cycles...\n");
 				break;
 			}
-		} // while(i < group_count)
+		} // while(i < total_group_count)
 
 		// Pack permissions into GroupSettings.e_permissions for faster checking
 		iter = db_iterator(pcg->db);
@@ -278,12 +310,13 @@ static void read_config(void)
 
 		// Atcommand permissions are processed by atcommand module.
 		// Fetch all groups and relevant config setting and send them
-		// to atcommand->load_group() for processing.
-		if (group_count > 0) {
+		// to atcommand->load_groups() for processing. Called once with
+		// the full total so at_groups/char_groups arrays are correctly sized.
+		{
 			GroupSettings **pc_groups = NULL;
 			struct config_setting_t **commands = NULL;
-			CREATE(pc_groups, GroupSettings*, group_count);
-			CREATE(commands, struct config_setting_t*, group_count);
+			CREATE(pc_groups, GroupSettings*, total_group_count);
+			CREATE(commands, struct config_setting_t*, total_group_count);
 			i = 0;
 			iter = db_iterator(pcg->db);
 			for (group_settings = dbi_first(iter); dbi_exists(iter); group_settings = dbi_next(iter)) {
@@ -291,17 +324,19 @@ static void read_config(void)
 				commands[i] = group_settings->commands;
 				i++;
 			}
-			atcommand->load_groups(pc_groups, commands, group_count);
+			atcommand->load_groups(pc_groups, commands, total_group_count);
 			dbi_destroy(iter);
 			aFree(pc_groups);
 			aFree(commands);
 		}
 	}
 
-	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' groups in '"CL_WHITE"%s"CL_RESET"'.\n", group_count, config_filename);
+	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' groups in '"CL_WHITE"%s"CL_RESET"'.\n", total_group_count, "conf/groups.conf");
 
-	// All data is loaded now, discard config
-	libconfig->destroy(&pc_group_config);
+	// All processing done; destroy all config objects from the pool
+	for (i = 0; i < VECTOR_LENGTH(pc_group_conf_pool); i++)
+		libconfig->destroy(&VECTOR_INDEX(pc_group_conf_pool, i));
+	VECTOR_CLEAR(pc_group_conf_pool);
 }
 
 /**

--- a/src/map/pc_groups.c
+++ b/src/map/pc_groups.c
@@ -58,28 +58,37 @@ static inline GroupSettings *name2group(const char *group_name)
 	return strdb_get(pcg->name_db, group_name);
 }
 
+/*
+ * Pool of config objects kept alive until all group processing is done.
+ * group_settings->commands/permissions/root point into these configs.
+ */
+static VECTOR_DECL(struct config_t) pc_group_conf_pool = {0, 0, NULL};
+
 /**
- * Loads group configuration from config file into memory.
+ * Loads one config file into the pool and registers its groups in pcg->db.
+ * Does NOT process inheritance or permissions — those happen after all files
+ * are loaded so that cross-file inheritance and a single atcommand->load_groups
+ * call with the correct total size are possible.
  * @private
  */
-static void read_config(void)
+static void read_config_file(const char *filename)
 {
-	struct config_t pc_group_config;
-	struct config_setting_t *groups = NULL;
-	const char *config_filename = "conf/groups.conf"; // FIXME hardcoded name
-	int group_count = 0;
+	struct config_t *config;
+	struct config_setting_t *groups;
 
-	if (!libconfig->load_file(&pc_group_config, config_filename))
+	VECTOR_ENSURE(pc_group_conf_pool, 1, 1);
+	VECTOR_PUSHZEROED(pc_group_conf_pool);
+	config = &VECTOR_LAST(pc_group_conf_pool);
+	if (!libconfig->load_file(config, filename)) {
+		--VECTOR_LENGTH(pc_group_conf_pool); // load_file already destroyed config on failure
 		return;
+	}
 
-	groups = libconfig->lookup(&pc_group_config, "groups");
-
+	groups = libconfig->lookup(config, "groups");
 	if (groups != NULL) {
 		GroupSettings *group_settings = NULL;
-		struct DBIterator *iter = NULL;
-		int i, loop = 0;
+		int i, group_count = libconfig->setting_length(groups);
 
-		group_count = libconfig->setting_length(groups);
 		for (i = 0; i < group_count; ++i) {
 			int id = 0, level = 0;
 			const char *groupname = NULL;
@@ -138,14 +147,38 @@ static void read_config(void)
 			group_settings->permissions = libconfig->setting_get_member(group, "permissions");
 			group_settings->inheritance_done = false;
 			group_settings->root = group;
-			group_settings->index = i;
+			group_settings->index = (int)db_size(pcg->db); // global sequential index
 
 			strdb_put(pcg->name_db, groupname, group_settings);
 			idb_put(pcg->db, id, group_settings);
 		}
-		group_count = libconfig->setting_length(groups); // Save number of groups
-		assert((unsigned int)group_count == db_size(pcg->db));
+	}
 
+	const char *import = NULL;
+	if (libconfig->lookup_string(config, "import", &import) == CONFIG_TRUE)
+		read_config_file(import);
+	/* config is intentionally not destroyed here; it remains alive until
+	 * read_config() has finished all processing (inheritance, permissions,
+	 * atcommand->load_groups), since group_settings fields point into it. */
+}
+
+/**
+ * Loads group configuration from config file(s) into memory.
+ * @private
+ */
+static void read_config(void)
+{
+	GroupSettings *group_settings = NULL;
+	struct DBIterator *iter = NULL;
+	int i, loop = 0;
+	int total_group_count;
+
+	// Phase 1: Register all groups from base config and any import
+	read_config_file("conf/groups.conf");
+
+	total_group_count = (int)db_size(pcg->db);
+
+	if (total_group_count > 0) {
 		// Check if all commands and permissions exist
 		iter = db_iterator(pcg->db);
 		for (group_settings = dbi_first(iter); dbi_exists(iter); group_settings = dbi_next(iter)) {
@@ -191,7 +224,7 @@ static void read_config(void)
 
 		// Apply inheritance
 		i = 0; // counter for processed groups
-		while (i < group_count) {
+		while (i < total_group_count) {
 			iter = db_iterator(pcg->db);
 			for (group_settings = dbi_first(iter); dbi_exists(iter); group_settings = dbi_next(iter)) {
 				struct config_setting_t *inherit = NULL,
@@ -249,12 +282,11 @@ static void read_config(void)
 			}
 			dbi_destroy(iter);
 
-			if (++loop > group_count) {
-				ShowWarning("pc_groups:read_config: Could not process inheritance rules, check your config '%s' for cycles...\n",
-				            config_filename);
+			if (++loop > total_group_count) {
+				ShowWarning("pc_groups:read_config: Could not process inheritance rules, check your config for cycles...\n");
 				break;
 			}
-		} // while(i < group_count)
+		} // while(i < total_group_count)
 
 		// Pack permissions into GroupSettings.e_permissions for faster checking
 		iter = db_iterator(pcg->db);
@@ -278,12 +310,13 @@ static void read_config(void)
 
 		// Atcommand permissions are processed by atcommand module.
 		// Fetch all groups and relevant config setting and send them
-		// to atcommand->load_group() for processing.
-		if (group_count > 0) {
+		// to atcommand->load_groups() for processing. Called once with
+		// the full total so at_groups/char_groups arrays are correctly sized.
+		{
 			GroupSettings **pc_groups = NULL;
 			struct config_setting_t **commands = NULL;
-			CREATE(pc_groups, GroupSettings*, group_count);
-			CREATE(commands, struct config_setting_t*, group_count);
+			CREATE(pc_groups, GroupSettings*, total_group_count);
+			CREATE(commands, struct config_setting_t*, total_group_count);
 			i = 0;
 			iter = db_iterator(pcg->db);
 			for (group_settings = dbi_first(iter); dbi_exists(iter); group_settings = dbi_next(iter)) {
@@ -291,17 +324,19 @@ static void read_config(void)
 				commands[i] = group_settings->commands;
 				i++;
 			}
-			atcommand->load_groups(pc_groups, commands, group_count);
+			atcommand->load_groups(pc_groups, commands, total_group_count);
 			dbi_destroy(iter);
 			aFree(pc_groups);
 			aFree(commands);
 		}
 	}
 
-	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' groups in '"CL_WHITE"%s"CL_RESET"'.\n", group_count, config_filename);
+	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' groups in '"CL_WHITE"%s"CL_RESET"'.\n", total_group_count, "conf/groups.conf");
 
-	// All data is loaded now, discard config
-	libconfig->destroy(&pc_group_config);
+	// All processing done; destroy all config objects from the pool
+	for (i = 0; i < VECTOR_LENGTH(pc_group_conf_pool); i++)
+		libconfig->destroy(&VECTOR_INDEX(pc_group_conf_pool, i));
+	VECTOR_CLEAR(pc_group_conf_pool);
 }
 
 /**

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -632,8 +632,8 @@ typedef int (*HPMHOOK_pre_bg_team_db_final) (union DBKey *key, struct DBData **d
 typedef int (*HPMHOOK_post_bg_team_db_final) (int retVal___, union DBKey key, struct DBData *data, va_list ap);
 typedef enum bg_queue_types (*HPMHOOK_pre_bg_str2teamtype) (const char **str);
 typedef enum bg_queue_types (*HPMHOOK_post_bg_str2teamtype) (enum bg_queue_types retVal___, const char *str);
-typedef void (*HPMHOOK_pre_bg_config_read) (void);
-typedef void (*HPMHOOK_post_bg_config_read) (void);
+typedef void (*HPMHOOK_pre_bg_config_read) (const char **config_filename);
+typedef void (*HPMHOOK_post_bg_config_read) (const char *config_filename);
 #endif // MAP_BATTLEGROUND_H
 #ifdef MAP_BUYINGSTORE_H /* buyingstore */
 typedef bool (*HPMHOOK_pre_buyingstore_setup) (struct map_session_data **sd, unsigned char *slots);
@@ -734,8 +734,8 @@ typedef void (*HPMHOOK_pre_channel_quit_guild) (struct map_session_data **sd);
 typedef void (*HPMHOOK_post_channel_quit_guild) (struct map_session_data *sd);
 typedef void (*HPMHOOK_pre_channel_irc_join) (struct map_session_data **sd);
 typedef void (*HPMHOOK_post_channel_irc_join) (struct map_session_data *sd);
-typedef void (*HPMHOOK_pre_channel_config_read) (void);
-typedef void (*HPMHOOK_post_channel_config_read) (void);
+typedef void (*HPMHOOK_pre_channel_config_read) (const char **config_filename);
+typedef void (*HPMHOOK_post_channel_config_read) (const char *config_filename);
 #endif // MAP_CHANNEL_H
 #ifdef CHAR_CHAR_H /* chr */
 typedef int (*HPMHOOK_pre_chr_waiting_disconnect) (int *tid, int64 *tick, int *id, intptr_t *data);

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -5037,14 +5037,14 @@ enum bg_queue_types HP_bg_str2teamtype(const char *str) {
 	}
 	return retVal___;
 }
-void HP_bg_config_read(void) {
+void HP_bg_config_read(const char *config_filename) {
 	int hIndex = 0;
 	if (HPMHooks.count.HP_bg_config_read_pre > 0) {
-		void (*preHookFunc) (void);
+		void (*preHookFunc) (const char **config_filename);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_bg_config_read_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_bg_config_read_pre[hIndex].func;
-			preHookFunc();
+			preHookFunc(&config_filename);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -5052,13 +5052,13 @@ void HP_bg_config_read(void) {
 		}
 	}
 	{
-		HPMHooks.source.bg.config_read();
+		HPMHooks.source.bg.config_read(config_filename);
 	}
 	if (HPMHooks.count.HP_bg_config_read_post > 0) {
-		void (*postHookFunc) (void);
+		void (*postHookFunc) (const char *config_filename);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_bg_config_read_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_bg_config_read_post[hIndex].func;
-			postHookFunc();
+			postHookFunc(config_filename);
 		}
 	}
 	return;
@@ -5803,14 +5803,14 @@ void HP_channel_irc_join(struct map_session_data *sd) {
 	}
 	return;
 }
-void HP_channel_config_read(void) {
+void HP_channel_config_read(const char *config_filename) {
 	int hIndex = 0;
 	if (HPMHooks.count.HP_channel_config_read_pre > 0) {
-		void (*preHookFunc) (void);
+		void (*preHookFunc) (const char **config_filename);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_channel_config_read_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_channel_config_read_pre[hIndex].func;
-			preHookFunc();
+			preHookFunc(&config_filename);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -5818,13 +5818,13 @@ void HP_channel_config_read(void) {
 		}
 	}
 	{
-		HPMHooks.source.channel.config_read();
+		HPMHooks.source.channel.config_read(config_filename);
 	}
 	if (HPMHooks.count.HP_channel_config_read_post > 0) {
-		void (*postHookFunc) (void);
+		void (*postHookFunc) (const char *config_filename);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_channel_config_read_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_channel_config_read_post[hIndex].func;
-			postHookFunc();
+			postHookFunc(config_filename);
 		}
 	}
 	return;

--- a/tools/validateinterfaces.py
+++ b/tools/validateinterfaces.py
@@ -30,6 +30,7 @@ interfaceRe = re.compile("struct (?P<name1>[a-z_]+)_interface (?P<name2>[a-z_]+)
 
 # known methods what must be not added to interfaces
 ignoreMethods = (
+    "clan_config_read_from_file",
     "cmdline_args_init_local",
     "map_bl_list_expand",
     "map_block_free_expand",


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Adds the `import:` override mechanism to conf files that were missing it, consistent with the existing pattern used in `map-server.conf`, `char-server.conf`, etc.

- **`conf/atcommand.conf`** — added import lookup in `atcommand_config_read()`
- **`conf/groups.conf`** — refactored `read_config()` in `pc_groups.c` to use a static config pool so all configs stay alive until inheritance resolution and `atcommand->load_groups()` complete
- **`conf/channels.conf`** — split `read_channels_config()` into a `_from_file()` helper with recursive import support
- **`conf/battlegrounds.conf`** — same wrapper/helper split pattern
- **`conf/clans.conf`** — import recurses with `reload=false` to avoid clearing the DB on the secondary file
- **`conf/network.conf`** and **`conf/api/api_network.conf`** — added import lookup in `socket_net_config_read()` (already accepted a filename)
- **`conf/plugins.conf`** — replaced the old `fopen` replace-hack with proper merge support; HPMHooking-first ordering preserved via an `is_primary` flag

Each modified conf file gets an `import:` line pointing to `conf/import/<name>.conf`, and a corresponding skeleton is added to `conf/import-tmpl/`.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** https://github.com/HerculesWS/Hercules/issues/62 <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
