### PR TITLE
Fix no EXP gain when pk_mode is enabled

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2578,7 +2578,7 @@ static int mob_dead(struct mob_data *md, struct block_list *src, int type)
 	}
 
 	if( !(type&2) //No exp
-	 && (!map->list[m].flag.pvp || battle_config.pvp_exp) //Pvp no exp rule [MouseJstr]
+	 && (!map->list[m].flag.pvp || battle_config.pvp_exp || battle_config.pk_mode) //Pvp no exp rule [MouseJstr]; pk_mode forces pvp on all maps, so it must not be subject to this rule
 	 && (!md->master_id || md->special_state.ai == AI_NONE) //Only player-summoned mobs do not give exp. [Skotlex]
 	 && (!map->list[m].flag.nobaseexp || !map->list[m].flag.nojobexp) //Gives Exp
 	) { //Experience calculation.

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -6924,8 +6924,8 @@ static bool pc_gainexp(struct map_session_data *sd, struct block_list *src, uint
 	if (sd->bl.prev == NULL || pc_isdead(sd))
 		return false;
 
-	if (!battle_config.pvp_exp && map->list[sd->bl.m].flag.pvp)  // [MouseJstr]
-		return false; // no exp on pvp maps
+	if (!battle_config.pvp_exp && !battle_config.pk_mode && map->list[sd->bl.m].flag.pvp)  // [MouseJstr]
+		return false; // no exp on pvp maps; pk_mode forces pvp on all maps, so it must not be subject to this rule
 
 	if (pc_has_permission(sd,PC_PERM_DISABLE_EXP))
 		return false;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

When `pk_mode` is enabled, `map_default_addflag` in `map.c` forces `flag.pvp = 1` on every map on the server, not just designated PvP maps. Both `pc_gainexp` (pc.c) and `mob_dead` (mob.c) suppress EXP gain on any map with `flag.pvp` set, unless `pvp_exp` is also enabled.

As a result, a server configured with `pk_mode: yes` and `pvp_exp: false` (a plausible combination for an operator who assumes "PK mode" and "PvP" should share the same no-exp rule) silently stops awarding base/job EXP from mob kills everywhere on the server, at all levels — matching the symptom originally reported.

This PR exempts `pk_mode` from the PvP no-exp rule in both gating checks, since the PvP flag in this case is a `pk_mode` side effect rather than an indication of an actual PvP-designated map. `pk_mode`'s PvP-specific mechanics (death penalties, PK ranking, kill-steal handling, etc.) are untouched.

**Issues addressed:** #591
