### PR TITLE
Fix stale ground skill tick cache after mob respawn

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -1099,6 +1099,10 @@ static int mob_setdelayspawn(struct mob_data *md)
 	if( md->spawn_timer != INVALID_TIMER )
 		timer->delete(md->spawn_timer, mob->delayspawn);
 	md->spawn_timer = timer->add(timer->gettick()+spawntime, mob->delayspawn, md->bl.id, 0);
+
+	// Clear per-target ground skill tick cache for the next natural life.
+	memset(md->ud.skillunittick, 0, sizeof(md->ud.skillunittick));
+
 	return 0;
 }
 

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -14184,7 +14184,7 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 	struct skill_unit_group_tickset *ts;
 	enum sc_type type;
 	uint16 skill_id;
-	int diff=0;
+	int64 diff = 0;
 
 	nullpo_ret(src);
 	nullpo_ret(bl);
@@ -14247,7 +14247,7 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 
 	if ((ts = skill->unitgrouptickset_search(bl,sg,tick))) {
 		//Not all have it, eg: Traps don't have it even though they can be hit by Heaven's Drive [Skotlex]
-		diff = DIFF_TICK32(tick,ts->tick);
+		diff = DIFF_TICK(tick,ts->tick);
 		if (diff < 0)
 			return 0;
 		ts->tick = tick+sg->interval;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This fixes a long-uptime ground skill issue where per-target ground skill tick entries could incorrectly suppress later skill effects.

Ground skill processing stores per-target tick entries in `unit_data.skillunittick`. For skills with `UF_NOOVERLAP`, the stored entry is keyed by `skill_id`. Since natural mob respawn reuses `mob_data` / `unit_data`, old entries can survive into the next life.

The tick comparison in `skill_unit_onplace_timer()` used `DIFF_TICK32()`, while timer ticks are `int64`. After long uptime, an old stored tick can wrap through the 32-bit comparison and be treated as if it were still in the future, causing the ground skill effect to be skipped.

This PR:
- uses `DIFF_TICK()` with an `int64` diff for ground skill tick checks;
- clears `skillunittick[]` when a mob is scheduled for natural respawn.

**Issues addressed:** Fixes #3417