### PR TITLE
Fix Homunculus skills being affected by Poem of Bragi

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -17584,7 +17584,7 @@ static int skill_castfix_sc(struct block_list *bl, int time)
 			if ((--sc->data[SC_MEMORIZE]->val2) <= 0)
 				status_change_end(bl, SC_MEMORIZE, INVALID_TIMER);
 		}
-		if (sc->data[SC_POEMBRAGI])
+		if (sc->data[SC_POEMBRAGI] && bl->type != BL_HOM) // Aegis: Homunculus skills are not affected by Bragi.
 			time -= time * sc->data[SC_POEMBRAGI]->val2 / 100;
 		if (sc->data[SC_SKF_CAST] != NULL)
 			time -= time * sc->data[SC_SKF_CAST]->val1 / 100;
@@ -17823,7 +17823,7 @@ static int skill_delay_fix(struct block_list *bl, uint16 skill_id, uint16 skill_
 	if (!(delaynodex&2))
 	{
 		if (sc && sc->count) {
-			if (sc->data[SC_POEMBRAGI])
+			if (sc->data[SC_POEMBRAGI] && bl->type != BL_HOM) // Aegis: Homunculus skills are not affected by Bragi.
 				time -= time * sc->data[SC_POEMBRAGI]->val3 / 100;
 			if (sc->data[SC_WIND_INSIGNIA] && sc->data[SC_WIND_INSIGNIA]->val1 == 3 && (skill->get_ele(skill_id, skill_lv) == ELE_WIND))
 				time /= 2; // After Delay of Wind element spells reduced by 50%.


### PR DESCRIPTION
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

On Aegis, Homunculus skills are not affected by Bard/Dancer's Poem of Bragi. In Hercules, `SC_POEMBRAGI` is applied indiscriminately to any unit standing in the song's area (no `bl->type` filter in `skill_unit_onplace`), and its cast-time/after-cast-delay reduction was then consumed unconditionally in `skill_castfix_sc` and `skill_delay_fix`, causing Homunculus skills to be spammed (e.g. Caprice) while standing in a Bragi song.

This excludes `BL_HOM` from both reductions, matching Aegis behavior.

**Issues addressed:** #1130 (bug 1)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style