### PR TITLE
Add addToSKILLDB/getFromSKILLDB/removeFromSKILLDB for plugins, closin…

### DIFF
--- a/src/common/HPM.c
+++ b/src/common/HPM.c
@@ -241,6 +241,7 @@ static bool hplugin_data_store_validate(enum HPluginDataTypes type, struct hplug
 		case HPDT_AUTOTRADE_VEND:
 		case HPDT_CLAN:
 		case HPDT_UNIT_PARAMETER:
+		case HPDT_SKILLDB:
 		default:
 			if (HPM->data_store_validate_sub == NULL) {
 				ShowError("HPM:validateHPData failed, type %u needs sub-handler!\n", type);

--- a/src/common/HPMi.h
+++ b/src/common/HPMi.h
@@ -99,6 +99,7 @@ enum HPluginDataTypes {
 	HPDT_AUTOTRADE_VEND, ///< For struct autotrade_vending.
 	HPDT_CLAN,           ///< For struct clan.
 	HPDT_UNIT_PARAMETER, ///< For struct unit_parameters_db.
+	HPDT_SKILLDB,        ///< For struct s_skill_db.
 };
 
 /* used in macros and conf storage */
@@ -171,6 +172,10 @@ enum HPluginConfType {
 #define addToUnitParam(ptr,data,classid,autofree) (HPMi->addToHPData(HPDT_UNIT_PARAMETER,HPMi->pid,&(ptr)->hdata,(data),(classid),(autofree)))
 #define getfromUnitParam(ptr,classid) (HPMi->getFromHPData(HPDT_UNIT_PARAMETER,HPMi->pid,(ptr)->hdata,(classid)))
 #define removefromUnitParam(ptr,classid) (HPMi->removeFromHPData(HPDT_UNIT_PARAMETER,HPMi->pid,(ptr)->hdata,(classid)))
+/* s_skill_db */
+#define addToSKILLDB(ptr,data,classid,autofree) (HPMi->addToHPData(HPDT_SKILLDB,HPMi->pid,&(ptr)->hdata,(data),(classid),(autofree)))
+#define getFromSKILLDB(ptr,classid) (HPMi->getFromHPData(HPDT_SKILLDB,HPMi->pid,(ptr)->hdata,(classid)))
+#define removeFromSKILLDB(ptr,classid) (HPMi->removeFromHPData(HPDT_SKILLDB,HPMi->pid,(ptr)->hdata,(classid)))
 
 /// HPMi->addCommand
 #define addAtcommand(cname,funcname) do { \

--- a/src/map/HPMmap.c
+++ b/src/map/HPMmap.c
@@ -139,6 +139,7 @@ bool HPM_map_data_store_validate(enum HPluginDataTypes type, struct hplugin_data
 	case HPDT_AUTOTRADE_VEND:
 	case HPDT_CLAN:
 	case HPDT_UNIT_PARAMETER:
+	case HPDT_SKILLDB:
 		// Initialized by the caller.
 		return true;
 	case HPDT_UNKNOWN:

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -51,6 +51,7 @@
 #include "map/unit.h"
 #include "common/cbasetypes.h"
 #include "common/ers.h"
+#include "common/HPM.h"
 #include "common/memmgr.h"
 #include "common/msgtable.h"
 #include "common/nullpo.h"
@@ -25419,6 +25420,9 @@ static void skill_readdb(bool minimal)
 
 	/* when != it was called during init and this procedure was already performed by skill_defaults()  */
 	if( core->runflag == MAPSERVER_ST_RUNNING ) {
+		for (int i = 0; i < MAX_SKILL_DB; i++) {
+			HPM->data_store_destroy(&skill->dbs->db[i].hdata);
+		}
 		memset(ZEROED_BLOCK_POS(skill->dbs), 0, ZEROED_BLOCK_SIZE(skill->dbs));
 	}
 
@@ -25549,6 +25553,9 @@ static int do_init_skill(bool minimal)
 
 static int do_final_skill(void)
 {
+	for (int i = 0; i < MAX_SKILL_DB; i++) {
+		HPM->data_store_destroy(&skill->dbs->db[i].hdata);
+	}
 	db_destroy(skill->name2id_db);
 	db_destroy(skill->group_db);
 	db_destroy(skill->unit_db);

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -33,6 +33,7 @@
  **/
 struct Damage;
 struct homun_data;
+struct hplugin_data_store;
 struct itemlist; // map/itemdb.h
 struct map_session_data;
 struct mercenary_data;
@@ -1886,6 +1887,7 @@ struct s_skill_db {
 	sc_type status_type;
 	struct skill_required_item_data req_items;
 	struct skill_required_item_data req_equip;
+	struct hplugin_data_store *hdata; ///< HPM Plugin Data Store
 };
 
 struct s_skill_unit_layout {


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Adds a plugin data store (`hdata`) to `struct s_skill_db`, along with the `HPDT_SKILLDB` type and `addToSKILLDB`/`getFromSKILLDB`/`removeFromSKILLDB` macros, mirroring the existing pattern used by `mob_db` and `item_data`.
This lets plugins attach and retrieve their own per-skill data without a custom out-of-band lookup structure.

**Issues addressed:** #2436

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
