### PR TITLE
Limit Warlock Summon Ball skills to 1 ball per skill level

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -16210,9 +16210,14 @@ static int skill_check_condition_castbegin(struct map_session_data *sd, uint16 s
 						}
 						break;
 					default:
-						if( i == 5 ){
-							clif->skill_fail(sd, skill_id, USESKILL_FAIL_SUMMON, 0, 0);
-							return 0;
+						{
+							int max_allowed = skill_lv;
+							if( max_allowed > 5 )
+								max_allowed = 5; // Hard cap due to SC_SUMMON1..SC_SUMMON5
+							if( i >= max_allowed ){
+								clif->skill_fail(sd, skill_id, USESKILL_FAIL_SUMMON, 0, 0);
+								return 0;
+							}
 						}
 				}
 			}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`WL_SUMMONFB`, `WL_SUMMONBL`, `WL_SUMMONWB`, and `WL_SUMMONSTONE` currently let a Warlock stack
up to 5 elemental balls (`SC_SUMMON1`..`SC_SUMMON5`) regardless of the skill's level. A level-1
Warlock casting the skill 5 times ends up with the same 5-ball pool as a level-5 Warlock.

This caps the number of active balls to the skill's level (still hard-capped at 5, since only
`SC_SUMMON1`..`SC_SUMMON5` exist), in `skill_check_condition_castbegin`.

**Issues addressed:** #892

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
