### PR TITLE
Fix GN_WALLOFTHORN to UNT_FIREWALL transition

### DIFF
--- a/db/pre-re/skill_db.conf
+++ b/db/pre-re/skill_db.conf
@@ -30352,7 +30352,7 @@ skill_db: (
 		Id: [ 0xe6, 0x7f ]
 		Layout: -1
 		Range: 2
-		Interval: -1
+		Interval: 300
 		Target: "All"
 	}
 },

--- a/db/re/skill_db.conf
+++ b/db/re/skill_db.conf
@@ -30749,7 +30749,7 @@ skill_db: (
 		Id: [ 0xe6, 0x7f ]
 		Layout: -1
 		Range: 2
-		Interval: -1
+		Interval: 300
 		Target: "All"
 	}
 },

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7004,6 +7004,10 @@ static enum damage_lv battle_weapon_attack(struct block_list *src, struct block_
 		struct skill_unit *su = BL_UCAST(BL_SKILL, target);
 		if (su->group && su->group->skill_id == HT_BLASTMINE)
 			skill->blown(src, target, 3, -1, 0);
+		if (su->group && su->group->skill_id == GN_WALLOFTHORN) {
+			if (--su->val2 <= 0)
+				skill->delunit(su);
+		}
 	}
 	map->freeblock_lock();
 

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -13843,8 +13843,8 @@ static struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16
 				val2 = 0;
 				break;
 			case GN_WALLOFTHORN:
-				val1 = 2000 + 2000 * skill_lv;
-				val2 = src->id;
+				val1 = 2000 + 2000 * skill_lv; // HP
+				val2 = 20; // Max hits
 				break;
 			case RL_B_TRAP:
 				val1 = 3500;
@@ -19767,7 +19767,7 @@ static int skill_unit_timer_sub(union DBKey key, struct DBData *data, va_list ap
 					su->limit = DIFF_TICK32(tick + 700,group->tick);
 				break;
 			case UNT_WALLOFTHORN:
-				if( su->val1 <= 0 ) {
+				if (su->val1 <= 0 || su->val2 <= 0) {
 					group->unit_id = UNT_USED_TRAPS;
 					group->limit = DIFF_TICK32(tick, group->tick) + 1500;
 				}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Wall of Thorn (GN_WALLOFTHORN) is supposed to burn into a Fire Wall (UNT_FIREWALL) when hit by fire damage, but the resulting fire never actually dealt damage:

- `GN_WALLOFTHORN`'s `Unit.Interval` was `-1` in both `db/re/skill_db.conf` and `db/pre-re/skill_db.conf`. Wall of Thorn itself has no periodic on-place tick, so this was fine for its own state, but the morphed Fire Wall unit inherits this same interval. With `interval == -1`, `skill_unit_onplace_timer` hits its early-exit guard and logs `"interval error"` instead of ticking, so the fire never dealt damage for its whole 3-second lifetime. Changed to `300`.
- The base Wall of Thorn unit was also missing its 20-hit break limit: `val2` held an unused caster ID instead of a hit counter. It now starts at 20 and is decremented on each weapon hit in `battle.c` (mirroring the existing `HT_BLASTMINE` hook in the same block), deleting the unit once depleted. `skill_unit_timer_sub`'s expiry check was updated to also break the wall when `val2` reaches 0, not just on HP depletion.

**Issues addressed:** #1118

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
