### PR TITLE
Use double-quoted string constants for type and race in level_penalty

### DIFF
--- a/db/re/level_penalty.conf
+++ b/db/re/level_penalty.conf
@@ -35,219 +35,219 @@ level_penalty_db: (
  **************************************************************************
 {
 	// Level of the defending element (by default, may be Lv1 up to Lv4)
-	type: <EXP_PENALTY_RATE or ITEM_DROP_PENALTY_RATE>,
-	race: <RC_* constant>,
+	type: <"EXP_PENALTY_RATE" or "ITEM_DROP_PENALTY_RATE">,
+	race: <RC_* constant (e.g. "RC_Boss", "RC_NonBoss")>,
 	diff: <level difference>,
 	rate: <penalty rate, where 100 means 100% (base rate, no additions/reductions)>
 },
 **************************************************************************/
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 16,
 	rate: 40
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 15,
 	rate: 115
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 14,
 	rate: 120
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 13,
 	rate: 125
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 12,
 	rate: 130
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 11,
 	rate: 135
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 10,
 	rate: 140
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 9,
 	rate: 135
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 8,
 	rate: 130
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 7,
 	rate: 125
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 6,
 	rate: 120
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 5,
 	rate: 115
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 4,
 	rate: 110
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 3,
 	rate: 105
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 0,
 	rate: 100
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -1,
 	rate: 100
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -6,
 	rate: 95
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -11,
 	rate: 90
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -16,
 	rate: 85
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -21,
 	rate: 60
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -26,
 	rate: 35
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -31,
 	rate: 10
 },
 {
-	type: EXP_PENALTY_RATE,
-	race: RC_BOSS,
+	type: "EXP_PENALTY_RATE",
+	race: "RC_Boss",
 	diff: 0,
 	rate: 100
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 16,
 	rate: 50
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 13,
 	rate: 60
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 10,
 	rate: 70
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 7,
 	rate: 80
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 4,
 	rate: 90
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: 0,
 	rate: 100
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -4,
 	rate: 90
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -7,
 	rate: 80
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -10,
 	rate: 70
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -13,
 	rate: 60
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_NONBOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_NonBoss",
 	diff: -16,
 	rate: 50
 },
 {
-	type: ITEM_DROP_PENALTY_RATE,
-	race: RC_BOSS,
+	type: "ITEM_DROP_PENALTY_RATE",
+	race: "RC_Boss",
 	diff: 0,
 	rate: 100
 }

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -11629,7 +11629,6 @@ static bool pc_read_level_penalty_db_sub(const struct config_setting_t *it, int 
 
 	const char *type_str = NULL;
 	if (libconfig->setting_lookup_string(it, "type", &type_str)) {
-		// Handle type constants
 		if (strcmp(type_str, "EXP_PENALTY_RATE") == 0) {
 			type = 1;
 		} else if (strcmp(type_str, "ITEM_DROP_PENALTY_RATE") == 0) {
@@ -11643,7 +11642,7 @@ static bool pc_read_level_penalty_db_sub(const struct config_setting_t *it, int 
 		return false;
 	}
 
-	if (!libconfig->setting_lookup_int(it, "race", &race)) {
+	if (!map->setting_lookup_const(it, "race", &race)) {
 		ShowError("%s: Invalid or missing race for entry %d in '%s', skipping...\n", __func__, n, source);
 		return false;
 	}

--- a/tools/level_penalty_converter.py
+++ b/tools/level_penalty_converter.py
@@ -30,19 +30,19 @@ import re
 import sys
 
 RACE_NAMES = {
-    0:  'RC_FORMLESS',
-    1:  'RC_UNDEAD',
-    2:  'RC_BRUTE',
-    3:  'RC_PLANT',
-    4:  'RC_INSECT',
-    5:  'RC_FISH',
-    6:  'RC_DEMON',
-    7:  'RC_DEMIHUMAN',
-    8:  'RC_ANGEL',
-    9:  'RC_DRAGON',
-    10: 'RC_PLAYER',
-    11: 'RC_BOSS',
-    12: 'RC_NONBOSS',
+    0:  'RC_Formless',
+    1:  'RC_Undead',
+    2:  'RC_Brute',
+    3:  'RC_Plant',
+    4:  'RC_Insect',
+    5:  'RC_Fish',
+    6:  'RC_Demon',
+    7:  'RC_DemiHuman',
+    8:  'RC_Angel',
+    9:  'RC_Dragon',
+    10: 'RC_Player',
+    11: 'RC_Boss',
+    12: 'RC_NonBoss',
 }
 
 TYPE_NAMES = {
@@ -88,8 +88,8 @@ level_penalty_db: (
  **************************************************************************
 {
 \t// Level of the defending element (by default, may be Lv1 up to Lv4)
-\ttype: <EXP_PENALTY_RATE or ITEM_DROP_PENALTY_RATE>,
-\trace: <RC_* constant>,
+\ttype: <"EXP_PENALTY_RATE" or "ITEM_DROP_PENALTY_RATE">,
+\trace: <RC_* constant (e.g. "RC_Boss", "RC_NonBoss")>,
 \tdiff: <level difference>,
 \trate: <penalty rate, where 100 means 100% (base rate, no additions/reductions)>
 },
@@ -128,8 +128,8 @@ def main():
     print(HEADER)
     for type_id, race_id, diff, rate in entries:
         print('{')
-        print(f'\ttype: {TYPE_NAMES[type_id]},')
-        print(f'\trace: {RACE_NAMES[race_id]},')
+        print(f'\ttype: "{TYPE_NAMES[type_id]}",')
+        print(f'\trace: "{RACE_NAMES[race_id]}",')
         print(f'\tdiff: {diff},')
         print(f'\trate: {rate}')
         print('},')


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
The `type` field in `level_penalty.conf` already supported quoted string constants (e.g. `"EXP_PENALTY_RATE"`), but `race` was integer-only and both fields were written as bare unquoted identifiers in the conf file and the converter output.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
