### PR TITLE
Add option to give duplicate NPCs independent local variables

### DIFF
--- a/conf/map/script.conf
+++ b/conf/map/script.conf
@@ -74,6 +74,16 @@ script_configuration: {
 	// those that consider them a security hazard to completely disable their
 	// functionality.
 	load_gm_scripts: true
+
+	// Specifies whether NPCs created with 'duplicate(...)' share their local
+	// ('.'-prefixed) variables and OnInit execution with the source NPC.
+	// When true (the default, for backward compatibility), all copies of a
+	// NPC read and write the same variable registry, and only the source
+	// NPC's OnInit event runs.
+	// When false, each duplicate gets its own independent variable registry
+	// (starting empty) and runs its own OnInit event, if any.
+	// Default: true
+	duplicate_npc_vars_shared: true
 }
 
 import: "conf/import/script.conf"

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -349,6 +349,12 @@ NPC duplicates inherit the script code.
 The rest (name, location, facing, sprite, span/trigger area) is
 obtained from the definition of the duplicate (not inherited).
 
+By default (script_configuration.duplicate_npc_vars_shared: true, see
+conf/map/script.conf) NPC duplicates also share their '.' (NPC-scoped)
+variables with the source NPC: reading or writing a '.' variable on any
+copy affects the same underlying storage. Setting this option to false
+gives each duplicate its own independent set of '.' variables instead.
+
 ** Define a function object
 
 function%TAB%script%TAB%<function name>%TAB%{<code>}

--- a/npc/dev/test.txt
+++ b/npc/dev/test.txt
@@ -116,6 +116,13 @@ function	script	F_TestVarOfAnotherNPC	{
 	end;
 }
 
+-	script	TestVarOfDuplicateOrigin	FAKE_NPC,{
+	// Used to test that duplicate(npc) NPCs share '.' variables by default
+	// (script_configuration.duplicate_npc_vars_shared, issue #1168)
+	end;
+}
+-	duplicate(TestVarOfDuplicateOrigin)	TestVarOfDuplicateCopy	FAKE_NPC
+
 -	script	export test	FAKE_NPC,{
 
 	function OnInit {
@@ -929,6 +936,10 @@ function	script	HerculesSelfTestHelper	{
 	set getvariableofnpc(.x, "TestVarOfAnotherNPC"), 1;
 	callsub(OnCheck, "Setting NPC variables of another NPC", getvariableofnpc(.x, "TestVarOfAnotherNPC"), 1);
 	callsub(OnCheck, "Setting NPC variables of another NPC (local variable overwrite check)", .x, 2);
+
+	// duplicate(npc) variable sharing (default: shared, issue #1168)
+	set getvariableofnpc(.x, "TestVarOfDuplicateOrigin"), 0xDEAD;
+	callsub(OnCheck, "duplicate(npc) shares '.' vars with its origin by default", getvariableofnpc(.x, "TestVarOfDuplicateCopy"), 0xDEAD);
 
 	// Callsub (advanced)
 	callsub(OnCheck, "Callsub return value", callsub(OnTestReturnValue, 1));

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -3193,12 +3193,12 @@ static int npc_unload(struct npc_data *nd, bool single, bool unload_mobs)
 		if (nd->u.scr.timer_event != NULL)
 			aFree(nd->u.scr.timer_event);
 
-		if (nd->src_id == 0) {
-			if (nd->u.scr.script != NULL) {
-				script->free_code(nd->u.scr.script);
-				nd->u.scr.script = NULL;
-			}
+		if ((nd->src_id == 0 || nd->u.scr.script_is_own) && nd->u.scr.script != NULL) {
+			script->free_code(nd->u.scr.script);
+			nd->u.scr.script = NULL;
+		}
 
+		if (nd->src_id == 0) {
 			if (nd->u.scr.label_list != NULL) {
 				aFree(nd->u.scr.label_list);
 				nd->u.scr.label_list = NULL;
@@ -4045,7 +4045,13 @@ static bool npc_duplicate_script_sub(struct npc_data *nd, const struct npc_data 
 	++npc->npc_script;
 	nd->u.scr.xs = xs;
 	nd->u.scr.ys = ys;
-	nd->u.scr.script = snd->u.scr.script;
+	if (script->config.duplicate_npc_vars_shared || snd->u.scr.script == NULL) {
+		nd->u.scr.script = snd->u.scr.script;
+		nd->u.scr.script_is_own = false;
+	} else {
+		nd->u.scr.script = script->clone_script(snd->u.scr.script);
+		nd->u.scr.script_is_own = true;
+	}
 	nd->u.scr.label_list = snd->u.scr.label_list;
 	nd->u.scr.label_list_num = snd->u.scr.label_list_num;
 	nd->u.scr.shop = snd->u.scr.shop;

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -129,6 +129,7 @@ struct npc_data {
 			/* */
 			struct npc_shop_data *shop;
 			bool trader;
+			bool script_is_own; ///< Whether this NPC owns a private (cloned) copy of `script` and must free it on unload.
 		} scr;
 		struct { /* TODO duck this as soon as the new shop formatting is deemed stable */
 			struct npc_item_list* shop_item;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -5333,6 +5333,7 @@ static bool script_config_read(const char *filename, bool imported)
 	libconfig->setting_lookup_bool_real(setting, "functions_private_by_default", &script->config.functions_private_by_default);
 	libconfig->setting_lookup_bool_real(setting, "functions_as_events", &script->config.functions_as_events);
 	libconfig->setting_lookup_bool_real(setting, "load_gm_scripts", &script->config.load_gm_scripts);
+	libconfig->setting_lookup_bool_real(setting, "duplicate_npc_vars_shared", &script->config.duplicate_npc_vars_shared);
 	libconfig->setting_lookup_int(setting, "check_cmdcount", &script->config.check_cmdcount);
 	libconfig->setting_lookup_int(setting, "check_gotocount", &script->config.check_gotocount);
 	libconfig->setting_lookup_int(setting, "input_min_value", &script->config.input_min_value);
@@ -31066,6 +31067,7 @@ void script_defaults(void)
 	script->config.onuntouch_name = "OnUnTouch";  //onuntouch_name (run whenever a char walks from the OnTouch area)
 	script->config.functions_private_by_default = true;
 	script->config.functions_as_events = false;
+	script->config.duplicate_npc_vars_shared = true; // true by default, for backward compatibility
 
 	// for ENABLE_CASE_CHECK
 	script->calc_hash_ci = calc_hash_ci;

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -641,6 +641,7 @@ struct Script_Config {
 	bool functions_private_by_default;
 	bool functions_as_events;
 	bool load_gm_scripts;
+	bool duplicate_npc_vars_shared;
 	int check_cmdcount;
 	int check_gotocount;
 	int input_min_value;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This adds a new `script_configuration.duplicate_npc_vars_shared` option (`conf/map/script.conf`, default `true` for full backward compatibility). When set to `false`, each `duplicate()` NPC gets its own independent script code and local variable registry instead of sharing the source NPC's.



**Issues addressed:** #1168, supersedes: https://github.com/HerculesWS/Hercules/pull/2121

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
