### PR TITLE
Fix VIT/INT from status changes not benefiting from bMaxHPrate/bMaxSP…

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3307,8 +3307,18 @@ static void status_calc_bl_main(struct block_list *bl, e_scb_flag flag)
 	if(flag&SCB_MAXHP) {
 		if( bl->type&BL_PC ) {
 			st->max_hp = status->get_base_maxhp(sd,st);
-			if (sd)
-				st->max_hp += bst->max_hp - sd->status.max_hp;
+			if (sd != NULL) {
+				// bst->max_hp already includes sd->hprate (bMaxHPrate) and battle_config.hp_rate
+				// applied over the VIT-based HP plus flat bonuses (see status_calc_pc_()).
+				// Re-apply the same combined rate to the freshly recalculated VIT-based HP
+				// (which may now include VIT granted by status changes, e.g. SC_FOOD_VIT) so
+				// that VIT from status changes benefits from those rates exactly like VIT
+				// from equipment does.
+				int64 rated_vit_hp = APPLY_RATE(APPLY_RATE((int64)st->max_hp, sd->hprate), battle_config.hp_rate);
+				int64 rated_base_vit_hp = APPLY_RATE(APPLY_RATE((int64)sd->status.max_hp, sd->hprate), battle_config.hp_rate);
+				int64 flat_bonus = (int64)bst->max_hp - rated_base_vit_hp;
+				st->max_hp = (unsigned int)cap_value(rated_vit_hp + flat_bonus, 0, INT_MAX);
+			}
 
 			st->max_hp = status->calc_maxhp(bl, sc, st->max_hp);
 
@@ -3330,7 +3340,14 @@ static void status_calc_bl_main(struct block_list *bl, e_scb_flag flag)
 		if( bl->type&BL_PC ) {
 			st->max_sp = status->get_base_maxsp(sd,st);
 			if (sd != NULL) {
-				st->max_sp += bst->max_sp - sd->status.max_sp;
+				// See the analogous SCB_MAXHP handling above: re-apply the combined
+				// sd->sprate (bMaxSPrate) and battle_config.sp_rate to the freshly
+				// recalculated INT-based SP so that INT from status changes benefits
+				// from those rates exactly like INT from equipment does.
+				int64 rated_int_sp = APPLY_RATE(APPLY_RATE((int64)st->max_sp, sd->sprate), battle_config.sp_rate);
+				int64 rated_base_int_sp = APPLY_RATE(APPLY_RATE((int64)sd->status.max_sp, sd->sprate), battle_config.sp_rate);
+				int64 flat_bonus = (int64)bst->max_sp - rated_base_int_sp;
+				st->max_sp = (unsigned int)cap_value(rated_int_sp + flat_bonus, 0, INT_MAX);
 				st->max_sp = status->calc_maxsp(&sd->bl, &sd->sc, st->max_sp);
 			}
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

VIT/INT granted by equipment and VIT/INT granted by status changes (e.g. `SC_FOOD_VIT`, `SC_FOOD_INT_CASH`) were going through different code paths when recalculating MaxHP/MaxSP, causing them to be worth different amounts of HP/SP
whenever `bMaxHPrate`/`bMaxSPrate` (or `battle_config.hp_rate`/`sp_rate`) was non-default:

- `status_calc_pc_()` computes the VIT-based HP, adds flat bonuses, then multiplies the whole thing by `sd->hprate` and `battle_config.hp_rate`. This path only sees equipment VIT, since it runs "from scratch, without SC
  adjustments."
- `status_calc_bl_main()`'s `SCB_MAXHP` handler recomputes the VIT-based HP using the SC-inclusive VIT, but instead of re-applying the same rate, it just added the delta between the previously-computed, already-rated `bst->max_hp` and the previously-computed, unrated `sd->status.max_hp`. That delta bakes in the rate for the equipment-VIT portion only, so any VIT contributed by a status change was added at 1x regardless of `bMaxHPrate`.

Note: this does not address the separate concern raised in the same issue about SC-based `%MaxHP` bonuses (`SC_FORCEOFVANGUARD`, `SC_RAISINGDRAGON`, `SC_EPICLESIS`, etc.) stacking multiplicatively rather than additively, Probably in another PR that will be fixed as I need to investigate for it further.

**Issues addressed:** #914

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
