### PR TITLE
Fix skill name not showing over Homunculus when using Caprice

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -5561,6 +5561,7 @@ static int skill_castend_damage_id(struct block_list *src, struct block_list *bl
 				case 2: sid=MG_LIGHTNINGBOLT; break;
 				case 3: sid=WZ_EARTHSPIKE; break;
 				}
+				clif->skill_nodamage(src, src, sid, skill_lv, 1); // Show the randomly picked skill's name over the homunculus.
 				skill->attack(BF_MAGIC,src,src,bl,sid,skill_lv,tick,flag|SD_LEVEL);
 			}
 			break;


### PR DESCRIPTION
- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

On Aegis, the skill name is shown over a Homunculus's head when it uses a skill. `HVAN_CAPRICE` picks a random bolt skill (Cold Bolt, Fire Bolt, Lightning Bolt, or Earth Spike) and attacks with it, but never announced that sub-skill, so no skill name showed over the homunculus.

This adds a `clif_skill_nodamage` call announcing the randomly-picked sub-skill before the attack, matching Aegis behavior.

**Issues addressed:** #1130 (bug 2)

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
