### PR TITLE
Fix NPC_EVILLAND and PR_SANCTUARY mechanics

### DIFF
--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -2522,16 +2522,16 @@ skill_db: (
 	KnockBackTiles: 1
 	CastTime: 5000
 	SkillData1: {
-		Lv1: 4000
-		Lv2: 7000
-		Lv3: 10000
-		Lv4: 13000
-		Lv5: 16000
-		Lv6: 19000
-		Lv7: 22000
-		Lv8: 25000
-		Lv9: 28000
-		Lv10: 31000
+		Lv1: 3500
+		Lv2: 6500
+		Lv3: 9500
+		Lv4: 12500
+		Lv5: 15500
+		Lv6: 18500
+		Lv7: 21500
+		Lv8: 24500
+		Lv9: 27500
+		Lv10: 30500
 	}
 	CoolDown: 0
 	Requirements: {
@@ -17771,7 +17771,7 @@ skill_db: (
 	StatusChange: "SC_BLIND"
 	Description: "Evil Land"
 	MaxLevel: 10
-	Range: 9
+	Range: 7
 	Hit: "BDT_SKILL"
 	SkillType: {
 		Place: true
@@ -17785,25 +17785,37 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 		IgnoreElement: true
+		IgnoreFlee: true
 		IgnoreDefCards: true
 	}
-	SkillData1: 30000
+	SkillData1: {
+		Lv1: 3500
+		Lv2: 4500
+		Lv3: 5500
+		Lv4: 6500
+		Lv5: 7500
+		Lv6: 8500
+		Lv7: 9500
+		Lv8: 10500
+		Lv9: 11500
+		Lv10: 12500
+	}
 	SkillData2: 30000
 	CoolDown: 0
 	Unit: {
 		Id: 0xc7
 		Layout: 1
 		Range: {
-			Lv1: 4
-			Lv2: 7
-			Lv3: 10
-			Lv4: 13
-			Lv5: 16
-			Lv6: 19
-			Lv7: 22
-			Lv8: 25
-			Lv9: 28
-			Lv10: 31
+			Lv1: 5
+			Lv2: 5
+			Lv3: 5
+			Lv4: 5
+			Lv5: 5
+			Lv6: 5
+			Lv7: 5
+			Lv8: 5
+			Lv9: 5
+			Lv10: 13
 		}
 		Interval: 1000
 		Target: "All"

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -2577,16 +2577,16 @@ skill_db: (
 	KnockBackTiles: 1
 	CastTime: 4000
 	SkillData1: {
-		Lv1: 4000
-		Lv2: 7000
-		Lv3: 10000
-		Lv4: 13000
-		Lv5: 16000
-		Lv6: 19000
-		Lv7: 22000
-		Lv8: 25000
-		Lv9: 28000
-		Lv10: 31000
+		Lv1: 3500
+		Lv2: 6500
+		Lv3: 9500
+		Lv4: 12500
+		Lv5: 15500
+		Lv6: 18500
+		Lv7: 21500
+		Lv8: 24500
+		Lv9: 27500
+		Lv10: 30500
 	}
 	FixedCastTime: 1000
 	Requirements: {
@@ -17874,7 +17874,7 @@ skill_db: (
 	StatusChange: "SC_BLIND"
 	Description: "Evil Land"
 	MaxLevel: 10
-	Range: 9
+	Range: 7
 	Hit: "BDT_SKILL"
 	SkillType: {
 		Place: true
@@ -17888,25 +17888,37 @@ skill_db: (
 	DamageType: {
 		NoDamage: true
 		IgnoreElement: true
+		IgnoreFlee: true
 		IgnoreDefCards: true
 	}
-	SkillData1: 30000
+	SkillData1: {
+		Lv1: 3500
+		Lv2: 4500
+		Lv3: 5500
+		Lv4: 6500
+		Lv5: 7500
+		Lv6: 8500
+		Lv7: 9500
+		Lv8: 10500
+		Lv9: 11500
+		Lv10: 12500
+	}
 	SkillData2: 30000
 	FixedCastTime: -1
 	Unit: {
 		Id: 0xc7
 		Layout: 1
 		Range: {
-			Lv1: 4
-			Lv2: 7
-			Lv3: 10
-			Lv4: 13
-			Lv5: 16
-			Lv6: 19
-			Lv7: 22
-			Lv8: 25
-			Lv9: 28
-			Lv10: 31
+			Lv1: 5
+			Lv2: 5
+			Lv3: 5
+			Lv4: 5
+			Lv5: 5
+			Lv6: 5
+			Lv7: 5
+			Lv8: 5
+			Lv9: 5
+			Lv10: 13
 		}
 		Interval: 1000
 		Target: "All"

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3777,7 +3777,7 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 
 	if( !dmg.amotion ) {
 		//Instant damage
-		if ((!sc || (!sc->data[SC_DEVOTION] && skill_id != CR_REFLECTSHIELD && !sc->data[SC_WATER_SCREEN_OPTION])) && !shadow_flag)
+		if ((!sc || (!sc->data[SC_DEVOTION] && skill_id != CR_REFLECTSHIELD && !sc->data[SC_WATER_SCREEN_OPTION]) || skill_id == NPC_EVILLAND) && !shadow_flag)
 			status_fix_damage(src,bl,damage,dmg.dmotion); //Deal damage before knockback to allow stuff like firewall+storm gust combo.
 		if( !status->isdead(bl) && additional_effects )
 			skill->additional_effect(src,bl,skill_id,skill_lv,dmg.flag,dmg.dmg_lv,tick);
@@ -3865,7 +3865,7 @@ static int skill_attack(int attack_type, struct block_list *src, struct block_li
 			battle->delay_damage(tick, dmg.amotion,src,bl,dmg.flag,skill_id,skill_lv,damage,dmg.dmg_lv,dmg.dmotion, additional_effects);
 	}
 
-	if (sc != NULL && skill_id != PA_PRESSURE && skill_id != SJ_NOVAEXPLOSING && skill_id != SP_SOULEXPLOSION) {
+	if (sc != NULL && skill_id != PA_PRESSURE && skill_id != SJ_NOVAEXPLOSING && skill_id != SP_SOULEXPLOSION && skill_id != NPC_EVILLAND) {
 		if (sc->data[SC_DEVOTION]) {
 			struct status_change_entry *sce = sc->data[SC_DEVOTION];
 			struct block_list *d_bl = map->id2bl(sce->val1);
@@ -13442,7 +13442,7 @@ static struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16
 
 		case PR_SANCTUARY:
 		case NPC_EVILLAND:
-			val1=(skill_lv+3)*2;
+			val1=skill_lv+3;
 			break;
 
 		case WZ_FIREPILLAR:
@@ -14290,7 +14290,7 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 			if( battle->check_undead(tstatus->race, tstatus->def_ele) || tstatus->race==RC_DEMON )
 			{ //Only damage enemies with offensive Sanctuary. [Skotlex]
 				if( battle->check_target(&src->bl,bl,BCT_ENEMY) > 0 && skill->attack(BF_MAGIC, ss, &src->bl, bl, sg->skill_id, sg->skill_lv, tick, 0) )
-					sg->val1 -= 2; // reduce healing count if this was meant for damaging [hekate]
+					sg->val1 -= 1; // Reduce the number of targets that can still be hit
 			} else {
 				int heal = skill->calc_heal(ss,bl,sg->skill_id,sg->skill_lv,true);
 				struct mob_data *md = BL_CAST(BL_MOB, bl);
@@ -14308,11 +14308,7 @@ static int skill_unit_onplace_timer(struct skill_unit *src, struct block_list *b
 				if (tsc && tsc->data[SC_AKAITSUKI] && heal)
 					heal = ~heal + 1;
 				status->heal(bl, heal, 0, STATUS_HEAL_DEFAULT);
-				if (diff >= 500)
-					sg->val1--;
 			}
-			if (sg->val1 <= 0)
-				skill->del_unitgroup(sg);
 			break;
 
 		case UNT_EVILLAND:
@@ -19345,9 +19341,6 @@ static struct skill_unit_group *skill_initunitgroup(struct block_list *src, int 
 
 	ud->skillunit[i] = group;
 
-	if (skill_id == PR_SANCTUARY) //Sanctuary starts healing +1500ms after casted. [Skotlex]
-		group->tick += 1500;
-
 	idb_put(skill->group_db, group->group_id, group);
 	return group;
 }
@@ -19771,6 +19764,10 @@ static int skill_unit_timer_sub(union DBKey key, struct DBData *data, va_list ap
 					group->unit_id = UNT_USED_TRAPS;
 					group->limit = DIFF_TICK32(tick, group->tick) + 1500;
 				}
+				break;
+			case UNT_SANCTUARY:
+				if (group->val1 <= 0)
+					skill->del_unitgroup(group);
 				break;
 		}
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

**NPC_EVILLAND:**
- Now always hits and ignores devotion redirection.
- Target range corrected from 9 to 7.
- Duration now scales per level instead of a flat 30 seconds.
- AoE fixed at 11x11 for levels 1-9 and 27x27 at level 10.

**PR_SANCTUARY:**
- Heals `[skill_lv+3]` times regardless of how many targets are standing on it, rather than the heal count being incorrectly shared with (and halved against) the hit-limit counter.
- Disappears strictly after hitting `[skill_lv+3]` enemies.
- Removed the legacy +1500ms healing-start delay.

**Issues addressed:** #1137

Thanks @Playtester for the details

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
