### PR TITLE
Fix King's Grace missing cooldown and versus-map lockdown (#590)

### DIFF
--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -35045,7 +35045,13 @@ skill_db: (
 	SplashRange: 5
 	CastTime: 1000
 	SkillData1: 5000
-	CoolDown: 0
+	CoolDown: {
+		Lv1: 100000
+		Lv2: 90000
+		Lv3: 80000
+		Lv4: 70000
+		Lv5: 60000
+	}
 	Requirements: {
 		SPCost: {
 			Lv1: 200

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -5381,6 +5381,7 @@ static int pc_useitem(struct map_session_data *sd, int n)
 		sd->sc.data[SC_SATURDAY_NIGHT_FEVER] ||
 		sd->sc.data[SC_COLD] ||
 		sd->sc.data[SC_SUHIDE] ||
+		(sd->sc.data[SC_KINGS_GRACE] && sd->sc.data[SC_KINGS_GRACE]->val3) ||
 		pc_ismuted(&sd->sc, MANNER_NOITEM)
 	    ))
 		return 0;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -10863,7 +10863,9 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 		case LG_KINGS_GRACE:
 			if( flag&1 ){
 				int i;
-				sc_start(src, bl, type, 100, skill_lv, skill->get_time(skill_id, skill_lv), skill_id);
+				// In versus/GvG maps, targets under King's Grace are immobilized and unable to act for the duration, trading total protection for helplessness.
+				bool locked = map_flag_vs(bl->m) || map_flag_gvg(bl->m);
+				sc_start4(src, bl, type, 100, skill_lv, 0, locked ? 1 : 0, 0, skill->get_time(skill_id, skill_lv), skill_id);
 				for(i=0; i<SC_MAX; i++)
 				{
 					if (!tsc->data[i])

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -870,6 +870,7 @@ static int status_check_skilluse(struct block_list *src, struct block_list *targ
 			|| (sc->data[SC_AUTOCOUNTER] && !flag && skill_id)
 			|| (sc->data[SC_GOSPEL] && sc->data[SC_GOSPEL]->val4 == BCT_SELF && skill_id != PA_GOSPEL)
 			|| (sc->data[SC_SUHIDE] && skill_id != SU_HIDE)
+			|| (sc->data[SC_KINGS_GRACE] && sc->data[SC_KINGS_GRACE]->val3)
 			)
 			return 0;
 

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1282,6 +1282,7 @@ static int unit_can_move(struct block_list *bl)
 		    || (sc->data[SC_CAMOUFLAGE] && sc->data[SC_CAMOUFLAGE]->val1 < 3 && !(sc->data[SC_CAMOUFLAGE]->val3&1))
 		    ||  sc->data[SC_MEIKYOUSISUI]
 		    ||  sc->data[SC_KG_KAGEHUMI]
+		    || (sc->data[SC_KINGS_GRACE] && sc->data[SC_KINGS_GRACE]->val3)
 		    ||  sc->data[SC_NEEDLE_OF_PARALYZE]
 		    ||  sc->data[SC_VACUUM_EXTREME]
 		    || (sc->data[SC_FEAR] && sc->data[SC_FEAR]->val2 > 0)


### PR DESCRIPTION
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`LG_KINGS_GRACE` (Royal Guard's King's Grace) had two bugs: the pre-renewal skill DB still had no cooldown (the renewal DB got a per-level cooldown fix in 2016, but pre-re was never updated), and the skill never applied the versus/GvG-map lockdown — officially, targets protected by King's Grace in PvP/WoE trade the status immunity for being unable to move, attack, use skills, or use items until the buff ends.


**Issues addressed:** #590

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
