### PR TITLE
Fix input command freezing the client on invisible NPCs

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -2545,6 +2545,53 @@ static void clif_sendfakenpc(struct map_session_data *sd, int npcid)
 	WFIFOSET(fd, packet_len(0x78));
 }
 
+/**
+ * Checks whether a fake NPC unit has to be sent to the client before an NPC
+ * dialog packet referencing the given NPC ID.
+ *
+ * The client silently ignores dialog packets (input boxes in particular) that
+ * reference an NPC ID it doesn't know about, which leaves the player stuck in
+ * a script that never receives an answer. This is the case when the NPC was
+ * never spawned client side (invisible NPCs, @see clif_spawn) or when it is
+ * out of the character's sight.
+ *
+ * @param sd    The character the dialog is sent to.
+ * @param npcid The NPC ID referenced by the dialog packet.
+ * @retval true if clif->sendfakenpc() has to be called for the given NPC ID.
+ */
+static bool clif_npc_requires_fakenpc(struct map_session_data *sd, int npcid)
+{
+	nullpo_retr(false, sd);
+
+	if (sd->state.using_fake_npc != 0)
+		return false; // A fake NPC is already registered client side.
+
+	if (npcid == npc->fake_nd->bl.id)
+		return true;
+
+	struct block_list *bl = map->id2bl(npcid);
+	if (bl == NULL)
+		return false; // Nothing can be sent for an NPC that doesn't exist anymore.
+
+	if (bl->m != sd->bl.m
+	    || bl->x < sd->bl.x - AREA_SIZE - 1 || bl->x > sd->bl.x + AREA_SIZE + 1
+	    || bl->y < sd->bl.y - AREA_SIZE - 1 || bl->y > sd->bl.y + AREA_SIZE + 1)
+		return true; // Out of sight, so it was never sent to the client.
+
+	// Invisible units are not spawned client side either (@see clif_spawn).
+	struct view_data *vd = status->get_viewdata(bl);
+	if (vd == NULL || vd->class_ == INVISIBLE_CLASS)
+		return true;
+
+	if (bl->type == BL_NPC) {
+		struct npc_data *nd = BL_UCAST(BL_NPC, bl);
+		if (nd->chat_id == 0 && (nd->option & OPTION_INVISIBLE) != 0)
+			return true;
+	}
+
+	return false;
+}
+
 /// Displays an NPC dialog menu (ZC_MENU_LIST).
 /// 00b7 <packet len>.W <npc id>.L <menu items>.?B
 /// Client behavior:
