### PR TITLE
Fix Fatal Menace unreliable teleport

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3913,8 +3913,12 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 			rate = rate + (status->get_lv(src) - status->get_lv(bl));
 			if(rnd()%100 < rate)
 				skill->addtimerskill(src,tick + 800,bl->id,0,0,skill_id,skill_lv,0,flag);
-		} else if( skill_id == SC_FATALMENACE )
-			skill->addtimerskill(src,tick + 800,bl->id,skill->area_temp[4],skill->area_temp[5],skill_id,skill_lv,0,flag);
+		} else if (skill_id == SC_FATALMENACE) {
+			short x = skill->area_temp[4], y = skill->area_temp[5];
+			map->search_free_cell(NULL, bl->m, &x, &y, 2, 2, SFC_XY_CENTER);
+			// Queued under bl's own unit data (not src's), giving each hit target its own timer slot.
+			skill->addtimerskill(bl, tick + 800, bl->id, x, y, skill_id, skill_lv, 0, flag);
+		}
 	}
 
 	if(skill_id == CR_GRANDCROSS || skill_id == NPC_GRANDDARKNESS)
@@ -4407,7 +4411,7 @@ static int skill_timerskill(int tid, int64 tick, int id, intptr_t data)
 			break; // Source not on Map
 		if(skl->target_id) {
 			target = map->id2bl(skl->target_id);
-			if( ( skl->skill_id == RG_INTIMIDATE || skl->skill_id == SC_FATALMENACE ) && (!target || target->prev == NULL || !check_distance_bl(src,target,AREA_SIZE)) )
+			if (skl->skill_id == RG_INTIMIDATE && (!target || target->prev == NULL || !check_distance_bl(src, target, AREA_SIZE)))
 				target = src; //Required since it has to warp.
 			if(target == NULL)
 				break; // Target offline?
@@ -4508,13 +4512,8 @@ static int skill_timerskill(int tid, int64 tick, int id, intptr_t data)
 					skill->attack(skill->get_type(skl->skill_id, skl->skill_lv), src, src, target, skl->skill_id, skl->skill_lv, 0, SD_LEVEL);
 					break;
 				case SC_FATALMENACE:
-					if( src == target ) // Casters Part
-						unit->warp(src, -1, skl->x, skl->y, CLR_TELEPORT);
-					else { // Target's Part
-						short x = skl->x, y = skl->y;
-						map->search_free_cell(NULL, target->m, &x, &y, 2, 2, SFC_XY_CENTER);
-						unit->warp(target,-1,x,y,CLR_TELEPORT);
-					}
+					// src is whichever entity owns this entry (caster or a hit target); see skill_attack.
+					unit->warp(src, -1, skl->x, skl->y, CLR_TELEPORT);
 					break;
 				case LG_MOONSLASHER:
 				case SR_WINDMILL:


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`SC_FATALMENACE` queued every hit target's delayed teleport under the caster's own unit data instead of the target's. This meant all of a splash's target-warps competed with the caster's own warp for the same 15-slot timer array (`MAX_SKILLTIMERSKILL`), so a wide hit could silently drop the caster's warp, and a target that died/left range before its 800ms timer fired got redirected into re-warping the caster a second time on top of its own dedicated entry.

**Issues addressed:** #773

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
