### PR TITLE
Fix attack animation not showing to players who can only see the attacker

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -5120,6 +5120,72 @@ static int clif_calc_walkdelay(struct block_list *bl, int delay, int type, int d
 	return delay>0?delay:1; //Return 1 to specify there should be no noticeable delay, but you should stop walking.
 }
 
+/**
+ * Sub-function of clif_send_actionpacket(), forwards a single player to clif_send_sub().
+ *
+ * Called from a map_foreachinarea() over the attacker's area. Players who are also
+ * within the target's area are skipped, since they are already served by the area
+ * send centered on the target.
+ *
+ * @param bl The player to send the packet to.
+ * @param ap Additional arguments: buffer, length, target, send type, target (again).
+ * @return The return value of clif_send_sub(), or 0 if the player was skipped.
+ */
+static int clif_send_actionpacket_sub(struct block_list *bl, va_list ap)
+{
+	va_list apcopy;
+
+	nullpo_ret(bl);
+
+	va_copy(apcopy, ap);
+	(void)va_arg(apcopy, const void *); // buf
+	(void)va_arg(apcopy, int); // len
+	(void)va_arg(apcopy, struct block_list *); // src_bl
+	(void)va_arg(apcopy, int); // type
+	struct block_list *dst = va_arg(apcopy, struct block_list *);
+	va_end(apcopy);
+
+	nullpo_ret(dst);
+
+	// Already covered by the area send centered on the target.
+	if (bl->m == dst->m
+	    && bl->x >= dst->x - AREA_SIZE && bl->x <= dst->x + AREA_SIZE
+	    && bl->y >= dst->y - AREA_SIZE && bl->y <= dst->y + AREA_SIZE)
+		return 0;
+
+	return clif->send_sub(bl, ap);
+}
+
+/**
+ * Sends an action packet (attack or offensive skill) to every player who can see
+ * either the attacker or the target.
+ *
+ * A plain area send is centered on the target only, which makes the attacker look
+ * idle to players who can see the attacker but not the target. This happens as soon
+ * as the two are far enough apart for their view ranges to differ, which is most
+ * noticeable with ranged attackers. (bugreport:7375)
+ *
+ * @param buf The packet buffer.
+ * @param len The packet length.
+ * @param src The attacker.
+ * @param dst The target.
+ * @param type The send type to use (AREA or AREA_WOS, relative to the target).
+ */
+static void clif_send_actionpacket(const void *buf, int len, struct block_list *src, struct block_list *dst, enum send_target type)
+{
+	nullpo_retv(buf);
+	nullpo_retv(src);
+	nullpo_retv(dst);
+
+	clif->send(buf, len, dst, type);
+
+	if (src == dst)
+		return;
+
+	map->foreachinarea(clif->send_actionpacket_sub, src->m, src->x - AREA_SIZE, src->y - AREA_SIZE,
+	                   src->x + AREA_SIZE, src->y + AREA_SIZE, BL_PC, buf, len, dst, type, dst);
+}
+
 /// Sends a 'damage' packet (src performs action on dst)
 /// 008a <src ID>.L <dst ID>.L <server tick>.L <src speed>.L <dst speed>.L <damage>.W <div>.W <type>.B <damage2>.W (ZC_NOTIFY_ACT)
 /// 02e1 <src ID>.L <dst ID>.L <server tick>.L <src speed>.L <dst speed>.L <damage>.L <div>.W <type>.B <damage2>.L (ZC_NOTIFY_ACT2)
