### PR TITLE
Fix Genetic Sling Item Banana Bomb chance/duration and Mysterious Powder self-debuff

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2907,8 +2907,10 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 								break;
 							case ITEMID_COCONUT_BOMB:
 							case ITEMID_PINEAPPLE_BOMB:
-							case ITEMID_BANANA_BOMB:
 								skillratio = st->str + st->dex + 800;
+								break;
+							case ITEMID_BANANA_BOMB:
+								skillratio = st->str + st->dex + 777;
 								break;
 							case ITEMID_BLACK_LUMP:
 								skillratio = (st->str + st->agi + st->dex) / 3; // Black Lump
@@ -2920,6 +2922,7 @@ static int battle_calc_skillratio(int attack_type, struct block_list *src, struc
 								skillratio = st->str + st->agi + st->dex; // Extremely Hard Black Lump
 								break;
 						}
+						RE_LVL_DMOD(100);
 					}
 					break;
 				case SO_VARETYR_SPEAR://ATK [{( Striking Level x 50 ) + ( Varetyr Spear Skill Level x 50 )} x Caster Base Level / 100 ] %

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -2237,8 +2237,8 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 						sc_start(src, bl, SC_MELON_BOMB, 100, skill_lv, 60000, skill_id); // Reduces ASPD and movement speed
 						break;
 					case ITEMID_BANANA_BOMB:
-						sc_start(src, bl, SC_BANANA_BOMB, 100, skill_lv, 60000, skill_id); // Reduces LUK? Needed confirm it, may be it's bugged in kRORE?
-						sc_start(src, bl, SC_BANANA_BOMB_SITDOWN_POSTDELAY, (sd? sd->status.job_level:0) + sstatus->dex / 6 + tstatus->agi / 4 - tstatus->luk / 5 - status->get_lv(bl) + status->get_lv(src), skill_lv, 1000, skill_id); // Sit down for 3 seconds.
+						sc_start(src, bl, SC_BANANA_BOMB, 100, skill_lv, 30000, skill_id); // Reduces LUK.
+						sc_start(src, bl, SC_BANANA_BOMB_SITDOWN_POSTDELAY, status->get_lv(src) + sd->status.job_level + sstatus->dex / 6 - status->get_lv(bl) - tstatus->agi / 4 - tstatus->luk / 5, skill_lv, 1000 * sd->status.job_level / 4, skill_id);
 						break;
 				}
 				sd->itemid = -1;
@@ -11473,10 +11473,11 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 					struct script_code *scriptroot = sd->inventory_data[equip_idx]->script;
 					if( !scriptroot )
 						break;
+					// Throwable items (buffs/debuffs) only affect player targets; running the item's
+					// script on the caster when there's no player target could turn a debuff item
+					// like Mysterious Powder into a self-debuff.
 					if( dstsd )
 						script->run(scriptroot,0,dstsd->bl.id,npc->fake_nd->bl.id);
-					else
-						script->run(scriptroot,0,src->id,0);
 				}
 			}
 			clif->skill_nodamage(src,bl,skill_id,skill_lv,1);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`GN_SLINGITEM` / `GN_SLINGITEM_RANGEMELEEATK` (Genetic's Sling Item skill) had several bugs affecting Banana Bomb and Mysterious Powder:

- Banana Bomb's sit-down chance formula had the target's AGI term inverted (`+ tstatus->agi/4` instead of `- tstatus->agi/4`), making high-AGI targets *more* likely to be knocked down instead of less.
- The sit-down duration and the LUK-drain duration used hardcoded placeholder values (`1000` and `60000`) instead of the job-level-scaled/official durations, and didn't match their own inline comments.
- Mysterious Powder (and other throwable items) could be applied to the caster instead of the target when there was no valid player target (e.g. against a mob), turning a debuff item into a self-debuff.
- Banana Bomb's damage skill ratio was lumped in with Coconut/Pineapple Bomb (`+800`) instead of using its own official value (`+777`), and the block was missing the renewal level modifier (`RE_LVL_DMOD`) applied to other Sling Item ammo.

**Issues addressed:** #616

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
