### PR TITLE
Fix autobonus not working with ammo, item combos, and pets

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6647,9 +6647,10 @@ for each kind in 'doc/item_bonus.txt'.
 *autobonus3(<bonus script>, <rate>, <duration>, <skill id>, {<other script>})
 *autobonus3(<bonus script>, <rate>, <duration>, "<skill name>", {<other script>})
 
-These commands are meant to be used in item scripts. They will probably
-work outside item scripts, but the bonus will not persist for long. They,
-as expected, refer only to an invoking character.
+These commands are meant to be used in item scripts, item combo scripts, or
+a pet's equip script. They will probably work outside of those, but the
+bonus will not persist for long. They, as expected, refer only to an
+invoking character.
 
 What these commands do is 'attach' a script to the player which will get
 executed on attack (or when attacked in the case of autobonus2()).

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -2285,12 +2285,44 @@ static int pc_bonus_item_drop(struct s_add_drop *drop, const short max, int id, 
 	return 1;
 }
 
-static int pc_addautobonus(struct s_autobonus *bonus, char max, const char *bonus_script, short rate, unsigned int dur, short flag, const char *other_script, unsigned int pos, bool onskill)
+/**
+ * Checks whether two autobonus source identities refer to the same source.
+ *
+ * pos identifies an equip slot (item or card source, 0 otherwise), card_id
+ * distinguishes a card's own autobonus from its host item's (0 for the item,
+ * the card's item id otherwise), combo_pos an item combo id (0 otherwise),
+ * and pet_id a pet (0 otherwise). Comparing all four keeps an item's
+ * autobonus, a card socketed in it, a combo, and a pet from being treated as
+ * the same activation slot just because they might share an EQP_* position.
+ */
+static bool pc_autobonus_source_equals(const struct s_autobonus_source *a, const struct s_autobonus_source *b)
+{
+	nullpo_retr(false, a);
+	nullpo_retr(false, b);
+	return a->pos == b->pos && a->card_id == b->card_id && a->combo_pos == b->combo_pos && a->pet_id == b->pet_id;
+}
+
+/**
+ * Checks whether an autobonus with the given source identity is currently active
+ * (registered with a running timer) in the given autobonus array.
+ */
+static bool pc_autobonus_is_active(struct s_autobonus *autobonus, char max, const struct s_autobonus_source *source)
+{
+	int i;
+
+	nullpo_retr(false, autobonus);
+	nullpo_retr(false, source);
+	ARR_FIND(0, max, i, autobonus[i].active != INVALID_TIMER && pc_autobonus_source_equals(&autobonus[i].source, source));
+	return i < max;
+}
+
+static int pc_addautobonus(struct s_autobonus *bonus, char max, const char *bonus_script, short rate, unsigned int dur, short flag, const char *other_script, const struct s_autobonus_source *source, bool onskill)
 {
 	int i;
 
 	nullpo_ret(bonus);
 	nullpo_ret(bonus_script);
+	nullpo_ret(source);
 	ARR_FIND(0, max, i, bonus[i].rate == 0);
 	if( i == max )
 	{
@@ -2317,10 +2349,61 @@ static int pc_addautobonus(struct s_autobonus *bonus, char max, const char *bonu
 	bonus[i].duration = dur;
 	bonus[i].active = INVALID_TIMER;
 	bonus[i].atk_type = flag;
-	bonus[i].pos = pos;
+	bonus[i].source = *source;
 	bonus[i].bonus_script = aStrdup(bonus_script);
 	bonus[i].other_script = other_script?aStrdup(other_script):NULL;
 	return 1;
+}
+
+/**
+ * Resolves the inventory index (equip context) to pass into an autobonus's
+ * script when it re-triggers, and reports whether the autobonus's source
+ * (an equip slot, an item combo, or a pet) is still present on the character.
+ *
+ * Combos and pets have no single backing inventory index, so -1 is returned
+ * as the context for those (matching the "no item" sentinel used elsewhere,
+ * e.g. status->current_equip_item_index outside of the equip/card loops).
+ */
+static bool pc_autobonus_source(struct map_session_data *sd, const struct s_autobonus *autobonus, int *out_index)
+{
+	const struct s_autobonus_source *source;
+
+	nullpo_retr(false, sd);
+	nullpo_retr(false, autobonus);
+	nullpo_retr(false, out_index);
+
+	source = &autobonus->source;
+	*out_index = -1;
+
+	if (source->combo_pos != 0) {
+		int i;
+		ARR_FIND(0, sd->combo_count, i, sd->combos[i].id + 1 == source->combo_pos);
+		return i < sd->combo_count;
+	}
+
+	if (source->pet_id != 0)
+		return sd->pd != NULL && sd->pd->pet.pet_id == source->pet_id;
+
+	if (source->pos != 0) {
+		int j, index;
+		ARR_FIND(0, EQI_MAX, j, sd->equip_index[j] >= 0 && sd->status.inventory[sd->equip_index[j]].equip == source->pos);
+		if (j == EQI_MAX)
+			return false;
+		index = sd->equip_index[j];
+
+		if (source->card_id != 0) {
+			// Card-sourced: the card must still be socketed in this equip slot.
+			int c;
+			ARR_FIND(0, MAX_SLOTS, c, sd->status.inventory[index].card[c] == source->card_id);
+			if (c == MAX_SLOTS)
+				return false;
+		}
+
+		*out_index = index;
+		return true;
+	}
+
+	return false;
 }
 
 static int pc_delautobonus(struct map_session_data *sd, struct s_autobonus *autobonus, char max, bool restore)
@@ -2333,19 +2416,17 @@ static int pc_delautobonus(struct map_session_data *sd, struct s_autobonus *auto
 	{
 		if( autobonus[i].active != INVALID_TIMER )
 		{
-			if( restore && sd->state.autobonus&autobonus[i].pos )
+			int index;
+			bool source_active = pc_autobonus_source(sd, &autobonus[i], &index);
+
+			if( restore && source_active )
 			{
 				if( autobonus[i].bonus_script )
-				{
-					int j;
-					ARR_FIND( 0, EQI_MAX, j, sd->equip_index[j] >= 0 && sd->status.inventory[sd->equip_index[j]].equip == autobonus[i].pos );
-					if( j < EQI_MAX )
-						script->run_autobonus(autobonus[i].bonus_script,sd->bl.id,sd->equip_index[j]);
-				}
+					script->run_autobonus(autobonus[i].bonus_script,sd->bl.id,index);
 				continue;
 			}
 			else
-			{ // Logout / Unequipped an item with an activated bonus
+			{ // Logout / Unequipped an item (or lost the combo/pet) with an activated bonus
 				timer->delete_(autobonus[i].active,pc->endautobonus);
 				autobonus[i].active = INVALID_TIMER;
 			}
@@ -2354,7 +2435,8 @@ static int pc_delautobonus(struct map_session_data *sd, struct s_autobonus *auto
 		if( autobonus[i].bonus_script ) aFree(autobonus[i].bonus_script);
 		if( autobonus[i].other_script ) aFree(autobonus[i].other_script);
 		autobonus[i].bonus_script = autobonus[i].other_script = NULL;
-		autobonus[i].rate = autobonus[i].atk_type = autobonus[i].duration = autobonus[i].pos = 0;
+		autobonus[i].rate = autobonus[i].atk_type = autobonus[i].duration = 0;
+		memset(&autobonus[i].source, 0, sizeof(autobonus[i].source));
 		autobonus[i].active = INVALID_TIMER;
 	}
 
@@ -2368,14 +2450,12 @@ static int pc_exeautobonus(struct map_session_data *sd, struct s_autobonus *auto
 
 	if( autobonus->other_script )
 	{
-		int j;
-		ARR_FIND( 0, EQI_MAX, j, sd->equip_index[j] >= 0 && sd->status.inventory[sd->equip_index[j]].equip == autobonus->pos );
-		if( j < EQI_MAX )
-			script->run_autobonus(autobonus->other_script,sd->bl.id,sd->equip_index[j]);
+		int index;
+		if (pc_autobonus_source(sd, autobonus, &index))
+			script->run_autobonus(autobonus->other_script,sd->bl.id,index);
 	}
 
 	autobonus->active = timer->add(timer->gettick()+autobonus->duration, pc->endautobonus, sd->bl.id, (intptr_t)autobonus);
-	sd->state.autobonus |= autobonus->pos;
 	status_calc_pc(sd,SCO_NONE);
 
 	return 0;
@@ -2390,7 +2470,6 @@ static int pc_endautobonus(int tid, int64 tick, int id, intptr_t data)
 	nullpo_ret(autobonus);
 
 	autobonus->active = INVALID_TIMER;
-	sd->state.autobonus &= ~autobonus->pos;
 	status_calc_pc(sd,SCO_NONE);
 	return 0;
 }
@@ -10552,10 +10631,15 @@ static int pc_unequipitem(struct map_session_data *sd, int n, int flag)
 			status_change_end(&sd->bl, SC_PLATINUM_ALTER, INVALID_TIMER);
 	}
 
-	if ((sd->state.autobonus & pos) != 0)  // Check for activated autobonus. [Inkfish]
-		sd->state.autobonus &= ~sd->status.inventory[n].equip;
-
 	sd->status.inventory[n].equip = 0;
+
+	// Cancel any autobonus this item (or a card in it) was the source of. Done unconditionally,
+	// independent of the status_calc_pc() call below, since that call is skipped unless the
+	// caller asked for a recalc or a combo/option was removed -- but an active autobonus timer
+	// must not be left running for an item that is no longer equipped.
+	pc->delautobonus(sd, sd->autobonus, ARRAYLENGTH(sd->autobonus), true);
+	pc->delautobonus(sd, sd->autobonus2, ARRAYLENGTH(sd->autobonus2), true);
+	pc->delautobonus(sd, sd->autobonus3, ARRAYLENGTH(sd->autobonus3), true);
 
 	bool status_calc = false;
 	int iflag = sd->npc_item_flag;
@@ -13065,6 +13149,7 @@ void pc_defaults(void)
 	pc->exeautobonus = pc_exeautobonus;
 	pc->endautobonus = pc_endautobonus;
 	pc->delautobonus = pc_delautobonus;
+	pc->autobonus_is_active = pc_autobonus_is_active;
 
 	pc->bonus_addele = pc_bonus_addele;
 	pc->bonus_subele = pc_bonus_subele;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -2295,7 +2295,7 @@ static int pc_bonus_item_drop(struct s_add_drop *drop, const short max, int id, 
  * autobonus, a card socketed in it, a combo, and a pet from being treated as
  * the same activation slot just because they might share an EQP_* position.
  */
-static bool pc_autobonus_source_equals(const struct s_autobonus_source *a, const struct s_autobonus_source *b)
+static bool autobonus_source_equals(const struct s_autobonus_source *a, const struct s_autobonus_source *b)
 {
 	nullpo_retr(false, a);
 	nullpo_retr(false, b);
@@ -2312,7 +2312,7 @@ static bool pc_autobonus_is_active(struct s_autobonus *autobonus, char max, cons
 
 	nullpo_retr(false, autobonus);
 	nullpo_retr(false, source);
-	ARR_FIND(0, max, i, autobonus[i].active != INVALID_TIMER && pc_autobonus_source_equals(&autobonus[i].source, source));
+	ARR_FIND(0, max, i, autobonus[i].active != INVALID_TIMER && autobonus_source_equals(&autobonus[i].source, source));
 	return i < max;
 }
 
@@ -2364,7 +2364,7 @@ static int pc_addautobonus(struct s_autobonus *bonus, char max, const char *bonu
  * as the context for those (matching the "no item" sentinel used elsewhere,
  * e.g. status->current_equip_item_index outside of the equip/card loops).
  */
-static bool pc_autobonus_source(struct map_session_data *sd, const struct s_autobonus *autobonus, int *out_index)
+static bool autobonus_source_resolve(struct map_session_data *sd, const struct s_autobonus *autobonus, int *out_index)
 {
 	const struct s_autobonus_source *source;
 
@@ -2417,7 +2417,7 @@ static int pc_delautobonus(struct map_session_data *sd, struct s_autobonus *auto
 		if( autobonus[i].active != INVALID_TIMER )
 		{
 			int index;
-			bool source_active = pc_autobonus_source(sd, &autobonus[i], &index);
+			bool source_active = autobonus_source_resolve(sd, &autobonus[i], &index);
 
 			if( restore && source_active )
 			{
@@ -2451,7 +2451,7 @@ static int pc_exeautobonus(struct map_session_data *sd, struct s_autobonus *auto
 	if( autobonus->other_script )
 	{
 		int index;
-		if (pc_autobonus_source(sd, autobonus, &index))
+		if (autobonus_source_resolve(sd, autobonus, &index))
 			script->run_autobonus(autobonus->other_script,sd->bl.id,index);
 	}
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -167,12 +167,27 @@ struct s_add_drop {
 	int id;
 	int race, rate;
 };
+/**
+ * Identifies what granted an autobonus: an equipped item (pos, card_id == 0),
+ * a card socketed in an equipped item (pos + card_id), an item combo
+ * (combo_pos), or a pet's equip script (pet_id). Exactly one of
+ * pos/combo_pos/pet_id is expected to be non-zero for any given source.
+ *
+ * combo_pos stores (itemdb combo id + 1), since combo ids are 0-based and 0
+ * here means "not combo-sourced".
+ */
+struct s_autobonus_source {
+	unsigned int pos;
+	int card_id;
+	int combo_pos;
+	int pet_id;
+};
 struct s_autobonus {
 	int rate,atk_type;
 	unsigned int duration;
 	char *bonus_script, *other_script;
 	int active;
-	unsigned int pos;
+	struct s_autobonus_source source;
 };
 enum npc_timeout_type {
 	NPCT_INPUT = 0,
@@ -255,7 +270,6 @@ struct map_session_data {
 		int autolootid[AUTOLOOTITEM_SIZE]; // [Zephyrus]
 		unsigned int autoloottype;
 		unsigned int autolooting : 1; //performance-saver, autolooting state for @alootid
-		unsigned int autobonus; //flag to indicate if an autobonus is activated. [Inkfish]
 		unsigned int gmaster_flag : 1;
 		unsigned int prevend : 1;//used to flag wheather you've spent 40sp to open the vending or not.
 		unsigned int warping : 1;//states whether you're in the middle of a warp processing
@@ -1045,10 +1059,11 @@ END_ZEROED_BLOCK; /* End */
 
 	int (*updateweightstatus) (struct map_session_data *sd);
 
-	int (*addautobonus) (struct s_autobonus *bonus,char max,const char *bonus_script,short rate,unsigned int dur,short atk_type,const char *o_script,unsigned int pos,bool onskill);
+	int (*addautobonus) (struct s_autobonus *bonus,char max,const char *bonus_script,short rate,unsigned int dur,short atk_type,const char *o_script,const struct s_autobonus_source *source,bool onskill);
 	int (*exeautobonus) (struct map_session_data* sd,struct s_autobonus *bonus);
 	int (*endautobonus) (int tid, int64 tick, int id, intptr_t data);
 	int (*delautobonus) (struct map_session_data* sd,struct s_autobonus *bonus,char max,bool restore);
+	bool (*autobonus_is_active) (struct s_autobonus *bonus,char max,const struct s_autobonus_source *source);
 
 	void (*bonus_addele) (struct map_session_data* sd, unsigned char ele, short rate, short flag);
 	void (*bonus_subele) (struct map_session_data* sd, unsigned char ele, short rate, short flag);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11159,7 +11159,7 @@ static BUILDIN(bonus)
  * Returns false if autobonus() was called outside of any of those contexts
  * (e.g. from a plain NPC script), in which case the caller should no-op.
  */
-static bool script_autobonus_source(struct map_session_data *sd, struct s_autobonus_source *out_source)
+static bool autobonus_source_from_script_context(struct map_session_data *sd, struct s_autobonus_source *out_source)
 {
 	nullpo_retr(false, sd);
 	nullpo_retr(false, out_source);
@@ -11195,7 +11195,7 @@ static BUILDIN(autobonus)
 	if (sd == NULL)
 		return true; // no player attached
 
-	if (!script_autobonus_source(sd, &source))
+	if (!autobonus_source_from_script_context(sd, &source))
 		return true;
 	if (pc->autobonus_is_active(sd->autobonus, ARRAYLENGTH(sd->autobonus), &source))
 		return true;
@@ -11233,7 +11233,7 @@ static BUILDIN(autobonus2)
 	if (sd == NULL)
 		return true; // no player attached
 
-	if (!script_autobonus_source(sd, &source))
+	if (!autobonus_source_from_script_context(sd, &source))
 		return true;
 	if (pc->autobonus_is_active(sd->autobonus2, ARRAYLENGTH(sd->autobonus2), &source))
 		return true;
@@ -11270,7 +11270,7 @@ static BUILDIN(autobonus3)
 	if (sd == NULL)
 		return true; // no player attached
 
-	if (!script_autobonus_source(sd, &source))
+	if (!autobonus_source_from_script_context(sd, &source))
 		return true;
 	if (pc->autobonus_is_active(sd->autobonus3, ARRAYLENGTH(sd->autobonus3), &source))
 		return true;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11150,17 +11150,54 @@ static BUILDIN(bonus)
 	return true;
 }
 
+/**
+ * Resolves the identity of the autobonus source currently executing a script
+ * (an equipped item, a card socketed in an equipped item, an item combo, or
+ * a pet), from the context globals set by status_calc_pc_() around each kind
+ * of script execution.
+ *
+ * Returns false if autobonus() was called outside of any of those contexts
+ * (e.g. from a plain NPC script), in which case the caller should no-op.
+ */
+static bool script_autobonus_source(struct map_session_data *sd, struct s_autobonus_source *out_source)
+{
+	nullpo_retr(false, sd);
+	nullpo_retr(false, out_source);
+	memset(out_source, 0, sizeof(*out_source));
+
+	if (status->current_equip_combo_pos != 0) {
+		out_source->combo_pos = status->current_equip_combo_pos;
+		return true;
+	}
+
+	if (status->current_equip_pet_id != 0) {
+		out_source->pet_id = status->current_equip_pet_id;
+		return true;
+	}
+
+	if (status->current_equip_item_index >= 0) {
+		out_source->pos = sd->status.inventory[status->current_equip_item_index].equip;
+		out_source->card_id = status->current_equip_card_id;
+		return out_source->pos != 0;
+	}
+
+	return false;
+}
+
 static BUILDIN(autobonus)
 {
 	unsigned int dur;
 	short rate;
 	short atk_type = 0;
 	const char *bonus_script, *other_script = NULL;
+	struct s_autobonus_source source;
 	struct map_session_data *sd = script->rid2sd(st);
 	if (sd == NULL)
 		return true; // no player attached
 
-	if (status->current_equip_item_index < 0 || sd->state.autobonus&sd->status.inventory[status->current_equip_item_index].equip)
+	if (!script_autobonus_source(sd, &source))
+		return true;
+	if (pc->autobonus_is_active(sd->autobonus, ARRAYLENGTH(sd->autobonus), &source))
 		return true;
 
 	rate = script_getnum(st,3);
@@ -11175,7 +11212,7 @@ static BUILDIN(autobonus)
 		other_script = script_getstr(st,6);
 
 	if( pc->addautobonus(sd->autobonus,ARRAYLENGTH(sd->autobonus),bonus_script,rate,dur,atk_type,other_script,
-	                     sd->status.inventory[status->current_equip_item_index].equip,false)
+	                     &source,false)
 	) {
 		script->add_autobonus(bonus_script);
 		if( other_script )
@@ -11191,11 +11228,14 @@ static BUILDIN(autobonus2)
 	short rate;
 	short atk_type = 0;
 	const char *bonus_script, *other_script = NULL;
+	struct s_autobonus_source source;
 	struct map_session_data *sd = script->rid2sd(st);
 	if (sd == NULL)
 		return true; // no player attached
 
-	if (status->current_equip_item_index < 0 || sd->state.autobonus&sd->status.inventory[status->current_equip_item_index].equip)
+	if (!script_autobonus_source(sd, &source))
+		return true;
+	if (pc->autobonus_is_active(sd->autobonus2, ARRAYLENGTH(sd->autobonus2), &source))
 		return true;
 
 	rate = script_getnum(st,3);
@@ -11210,7 +11250,7 @@ static BUILDIN(autobonus2)
 		other_script = script_getstr(st,6);
 
 	if( pc->addautobonus(sd->autobonus2,ARRAYLENGTH(sd->autobonus2),bonus_script,rate,dur,atk_type,other_script,
-	                     sd->status.inventory[status->current_equip_item_index].equip,false)
+	                     &source,false)
 	) {
 		script->add_autobonus(bonus_script);
 		if( other_script )
@@ -11225,11 +11265,14 @@ static BUILDIN(autobonus3)
 	unsigned int dur;
 	short rate,atk_type;
 	const char *bonus_script, *other_script = NULL;
+	struct s_autobonus_source source;
 	struct map_session_data *sd = script->rid2sd(st);
 	if (sd == NULL)
 		return true; // no player attached
 
-	if (status->current_equip_item_index < 0 || sd->state.autobonus&sd->status.inventory[status->current_equip_item_index].equip)
+	if (!script_autobonus_source(sd, &source))
+		return true;
+	if (pc->autobonus_is_active(sd->autobonus3, ARRAYLENGTH(sd->autobonus3), &source))
 		return true;
 
 	rate = script_getnum(st,3);
@@ -11243,7 +11286,7 @@ static BUILDIN(autobonus3)
 		other_script = script_getstr(st,6);
 
 	if( pc->addautobonus(sd->autobonus3,ARRAYLENGTH(sd->autobonus3),bonus_script,rate,dur,atk_type,other_script,
-	                     sd->status.inventory[status->current_equip_item_index].equip,true)
+	                     &source,true)
 	) {
 		script->add_autobonus(bonus_script);
 		if( other_script )

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -1562,6 +1562,7 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 	// Parse equipment.
 	for(i=0;i<EQI_MAX;i++) {
 		status->current_equip_item_index = index = sd->equip_index[i]; //We pass INDEX to status->current_equip_item_index - for EQUIP_SCRIPT (new cards solution) [Lupus]
+		status->current_equip_card_id = 0; // This is the item's own script, not a card's; stops autobonus() from misattributing it to whatever card was last processed.
 		if(index < 0)
 			continue;
 		if(i == EQI_AMMO) continue;/* ammo has special handler down there */
@@ -1679,7 +1680,8 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 	}
 
 	if(sd->equip_index[EQI_AMMO] >= 0){
-		index = sd->equip_index[EQI_AMMO];
+		status->current_equip_item_index = index = sd->equip_index[EQI_AMMO];
+		status->current_equip_card_id = 0; // Ammo cannot hold cards; this is always the ammo item's own script.
 		if (sd->inventory_data[index]) {
 			// Arrows
 			sd->bonus.arrow_atk += sd->inventory_data[index]->atk;
@@ -1713,7 +1715,9 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 		if( j != combo->count )
 			continue;
 
+		status->current_equip_combo_pos = sd->combos[i].id + 1; // +1: 0 is reserved to mean "no combo" (combo ids are 0-based)
 		script->run(sd->combos[i].bonus,0,sd->bl.id,0);
+		status->current_equip_combo_pos = 0;
 		if (!calculating) //Abort, script->run retriggered this.
 			return 1;
 	}
@@ -1787,6 +1791,7 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 	for (i = 0; i < EQI_MAX; i++) {
 		status->current_equip_item_index = index = sd->equip_index[i];
 		status->current_equip_option_index = -1;
+		status->current_equip_card_id = 0; // This is the item's own option script, not a card's; stops autobonus() from misattributing it to whatever card was last processed.
 
 		if (i == EQI_HAND_R && sd->equip_index[EQI_HAND_L] == index)
 			continue;
@@ -1815,6 +1820,7 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 
 	status->current_equip_option_index = -1;
 	status->current_equip_item_index = -1;
+	status->current_equip_card_id = 0;
 
 	// Clan Buffs
 	if (sd->status.clan_id > 0) {
@@ -1827,8 +1833,11 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 	if (sd->pd != NULL) { // Pet bonus.
 		struct pet_data *pd = sd->pd;
 
-		if (pd->petDB != NULL && pd->petDB->equip_script != NULL)
+		if (pd->petDB != NULL && pd->petDB->equip_script != NULL) {
+			status->current_equip_pet_id = pd->pet.pet_id;
 			script->run(pd->petDB->equip_script, 0, sd->bl.id, 0);
+			status->current_equip_pet_id = 0;
+		}
 
 		if (pd->pet.intimate > PET_INTIMACY_NONE && pd->state.skillbonus == 1 && pd->bonus != NULL
 		    && (battle_config.pet_equip_required == 0 || pd->pet.equip > 0)) {
@@ -15051,6 +15060,8 @@ void status_defaults(void)
 	//to avoid cards exploits
 	status->current_equip_item_index = 0; //Contains inventory index of an equipped item. To pass it into the EQUP_SCRIPT [Lupus]
 	status->current_equip_card_id = 0;    //To prevent card-stacking (from jA) [Skotlex]
+	status->current_equip_combo_pos = 0;  //Contains (itemdb combo id + 1) of the combo currently executing its bonus script, for autobonus. 0 means none.
+	status->current_equip_pet_id = 0;     //Contains the pet_id of the pet currently executing its equip/pet script, for autobonus.
 
 	// These macros are used instead of a sum of sizeof(), to ensure that padding won't interfere with our size, and code won't rot when adding more fields
 	memset(ZEROED_BLOCK_POS(status->dbs), 0, ZEROED_BLOCK_SIZE(status->dbs));

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -1407,6 +1407,8 @@ struct status_interface {
 	int current_equip_item_index;
 	int current_equip_card_id;
 	int current_equip_option_index;
+	int current_equip_combo_pos;
+	int current_equip_pet_id;
 
 	struct s_status_dbs *dbs;
 	VECTOR_DECL(struct s_unit_params) unit_params_groups;

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -7136,14 +7136,16 @@ typedef bool (*HPMHOOK_pre_pc_adoption) (struct map_session_data **p1_sd, struct
 typedef bool (*HPMHOOK_post_pc_adoption) (bool retVal___, struct map_session_data *p1_sd, struct map_session_data *p2_sd, struct map_session_data *b_sd);
 typedef int (*HPMHOOK_pre_pc_updateweightstatus) (struct map_session_data **sd);
 typedef int (*HPMHOOK_post_pc_updateweightstatus) (int retVal___, struct map_session_data *sd);
-typedef int (*HPMHOOK_pre_pc_addautobonus) (struct s_autobonus **bonus, char *max, const char **bonus_script, short *rate, unsigned int *dur, short *atk_type, const char **o_script, unsigned int *pos, bool *onskill);
-typedef int (*HPMHOOK_post_pc_addautobonus) (int retVal___, struct s_autobonus *bonus, char max, const char *bonus_script, short rate, unsigned int dur, short atk_type, const char *o_script, unsigned int pos, bool onskill);
+typedef int (*HPMHOOK_pre_pc_addautobonus) (struct s_autobonus **bonus, char *max, const char **bonus_script, short *rate, unsigned int *dur, short *atk_type, const char **o_script, const struct s_autobonus_source **source, bool *onskill);
+typedef int (*HPMHOOK_post_pc_addautobonus) (int retVal___, struct s_autobonus *bonus, char max, const char *bonus_script, short rate, unsigned int dur, short atk_type, const char *o_script, const struct s_autobonus_source *source, bool onskill);
 typedef int (*HPMHOOK_pre_pc_exeautobonus) (struct map_session_data **sd, struct s_autobonus **bonus);
 typedef int (*HPMHOOK_post_pc_exeautobonus) (int retVal___, struct map_session_data *sd, struct s_autobonus *bonus);
 typedef int (*HPMHOOK_pre_pc_endautobonus) (int *tid, int64 *tick, int *id, intptr_t *data);
 typedef int (*HPMHOOK_post_pc_endautobonus) (int retVal___, int tid, int64 tick, int id, intptr_t data);
 typedef int (*HPMHOOK_pre_pc_delautobonus) (struct map_session_data **sd, struct s_autobonus **bonus, char *max, bool *restore);
 typedef int (*HPMHOOK_post_pc_delautobonus) (int retVal___, struct map_session_data *sd, struct s_autobonus *bonus, char max, bool restore);
+typedef bool (*HPMHOOK_pre_pc_autobonus_is_active) (struct s_autobonus **bonus, char *max, const struct s_autobonus_source **source);
+typedef bool (*HPMHOOK_post_pc_autobonus_is_active) (bool retVal___, struct s_autobonus *bonus, char max, const struct s_autobonus_source *source);
 typedef void (*HPMHOOK_pre_pc_bonus_addele) (struct map_session_data **sd, unsigned char *ele, short *rate, short *flag);
 typedef void (*HPMHOOK_post_pc_bonus_addele) (struct map_session_data *sd, unsigned char ele, short rate, short flag);
 typedef void (*HPMHOOK_pre_pc_bonus_subele) (struct map_session_data **sd, unsigned char *ele, short *rate, short *flag);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -5122,6 +5122,8 @@ struct {
 	struct HPMHookPoint *HP_pc_endautobonus_post;
 	struct HPMHookPoint *HP_pc_delautobonus_pre;
 	struct HPMHookPoint *HP_pc_delautobonus_post;
+	struct HPMHookPoint *HP_pc_autobonus_is_active_pre;
+	struct HPMHookPoint *HP_pc_autobonus_is_active_post;
 	struct HPMHookPoint *HP_pc_bonus_addele_pre;
 	struct HPMHookPoint *HP_pc_bonus_addele_post;
 	struct HPMHookPoint *HP_pc_bonus_subele_pre;
@@ -12743,6 +12745,8 @@ struct {
 	int HP_pc_endautobonus_post;
 	int HP_pc_delautobonus_pre;
 	int HP_pc_delautobonus_post;
+	int HP_pc_autobonus_is_active_pre;
+	int HP_pc_autobonus_is_active_post;
 	int HP_pc_bonus_addele_pre;
 	int HP_pc_bonus_addele_post;
 	int HP_pc_bonus_subele_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -2626,6 +2626,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(pc->exeautobonus, HP_pc_exeautobonus) },
 	{ HP_POP(pc->endautobonus, HP_pc_endautobonus) },
 	{ HP_POP(pc->delautobonus, HP_pc_delautobonus) },
+	{ HP_POP(pc->autobonus_is_active, HP_pc_autobonus_is_active) },
 	{ HP_POP(pc->bonus_addele, HP_pc_bonus_addele) },
 	{ HP_POP(pc->bonus_subele, HP_pc_bonus_subele) },
 	{ HP_POP(pc->bonus, HP_pc_bonus) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -67977,15 +67977,15 @@ int HP_pc_updateweightstatus(struct map_session_data *sd) {
 	}
 	return retVal___;
 }
-int HP_pc_addautobonus(struct s_autobonus *bonus, char max, const char *bonus_script, short rate, unsigned int dur, short atk_type, const char *o_script, unsigned int pos, bool onskill) {
+int HP_pc_addautobonus(struct s_autobonus *bonus, char max, const char *bonus_script, short rate, unsigned int dur, short atk_type, const char *o_script, const struct s_autobonus_source *source, bool onskill) {
 	int hIndex = 0;
 	int retVal___ = 0;
 	if (HPMHooks.count.HP_pc_addautobonus_pre > 0) {
-		int (*preHookFunc) (struct s_autobonus **bonus, char *max, const char **bonus_script, short *rate, unsigned int *dur, short *atk_type, const char **o_script, unsigned int *pos, bool *onskill);
+		int (*preHookFunc) (struct s_autobonus **bonus, char *max, const char **bonus_script, short *rate, unsigned int *dur, short *atk_type, const char **o_script, const struct s_autobonus_source **source, bool *onskill);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_addautobonus_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_pc_addautobonus_pre[hIndex].func;
-			retVal___ = preHookFunc(&bonus, &max, &bonus_script, &rate, &dur, &atk_type, &o_script, &pos, &onskill);
+			retVal___ = preHookFunc(&bonus, &max, &bonus_script, &rate, &dur, &atk_type, &o_script, &source, &onskill);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -67993,13 +67993,13 @@ int HP_pc_addautobonus(struct s_autobonus *bonus, char max, const char *bonus_sc
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.pc.addautobonus(bonus, max, bonus_script, rate, dur, atk_type, o_script, pos, onskill);
+		retVal___ = HPMHooks.source.pc.addautobonus(bonus, max, bonus_script, rate, dur, atk_type, o_script, source, onskill);
 	}
 	if (HPMHooks.count.HP_pc_addautobonus_post > 0) {
-		int (*postHookFunc) (int retVal___, struct s_autobonus *bonus, char max, const char *bonus_script, short rate, unsigned int dur, short atk_type, const char *o_script, unsigned int pos, bool onskill);
+		int (*postHookFunc) (int retVal___, struct s_autobonus *bonus, char max, const char *bonus_script, short rate, unsigned int dur, short atk_type, const char *o_script, const struct s_autobonus_source *source, bool onskill);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_addautobonus_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_pc_addautobonus_post[hIndex].func;
-			retVal___ = postHookFunc(retVal___, bonus, max, bonus_script, rate, dur, atk_type, o_script, pos, onskill);
+			retVal___ = postHookFunc(retVal___, bonus, max, bonus_script, rate, dur, atk_type, o_script, source, onskill);
 		}
 	}
 	return retVal___;
@@ -68081,6 +68081,33 @@ int HP_pc_delautobonus(struct map_session_data *sd, struct s_autobonus *bonus, c
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_delautobonus_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_pc_delautobonus_post[hIndex].func;
 			retVal___ = postHookFunc(retVal___, sd, bonus, max, restore);
+		}
+	}
+	return retVal___;
+}
+bool HP_pc_autobonus_is_active(struct s_autobonus *bonus, char max, const struct s_autobonus_source *source) {
+	int hIndex = 0;
+	bool retVal___ = false;
+	if (HPMHooks.count.HP_pc_autobonus_is_active_pre > 0) {
+		bool (*preHookFunc) (struct s_autobonus **bonus, char *max, const struct s_autobonus_source **source);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_autobonus_is_active_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_pc_autobonus_is_active_pre[hIndex].func;
+			retVal___ = preHookFunc(&bonus, &max, &source);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.pc.autobonus_is_active(bonus, max, source);
+	}
+	if (HPMHooks.count.HP_pc_autobonus_is_active_post > 0) {
+		bool (*postHookFunc) (bool retVal___, struct s_autobonus *bonus, char max, const struct s_autobonus_source *source);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_autobonus_is_active_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_pc_autobonus_is_active_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, bonus, max, source);
 		}
 	}
 	return retVal___;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`autobonus()`/`autobonus2()`/`autobonus3()` identified the source of an autobonus purely by reading `status->current_equip_item_index` (an inventory index) and deriving an `EQP_*` position bitmask from it. That global was only correctly maintained by the plain equip-item loop and the card loop in `status_calc_pc_()`, so every other script-execution path silently failed to register a working autobonus:

- **Ammo**: the ammo script-execution block never set `status->current_equip_item_index`, so `autobonus()` called from an ammo item's script either no-op'd or registered against whatever equip slot was last processed by the main loop.
- **Item combos**: combo scripts have no single backing equip slot, so there was no way to give them a valid position at all.
- **Pets**: the pet equip-script block runs after `current_equip_item_index` is explicitly reset to `-1`, so `autobonus()` there was a guaranteed no-op.
- **Item + card collision**: an item's own script and a card socketed in it both run with `current_equip_item_index` pointing at the same inventory slot, so their autobonuses shared the exact same identity and could suppress or interfere with each other.

This PR replaces the single `EQP_*`-bitmask identity with a proper `struct s_autobonus_source { pos, card_id, combo_pos, pet_id }`, threaded through `pc_addautobonus`/`pc_delautobonus`/`pc_exeautobonus`/`autobonus_is_active` and the three `autobonus*()` builtins. New context globals (`current_equip_combo_pos`, `current_equip_pet_id`) mirror the existing `current_equip_card_id` pattern and are set around the combo and pet-equip script executions in `status_calc_pc_()`. The old `sd->state.autobonus` position bitmask (which could only represent one active autobonus per equip slot) is removed in favor of per-entry lookups that re-validate the exact source (equip slot + specific card, or specific combo id, or specific pet id) against the character's live state.

Also fixes a related gap: `pc_unequipitem()` used to clear autobonus activation via that same bitmask unconditionally on unequip; since `status_calc_pc()` isn't always called synchronously after an unequip (e.g. `PCUNEQUIPITEM_FORCE` without `PCUNEQUIPITEM_RECALC`), this PR now calls `pc->delautobonus(..., true)` directly in `pc_unequipitem()` so an unequipped item's autobonus timer is always stopped promptly regardless of the caller's recalc flag.

Regenerated the affected `HPMHooking` trampolines/typedefs by hand for the changed `pc->addautobonus`/new `pc->autobonus_is_active` interface entries, since `pc_addautobonus`'s signature changed; maintainers may want to re-run `HPMHookGen.pl` to confirm these match exactly.

**Issues addressed:** #2764

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style