### PR TITLE
Fix SC_STONE skipping OPT1_STONEWAIT for item-triggered petrify

### DIFF
--- a/doc/item_bonus.md
+++ b/doc/item_bonus.md
@@ -318,10 +318,13 @@ bonus2 bAddEff,`eff`,`n`;                    | Adds a `n`/100% chance to cause e
 bonus2 bAddEff2,`eff`,`n`;                   | Adds a `n`/100% chance to cause effect `eff` on self when attacking.
 bonus3 bAddEff,`eff`,`n`,`abf`;              | Adds a `n`/100% chance to cause effect `eff` to the target when attacking for target abf
 bonus4 bAddEff,`eff`,`n`,`abf`,`t`;          | Adds a `n`/100% chance to cause effect `eff` to the target when attacking for target `abf` for `t` milliseconds <br/> (Note:The effect can't be avoided nor its duration reduced. Duration: 0-65535)
+bonus5 bAddEff,`eff`,`n`,`abf`,`t`,`wait`;   | Same as the `bonus4` form, but also sets the opt1 wait/transition duration (in milliseconds) for effects that have one (currently only `SC_STONE`'s `OPT1_STONEWAIT`). If `wait` is 0 or omitted, a built-in default is used. Ignored by effects with no wait/transition state.
 bonus3 bAddEffOnSkill,`sk`,`eff`,`n`;        | Adds a `n`/100% chance to cause effect `eff` on enemy when using skill `sk`
 bonus4 bAddEffOnSkill,`sk`,`eff`,`n`,`abf`;  | Adds a `n`/100% chance to cause effect `eff` when using skill `sk`
+bonus5 bAddEffOnSkill,`sk`,`eff`,`n`,`abf`,`wait`; | Same as the `bonus4` form, but also sets the opt1 wait/transition duration (in milliseconds); see `bAddEff`'s `bonus5` form above.
 bonus2 bAddEffWhenHit,`eff`,`n`;             | `n`/100% chance to cause effect `eff` to the enemy when being hit by physical damage
 bonus3 bAddEffWhenHit,`eff`,`n`,`abf`;       | Adds a `n`/100% chance to cause effect `eff` to the enemy when being hit by physical damage
+bonus5 bAddEffWhenHit,`eff`,`n`,`abf`,`t`,`wait`; | Same as the `bonus3` form, but also sets a fixed duration `t` (in milliseconds) and the opt1 wait/transition duration `wait` (in milliseconds); see `bAddEff`'s `bonus5` form above. Pass 0 for `t` to keep the default, reducible duration.
 bonus2 bWeaponComaRace,`r`,`n`;              | Adds a `n`/100% chance to cause Coma when attacking a monster of race `r` with a weapon attack
 bonus2 bWeaponComaEle,`e`,`n`;               | Adds a `n`/100% chance to cause Coma when attacking a monster of element `e` with weapon attack
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -2184,7 +2184,7 @@ static int pc_bonus_autospell_onskill(struct s_autospell *spell, int max, short 
  * @retval 1 on success.
  * @retval 0 on failure.
  */
-static int pc_bonus_addeff(struct s_addeffect *effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration)
+static int pc_bonus_addeff(struct s_addeffect *effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration, uint16 wait_duration)
 {
 	int i;
 
@@ -2198,7 +2198,7 @@ static int pc_bonus_addeff(struct s_addeffect *effect, int max, enum sc_type id,
 
 	for (i = 0; i < max && effect[i].flag; i++) {
 		// Update existing effect if any.
-		if (effect[i].id == id && effect[i].flag == flag && effect[i].duration == duration) {
+		if (effect[i].id == id && effect[i].flag == flag && effect[i].duration == duration && effect[i].wait_duration == wait_duration) {
 			effect[i].rate += rate;
 			effect[i].arrow_rate += arrow_rate;
 			return 1;
@@ -2213,16 +2213,17 @@ static int pc_bonus_addeff(struct s_addeffect *effect, int max, enum sc_type id,
 	effect[i].arrow_rate = arrow_rate;
 	effect[i].flag = flag;
 	effect[i].duration = duration;
+	effect[i].wait_duration = wait_duration;
 	return 1;
 }
 
-static int pc_bonus_addeff_onskill(struct s_addeffectonskill *effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target)
+static int pc_bonus_addeff_onskill(struct s_addeffectonskill *effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target, uint16 wait_duration)
 {
 	int i;
 
 	nullpo_ret(effect);
 	for( i = 0; i < max && effect[i].skill; i++ ) {
-		if( effect[i].id == id && effect[i].skill == skill_id && effect[i].target == target ) {
+		if( effect[i].id == id && effect[i].skill == skill_id && effect[i].target == target && effect[i].wait_duration == wait_duration ) {
 			effect[i].rate += rate;
 			return 1;
 		}
@@ -2235,6 +2236,7 @@ static int pc_bonus_addeff_onskill(struct s_addeffectonskill *effect, int max, e
 	effect[i].rate = rate;
 	effect[i].skill = skill_id;
 	effect[i].target = target;
+	effect[i].wait_duration = wait_duration;
 	return 1;
 }
 
@@ -3230,7 +3232,7 @@ static int pc_bonus2(struct map_session_data *sd, int type, int type2, int val)
 				break;
 			}
 			pc->bonus_addeff(sd->addeff, ARRAYLENGTH(sd->addeff), (sc_type)type2,
-			                 sd->state.lr_flag!=2?val:0, sd->state.lr_flag==2?val:0, 0, 0);
+			                 sd->state.lr_flag!=2?val:0, sd->state.lr_flag==2?val:0, 0, 0, 0);
 			break;
 		case SP_ADDEFF2:
 			if (type2 > SC_MAX) {
@@ -3238,7 +3240,7 @@ static int pc_bonus2(struct map_session_data *sd, int type, int type2, int val)
 				break;
 			}
 			pc->bonus_addeff(sd->addeff, ARRAYLENGTH(sd->addeff), (sc_type)type2,
-			                 sd->state.lr_flag!=2?val:0, sd->state.lr_flag==2?val:0, ATF_SELF, 0);
+			                 sd->state.lr_flag!=2?val:0, sd->state.lr_flag==2?val:0, ATF_SELF, 0, 0);
 			break;
 		case SP_RESEFF:
 			if (type2 < SC_COMMON_MIN || type2 > SC_COMMON_MAX) {
@@ -3511,7 +3513,7 @@ static int pc_bonus2(struct map_session_data *sd, int type, int type2, int val)
 				break;
 			}
 			if(sd->state.lr_flag != 2)
-				pc->bonus_addeff(sd->addeff2, ARRAYLENGTH(sd->addeff2), (sc_type)type2, val, 0, 0, 0);
+				pc->bonus_addeff(sd->addeff2, ARRAYLENGTH(sd->addeff2), (sc_type)type2, val, 0, 0, 0, 0);
 			break;
 		case SP_SKILL_ATK:
 			if(sd->state.lr_flag == 2)
@@ -4058,7 +4060,7 @@ static int pc_bonus3(struct map_session_data *sd, int type, int type2, int type3
 				break;
 			}
 			pc->bonus_addeff(sd->addeff, ARRAYLENGTH(sd->addeff), (sc_type)type2,
-			                 sd->state.lr_flag!=2?type3:0, sd->state.lr_flag==2?type3:0, val, 0);
+			                 sd->state.lr_flag!=2?type3:0, sd->state.lr_flag==2?type3:0, val, 0, 0);
 			break;
 
 		case SP_ADDEFF_WHENHIT:
@@ -4067,7 +4069,7 @@ static int pc_bonus3(struct map_session_data *sd, int type, int type2, int type3
 				break;
 			}
 			if(sd->state.lr_flag != 2)
-				pc->bonus_addeff(sd->addeff2, ARRAYLENGTH(sd->addeff2), (sc_type)type2, type3, 0, val, 0);
+				pc->bonus_addeff(sd->addeff2, ARRAYLENGTH(sd->addeff2), (sc_type)type2, type3, 0, val, 0, 0);
 			break;
 
 		case SP_ADDEFF_ONSKILL:
@@ -4076,7 +4078,7 @@ static int pc_bonus3(struct map_session_data *sd, int type, int type2, int type3
 				break;
 			}
 			if( sd->state.lr_flag != 2 )
-				pc->bonus_addeff_onskill(sd->addeff3, ARRAYLENGTH(sd->addeff3), (sc_type)type3, val, type2, ATF_TARGET);
+				pc->bonus_addeff_onskill(sd->addeff3, ARRAYLENGTH(sd->addeff3), (sc_type)type3, val, type2, ATF_TARGET, 0);
 			break;
 
 		case SP_ADDELE:
@@ -4225,7 +4227,7 @@ static int pc_bonus4(struct map_session_data *sd, int type, int type2, int type3
 			break;
 		}
 		if( sd->state.lr_flag != 2 )
-			pc->bonus_addeff_onskill(sd->addeff3, ARRAYLENGTH(sd->addeff3), (sc_type)type3, type4, type2, val);
+			pc->bonus_addeff_onskill(sd->addeff3, ARRAYLENGTH(sd->addeff3), (sc_type)type3, type4, type2, val, 0);
 		break;
 
 	case SP_SET_DEF_RACE: //bonus4 bSetDefRace,n,x,r,y;
@@ -4277,7 +4279,7 @@ static int pc_bonus4(struct map_session_data *sd, int type, int type2, int type3
 		}
 
 		pc->bonus_addeff(sd->addeff, ARRAYLENGTH(sd->addeff), (sc_type)type2,
-		                 sd->state.lr_flag!=2?type3:0, sd->state.lr_flag==2?type3:0, type4, duration);
+		                 sd->state.lr_flag!=2?type3:0, sd->state.lr_flag==2?type3:0, type4, duration, 0);
 	}
 		break;
 
@@ -4308,6 +4310,53 @@ static int pc_bonus5(struct map_session_data *sd, int type, int type2, int type3
 		case SP_AUTOSPELL_ONSKILL:
 			if(sd->state.lr_flag != 2)
 				pc->bonus_autospell_onskill(sd->autospell3, ARRAYLENGTH(sd->autospell3), type2, (val&1) ? -type3 : type3, (val&2) ? -type4 : type4, type5, status->current_equip_card_id);
+			break;
+
+		case SP_ADDEFF: //bonus5 bAddEff,sc,rate,flag,duration,wait;
+		{
+			uint16 duration;
+			if (type2 > SC_MAX) {
+				ShowWarning("pc_bonus5 (Add Effect): %d is not supported.\n", type2);
+				break;
+			}
+			if (type5 < 0 || type5 > UINT16_MAX) {
+				ShowWarning("pc_bonus5 (Add Effect): invalid duration %d. Valid range: [0:%d].\n", type5, UINT16_MAX);
+				duration = (type5 < 0 ? 0 : UINT16_MAX);
+			} else {
+				duration = (uint16)type5;
+			}
+
+			pc->bonus_addeff(sd->addeff, ARRAYLENGTH(sd->addeff), (sc_type)type2,
+			                 sd->state.lr_flag!=2?type3:0, sd->state.lr_flag==2?type3:0, type4, duration, (uint16)cap_value(val, 0, UINT16_MAX));
+		}
+			break;
+
+		case SP_ADDEFF_ONSKILL: //bonus5 bAddEffOnSkill,skill,sc,rate,target,wait;
+			if (type3 > SC_MAX) {
+				ShowWarning("pc_bonus5 (Add Effect on skill): %d is not supported.\n", type3);
+				break;
+			}
+			if (sd->state.lr_flag != 2)
+				pc->bonus_addeff_onskill(sd->addeff3, ARRAYLENGTH(sd->addeff3), (sc_type)type3, type4, type2, type5, (uint16)cap_value(val, 0, UINT16_MAX));
+			break;
+
+		case SP_ADDEFF_WHENHIT: //bonus5 bAddEffWhenHit,sc,rate,flag,duration,wait;
+		{
+			uint16 duration;
+			if (type2 > SC_MAX) {
+				ShowWarning("pc_bonus5 (Add Effect when hit): %d is not supported.\n", type2);
+				break;
+			}
+			if (type5 < 0 || type5 > UINT16_MAX) {
+				ShowWarning("pc_bonus5 (Add Effect when hit): invalid duration %d. Valid range: [0:%d].\n", type5, UINT16_MAX);
+				duration = (type5 < 0 ? 0 : UINT16_MAX);
+			} else {
+				duration = (uint16)type5;
+			}
+
+			if (sd->state.lr_flag != 2)
+				pc->bonus_addeff(sd->addeff2, ARRAYLENGTH(sd->addeff2), (sc_type)type2, type3, 0, type4, duration, (uint16)cap_value(val, 0, UINT16_MAX));
+		}
 			break;
 
 		default:

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -150,17 +150,18 @@ struct s_autospell {
 };
 /// AddEff bonus data
 struct s_addeffect {
-	enum sc_type id;  ///< Effect ID
-	int16 rate;       ///< Base success rate
-	int16 arrow_rate; ///< Success rate modifier for ranged attacks (adds to the base rate)
-	uint8 flag;       ///< Trigger flag (@see enum auto_trigger_flag)
-	uint16 duration;  ///< Optional, non-reducible duration in ms. If 0, the default, reducible effect's duration is used.
-	// TODO[Haru]: Duration is only used in addeff (set through bonus4 bAddEff). The other addeffect types could also use it.
+	enum sc_type id;      ///< Effect ID
+	int16 rate;           ///< Base success rate
+	int16 arrow_rate;     ///< Success rate modifier for ranged attacks (adds to the base rate)
+	uint8 flag;           ///< Trigger flag (@see enum auto_trigger_flag)
+	uint16 duration;      ///< Optional, non-reducible duration in ms. If 0, the default, reducible effect's duration is used.
+	uint16 wait_duration; ///< Optional wait/transition duration in ms, for opt1 states that use one (e.g. OPT1_STONEWAIT for SC_STONE). Ignored by effects that don't use it. If 0, a built-in default is used.
 };
 struct s_addeffectonskill {
 	enum sc_type id;
 	int rate, skill;
 	unsigned char target;
+	uint16 wait_duration; ///< @see s_addeffect::wait_duration
 };
 struct s_add_drop {
 	bool is_group;
@@ -1229,8 +1230,8 @@ END_ZEROED_BLOCK; /* End */
 	void (*check_skilltree) (struct map_session_data *sd, int skill_id);
 	int (*bonus_autospell) (struct s_autospell *spell, int max, short id, short lv, short rate, short flag, int card_id);
 	int (*bonus_autospell_onskill) (struct s_autospell *spell, int max, short src_skill, short id, short lv, short rate, int card_id);
-	int (*bonus_addeff) (struct s_addeffect* effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration);
-	int (*bonus_addeff_onskill) (struct s_addeffectonskill* effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target);
+	int (*bonus_addeff) (struct s_addeffect* effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration, uint16 wait_duration);
+	int (*bonus_addeff_onskill) (struct s_addeffectonskill* effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target, uint16 wait_duration);
 	int (*bonus_item_drop) (struct s_add_drop *drop, const short max, int id, bool is_group, int race, int rate);
 	void (*calcexp) (struct map_session_data *sd, uint64 *base_exp, uint64 *job_exp, struct block_list *src, enum gainexp_flags flags);
 	int (*respawn_timer) (int tid, int64 tick, int id, intptr_t data);

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -69,6 +69,10 @@
 
 #define SKILLUNITTIMER_INTERVAL 100
 
+/// Default OPT1_STONEWAIT duration (ms) for SC_STONE triggered by an addeff-family
+/// item bonus (bAddEff, bAddEffWhenHit, bAddEffOnSkill) that doesn't specify one explicitly.
+#define SKILL_ADDEFF_STONEWAIT_DEFAULT 1000
+
 static struct skill_interface skill_s;
 static struct s_skill_dbs skilldbs;
 
@@ -1599,11 +1603,17 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 					flag = SCFLAG_NONE;
 				}
 
-				if (sd->addeff[i].flag&ATF_TARGET)
-					status->change_start(src, bl, type, rate, 7, 0, (type == SC_BURNING) ? src->id : 0, 0, temp, flag, skill_id);
+				{
+					int val4 = sd->addeff[i].wait_duration;
+					if (val4 == 0 && type == SC_STONE)
+						val4 = SKILL_ADDEFF_STONEWAIT_DEFAULT;
 
-				if (sd->addeff[i].flag&ATF_SELF)
-					status->change_start(src, src, type, rate, 7, 0, (type == SC_BURNING) ? src->id : 0, 0, temp, flag, skill_id);
+					if (sd->addeff[i].flag&ATF_TARGET)
+						status->change_start(src, bl, type, rate, 7, 0, (type == SC_BURNING) ? src->id : 0, val4, temp, flag, skill_id);
+
+					if (sd->addeff[i].flag&ATF_SELF)
+						status->change_start(src, src, type, rate, 7, 0, (type == SC_BURNING) ? src->id : 0, val4, temp, flag, skill_id);
+				}
 			}
 		}
 
@@ -1612,15 +1622,20 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 			enum sc_type type;
 			int i;
 			for( i = 0; i < ARRAYLENGTH(sd->addeff3) && sd->addeff3[i].skill; i++ ) {
+				int val4;
 				if( skill_id != sd->addeff3[i].skill || !sd->addeff3[i].rate )
 					continue;
 				type = sd->addeff3[i].id;
 				temp = skill->get_time2(status->sc2skill(type),7);
 
+				val4 = sd->addeff3[i].wait_duration;
+				if (val4 == 0 && type == SC_STONE)
+					val4 = SKILL_ADDEFF_STONEWAIT_DEFAULT;
+
 				if( sd->addeff3[i].target&ATF_TARGET )
-					status->change_start(src, bl, type, sd->addeff3[i].rate, 7, 0, 0, 0, temp, SCFLAG_NONE, skill_id);
+					status->change_start(src, bl, type, sd->addeff3[i].rate, 7, 0, 0, val4, temp, SCFLAG_NONE, skill_id);
 				if( sd->addeff3[i].target&ATF_SELF )
-					status->change_start(src, src, type, sd->addeff3[i].rate, 7, 0, 0, 0, temp, SCFLAG_NONE, skill_id);
+					status->change_start(src, src, type, sd->addeff3[i].rate, 7, 0, 0, val4, temp, SCFLAG_NONE, skill_id);
 			}
 		}
 	}
@@ -2734,7 +2749,7 @@ static int skill_counter_additional_effect(struct block_list *src, struct block_
 	if(dstsd && attack_type&BF_WEAPON) {
 		//Counter effects.
 		enum sc_type type;
-		int i, time;
+		int i, time, sc_flag;
 		for(i=0; i < ARRAYLENGTH(dstsd->addeff2) && dstsd->addeff2[i].flag; i++) {
 			rate = dstsd->addeff2[i].rate;
 			if (attack_type&BF_LONG)
@@ -2748,13 +2763,28 @@ static int skill_counter_additional_effect(struct block_list *src, struct block_
 					continue; //Range Failed.
 			}
 			type = dstsd->addeff2[i].id;
-			time = skill->get_time2(status->sc2skill(type),7);
 
-			if (dstsd->addeff2[i].flag&ATF_TARGET)
-				status->change_start(bl, src, type, rate, 7, 0, 0, 0, time, SCFLAG_NONE, skill_id);
+			if (dstsd->addeff2[i].duration > 0) {
+				// Fixed duration
+				time = dstsd->addeff2[i].duration;
+				sc_flag = SCFLAG_FIXEDRATE|SCFLAG_FIXEDTICK;
+			} else {
+				// Default duration
+				time = skill->get_time2(status->sc2skill(type),7);
+				sc_flag = SCFLAG_NONE;
+			}
 
-			if (dstsd->addeff2[i].flag&ATF_SELF && !status->isdead(bl))
-				status->change_start(bl, bl, type, rate, 7, 0, 0, 0, time, SCFLAG_NONE, skill_id);
+			{
+				int val4 = dstsd->addeff2[i].wait_duration;
+				if (val4 == 0 && type == SC_STONE)
+					val4 = SKILL_ADDEFF_STONEWAIT_DEFAULT;
+
+				if (dstsd->addeff2[i].flag&ATF_TARGET)
+					status->change_start(bl, src, type, rate, 7, 0, 0, val4, time, sc_flag, skill_id);
+
+				if (dstsd->addeff2[i].flag&ATF_SELF && !status->isdead(bl))
+					status->change_start(bl, bl, type, rate, 7, 0, 0, val4, time, sc_flag, skill_id);
+			}
 		}
 	}
 

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -7446,10 +7446,10 @@ typedef int (*HPMHOOK_pre_pc_bonus_autospell) (struct s_autospell **spell, int *
 typedef int (*HPMHOOK_post_pc_bonus_autospell) (int retVal___, struct s_autospell *spell, int max, short id, short lv, short rate, short flag, int card_id);
 typedef int (*HPMHOOK_pre_pc_bonus_autospell_onskill) (struct s_autospell **spell, int *max, short *src_skill, short *id, short *lv, short *rate, int *card_id);
 typedef int (*HPMHOOK_post_pc_bonus_autospell_onskill) (int retVal___, struct s_autospell *spell, int max, short src_skill, short id, short lv, short rate, int card_id);
-typedef int (*HPMHOOK_pre_pc_bonus_addeff) (struct s_addeffect **effect, int *max, enum sc_type *id, int16 *rate, int16 *arrow_rate, uint8 *flag, uint16 *duration);
-typedef int (*HPMHOOK_post_pc_bonus_addeff) (int retVal___, struct s_addeffect *effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration);
-typedef int (*HPMHOOK_pre_pc_bonus_addeff_onskill) (struct s_addeffectonskill **effect, int *max, enum sc_type *id, short *rate, short *skill_id, unsigned char *target);
-typedef int (*HPMHOOK_post_pc_bonus_addeff_onskill) (int retVal___, struct s_addeffectonskill *effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target);
+typedef int (*HPMHOOK_pre_pc_bonus_addeff) (struct s_addeffect **effect, int *max, enum sc_type *id, int16 *rate, int16 *arrow_rate, uint8 *flag, uint16 *duration, uint16 *wait_duration);
+typedef int (*HPMHOOK_post_pc_bonus_addeff) (int retVal___, struct s_addeffect *effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration, uint16 wait_duration);
+typedef int (*HPMHOOK_pre_pc_bonus_addeff_onskill) (struct s_addeffectonskill **effect, int *max, enum sc_type *id, short *rate, short *skill_id, unsigned char *target, uint16 *wait_duration);
+typedef int (*HPMHOOK_post_pc_bonus_addeff_onskill) (int retVal___, struct s_addeffectonskill *effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target, uint16 wait_duration);
 typedef int (*HPMHOOK_pre_pc_bonus_item_drop) (struct s_add_drop **drop, const short *max, int *id, bool *is_group, int *race, int *rate);
 typedef int (*HPMHOOK_post_pc_bonus_item_drop) (int retVal___, struct s_add_drop *drop, const short max, int id, bool is_group, int race, int rate);
 typedef void (*HPMHOOK_pre_pc_calcexp) (struct map_session_data **sd, uint64 **base_exp, uint64 **job_exp, struct block_list **src, enum gainexp_flags *flags);

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -72134,15 +72134,15 @@ int HP_pc_bonus_autospell_onskill(struct s_autospell *spell, int max, short src_
 	}
 	return retVal___;
 }
-int HP_pc_bonus_addeff(struct s_addeffect *effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration) {
+int HP_pc_bonus_addeff(struct s_addeffect *effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration, uint16 wait_duration) {
 	int hIndex = 0;
 	int retVal___ = 0;
 	if (HPMHooks.count.HP_pc_bonus_addeff_pre > 0) {
-		int (*preHookFunc) (struct s_addeffect **effect, int *max, enum sc_type *id, int16 *rate, int16 *arrow_rate, uint8 *flag, uint16 *duration);
+		int (*preHookFunc) (struct s_addeffect **effect, int *max, enum sc_type *id, int16 *rate, int16 *arrow_rate, uint8 *flag, uint16 *duration, uint16 *wait_duration);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_bonus_addeff_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_pc_bonus_addeff_pre[hIndex].func;
-			retVal___ = preHookFunc(&effect, &max, &id, &rate, &arrow_rate, &flag, &duration);
+			retVal___ = preHookFunc(&effect, &max, &id, &rate, &arrow_rate, &flag, &duration, &wait_duration);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -72150,26 +72150,26 @@ int HP_pc_bonus_addeff(struct s_addeffect *effect, int max, enum sc_type id, int
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.pc.bonus_addeff(effect, max, id, rate, arrow_rate, flag, duration);
+		retVal___ = HPMHooks.source.pc.bonus_addeff(effect, max, id, rate, arrow_rate, flag, duration, wait_duration);
 	}
 	if (HPMHooks.count.HP_pc_bonus_addeff_post > 0) {
-		int (*postHookFunc) (int retVal___, struct s_addeffect *effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration);
+		int (*postHookFunc) (int retVal___, struct s_addeffect *effect, int max, enum sc_type id, int16 rate, int16 arrow_rate, uint8 flag, uint16 duration, uint16 wait_duration);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_bonus_addeff_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_pc_bonus_addeff_post[hIndex].func;
-			retVal___ = postHookFunc(retVal___, effect, max, id, rate, arrow_rate, flag, duration);
+			retVal___ = postHookFunc(retVal___, effect, max, id, rate, arrow_rate, flag, duration, wait_duration);
 		}
 	}
 	return retVal___;
 }
-int HP_pc_bonus_addeff_onskill(struct s_addeffectonskill *effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target) {
+int HP_pc_bonus_addeff_onskill(struct s_addeffectonskill *effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target, uint16 wait_duration) {
 	int hIndex = 0;
 	int retVal___ = 0;
 	if (HPMHooks.count.HP_pc_bonus_addeff_onskill_pre > 0) {
-		int (*preHookFunc) (struct s_addeffectonskill **effect, int *max, enum sc_type *id, short *rate, short *skill_id, unsigned char *target);
+		int (*preHookFunc) (struct s_addeffectonskill **effect, int *max, enum sc_type *id, short *rate, short *skill_id, unsigned char *target, uint16 *wait_duration);
 		*HPMforce_return = false;
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_bonus_addeff_onskill_pre; hIndex++) {
 			preHookFunc = HPMHooks.list.HP_pc_bonus_addeff_onskill_pre[hIndex].func;
-			retVal___ = preHookFunc(&effect, &max, &id, &rate, &skill_id, &target);
+			retVal___ = preHookFunc(&effect, &max, &id, &rate, &skill_id, &target, &wait_duration);
 		}
 		if (*HPMforce_return) {
 			*HPMforce_return = false;
@@ -72177,13 +72177,13 @@ int HP_pc_bonus_addeff_onskill(struct s_addeffectonskill *effect, int max, enum 
 		}
 	}
 	{
-		retVal___ = HPMHooks.source.pc.bonus_addeff_onskill(effect, max, id, rate, skill_id, target);
+		retVal___ = HPMHooks.source.pc.bonus_addeff_onskill(effect, max, id, rate, skill_id, target, wait_duration);
 	}
 	if (HPMHooks.count.HP_pc_bonus_addeff_onskill_post > 0) {
-		int (*postHookFunc) (int retVal___, struct s_addeffectonskill *effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target);
+		int (*postHookFunc) (int retVal___, struct s_addeffectonskill *effect, int max, enum sc_type id, short rate, short skill_id, unsigned char target, uint16 wait_duration);
 		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_bonus_addeff_onskill_post; hIndex++) {
 			postHookFunc = HPMHooks.list.HP_pc_bonus_addeff_onskill_post[hIndex].func;
-			retVal___ = postHookFunc(retVal___, effect, max, id, rate, skill_id, target);
+			retVal___ = postHookFunc(retVal___, effect, max, id, rate, skill_id, target, wait_duration);
 		}
 	}
 	return retVal___;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Fixes the three call sites in `skill.c` to pass a real wait duration for `SC_STONE`, defaulting to `1000`ms (matching the existing minimum-duration clamp already in `status.c`) when the scripter doesn't specify one.
- Adds a `wait_duration` field to `s_addeffect` / `s_addeffectonskill` (`pc.h`) and a new `bonus5` form for `bAddEff`, `bAddEffOnSkill`, and `bAddEffWhenHit` so item/card scripts can set this wait duration explicitly instead of relying on the hardcoded default.
- Along the way, wires up `bAddEffWhenHit` to also support a fixed `duration` argument (via its new `bonus5` form), which it never had. Closing @MishimaHaruna TODO 😄 


**Issues addressed:** #576

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
