### PR TITLE
Let non-damage skills bypass player_invincible_time

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7317,13 +7317,22 @@ static int battle_check_target(struct block_list *src, struct block_list *target
 			const struct status_change *sc = status->get_sc(src);
 			const struct map_session_data *t_sd = BL_UCCAST(BL_PC, target);
 			if (t_sd->invincible_timer != INVALID_TIMER) {
-				switch( battle->get_current_skill(src) ) {
-					/* TODO a proper distinction should be established bugreport:8397 */
-					case PR_SANCTUARY:
-					case PR_MAGNIFICAT:
-						break;
-					default:
+				int skill_id = battle->get_current_skill(src);
+				switch (skill_id) {
+					/* Equip-strip skills deal no damage but are still an offensive
+					 * debuff on official servers, so they stay blocked. (bugreport:8397) */
+					case RG_STRIPWEAPON:
+					case RG_STRIPSHIELD:
+					case RG_STRIPARMOR:
+					case RG_STRIPHELM:
+					case ST_FULLSTRIP:
+					case SC_STRIPACCESSARY:
+					case GC_WEAPONCRUSH:
 						return -1;
+					default:
+						if ((skill->get_nk(skill_id) & NK_NO_DAMAGE) == 0)
+							return -1;
+						break;
 				}
 			}
 			if (pc_isinvisible(t_sd))

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7317,7 +7317,10 @@ static int battle_check_target(struct block_list *src, struct block_list *target
 			const struct status_change *sc = status->get_sc(src);
 			const struct map_session_data *t_sd = BL_UCCAST(BL_PC, target);
 			if (t_sd->invincible_timer != INVALID_TIMER) {
-				int skill_id = battle->get_current_skill(src);
+				/* unit_data::skill_id only reflects the last skill *cast* by src
+				 * and is never cleared afterwards, so it must not be trusted for
+				 * a plain attack (flagged explicitly by unit->attack()). */
+				int skill_id = (flag & BCT_NORMAL_ATTACK) != 0 ? 0 : battle->get_current_skill(src);
 				switch (skill_id) {
 					/* Equip-strip skills deal no damage but are still an offensive
 					 * debuff on official servers, so they stay blocked. (bugreport:8397) */

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -93,6 +93,12 @@ enum e_battle_check_target { //New definitions [Skotlex]
 	BCT_NOENEMY     =   0x3d0000, ///< This must be (~BCT_ENEMY&BCT_ALL)
 
 	BCT_ALL         =   0x3f0000, ///< Sum of BCT_NOONE to BCT_SAMEGUILD
+
+	/// Set by unit->attack() to tell battle->check_target() this is a normal
+	/// attack, not a skill, so the caller's stale unit_data::skill_id (which
+	/// only reflects the last skill *cast*, not the current action) must not
+	/// be used to decide whether to bypass a target's invincible_timer.
+	BCT_NORMAL_ATTACK = 0x1000000,
 };
 
 /**

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -2169,7 +2169,7 @@ static int unit_attack(struct block_list *src, int target_id, int continuous)
 			return 0;
 		}
 	}
-	if( battle->check_target(src,target,BCT_ENEMY) <= 0 || !status->check_skilluse(src, target, 0, 0) ) {
+	if (battle->check_target(src, target, BCT_ENEMY | BCT_NORMAL_ATTACK) <= 0 || !status->check_skilluse(src, target, 0, 0)) {
 		unit->unattackable(src);
 		return 1;
 	}


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and enable the setting "[√] Allow edits from maintainers." when creating your pull request if you have not already enabled it. -->

### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`battle_check_target()` blocked *all* skill targeting against a player under `player_invincible_time` (post-spawn/teleport grace period), except for a hardcoded two-skill allowlist (`PR_SANCTUARY`, `PR_MAGNIFICAT`) added in 2015 as an admittedly incomplete fix for bugreport:8397.

On official servers, invincibility only protects against damage and other hostile/offensive effects — non-damage skills such as `SA_DISPELL`, songs (`BA_POEMBRAGI`, `DC_SERVICEFORYOU`), and other buffs/debuffs should apply immediately regardless of the target's invincible state.

This replaces the two-skill allowlist with a general check against `skill->get_nk(skill_id) & NK_NO_DAMAGE`, so any non-damage skill bypasses the invincibility gate by default instead of needing to be special-cased individually. Equip-strip skills (`RG_STRIPWEAPON`/`STRIPSHIELD`/`STRIPARMOR`/`STRIPHELM`, `ST_FULLSTRIP`, `SC_STRIPACCESSARY`, `GC_WEAPONCRUSH`) are kept blocked despite being `NK_NO_DAMAGE`, since they're still an offensive debuff. Plain melee attacks (`skill_id == 0`) are unaffected and remain blocked.

**Issues addressed:** #966

Thanks @kyeme and @Playtester


[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
