### PR TITLE
Fix Neutral Barrier/Stealth Field being cancelled on map warp

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -6075,10 +6075,10 @@ static int pc_setpos(struct map_session_data *sd, unsigned short map_index, int 
 			status_change_end(&sd->bl, SC_MOON_COMFORT, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_STAR_COMFORT, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_MIRACLE, INVALID_TIMER);
-			status_change_end(&sd->bl, SC_NEUTRALBARRIER_MASTER, INVALID_TIMER); // Will later check if this is needed. [Rytech]
-			status_change_end(&sd->bl, SC_NEUTRALBARRIER, INVALID_TIMER);
+			// Only the caster's control status ends on map change; the buff granted to units
+			// standing in the barrier/field is not warp-cancelled and simply expires on its own. (issue:805)
+			status_change_end(&sd->bl, SC_NEUTRALBARRIER_MASTER, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_STEALTHFIELD_MASTER, INVALID_TIMER);
-			status_change_end(&sd->bl, SC_STEALTHFIELD, INVALID_TIMER);
 
 			if (sd->sc.data[SC_KNOWLEDGE] != NULL) {
 				struct status_change_entry *sce = sd->sc.data[SC_KNOWLEDGE];

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -2706,10 +2706,10 @@ static int unit_remove_map(struct block_list *bl, enum clr_type clrtype, const c
 		status_change_end(bl, SC_WUGDASH, INVALID_TIMER);
 		status_change_end(bl, SC_CAMOUFLAGE, INVALID_TIMER);
 		status_change_end(bl, SC_MAGNETICFIELD, INVALID_TIMER);
+		// Only the caster's control status ends on map change; the buff granted to units
+		// standing in the barrier/field is not warp-cancelled and simply expires on its own. (issue:805)
 		status_change_end(bl, SC_NEUTRALBARRIER_MASTER, INVALID_TIMER);
-		status_change_end(bl, SC_NEUTRALBARRIER, INVALID_TIMER);
 		status_change_end(bl, SC_STEALTHFIELD_MASTER, INVALID_TIMER);
-		status_change_end(bl, SC_STEALTHFIELD, INVALID_TIMER);
 		status_change_end(bl, SC__SHADOWFORM, INVALID_TIMER);
 		status_change_end(bl, SC__MANHOLE, INVALID_TIMER);
 		status_change_end(bl, SC_VACUUM_EXTREME, INVALID_TIMER);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`NC_NEUTRALBARRIER`/`NC_STEALTHFIELD` were being fully cancelled for any unit crossing a map
portal: both the caster's `_MASTER` control status and the buff granted to units standing in
the barrier/field were force-ended in `pc_setpos` and `unit_remove_map`.


**Issues addressed:** #805

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
