### PR TITLE
Fix #166: Replace pc_autosave O(N) iterator with a save queue

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2039,6 +2039,8 @@ static int map_quit(struct map_session_data *sd)
 		return 0;
 	}
 
+	pc->autosave_remove(sd->bl.id);
+
 	if( sd->expiration_tid != INVALID_TIMER )
 		timer->delete(sd->expiration_tid,pc->expiration_timer);
 

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2039,6 +2039,8 @@ static int map_quit(struct map_session_data *sd)
 		return 0;
 	}
 
+	pc->autosave_remove(sd->bl.id);
+
 	if( sd->expiration_tid != INVALID_TIMER )
 		timer->delete_(sd->expiration_tid,pc->expiration_timer);
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -82,6 +82,8 @@
 static struct pc_interface pc_s;
 struct pc_interface *pc;
 
+static void pc_autosave_start(void);
+
 static struct class_exp_tables exptables;
 
 //Converts a class to its array index for CLASS_COUNT defined arrays.
@@ -1599,6 +1601,9 @@ static int pc_reg_received(struct map_session_data *sd)
 	intif->Mail_requestinbox(sd->status.char_id, 0); // MAIL SYSTEM - Request Mail Inbox
 	intif->request_questlog(sd);
 	intif->rodex_checkhasnew(sd);
