### PR TITLE
Validate before allocating WFIFO buffer, not after

### DIFF
--- a/src/map/chrif.c
+++ b/src/map/chrif.c
@@ -1089,11 +1089,26 @@ static bool chrif_save_scdata(struct map_session_data *sd)
 	chrif_check(false);
 	tick = timer->gettick();
 
+	for (i = 0; i < SC_MAX; i++) {
+		if (!sc->data[i])
+			continue;
+		if (sc->data[i]->timer != INVALID_TIMER) {
+			td = timer->get(sc->data[i]->timer);
+			if (td == NULL || td->func != status->change_timer)
+				continue;
+		}
+		count++;
+	}
+
+	if (count == 0)
+		return true; //Nothing to save. | Everything was as successful as if there was something to save.
+
 	WFIFOHEAD(chrif->fd, 14 + SC_MAX*sizeof(struct status_change_data));
 	WFIFOW(chrif->fd,0) = 0x2b1c;
 	WFIFOL(chrif->fd,4) = sd->status.account_id;
 	WFIFOL(chrif->fd,8) = sd->status.char_id;
 
+	count = 0;
 	for (i = 0; i < SC_MAX; i++) {
 		if (!sc->data[i])
 			continue;
@@ -1118,9 +1133,6 @@ static bool chrif_save_scdata(struct map_session_data *sd)
 			&data, sizeof(struct status_change_data));
 		count++;
 	}
-
-	if (count == 0)
-		return true; //Nothing to save. | Everything was as successful as if there was something to save.
 
 	WFIFOW(chrif->fd,12) = count;
 	WFIFOW(chrif->fd,2) = 14 +count*sizeof(struct status_change_data); //Total packet size
