### PR TITLE
Make SA_SPELLBREAKER's HP siphon deal visible, non-lethal damage

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -8962,7 +8962,7 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 					sp = skill->get_sp(bl_skill_id,bl_skill_lv);
 					status_zap(bl, 0, sp);
 
-					if (hp && hp < tstatus->hp) // Don't let the HP siphon kill the target.
+					if (hp && (unsigned int)hp < tstatus->hp) // Don't let the HP siphon kill the target.
 						status_fix_damage(src, bl, hp, clif->damage(src, bl, 0, 0, hp, 0, BDT_NORMAL, 0));
 					else
 						hp = 0;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -8960,7 +8960,12 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 					clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
 					unit->skillcastcancel(bl,0);
 					sp = skill->get_sp(bl_skill_id,bl_skill_lv);
-					status_zap(bl, hp, sp);
+					status_zap(bl, 0, sp);
+
+					if (hp && hp < tstatus->hp) // Don't let the HP siphon kill the target.
+						status_fix_damage(src, bl, hp, clif->damage(src, bl, 0, 0, hp, 0, BDT_NORMAL, 0));
+					else
+						hp = 0;
 
 					if (hp && skill_lv >= 5)
 						hp>>=1; //Recover half damaged HP at level 5 [Skotlex]


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

In official Aegis, `SA_SPELLBREAKER` deals visible damage to the target as part of its HP siphon effect (recovering 2% max HP for the caster at skill level 5+, on PvP maps against players). Hercules currently applies this via `status_zap()`, which reduces the target's HP silently with no `clif->damage` packet, so the target sees no hit or damage number.

SP drain from the skill is unaffected and remains silent.

**Issues addressed:** #880

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
