### PR TITLE
Fix elemental hit/flee reset on stat recalculation

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2514,6 +2514,10 @@ static int status_calc_elemental_(struct elemental_data *ed, enum e_status_calc_
 		memcpy(&ed->battle_status, estatus, sizeof(struct status_data));
 	} else {
 		status->calc_misc(&ed->bl, estatus, 0);
+
+		estatus->flee = ele->flee;
+		estatus->hit = ele->hit;
+
 		status->copy(&ed->battle_status, estatus);
 	}
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR will be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR reapplies `ele->hit`/`ele->flee` after `calc_misc()` in the recalculation branch too, mirroring what the `SCO_FIRST` branch already does.

Issues addressed: https://github.com/HerculesWS/Hercules/issues/1013

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