@@ -2568,7 +2615,6 @@ static void clif_sendfakenpc(struct map_session_data *sd, int npcid)
 static void clif_scriptmenu(struct map_session_data *sd, int npcid, const char *mes)
 {
 	int fd, slen;
-	struct block_list *bl = NULL;
 
 	nullpo_retv(sd);
 	nullpo_retv(mes);
@@ -2577,9 +2623,7 @@ static void clif_scriptmenu(struct map_session_data *sd, int npcid, const char *
 	slen = (int)strlen(mes) + 9;
 	Assert_retv(slen <= INT16_MAX);
 
-	if (!sd->state.using_fake_npc && (npcid == npc->fake_nd->bl.id || ((bl = map->id2bl(npcid)) != NULL && (bl->m!=sd->bl.m ||
-						bl->x<sd->bl.x-AREA_SIZE-1 || bl->x>sd->bl.x+AREA_SIZE+1 ||
-						bl->y<sd->bl.y-AREA_SIZE-1 || bl->y>sd->bl.y+AREA_SIZE+1))))
+	if (clif->npc_requires_fakenpc(sd, npcid))
 		clif->sendfakenpc(sd, npcid);
 
 	pc->update_idle_time(sd, BCIDLE_SCRIPT);
@@ -2605,10 +2649,7 @@ static void clif_zc_quest_dialog_menu_list(struct map_session_data *sd, int npci
 
 	pc->update_idle_time(sd, BCIDLE_SCRIPT);
 
-	struct block_list *bl = NULL;
-	if (!sd->state.using_fake_npc && (npcid == npc->fake_nd->bl.id || ((bl = map->id2bl(npcid)) != NULL && (bl->m != sd->bl.m ||
-						bl->x < sd->bl.x - AREA_SIZE - 1 || bl->x > sd->bl.x + AREA_SIZE + 1 ||
-						bl->y < sd->bl.y - AREA_SIZE - 1 || bl->y > sd->bl.y + AREA_SIZE + 1)))) {
+	if (clif->npc_requires_fakenpc(sd, npcid)) {
 		clif->sendfakenpc(sd, npcid);
 	}
 
@@ -2637,13 +2678,10 @@ static void clif_zc_quest_dialog_menu_list(struct map_session_data *sd, int npci
 static void clif_scriptinput(struct map_session_data *sd, int npcid)
 {
 	int fd;
-	struct block_list *bl = NULL;
 
 	nullpo_retv(sd);
 
-	if (!sd->state.using_fake_npc && (npcid == npc->fake_nd->bl.id || ((bl = map->id2bl(npcid)) != NULL && (bl->m!=sd->bl.m ||
-						bl->x<sd->bl.x-AREA_SIZE-1 || bl->x>sd->bl.x+AREA_SIZE+1 ||
-						bl->y<sd->bl.y-AREA_SIZE-1 || bl->y>sd->bl.y+AREA_SIZE+1))))
+	if (clif->npc_requires_fakenpc(sd, npcid))
 		clif->sendfakenpc(sd, npcid);
 
 	pc->update_idle_time(sd, BCIDLE_SCRIPT);
@@ -2670,15 +2708,7 @@ static void clif_scriptinputstr(struct map_session_data *sd, int npcid)
 {
 	nullpo_retv(sd);
 
-	struct block_list *bl = map->id2bl(npcid);
-	int x1 = sd->bl.x - AREA_SIZE - 1;
-	int x2 = sd->bl.x + AREA_SIZE + 1;
-	int y1 = sd->bl.y - AREA_SIZE - 1;
-	int y2 = sd->bl.y + AREA_SIZE + 1;
-	bool out_of_sight = (bl != NULL && (bl->m != sd->bl.m || bl->x < x1 || bl->x > x2 || bl->y < y1 || bl->y > y2));
-
-	if (sd->state.using_fake_npc == 0 && sd->state.using_megaphone == 0
-	    && (npcid == npc->fake_nd->bl.id || out_of_sight)) {
+	if (sd->state.using_megaphone == 0 && clif->npc_requires_fakenpc(sd, npcid)) {
 		clif->sendfakenpc(sd, npcid);
 	}
 
@@ -26739,6 +26769,7 @@ void clif_defaults(void)
 	clif->scriptinputstr = clif_scriptinputstr;
 	clif->cutin = clif_cutin;
 	clif->sendfakenpc = clif_sendfakenpc;
+	clif->npc_requires_fakenpc = clif_npc_requires_fakenpc;
 	clif->scriptclear = clif_scriptclear;
 	/* client-user-interface-related */
 	clif->viewpoint = clif_viewpoint;

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -1068,6 +1068,7 @@ struct clif_interface {
 	void (*scriptinputstr) (struct map_session_data *sd, int npcid);
 	void (*cutin) (struct map_session_data* sd, const char* image, int type);
 	void (*sendfakenpc) (struct map_session_data *sd, int npcid);
+	bool (*npc_requires_fakenpc) (struct map_session_data *sd, int npcid);
 	void (*scriptclear) (struct map_session_data *sd, int npcid);
 	/* client-user-interface-related */
 	void (*viewpoint) (struct map_session_data *sd, int npc_id, int type, int x, int y, int id, int color);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -1526,6 +1526,8 @@ typedef void (*HPMHOOK_pre_clif_cutin) (struct map_session_data **sd, const char
 typedef void (*HPMHOOK_post_clif_cutin) (struct map_session_data *sd, const char *image, int type);
 typedef void (*HPMHOOK_pre_clif_sendfakenpc) (struct map_session_data **sd, int *npcid);
 typedef void (*HPMHOOK_post_clif_sendfakenpc) (struct map_session_data *sd, int npcid);
+typedef bool (*HPMHOOK_pre_clif_npc_requires_fakenpc) (struct map_session_data **sd, int *npcid);
+typedef bool (*HPMHOOK_post_clif_npc_requires_fakenpc) (bool retVal___, struct map_session_data *sd, int npcid);
 typedef void (*HPMHOOK_pre_clif_scriptclear) (struct map_session_data **sd, int *npcid);
 typedef void (*HPMHOOK_post_clif_scriptclear) (struct map_session_data *sd, int npcid);
 typedef void (*HPMHOOK_pre_clif_viewpoint) (struct map_session_data **sd, int *npc_id, int *type, int *x, int *y, int *id, int *color);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -884,6 +884,8 @@ struct {
 	struct HPMHookPoint *HP_clif_cutin_post;
 	struct HPMHookPoint *HP_clif_sendfakenpc_pre;
 	struct HPMHookPoint *HP_clif_sendfakenpc_post;
+	struct HPMHookPoint *HP_clif_npc_requires_fakenpc_pre;
+	struct HPMHookPoint *HP_clif_npc_requires_fakenpc_post;
 	struct HPMHookPoint *HP_clif_scriptclear_pre;
 	struct HPMHookPoint *HP_clif_scriptclear_post;
 	struct HPMHookPoint *HP_clif_viewpoint_pre;
@@ -8505,6 +8507,8 @@ struct {
 	int HP_clif_cutin_post;
 	int HP_clif_sendfakenpc_pre;
 	int HP_clif_sendfakenpc_post;
+	int HP_clif_npc_requires_fakenpc_pre;
+	int HP_clif_npc_requires_fakenpc_post;
 	int HP_clif_scriptclear_pre;
 	int HP_clif_scriptclear_post;
 	int HP_clif_viewpoint_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -467,6 +467,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(clif->scriptinputstr, HP_clif_scriptinputstr) },
 	{ HP_POP(clif->cutin, HP_clif_cutin) },
 	{ HP_POP(clif->sendfakenpc, HP_clif_sendfakenpc) },
+	{ HP_POP(clif->npc_requires_fakenpc, HP_clif_npc_requires_fakenpc) },
 	{ HP_POP(clif->scriptclear, HP_clif_scriptclear) },
 	{ HP_POP(clif->viewpoint, HP_clif_viewpoint) },
 	{ HP_POP(clif->damage, HP_clif_damage) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -11513,6 +11513,33 @@ void HP_clif_sendfakenpc(struct map_session_data *sd, int npcid) {
 	}
 	return;
 }
+bool HP_clif_npc_requires_fakenpc(struct map_session_data *sd, int npcid) {
+	int hIndex = 0;
+	bool retVal___ = false;
+	if (HPMHooks.count.HP_clif_npc_requires_fakenpc_pre > 0) {
+		bool (*preHookFunc) (struct map_session_data **sd, int *npcid);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_npc_requires_fakenpc_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_clif_npc_requires_fakenpc_pre[hIndex].func;
+			retVal___ = preHookFunc(&sd, &npcid);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.clif.npc_requires_fakenpc(sd, npcid);
+	}
+	if (HPMHooks.count.HP_clif_npc_requires_fakenpc_post > 0) {
+		bool (*postHookFunc) (bool retVal___, struct map_session_data *sd, int npcid);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_clif_npc_requires_fakenpc_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_clif_npc_requires_fakenpc_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, sd, npcid);
+		}
+	}
+	return retVal___;
+}
 void HP_clif_scriptclear(struct map_session_data *sd, int npcid) {
 	int hIndex = 0;
 	if (HPMHooks.count.HP_clif_scriptclear_pre > 0) {


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The client silently ignores NPC dialog packets (input boxes in particular) that reference an NPC ID it was never told to spawn. NPCs with sprite ID -1 (`INVISIBLE_CLASS`) or hidden via `OPTION_INVISIBLE` are deliberately skipped in `clif_spawn`, so when such an NPC calls `input`, the client has no record of its block ID and drops the resulting `ZC_OPEN_EDITDLG` packet, leaving the player stuck until they relog.

`clif_scriptmenu`, `clif_zc_quest_dialog_menu_list`, `clif_scriptinput`, and `clif_scriptinputstr` already special-cased two other conditions where the NPC wasn't spawned client-side (the fake NPC singleton, and out-of-sight NPCs) by sending a fake NPC unit first (`clif->sendfakenpc`), but none of them accounted for invisible NPCs. This PR extracts the duplicated guard logic into a single `clif->npc_requires_fakenpc()` function and adds the missing invisible-NPC check, mirroring the exact conditions `clif_spawn` uses to decide whether a unit needs spawning.

**Issues addressed:** #577

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style