@@ -1258,8 +1270,6 @@ static void chrif_update_ip(int fd)
 {
 	uint32 new_ip;
 
-	WFIFOHEAD(fd,6);
-
 	new_ip = sockt->host2ip(chrif->ip_str);
 
 	if (new_ip && new_ip != chrif->ip)
@@ -1270,6 +1280,7 @@ static void chrif_update_ip(int fd)
 	if (!new_ip)
 		return; //No change
 
+	WFIFOHEAD(fd,6);
 	WFIFOW(fd,0) = 0x2736;
 	WFIFOL(fd,2) = htonl(new_ip);
 	WFIFOSET(fd,6);

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -3591,6 +3591,70 @@ static void clif_updatestatus(struct map_session_data *sd, enum status_point_typ
 	if (!sockt->session_is_active(fd)) // Invalid pointer fix, by sasuke [Kevin]
 		return;
 
+	// Reject unrecognized types before allocating/building the packet below.
+	PRAGMA_GCC46(GCC diagnostic push)
+	PRAGMA_GCC46(GCC diagnostic ignored "-Wswitch-enum")
+	switch (type) {
+		case SP_WEIGHT:
+		case SP_MAXWEIGHT:
+		case SP_SPEED:
+		case SP_BASELEVEL:
+		case SP_JOBLEVEL:
+		case SP_KARMA:
+		case SP_MANNER:
+		case SP_STATUSPOINT:
+		case SP_SKILLPOINT:
+		case SP_HIT:
+		case SP_FLEE1:
+		case SP_FLEE2:
+		case SP_MAXHP:
+		case SP_MAXSP:
+		case SP_HP:
+		case SP_SP:
+		case SP_ASPD:
+		case SP_ATK1:
+		case SP_DEF1:
+		case SP_MDEF1:
+		case SP_ATK2:
+		case SP_DEF2:
+		case SP_MDEF2:
+		case SP_CRITICAL:
+		case SP_MATK1:
+		case SP_MATK2:
+		case SP_ZENY:
+		case SP_BASEEXP:
+		case SP_JOBEXP:
+		case SP_NEXTBASEEXP:
+		case SP_NEXTJOBEXP:
+#if PACKETVER_MAIN_NUM >= 20200916 || PACKETVER_RE_NUM >= 20200723 || PACKETVER_ZERO_NUM >= 20221024
+		case SP_POW:
+		case SP_STA:
+		case SP_WIS:
+		case SP_SPL:
+		case SP_CON:
+		case SP_CRT:
+#endif  // PACKETVER_MAIN_NUM >= 20200916 || PACKETVER_RE_NUM >= 20200723 || PACKETVER_ZERO_NUM >= 20221024
+		case SP_USTR:
+		case SP_UAGI:
+		case SP_UVIT:
+		case SP_UINT:
+		case SP_UDEX:
+		case SP_ULUK:
+		case SP_ATTACKRANGE:
+		case SP_STR:
+		case SP_AGI:
+		case SP_VIT:
+		case SP_INT:
+		case SP_DEX:
+		case SP_LUK:
+		case SP_CARTINFO:
+			break;
+		default:
+			ShowError("clif->updatestatus : unrecognized type %d\n",type);
+			return;
+	}
+	PRAGMA_GCC46(GCC diagnostic pop)
+
 	int packetId = HEADER_ZC_PAR_CHANGE;
 
 	WFIFOHEAD(fd, 14);
@@ -6838,6 +6902,13 @@ static void clif_use_card(struct map_session_data *sd, int idx)
 	if (!pc->can_insert_card(sd, idx))
 		return;
 
+	for (i = c = 0; i < sd->status.inventorySize; i++) {
+		if (pc->can_insert_card_into(sd, idx, i))
+			c++;
+	}
+
+	if (!c) return; // no item is available for card insertion
+
 	WFIFOHEAD(fd, sd->status.inventorySize * 2 + 4);
 	WFIFOW(fd, 0) = 0x17b;
 
@@ -6847,8 +6918,6 @@ static void clif_use_card(struct map_session_data *sd, int idx)
 		WFIFOW(fd, 4 + c * 2) = i + 2;
 		c++;
 	}
-
-	if (!c) return; // no item is available for card insertion
 
 	WFIFOW(fd, 2) = 4 + c * 2;
 	WFIFOSET(fd, WFIFOW(fd, 2));
@@ -7896,6 +7965,14 @@ static void clif_sendegg(struct map_session_data *sd)
 		return;
 	}
 
+	for (i = n = 0; i < sd->status.inventorySize; i++) {
+		if (sd->status.inventory[i].nameid <= 0 || sd->inventory_data[i] == NULL || sd->inventory_data[i]->type!=IT_PETEGG || sd->status.inventory[i].amount <= 0)
+			continue;
+		n++;
+	}
+
+	if (!n) return;
+
 	WFIFOHEAD(fd, sd->status.inventorySize * 2 + 4);
 	WFIFOW(fd,0) = 0x1a6;
 	for (i = n = 0; i < sd->status.inventorySize; i++) {
@@ -7904,8 +7981,6 @@ static void clif_sendegg(struct map_session_data *sd)
 		WFIFOW(fd, n * 2 + 4) = i + 2;
 		n++;
 	}
-
-	if (!n) return;
 
 	WFIFOW(fd, 2) = 4 + n * 2;
 	WFIFOSET(fd, WFIFOW(fd, 2));


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Several functions called `WFIFOHEAD` before finishing validation/data-gathering, then `return`ed without calling `WFIFOSET`. Reordered so checks happen first and the buffer is only allocated once a packet is actually going to be sent:

- `chrif_save_scdata`: count active status changes before allocating.
- `chrif_update_ip`: check whether the IP changed before allocating.
- `clif_updatestatus`: reject an unrecognized `type` before allocating (added a validation switch mirroring the real switch's case labels,  since the valid values aren't a contiguous range).
- `clif_use_card`: count insertable items before allocating.
- `clif_sendegg`: count hatchable pet eggs before allocating.


**Issues addressed:** #1041

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