+
+	VECTOR_PUSH(pc->autosave_queue, sd->bl.id);
+	pc_autosave_start();
 
 	if (sd->state.connect_new == 0 && sd->fd) { //Character already loaded map! Gotta trigger LoadEndAck manually.
 		sd->state.connect_new = 1;
@@ -11068,43 +11073,65 @@ static int pc_setsavepoint(struct map_session_data *sd, short map_index, int x, 
 }
 
 /*==========================================
- * Save 1 player data at autosave intervall
+ * Start the autosave timer if not already running.
+ *------------------------------------------*/
+static void pc_autosave_start(void)
+{
+	int interval;
+
+	if (pc->autosave_tid != INVALID_TIMER)
+		return;
+
+	interval = map->autosave_interval / (VECTOR_LENGTH(pc->autosave_queue) + 1);
+	if (interval < map->minsave_interval)
+		interval = map->minsave_interval;
+	pc->autosave_tid = timer->add(timer->gettick() + interval, pc->autosave, 0, 0);
+}
+
+/*==========================================
+ * Remove a player from the autosave queue (called on logout).
+ *------------------------------------------*/
+static void pc_autosave_remove(int bl_id)
+{
+	int i;
+	ARR_FIND(0, VECTOR_LENGTH(pc->autosave_queue), i, VECTOR_INDEX(pc->autosave_queue, i) == bl_id);
+	if (i < VECTOR_LENGTH(pc->autosave_queue))
+		VECTOR_ERASE(pc->autosave_queue, i);
+}
+
+/*==========================================
+ * Save 1 player data at autosave interval.
+ * Uses a queue to find the next player in O(1) instead of iterating all players.
+ * Stops the timer when no players remain; restarted by pc_autosave_start on login.
  *------------------------------------------*/
 static int pc_autosave(int tid, int64 tick, int id, intptr_t data)
 {
 	int interval;
-	struct s_mapiterator* iter;
-	struct map_session_data* sd;
-	static int last_save_id = 0, save_flag = 0;
 
-	if(save_flag == 2) //Someone was saved on last call, normal cycle
-		save_flag = 0;
-	else
-		save_flag = 1; //Noone was saved, so save first found char.
+	pc->autosave_tid = INVALID_TIMER;
 
-	iter = mapit_getallusers();
-	for (sd = BL_UCAST(BL_PC, mapit->first(iter)); mapit->exists(iter); sd = BL_UCAST(BL_PC, mapit->next(iter))) {
-		if(sd->bl.id == last_save_id && save_flag != 1) {
-			save_flag = 1;
-			continue;
-		}
+	// Find and save the next valid player, skipping any who have disconnected
+	while (VECTOR_LENGTH(pc->autosave_queue) > 0) {
+		int bl_id = VECTOR_INDEX(pc->autosave_queue, 0);
+		struct map_session_data *sd;
 
-		if(save_flag != 1) //Not our turn to save yet.
-			continue;
+		VECTOR_ERASE(pc->autosave_queue, 0);
+		sd = map->id2sd(bl_id);
+		if (sd == NULL)
+			continue; // disconnected without queue cleanup; skip
 
-		//Save char.
-		last_save_id = sd->bl.id;
-		save_flag = 2;
-
-		chrif->save(sd,0);
+		chrif->save(sd, 0);
+		VECTOR_PUSH(pc->autosave_queue, bl_id);
 		break;
 	}
-	mapit->free(iter);
 
-	interval = map->autosave_interval/(map->usercount()+1);
-	if(interval < map->minsave_interval)
+	if (VECTOR_LENGTH(pc->autosave_queue) == 0)
+		return 0; // no players; timer stays stopped until next login
+
+	interval = map->autosave_interval / VECTOR_LENGTH(pc->autosave_queue);
+	if (interval < map->minsave_interval)
 		interval = map->minsave_interval;
-	timer->add(timer->gettick()+interval,pc->autosave,0,0);
+	pc->autosave_tid = timer->add(timer->gettick() + interval, pc->autosave, 0, 0);
 
 	return 0;
 }
@@ -12913,7 +12940,8 @@ static void do_init_pc(bool minimal)
 	timer->add_func_list(pc->global_expiration_timer,"pc_global_expiration_timer");
 	timer->add_func_list(pc->expiration_timer,"pc_expiration_timer");
 
-	timer->add(timer->gettick() + map->autosave_interval, pc->autosave, 0, 0);
+	pc->autosave_tid = INVALID_TIMER;
+	VECTOR_INIT(pc->autosave_queue);
 
 	// 0=day, 1=night [Yor]
 	map->night_flag = battle_config.night_at_start ? 1 : 0;
@@ -13244,6 +13272,7 @@ void pc_defaults(void)
 	pc->daynight_timer_sub = pc_daynight_timer_sub;
 	pc->charm_timer = pc_charm_timer;
 	pc->autosave = pc_autosave;
+	pc->autosave_remove = pc_autosave_remove;
 	pc->follow_timer = pc_follow_timer;
 	pc->read_skill_tree = pc_read_skill_tree;
 	pc->read_skill_job_skip = pc_read_skill_job_skip;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -11082,7 +11082,7 @@ static void pc_autosave_start(void)
 	if (pc->autosave_tid != INVALID_TIMER)
 		return;
 
-	interval = map->autosave_interval / (VECTOR_LENGTH(pc->autosave_queue) + 1);
+	interval = map->autosave_interval / VECTOR_LENGTH(pc->autosave_queue);
 	if (interval < map->minsave_interval)
 		interval = map->minsave_interval;
 	pc->autosave_tid = timer->add(timer->gettick() + interval, pc->autosave, 0, 0);

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -82,6 +82,8 @@
 static struct pc_interface pc_s;
 struct pc_interface *pc;
 
+static void pc_autosave_start(void);
+
 static struct class_exp_tables exptables;
 
 //Converts a class to its array index for CLASS_COUNT defined arrays.
@@ -1600,6 +1602,9 @@ static int pc_reg_received(struct map_session_data *sd)
 	intif->Mail_requestinbox(sd->status.char_id, 0); // MAIL SYSTEM - Request Mail Inbox
 	intif->request_questlog(sd);
 	intif->rodex_checkhasnew(sd);
+
+	VECTOR_PUSH(pc->autosave_queue, sd->bl.id);
+	pc_autosave_start();
 
 	if (sd->state.connect_new == 0 && sd->fd) { //Character already loaded map! Gotta trigger LoadEndAck manually.
 		sd->state.connect_new = 1;
@@ -11077,43 +11082,65 @@ static int pc_setsavepoint(struct map_session_data *sd, short map_index, int x, 
 }
 
 /*==========================================
- * Save 1 player data at autosave intervall
+ * Start the autosave timer if not already running.
+ *------------------------------------------*/
+static void pc_autosave_start(void)
+{
+	int interval;
+
+	if (pc->autosave_tid != INVALID_TIMER)
+		return;
+
+	interval = map->autosave_interval / (VECTOR_LENGTH(pc->autosave_queue) + 1);
+	if (interval < map->minsave_interval)
+		interval = map->minsave_interval;
+	pc->autosave_tid = timer->add(timer->gettick() + interval, pc->autosave, 0, 0);
+}
+
+/*==========================================
+ * Remove a player from the autosave queue (called on logout).
+ *------------------------------------------*/
+static void pc_autosave_remove(int bl_id)
+{
+	int i;
+	ARR_FIND(0, VECTOR_LENGTH(pc->autosave_queue), i, VECTOR_INDEX(pc->autosave_queue, i) == bl_id);
+	if (i < VECTOR_LENGTH(pc->autosave_queue))
+		VECTOR_ERASE(pc->autosave_queue, i);
+}
+
+/*==========================================
+ * Save 1 player data at autosave interval.
+ * Uses a queue to find the next player in O(1) instead of iterating all players.
+ * Stops the timer when no players remain; restarted by pc_autosave_start on login.
  *------------------------------------------*/
 static int pc_autosave(int tid, int64 tick, int id, intptr_t data)
 {
 	int interval;
-	struct s_mapiterator* iter;
-	struct map_session_data* sd;
-	static int last_save_id = 0, save_flag = 0;
 
-	if(save_flag == 2) //Someone was saved on last call, normal cycle
-		save_flag = 0;
-	else
-		save_flag = 1; //Noone was saved, so save first found char.
+	pc->autosave_tid = INVALID_TIMER;
 
-	iter = mapit_getallusers();
-	for (sd = BL_UCAST(BL_PC, mapit->first(iter)); mapit->exists(iter); sd = BL_UCAST(BL_PC, mapit->next(iter))) {
-		if(sd->bl.id == last_save_id && save_flag != 1) {
-			save_flag = 1;
-			continue;
-		}
+	// Find and save the next valid player, skipping any who have disconnected
+	while (VECTOR_LENGTH(pc->autosave_queue) > 0) {
+		int bl_id = VECTOR_INDEX(pc->autosave_queue, 0);
+		struct map_session_data *sd;
 
-		if(save_flag != 1) //Not our turn to save yet.
-			continue;
+		VECTOR_ERASE(pc->autosave_queue, 0);
+		sd = map->id2sd(bl_id);
+		if (sd == NULL)
+			continue; // disconnected without queue cleanup; skip
 
-		//Save char.
-		last_save_id = sd->bl.id;
-		save_flag = 2;
-
-		chrif->save(sd,0);
+		chrif->save(sd, 0);
+		VECTOR_PUSH(pc->autosave_queue, bl_id);
 		break;
 	}
-	mapit->free(iter);
 
-	interval = map->autosave_interval/(map->usercount()+1);
-	if(interval < map->minsave_interval)
+	if (VECTOR_LENGTH(pc->autosave_queue) == 0)
+		return 0; // no players; timer stays stopped until next login
+
+	interval = map->autosave_interval / VECTOR_LENGTH(pc->autosave_queue);
+	if (interval < map->minsave_interval)
 		interval = map->minsave_interval;
-	timer->add(timer->gettick()+interval,pc->autosave,0,0);
+	pc->autosave_tid = timer->add(timer->gettick() + interval, pc->autosave, 0, 0);
 
 	return 0;
 }
@@ -12927,7 +12954,8 @@ static void do_init_pc(bool minimal)
 	timer->add_func_list(pc->global_expiration_timer,"pc_global_expiration_timer");
 	timer->add_func_list(pc->expiration_timer,"pc_expiration_timer");
 
-	timer->add(timer->gettick() + map->autosave_interval, pc->autosave, 0, 0);
+	pc->autosave_tid = INVALID_TIMER;
+	VECTOR_INIT(pc->autosave_queue);
 
 	// 0=day, 1=night [Yor]
 	map->night_flag = battle_config.night_at_start ? 1 : 0;
@@ -13258,6 +13286,7 @@ void pc_defaults(void)
 	pc->daynight_timer_sub = pc_daynight_timer_sub;
 	pc->charm_timer = pc_charm_timer;
 	pc->autosave = pc_autosave;
+	pc->autosave_remove = pc_autosave_remove;
 	pc->follow_timer = pc_follow_timer;
 	pc->read_skill_tree = pc_read_skill_tree;
 	pc->read_skill_job_skip = pc_read_skill_job_skip;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -11091,7 +11091,7 @@ static void pc_autosave_start(void)
 	if (pc->autosave_tid != INVALID_TIMER)
 		return;
 
-	interval = map->autosave_interval / (VECTOR_LENGTH(pc->autosave_queue) + 1);
+	interval = map->autosave_interval / VECTOR_LENGTH(pc->autosave_queue);
 	if (interval < map->minsave_interval)
 		interval = map->minsave_interval;
 	pc->autosave_tid = timer->add(timer->gettick() + interval, pc->autosave, 0, 0);

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -82,8 +82,6 @@
 static struct pc_interface pc_s;
 struct pc_interface *pc;
 
-static void pc_autosave_start(void);
-
 static struct class_exp_tables exptables;
 
 //Converts a class to its array index for CLASS_COUNT defined arrays.
@@ -1604,7 +1602,7 @@ static int pc_reg_received(struct map_session_data *sd)
 	intif->rodex_checkhasnew(sd);
 
 	VECTOR_PUSH(pc->autosave_queue, sd->bl.id);
-	pc_autosave_start();
+	pc->autosave_start();
 
 	if (sd->state.connect_new == 0 && sd->fd) { //Character already loaded map! Gotta trigger LoadEndAck manually.
 		sd->state.connect_new = 1;
@@ -13286,6 +13284,7 @@ void pc_defaults(void)
 	pc->daynight_timer_sub = pc_daynight_timer_sub;
 	pc->charm_timer = pc_charm_timer;
 	pc->autosave = pc_autosave;
+	pc->autosave_start = pc_autosave_start;
 	pc->autosave_remove = pc_autosave_remove;
 	pc->follow_timer = pc_follow_timer;
 	pc->read_skill_tree = pc_read_skill_tree;

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -948,6 +948,8 @@ struct pc_interface {
 	/* */
 	int day_timer_tid;
 	int night_timer_tid;
+	int autosave_tid;
+	VECTOR_DECL(int) autosave_queue;
 	/* */
 
 BEGIN_ZEROED_BLOCK; /* Everything within this block will be memset to 0 when status_defaults() is executed */
@@ -1241,6 +1243,7 @@ END_ZEROED_BLOCK; /* End */
 	int (*daynight_timer_sub) (struct map_session_data *sd,va_list ap);
 	int (*charm_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*autosave) (int tid, int64 tick, int id, intptr_t data);
+	void (*autosave_remove) (int bl_id);
 	int (*follow_timer) (int tid, int64 tick, int id, intptr_t data);
 	void (*read_skill_tree) (void);
 	bool (*read_skill_job_skip) (short skill_id, int job_id);

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -943,6 +943,8 @@ struct pc_interface {
 	/* */
 	int day_timer_tid;
 	int night_timer_tid;
+	int autosave_tid;
+	VECTOR_DECL(int) autosave_queue;
 	/* */
 
 BEGIN_ZEROED_BLOCK; /* Everything within this block will be memset to 0 when status_defaults() is executed */
@@ -1236,6 +1238,7 @@ END_ZEROED_BLOCK; /* End */
 	int (*daynight_timer_sub) (struct map_session_data *sd,va_list ap);
 	int (*charm_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*autosave) (int tid, int64 tick, int id, intptr_t data);
+	void (*autosave_remove) (int bl_id);
 	int (*follow_timer) (int tid, int64 tick, int id, intptr_t data);
 	void (*read_skill_tree) (void);
 	bool (*read_skill_job_skip) (short skill_id, int job_id);

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -1243,6 +1243,7 @@ END_ZEROED_BLOCK; /* End */
 	int (*daynight_timer_sub) (struct map_session_data *sd,va_list ap);
 	int (*charm_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*autosave) (int tid, int64 tick, int id, intptr_t data);
+	void (*autosave_start) (void);
 	void (*autosave_remove) (int bl_id);
 	int (*follow_timer) (int tid, int64 tick, int id, intptr_t data);
 	void (*read_skill_tree) (void);


### PR DESCRIPTION
The previous implementation iterated all connected players on every autosave tick (O(N)) to find the next one to save, and kept the timer running even with no players online.

This replaces that with a FIFO queue of bl.ids (O(1) lookup via map->id2sd). Players are enqueued on login and dequeued on logout. The timer is started by the first login and stops when the queue empties, eliminating idle wakeups on an empty server.

The interval is now computed as autosave_interval / queue_length, preserving the original intent of distributing saves evenly across the configured window.

<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** #166 <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
