### PR TITLE
Fix SC_BURNING dealing no damage to monsters

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7192,11 +7192,16 @@ static int status_get_sc_def(struct block_list *src, struct block_list *bl, enum
 	PRAGMA_GCC46(GCC diagnostic ignored "-Wswitch-enum")
 	switch (type) {
 	case SC_ANKLESNARE:
-	case SC_BURNING:
 	case SC_MARSHOFABYSS:
 	case SC_STASIS:
 	case SC_DEEP_SLEEP:
 		tick = max(tick, 5000); //Minimum duration 5s
+		break;
+	case SC_BURNING:
+		// The damage timer only deals damage while the remaining tick counter
+		// is still above zero, so a duration short enough to yield a single
+		// tick burns for no damage at all. Guarantee at least two ticks.
+		tick = max(tick, 2 * STATUS_BURNING_INTERVAL);
 		break;
 	case SC_FROSTMISTY:
 		tick = max(tick, 6000);
@@ -9120,8 +9125,8 @@ static int status_change_start_sub(struct block_list *src, struct block_list *bl
 				tick_time = 1000; // [GodLesZ] tick time
 				break;
 			case SC_BURNING:
-				val4 = total_tick / 3000; // Total Ticks to Burn!!
-				tick_time = 3000; // [GodLesZ] tick time
+				val4 = total_tick / STATUS_BURNING_INTERVAL; // Total Ticks to Burn!!
+				tick_time = STATUS_BURNING_INTERVAL; // [GodLesZ] tick time
 				break;
 				/**
 				* Rune Knight
@@ -12837,7 +12842,7 @@ static int status_change_timer(int tid, int64 tick, int id, intptr_t data)
 				status->damage(src, bl, damage, 0, 0, 1);
 
 				if( sc->data[type]){ // Target still lives. [LimitLine]
-					sc_timer_next(3000 + tick, status->change_timer, bl->id, data);
+					sc_timer_next(STATUS_BURNING_INTERVAL + tick, status->change_timer, bl->id, data);
 				}
 				map->freeblock_unlock();
 				return 0;

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -33,6 +33,9 @@ struct mob_data;
 struct npc_data;
 struct pet_data;
 
+/// Interval, in milliseconds, between two SC_BURNING damage ticks.
+#define STATUS_BURNING_INTERVAL 3000
+
 //Change the equation when the values are high enough to discard the
 //imprecision in exchange of overflow protection [Skotlex]
 //Also add 100% checks since those are the most used cases where we don't


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`SC_BURNING` could be applied to a target — showing the `OPT1_BURNING` animation and a valid duration — while dealing no damage at all. This is most visible on monsters, which is why it has been reported as a mob-only problem.