@@ -5181,11 +5247,11 @@ static int clif_damage(struct block_list *src, struct block_list *dst, int sdela
 #endif
 
 	if (clif->isdisguised(dst)) {
-		clif->send(&p,sizeof(p),dst,AREA_WOS);
+		clif->send_actionpacket(&p, sizeof(p), src, dst, AREA_WOS);
 		p.targetGID = -dst->id;
 		clif->send(&p,sizeof(p),dst,SELF);
 	} else {
-		clif->send(&p,sizeof(p),dst,AREA);
+		clif->send_actionpacket(&p, sizeof(p), src, dst, AREA);
 	}
 
 	if (clif->isdisguised(src)) {
@@ -5963,11 +6029,11 @@ static int clif_skill_damage(struct block_list *src, struct block_list *dst, int
 	p.action = type;
 
 	if (clif->isdisguised(dst)) {
-		clif->send(&p, sizeof(p), dst, AREA_WOS);
+		clif->send_actionpacket(&p, sizeof(p), src, dst, AREA_WOS);
 		p.targetID = -dst->id;
 		clif->send(&p, sizeof(p), dst, SELF);
 	} else {
-		clif->send(&p, sizeof(p), dst, AREA);
+		clif->send_actionpacket(&p, sizeof(p), src, dst, AREA);
 	}
 
 	if (clif->isdisguised(src)) {
@@ -26634,6 +26700,8 @@ void clif_defaults(void)
 	clif->refresh_ip = clif_refresh_ip;
 	clif->send = clif_send;
 	clif->send_sub = clif_send_sub;
+	clif->send_actionpacket_sub = clif_send_actionpacket_sub;
+	clif->send_actionpacket = clif_send_actionpacket;
 	clif->send_actual = clif_send_actual;
 	clif->parse = clif_parse;
 	clif->parse_cmd = clif_parse_cmd_optional;

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -958,6 +958,8 @@ struct clif_interface {
 	uint32 (*refresh_ip) (void);
 	bool (*send) (const void* buf, int len, struct block_list* bl, enum send_target type);
 	int (*send_sub) (struct block_list *bl, va_list ap);
+	int (*send_actionpacket_sub) (struct block_list *bl, va_list ap);
+	void (*send_actionpacket) (const void *buf, int len, struct block_list *src, struct block_list *dst, enum send_target type);
 	int (*send_actual) (int fd, void *buf, int len);
 	int (*parse) (int fd);
 	const struct s_packet_db *(*packet) (int packet_id);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -1324,6 +1324,10 @@ typedef bool (*HPMHOOK_pre_clif_send) (const void **buf, int *len, struct block_
 typedef bool (*HPMHOOK_post_clif_send) (bool retVal___, const void *buf, int len, struct block_list *bl, enum send_target type);
 typedef int (*HPMHOOK_pre_clif_send_sub) (struct block_list **bl, va_list ap);
 typedef int (*HPMHOOK_post_clif_send_sub) (int retVal___, struct block_list *bl, va_list ap);
+typedef int (*HPMHOOK_pre_clif_send_actionpacket_sub) (struct block_list **bl, va_list ap);
+typedef int (*HPMHOOK_post_clif_send_actionpacket_sub) (int retVal___, struct block_list *bl, va_list ap);
+typedef void (*HPMHOOK_pre_clif_send_actionpacket) (const void **buf, int *len, struct block_list **src, struct block_list **dst, enum send_target *type);
+typedef void (*HPMHOOK_post_clif_send_actionpacket) (const void *buf, int len, struct block_list *src, struct block_list *dst, enum send_target type);
 typedef int (*HPMHOOK_pre_clif_send_actual) (int *fd, void **buf, int *len);
 typedef int (*HPMHOOK_post_clif_send_actual) (int retVal___, int fd, void *buf, int len);
 typedef int (*HPMHOOK_pre_clif_parse) (int *fd);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -682,6 +682,10 @@ struct {
 	struct HPMHookPoint *HP_clif_send_post;
 	struct HPMHookPoint *HP_clif_send_sub_pre;
 	struct HPMHookPoint *HP_clif_send_sub_post;
+	struct HPMHookPoint *HP_clif_send_actionpacket_sub_pre;
+	struct HPMHookPoint *HP_clif_send_actionpacket_sub_post;
+	struct HPMHookPoint *HP_clif_send_actionpacket_pre;
+	struct HPMHookPoint *HP_clif_send_actionpacket_post;
 	struct HPMHookPoint *HP_clif_send_actual_pre;
 	struct HPMHookPoint *HP_clif_send_actual_post;
 	struct HPMHookPoint *HP_clif_parse_pre;
@@ -8303,6 +8307,10 @@ struct {
 	int HP_clif_send_post;
 	int HP_clif_send_sub_pre;
 	int HP_clif_send_sub_post;
+	int HP_clif_send_actionpacket_sub_pre;
+	int HP_clif_send_actionpacket_sub_post;
+	int HP_clif_send_actionpacket_pre;
+	int HP_clif_send_actionpacket_post;
 	int HP_clif_send_actual_pre;
 	int HP_clif_send_actual_post;
 	int HP_clif_parse_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -366,6 +366,8 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(clif->refresh_ip, HP_clif_refresh_ip) },
 	{ HP_POP(clif->send, HP_clif_send) },
 	{ HP_POP(clif->send_sub, HP_clif_send_sub) },
+	{ HP_POP(clif->send_actionpacket_sub, HP_clif_send_actionpacket_sub) },
+	{ HP_POP(clif->send_actionpacket, HP_clif_send_actionpacket) },
 	{ HP_POP(clif->send_actual, HP_clif_send_actual) },
 	{ HP_POP(clif->parse, HP_clif_parse) },
 	{ HP_POP(clif->packet, HP_clif_packet) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -8872,6 +8872,65 @@ int HP_clif_send_sub(struct block_list *bl, va_list ap) {
 	}
 	return retVal___;
 }
+int HP_clif_send_actionpacket_sub(struct block_list *bl, va_list ap) {
+	int hIndex = 0;
+	int retVal___ = 0;
+	if (HPMHooks.count.HP_clif_send_actionpacket_sub_pre > 0) {
+		int (*preHookFunc) (struct block_list **bl, va_list ap);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_send_actionpacket_sub_pre; hIndex++) {
+			va_list ap___copy; va_copy(ap___copy, ap);
+			preHookFunc = HPMHooks.list.HP_clif_send_actionpacket_sub_pre[hIndex].func;
+			retVal___ = preHookFunc(&bl, ap___copy);
+			va_end(ap___copy);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		va_list ap___copy; va_copy(ap___copy, ap);
+		retVal___ = HPMHooks.source.clif.send_actionpacket_sub(bl, ap___copy);
+		va_end(ap___copy);
+	}
+	if (HPMHooks.count.HP_clif_send_actionpacket_sub_post > 0) {
+		int (*postHookFunc) (int retVal___, struct block_list *bl, va_list ap);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_send_actionpacket_sub_post; hIndex++) {
+			va_list ap___copy; va_copy(ap___copy, ap);
+			postHookFunc = HPMHooks.list.HP_clif_send_actionpacket_sub_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, bl, ap___copy);
+			va_end(ap___copy);
+		}
+	}
+	return retVal___;
+}
+void HP_clif_send_actionpacket(const void *buf, int len, struct block_list *src, struct block_list *dst, enum send_target type) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_clif_send_actionpacket_pre > 0) {
+		void (*preHookFunc) (const void **buf, int *len, struct block_list **src, struct block_list **dst, enum send_target *type);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_send_actionpacket_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_clif_send_actionpacket_pre[hIndex].func;
+			preHookFunc(&buf, &len, &src, &dst, &type);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.clif.send_actionpacket(buf, len, src, dst, type);
+	}
+	if (HPMHooks.count.HP_clif_send_actionpacket_post > 0) {
+		void (*postHookFunc) (const void *buf, int len, struct block_list *src, struct block_list *dst, enum send_target type);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_send_actionpacket_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_clif_send_actionpacket_post[hIndex].func;
+			postHookFunc(buf, len, src, dst, type);
+		}
+	}
+	return;
+}
 int HP_clif_send_actual(int fd, void *buf, int len) {
 	int hIndex = 0;
 	int retVal___ = 0;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`ZC_NOTIFY_ACT` and `ZC_NOTIFY_SKILL` were broadcast with a plain `AREA` send centered on the **target**, so the recipient set was "players near the target" rather than "players who can see this fight". Any observer who is within view range of the attacker but outside the target's `AREA_SIZE` box receives nothing, and the attacker appears to stand idle while actually attacking.

This is most visible with ranged attackers, where the attacker and target are far enough apart that their view bubbles diverge significantly, but it affects melee too once the attacker sits at the very edge of the observer's view range. 


**Issues addressed:** #1016

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
