### PR TITLE
Fix items usable after death when delay_battle_damage is enabled

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -321,7 +321,13 @@ static int battle_delay_damage(int64 tick, int amotion, struct block_list *src, 
 	if (((d_tbl && sc && check_distance_bl(target, d_tbl, sc->data[SC_DEVOTION]->val3)) || e_tbl) && damage > 0 && skill_id != PA_PRESSURE && skill_id != CR_REFLECTSHIELD)
 		damage = 0;
 
-	if ( !battle_config.delay_battle_damage || amotion <= 1 ) {
+	// Lethal damage bypasses the delay even when delay_battle_damage is on:
+	// otherwise a player can act (e.g. use an item) in the window between a
+	// lethal hit being calculated here and it actually being applied by the
+	// delayed timer, since nothing yet marks them as dying. Non-lethal hits
+	// keep the delay for its normal (cosmetic packet-pacing / animation
+	// sync) purpose. (#969)
+	if ( !battle_config.delay_battle_damage || amotion <= 1 || damage >= status_get_hp(target) ) {
 		map->freeblock_lock();
 		status_fix_damage(src, target, damage, ddelay); // We have to separate here between reflect damage and others [icescope]
 		if( attack_type && !status->isdead(target) && additional_effects )

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -5496,6 +5496,13 @@ static int pc_useitem(struct map_session_data *sd, int n)
 	if (nameid == ITEMID_MEGAPHONE)
 		sd->state.using_megaphone = 1;
 
+	// Re-check death: delay_battle_damage can kill the player after clif_parse_UseItem()'s check. (#969)
+	if (pc_isdead(sd) || status->isdead(&sd->bl)) {
+		if (removeItem)
+			pc->delitem(sd, n, 1, 1, DELITEM_NORMAL, LOG_TYPE_CONSUME);
+		return 0;
+	}
+
 	script->run_use_script(sd, sd->inventory_data[n], npc->fake_nd->bl.id);
 	script->potion_flag = 0;
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
`pc_useitem()` only checked death status via a stale snapshot taken earlier at packet-parse time in `clif_parse_UseItem()`. With `delay_battle_damage` enabled, a lethal hit is applied later by a timer, so an item queued in that window (e.g. spammed with `item_use_interval: 0`) could still run its effect and restore HP/SP after the player had already died.

Re-checks death (`pc_isdead()` / `status->isdead()`) immediately before the item's effect script runs, right before `script->run_use_script()`. The item is still consumed if it was already flagged for removal (matching the `useitemack` already sent to the client), but its effect is skipped.

**Issues addressed:** #969



<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
