### PR TITLE
Fix guild aura skills not working on pvp_noguild maps (fixes #793)

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7625,13 +7625,15 @@ static int battle_check_target(struct block_list *src, struct block_list *target
 		if (flag & (BCT_GUILD | BCT_ENEMY)) {
 			int s_guild = status->get_guild_id(s_bl);
 			int t_guild = status->get_guild_id(t_bl);
-			if (!(map->list[m].flag.pvp && map->list[m].flag.pvp_noguild)
-			 && s_guild && t_guild
+			if (s_guild != 0 && t_guild != 0
 			 && (s_guild == t_guild || (!(flag & BCT_SAMEGUILD) && guild->isallied(s_guild, t_guild)))
 			 && (!map->list[m].flag.battleground || sbg_id == tbg_id)
 			 && (!map->list[m].flag.cvc || s_clan == t_clan)
 			) {
-				state |= BCT_GUILD;
+				if (map->list[m].flag.pvp != 0 && map->list[m].flag.pvp_noguild != 0)
+					state |= flag & BCT_ENEMY ? BCT_ENEMY : BCT_GUILD;
+				else
+					state |= BCT_GUILD;
 			} else {
 				state |= BCT_ENEMY;
 			}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`battle_check_target()` forced `BCT_ENEMY` for any guild-relation query on maps with the `pvp_noguild` mapflag set, even pure guild-membership checks (`BCT_SAMEGUILD`, no `BCT_ENEMY` bit) that don't relate to combat at all. Guild Aura buff application (`GD_LEADERSHIP`, `GD_GLORYWOUNDS`, `GD_SOULCOLD`, `GD_HAWKEYES`) uses exactly this kind of query in `skill_unit_onplace()`, so the aura silently failed to buff guildmates on any `pvp_noguild` map (e.g. the default PvP arena maps), regardless of the `guild_aura` battle_config setting.

This change only forces `BCT_ENEMY` when the caller's `flag` actually includes `BCT_ENEMY` — i.e. real attack/targeting checks — so `pvp_noguild`'s intended behavior (guildmates can still damage each other on such maps) is preserved, while non-combat guild-membership queries like guild aura now resolve correctly. This mirrors the existing `BCT_PARTY`/`gvg_noparty` handling a few lines above in the same function.

**Issues addressed:** #793

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
