### PR TITLE
Fix uninitialized WFIFO/RFIFO buffer memory on realloc

### DIFF
--- a/src/common/socket.c
+++ b/src/common/socket.c
@@ -793,12 +793,18 @@ static int realloc_fifo(int fd, unsigned int rfifo_size, unsigned int wfifo_size
 		return 0;
 
 	if( sockt->session[fd]->max_rdata != rfifo_size && sockt->session[fd]->rdata_size < rfifo_size) {
+		size_t old_rdata = sockt->session[fd]->max_rdata;
 		RECREATE(sockt->session[fd]->rdata, unsigned char, rfifo_size);
+		if (rfifo_size > old_rdata)
+			memset(sockt->session[fd]->rdata + old_rdata, 0, rfifo_size - old_rdata);
 		sockt->session[fd]->max_rdata  = rfifo_size;
 	}
 
 	if( sockt->session[fd]->max_wdata != wfifo_size && sockt->session[fd]->wdata_size < wfifo_size) {
+		size_t old_wdata = sockt->session[fd]->max_wdata;
 		RECREATE(sockt->session[fd]->wdata, unsigned char, wfifo_size);
+		if (wfifo_size > old_wdata)
+			memset(sockt->session[fd]->wdata + old_wdata, 0, wfifo_size - old_wdata);
 		sockt->session[fd]->max_wdata  = wfifo_size;
 	}
 	return 0;
@@ -807,25 +813,33 @@ static int realloc_fifo(int fd, unsigned int rfifo_size, unsigned int wfifo_size
 static int realloc_writefifo(int fd, size_t addition)
 {
 	size_t newsize;
+	size_t old_wdata;
+	bool growing;
 
 	if (!sockt->session_is_valid(fd)) // might not happen
 		return 0;
+
+	old_wdata = sockt->session[fd]->max_wdata;
 
 	if (sockt->session[fd]->wdata_size + addition  > sockt->session[fd]->max_wdata) {
 		// grow rule; grow in multiples of WFIFO_SIZE
 		newsize = WFIFO_SIZE;
 		while( sockt->session[fd]->wdata_size + addition > newsize ) newsize += WFIFO_SIZE;
+		growing = true;
 	} else if (sockt->session[fd]->max_wdata >= (size_t)2*(sockt->session[fd]->flag.server?FIFOSIZE_SERVERLINK:WFIFO_SIZE)
 	       && (sockt->session[fd]->wdata_size+addition)*4 < sockt->session[fd]->max_wdata
 	) {
 		// shrink rule, shrink by 2 when only a quarter of the fifo is used, don't shrink below nominal size.
 		newsize = sockt->session[fd]->max_wdata / 2;
+		growing = false;
 	} else {
 		// no change
 		return 0;
 	}
 
 	RECREATE(sockt->session[fd]->wdata, unsigned char, newsize);
+	if (growing && newsize > old_wdata)
+		memset(sockt->session[fd]->wdata + old_wdata, 0, newsize - old_wdata);
 	sockt->session[fd]->max_wdata  = newsize;
 
 	return 0;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- `realloc_fifo()`: zero the newly added tail of `rdata`/`wdata` after each `RECREATE`, when the new size is larger than the old one.
- `realloc_writefifo()`: same, but only on the grow path (the shrink path frees no new memory, so nothing to zero there).
- Both are guarded against a hypothetical shrink-sized "grow" call to avoid a `size_t` underflow in the `memset` length.


**Issues addressed:** #1743

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
