### PR TITLE
Fix NC_SELFDESTRUCTION damage underflow when caster HP is low

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -4614,7 +4614,7 @@ static struct Damage battle_calc_misc_attack(struct block_list *src, struct bloc
 #endif
 			md.damage = (int64)((sd ? pc->checkskill(sd,NC_MAINFRAME) : 10) + 8) * (skill_lv + 1) * (status_get_sp(src) + sstatus->vit);
 			RE_LVL_MDMOD(100);
-			md.damage += status_get_hp(src) - totaldef;
+			md.damage += (int64)status_get_hp(src) - totaldef;
 		}
 		break;
 	case NC_MAGMA_ERUPTION:


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Cast `status_get_hp(src)` to `int64` before the subtraction so it's evaluated as signed arithmetic, matching the `int64` accumulator it's added into.

**Issues addressed:** #959

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
