### PR TITLE
Add Doram-specific start point and starting items

### DIFF
--- a/conf/char/char-server.conf
+++ b/conf/char/char-server.conf
@@ -117,6 +117,14 @@ char_configuration: {
 				x: 53
 				y: 111
 			}
+			// Start point (Doram)
+			// Doram characters begin their journey in Lasagna, as in kRO EP16.1.
+			// Note: requires client 20151001 or newer.
+			start_point_doram: {
+				map: "lasa_fild01"
+				x: 48
+				y: 297
+			}
 
 			// Starting items for new characters
 			//{
@@ -128,6 +136,25 @@ char_configuration: {
 			start_items: (
 			{
 				id: 1201 // Knife
+				amount: 1
+				loc: 2
+				stackable: false
+			},
+			{
+				id: 2301 // Cotton_Shirt
+				amount: 1
+				loc: 16
+				stackable: false
+			},
+			)
+
+			// Starting items for new Doram characters
+			// Same format as start_items. Dorams can only equip Doram-exclusive
+			// weapons, so they get a Short Foxtail Staff instead of a Knife.
+			// If this list is empty, start_items is used instead.
+			start_items_doram: (
+			{
+				id: 1681 // Short_Foxtail_Staff
 				amount: 1
 				loc: 2
 				stackable: false

--- a/src/char/char.c
+++ b/src/char/char.c
@@ -155,7 +155,9 @@ struct start_item_s {
 	int loc;
 	bool stackable;
 };
-static VECTOR_DECL(struct start_item_s) start_items;
+VECTOR_STRUCT_DECL(start_item_list, struct start_item_s);
+static struct start_item_list start_items;
+static struct start_item_list start_items_doram;
 
 int guild_exp_rate = 100;
 
@@ -175,6 +177,8 @@ static struct point start_point = { 0, 97, 90 };
 #else
 static struct point start_point = { 0, 53, 111 };
 #endif
+// Initial position for Doram characters (kRO EP16.1 Lasagna)
+static struct point start_point_doram = { 0, 48, 297 };
 
 static unsigned short skillid2idx[MAX_SKILL_ID];
 
@@ -1722,6 +1726,8 @@ static int char_make_new_char_sql(struct char_session_data *sd, const char *name
 	char name[NAME_LENGTH];
 	char esc_name[NAME_LENGTH*2+1];
 	int char_id, flag, i;
+	const struct point *spoint = &start_point;
+	const struct start_item_list *sitems = &start_items;
 
 	nullpo_retr(-2, sd);
 	nullpo_retr(-2, name_);
@@ -1735,6 +1741,12 @@ static int char_make_new_char_sql(struct char_session_data *sd, const char *name
 
 	switch (starting_class) {
 		case JOB_SUMMONER:
+			// Doram characters start in Lasagna with their own equipment set. (kRO EP16.1)
+			if (start_point_doram.map != 0)
+				spoint = &start_point_doram;
+			if (VECTOR_LENGTH(start_items_doram) > 0)
+				sitems = &start_items_doram;
+			break;
 		case JOB_NOVICE:
 			break;
 		default:
@@ -1768,7 +1780,7 @@ static int char_make_new_char_sql(struct char_session_data *sd, const char *name
 		"'%d', '%d', '%s', '%d', '%d', '%d', '%d', '%d', '%d', '%d', '%d', '%d', '%d', '%d','%d', '%d','%d', '%d', '%s', '%d', '%d', '%s', '%d', '%d', '%c', '%d')",
 		char_db, sd->account_id , slot, esc_name, starting_class, start_zeny, 48, str, agi, vit, int_, dex, luk,
 		(40 * (100 + vit)/100) , (40 * (100 + vit)/100 ),  (11 * (100 + int_)/100), (11 * (100 + int_)/100), hair_style, hair_color,
-		mapindex_id2name(start_point.map), start_point.x, start_point.y, mapindex_id2name(start_point.map), start_point.x, start_point.y, sex, FIXED_INVENTORY_SIZE)) {
+		mapindex_id2name(spoint->map), spoint->x, spoint->y, mapindex_id2name(spoint->map), spoint->x, spoint->y, sex, FIXED_INVENTORY_SIZE)) {
 			Sql_ShowDebug(inter->sql_handle);
 			return -2; //No, stop the procedure!
 	}
@@ -1779,7 +1791,7 @@ static int char_make_new_char_sql(struct char_session_data *sd, const char *name
 							   "'%d', '%d', '%s', '%d',  '%d', '%d', '%d', '%d', '%d', '%d', '%d', '%d', '%d','%d', '%d','%d', '%d', '%s', '%d', '%d', '%s', '%d', '%d', '%d')",
 							   char_db, sd->account_id , slot, esc_name, starting_class, start_zeny, str, agi, vit, int_, dex, luk,
 							   (40 * (100 + vit)/100) , (40 * (100 + vit)/100 ),  (11 * (100 + int_)/100), (11 * (100 + int_)/100), hair_style, hair_color,
-							   mapindex_id2name(start_point.map), start_point.x, start_point.y, mapindex_id2name(start_point.map), start_point.x, start_point.y, FIXED_INVENTORY_SIZE) )
+							   mapindex_id2name(spoint->map), spoint->x, spoint->y, mapindex_id2name(spoint->map), spoint->x, spoint->y, FIXED_INVENTORY_SIZE) )
 	{
 		Sql_ShowDebug(inter->sql_handle);
 		return -2; //No, stop the procedure!
@@ -1801,8 +1813,8 @@ static int char_make_new_char_sql(struct char_session_data *sd, const char *name
 	}
 
 	//Give the char the default items
-	for (i = 0; i < VECTOR_LENGTH(start_items); i++) {
-		struct start_item_s *item = &VECTOR_INDEX(start_items, i);
+	for (i = 0; i < VECTOR_LENGTH(*sitems); i++) {
+		const struct start_item_s *item = &VECTOR_INDEX(*sitems, i);
 		if (item->stackable) {
 			if (SQL_ERROR == SQL->Query(inter->sql_handle,
 			                            "INSERT INTO `%s` (`char_id`,`nameid`, `amount`, `identify`) VALUES ('%d', '%d', '%d', '%d')",
@@ -5920,23 +5932,26 @@ static bool char_config_read_player_name(const char *filename, const struct conf
 }
 
 /**
- * Defines start_items based on '(...)/player/new/start_item'.
+ * Defines the start items based on '(...)/player/new/start_items' or
+ * '(...)/player/new/start_items_doram'.
  *
- * @param setting The already retrieved start_item setting.
+ * @param setting The already retrieved start items setting.
+ * @param doram   Whether the setting holds the Doram-specific item list.
  */
-static void char_config_set_start_item(const struct config_setting_t *setting)
+static void char_config_set_start_item(const struct config_setting_t *setting, bool doram)
 {
+	struct start_item_list *items = doram ? &start_items_doram : &start_items;
 	int i, count;
 
 	nullpo_retv(setting);
 
-	VECTOR_CLEAR(start_items);
+	VECTOR_CLEAR(*items);
 
 	count = libconfig->setting_length(setting);
 	if (!count)
 		return;
 
-	VECTOR_ENSURE(start_items, count, 1);
+	VECTOR_ENSURE(*items, count, 1);
 
 	for (i = 0; i < count; i++) {
 		const struct config_setting_t *t = libconfig->setting_get_elem(setting, i);
@@ -5960,7 +5975,7 @@ static void char_config_set_start_item(const struct config_setting_t *setting)
 		}
 		if (libconfig->setting_lookup_int(t, "loc", &start_item.loc) != CONFIG_TRUE)
 			start_item.loc = 0;
-		VECTOR_PUSH(start_items, start_item);
+		VECTOR_PUSH(*items, start_item);
 	}
 }
 
@@ -6003,7 +6018,10 @@ static bool char_config_read_player_new(const char *filename, const struct confi
 	}
 
 	if ((setting2 = libconfig->setting_get_member(setting, "start_items")))
-		chr->config_set_start_item(setting2);
+		chr->config_set_start_item(setting2, false);
+
+	if ((setting2 = libconfig->setting_get_member(setting, "start_items_doram")))
+		chr->config_set_start_item(setting2, true);
 
 	// start_point / start_point_pre
 	if ((setting2 = libconfig->setting_get_member(setting, start_point_setting))) {
@@ -6014,6 +6032,18 @@ static bool char_config_read_player_new(const char *filename, const struct confi
 				ShowError("char_config_read_player_new: Specified start_point %s not found in map-index cache.\n", str);
 			libconfig->setting_lookup_int16(setting2, "x", &start_point.x);
 			libconfig->setting_lookup_int16(setting2, "y", &start_point.y);
+		}
+	}
+
+	// start_point_doram
+	if ((setting2 = libconfig->setting_get_member(setting, "start_point_doram"))) {
+		const char *str = NULL;
+		if (libconfig->setting_lookup_string(setting2, "map", &str) == CONFIG_TRUE) {
+			start_point_doram.map = mapindex->name2id(str);
+			if (start_point_doram.map == 0)
+				ShowError("char_config_read_player_new: Specified start_point_doram %s not found in map-index cache.\n", str);
+			libconfig->setting_lookup_int16(setting2, "x", &start_point_doram.x);
+			libconfig->setting_lookup_int16(setting2, "y", &start_point_doram.y);
 		}
 	}
 
@@ -6164,6 +6194,7 @@ int do_final(void)
 	VECTOR_CLEAR(chr->map_server.maps);
 
 	VECTOR_CLEAR(start_items);
+	VECTOR_CLEAR(start_items_doram);
 
 	aFree(chr->CHAR_CONF_NAME);
 	aFree(chr->NET_CONF_NAME);
@@ -6277,6 +6308,7 @@ int do_init(int argc, char **argv)
 	chr->INTER_CONF_NAME = aStrdup("conf/common/inter-server.conf");
 
 	VECTOR_INIT(start_items);
+	VECTOR_INIT(start_items_doram);
 
 	VECTOR_INIT(chr->map_server.maps);
 
@@ -6295,6 +6327,7 @@ int do_init(int argc, char **argv)
 	#else
 		start_point.map = mapindex->name2id("new_1-1");
 	#endif
+	start_point_doram.map = mapindex->name2id("lasa_fild01");
 
 	safestrncpy(chr->userid, "s1", sizeof(chr->userid));
 	safestrncpy(chr->passwd, "p1", sizeof(chr->passwd));

--- a/src/char/char.h
+++ b/src/char/char.h
@@ -307,7 +307,7 @@ struct char_interface {
 	bool (*config_read_player_fame) (const char *filename, const struct config_t *config, bool imported);
 	bool (*config_read_player_deletion) (const char *filename, const struct config_t *config, bool imported);
 	bool (*config_read_player_name) (const char *filename, const struct config_t *config, bool imported);
-	void (*config_set_start_item) (const struct config_setting_t *setting);
+	void (*config_set_start_item) (const struct config_setting_t *setting, bool doram);
 	bool (*config_read_player_new) (const char *filename, const struct config_t *config, bool imported);
 	bool (*config_read_player) (const char *filename, const struct config_t *config, bool imported);
 	bool (*config_read_permission) (const char *filename, const struct config_t *config, bool imported);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -1076,8 +1076,8 @@ typedef bool (*HPMHOOK_pre_chr_config_read_player_deletion) (const char **filena
 typedef bool (*HPMHOOK_post_chr_config_read_player_deletion) (bool retVal___, const char *filename, const struct config_t *config, bool imported);
 typedef bool (*HPMHOOK_pre_chr_config_read_player_name) (const char **filename, const struct config_t **config, bool *imported);
 typedef bool (*HPMHOOK_post_chr_config_read_player_name) (bool retVal___, const char *filename, const struct config_t *config, bool imported);
-typedef void (*HPMHOOK_pre_chr_config_set_start_item) (const struct config_setting_t **setting);
-typedef void (*HPMHOOK_post_chr_config_set_start_item) (const struct config_setting_t *setting);
+typedef void (*HPMHOOK_pre_chr_config_set_start_item) (const struct config_setting_t **setting, bool *doram);
+typedef void (*HPMHOOK_post_chr_config_set_start_item) (const struct config_setting_t *setting, bool doram);
 typedef bool (*HPMHOOK_pre_chr_config_read_player_new) (const char **filename, const struct config_t **config, bool *imported);
 typedef bool (*HPMHOOK_post_chr_config_read_player_new) (bool retVal___, const char *filename, const struct config_t *config, bool imported);
 typedef bool (*HPMHOOK_pre_chr_config_read_player) (const char **filename, const struct config_t **config, bool *imported);

--- a/src/plugins/HPMHooking/HPMHooking_char.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_char.Hooks.inc
@@ -5124,14 +5124,14 @@ bool HP_chr_config_read_player_name(const char *filename, const struct config_t 
 	}
 	return retVal___;
 }
-void HP_chr_config_set_start_item(const struct config_setting_t *setting) {
+void HP_chr_config_set_start_item(const struct config_setting_t *setting, bool doram) {
 	int hIndex = 0;
 	if (HPMHooks.count.HP_chr_config_set_start_item_pre > 0) {
-		void (*preHookFunc) (const struct config_setting_t **setting);
+		void (*preHookFunc) (const struct config_setting_t **setting, bool *doram);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_chr_config_set_start_item_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_chr_config_set_start_item_pre[hIndex].func;
-			preHookFunc(&setting);
+			preHookFunc(&setting, &doram);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -5139,13 +5139,13 @@ void HP_chr_config_set_start_item(const struct config_setting_t *setting) {
 		}
 	}
 	{
-		HPMHooks.source.chr.config_set_start_item(setting);
+		HPMHooks.source.chr.config_set_start_item(setting, doram);
 	}
 	if (HPMHooks.count.HP_chr_config_set_start_item_post > 0) {
-		void (*postHookFunc) (const struct config_setting_t *setting);
+		void (*postHookFunc) (const struct config_setting_t *setting, bool doram);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_chr_config_set_start_item_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_chr_config_set_start_item_post[hIndex].func;
-			postHookFunc(setting);
+			postHookFunc(setting, doram);
 		}
 	}
 	return;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

New Doram characters were handed a Knife, which a Summoner can never equip, and were sent to the same start point as everyone else.

They now begin in Lasagna with a Short Foxtail Staff, the way kRO does it since EP16.1. Both the start point and the item list are configurable in `conf/char/char-server.conf` via the new `start_point_doram` and `start_items_doram` settings, and existing servers see no change unless they set them.

**Issues addressed:** #3407

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
