### PR TITLE
Add option to display official-style (Aegis) refine DEF in the pre-renewal status window

### DIFF
--- a/conf/map/battle/player.conf
+++ b/conf/map/battle/player.conf
@@ -209,6 +209,14 @@ costume_refine_def: true
 shadow_refine_def: true
 shadow_refine_atk: true
 
+// Show the official (Aegis) client status window DEF, which awards a flat +1 DEF
+// per armor refine level for display purposes, rather than the real value used in
+// damage calculations (see refine_db.conf, typically 0.7~1.0 DEF/level depending on
+// refine chance group). This only changes what is displayed; actual damage reduction
+// from refine is unaffected either way.
+// Default: false (Hercules shows the real, effective DEF)
+official_def_display: false
+
 // Keep player facing direction after warping? (Note 1)
 // Default: false (on official servers, players always faces north)
 player_warp_keep_direction: false

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -8117,6 +8117,7 @@ static const struct config_data_old battle_data[] = {
 	{ "costume_refine_def",                 &battle_config.costume_refine_def,              1,      0,      1,              },
 	{ "shadow_refine_def",                  &battle_config.shadow_refine_def,               1,      0,      1,              },
 	{ "shadow_refine_atk",                  &battle_config.shadow_refine_atk,               1,      0,      1,              },
+	{ "official_def_display",               &battle_config.official_def_display,            0,      0,      1,              },
 	{ "min_body_style",                     &battle_config.min_body_style,                  0,      0,      SHRT_MAX,       },
 	{ "max_body_style",                     &battle_config.max_body_style,                  4,      0,      SHRT_MAX,       },
 	{ "save_body_style",                    &battle_config.save_body_style,                 0,      0,      1,              },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -552,6 +552,7 @@ struct Battle_Config {
 	// Refine Def/Atk
 	int costume_refine_def, shadow_refine_def;
 	int shadow_refine_atk;
+	int official_def_display;
 
 	// BodyStyle
 	int min_body_style, max_body_style;

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -362,6 +362,7 @@ struct map_session_data {
 
 BEGIN_ZEROED_BLOCK; // this block will be globally zeroed at the beginning of status_calc_pc()
 	int param_bonus[6],param_equip[6]; //Stores card/equipment bonuses.
+	int official_def_display_bonus; //Gap between official and real armor refine DEF.
 	int subele[ELE_MAX];
 	int subrace[RC_MAX];
 	int subrace2[RC2_MAX];
@@ -807,7 +808,10 @@ END_ZEROED_BLOCK;
 		* (sd)->battle_status.atk_percent) / 100\
 	)
 	#define pc_rightside_atk(sd) ((sd)->battle_status.rhw.atk2 + (sd)->battle_status.lhw.atk2)
-	#define pc_leftside_def(sd) ((sd)->battle_status.def)
+	#define pc_leftside_def(sd) (\
+		(sd)->battle_status.def \
+		+ (battle_config.official_def_display ? (sd)->official_def_display_bonus : 0) \
+	)
 	#define pc_rightside_def(sd) (((sd)->battle_status.def2 * (sd)->battle_status.def_percent) / 100)
 	#define pc_leftside_mdef(sd) ((sd)->battle_status.mdef)
 	#define pc_rightside_mdef(sd) ( (sd)->battle_status.mdef2 - ((sd)->battle_status.vit>>1) )

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -1461,7 +1461,7 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 	const struct status_change *sc;
 	struct s_skill b_skill[MAX_SKILL_DB]; // previous skill tree
 	int b_cart_weight_max, // previous weight
-		i, k, index, skill_lv,refinedef=0;
+		i, k, index, skill_lv, refinedef = 0, refine_level_sum = 0;
 	unsigned int b_weight, b_max_weight;
 	int64 i64;
 
@@ -1663,8 +1663,10 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 				)
 				r = 0;
 
-			if (r)
+			if (r > 0) {
 				refinedef += refine->get_bonus(REFINE_TYPE_ARMOR, r);
+				refine_level_sum += r;
+			}
 
 			if(sd->inventory_data[index]->script) {
 				if( i == EQI_HAND_L ) //Shield
@@ -1723,6 +1725,12 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 	memset(sd->param_bonus, 0, sizeof(sd->param_bonus));
 
 	bstatus->def += (refinedef+50)/100;
+	// Pre-renewal official (Aegis) clients display a flat +1 DEF per armor refine level,
+	// regardless of the real, lower per-level bonus used for the actual damage reduction
+	// above. Store the gap so the status window can optionally show the official-looking
+	// number. (Unused in renewal builds: renewal's DEF display already matches its own,
+	// non-linear refine formula, so no equivalent correction applies there.)
+	sd->official_def_display_bonus = refine_level_sum - (refinedef + 50) / 100;
 
 	//Parse Cards
 	for(i=0;i<EQI_MAX;i++) {


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

On pre-renewal, the status window's DEF has always shown the real, effective DEF from armor refine (e.g. +7 at +10 refine, since `refine_db.conf`'s pre-re `StatsPerLevel` is 0.66/level). Official (Aegis) clients instead show a flat +1 DEF per armor refine level on screen, even though only the smaller amount is actually applied to damage reduction server-side, so at the same +10 refine, official displays +10 while the real reduction is only +7.

This adds an off-by-default `official_def_display` battle_config option. When enabled, the pre-renewal status window shows the official-style (+1/refine) number instead of the real one, for server admins who want visual parity with official servers. The real value used in damage calculations (`battle_status.def`) is never changed by this option.


**Issues addressed:** #1144

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
