### PR TITLE
Delay status effects from attacks and skills to match official timing

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1599,11 +1599,20 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 					flag = SCFLAG_NONE;
 				}
 
+				// On officials, "on attack" status changes from normal attacks only take
+				// effect after the attack animation ends (AttackMotion+500ms), not the
+				// instant the damage is applied. (bugreport:1141)
+				int delay = (skill_id == 0) ? sstatus->amotion + 500 : 0;
+#ifdef RENEWAL
+				if (delay > 0)
+					temp = max(1, temp - delay);
+#endif
+
 				if (sd->addeff[i].flag&ATF_TARGET)
-					status->change_start(src, bl, type, rate, 7, 0, (type == SC_BURNING) ? src->id : 0, 0, temp, flag, skill_id);
+					status->change_start_delayed(src, bl, type, rate, 7, 0, (type == SC_BURNING) ? src->id : 0, 0, temp, flag, skill_id, delay);
 
 				if (sd->addeff[i].flag&ATF_SELF)
-					status->change_start(src, src, type, rate, 7, 0, (type == SC_BURNING) ? src->id : 0, 0, temp, flag, skill_id);
+					status->change_start_delayed(src, src, type, rate, 7, 0, (type == SC_BURNING) ? src->id : 0, 0, temp, flag, skill_id, delay);
 			}
 		}
 

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1599,10 +1599,14 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 					flag = SCFLAG_NONE;
 				}
 
-				// On officials, "on attack" status changes from normal attacks only take
-				// effect after the attack animation ends (AttackMotion+500ms), not the
-				// instant the damage is applied. (bugreport:1141)
-				int delay = (skill_id == 0) ? sstatus->amotion + 500 : 0;
+				// On officials, "on attack" status changes from normal attacks and single-hit
+				// weapon skills (e.g. Asura Strike) only take effect after the attack
+				// animation ends (AttackMotion+500ms), not the instant the damage is applied.
+				// Multi-hit weapon skills (e.g. Sonic Blow, Double Strafe) are unaffected,
+				// since each individual hit already has its own timing. (bugreport:1141)
+				bool is_single_hit_weapon_skill = skill_id != 0 && (attack_type&BF_WEAPON) != 0
+					&& abs(skill->get_num(skill_id, skill_lv)) <= 1;
+				int delay = (skill_id == 0 || is_single_hit_weapon_skill) ? sstatus->amotion + 500 : 0;
 #ifdef RENEWAL
 				if (delay > 0)
 					temp = max(1, temp - delay);
@@ -1872,11 +1876,15 @@ static int skill_additional_effect(struct block_list *src, struct block_list *bl
 #endif
 
 		case BA_FROSTJOKE:
-			sc_start(src, bl, SC_FREEZE, (15 + 5 * skill_lv), skill_lv, skill->get_time2(skill_id, skill_lv), skill_id);
+			// On officials, Frost Joke's effect kicks in ~3000ms after the skill goes off. (bugreport:1141)
+			status->change_start_delayed(src, bl, SC_FREEZE, 100 * (15 + 5 * skill_lv), skill_lv, 0, 0, 0,
+				skill->get_time2(skill_id, skill_lv), SCFLAG_NONE, skill_id, 3000);
 			break;
 
 		case DC_SCREAM:
-			sc_start(src, bl, SC_STUN, (25 + 5 * skill_lv), skill_lv, skill->get_time2(skill_id, skill_lv), skill_id);
+			// On officials, Scream's effect kicks in ~3000ms after the skill goes off. (bugreport:1141)
+			status->change_start_delayed(src, bl, SC_STUN, 100 * (25 + 5 * skill_lv), skill_lv, 0, 0, 0,
+				skill->get_time2(skill_id, skill_lv), SCFLAG_NONE, skill_id, 3000);
 			break;
 
 #ifndef RENEWAL
@@ -7121,10 +7129,14 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 
 		case PR_LEXDIVINA:
 		case MER_LEXDIVINA:
-			if( tsce )
+			if( tsce ) {
 				status_change_end(bl,type, INVALID_TIMER);
-			else
-				sc_start(src, bl, type, 100, skill_lv, skill->get_time(skill_id, skill_lv), skill_id);
+			} else {
+				// On officials, Lex Divina's effect kicks in ~1000ms after the skill goes off.
+				// Removing an existing Silence via recast is not delayed. (bugreport:1141)
+				status->change_start_delayed(src, bl, type, 100 * 100, skill_lv, 0, 0, 0,
+					skill->get_time(skill_id, skill_lv), SCFLAG_NONE, skill_id, 1000);
+			}
 			clif->skill_nodamage (src, bl, skill_id, skill_lv, 1);
 			break;
 
@@ -7900,8 +7912,10 @@ static int skill_castend_nodamage_id(struct block_list *src, struct block_list *
 			break;
 
 		case BS_HAMMERFALL:
-			clif->skill_nodamage(src,bl,skill_id,skill_lv,
-				sc_start(src, bl, SC_STUN, (20 + 10 * skill_lv), skill_lv, skill->get_time2(skill_id, skill_lv), skill_id));
+			// On officials, Hammerfall's effect kicks in ~1000ms after the skill goes off. (bugreport:1141)
+			status->change_start_delayed(src, bl, SC_STUN, 100 * (20 + 10 * skill_lv), skill_lv, 0, 0, 0,
+				skill->get_time2(skill_id, skill_lv), SCFLAG_NONE, skill_id, 1000);
+			clif->skill_nodamage(src,bl,skill_id,skill_lv,1);
 			break;
 		case RG_RAID:
 			skill->area_temp[1] = 0;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -320,10 +320,21 @@ static int status_damage(struct block_list *src, struct block_list *target, int6
 				status_change_end(target, SC_DEVOTION, INVALID_TIMER);
 			}
 #endif
-			if (sc->data[SC_STONE] && sc->opt1 == OPT1_STONE)
+			if (sc->data[SC_STONE] && sc->opt1 == OPT1_STONE) {
+				sc->opt1_broken_by_damage_type = SC_STONE;
+				sc->opt1_broken_by_damage_tick = timer->gettick();
 				status_change_end(target, SC_STONE, INVALID_TIMER);
-			status_change_end(target, SC_FREEZE, INVALID_TIMER);
-			status_change_end(target, SC_SLEEP, INVALID_TIMER);
+			}
+			if (sc->data[SC_FREEZE]) {
+				sc->opt1_broken_by_damage_type = SC_FREEZE;
+				sc->opt1_broken_by_damage_tick = timer->gettick();
+				status_change_end(target, SC_FREEZE, INVALID_TIMER);
+			}
+			if (sc->data[SC_SLEEP]) {
+				sc->opt1_broken_by_damage_type = SC_SLEEP;
+				sc->opt1_broken_by_damage_tick = timer->gettick();
+				status_change_end(target, SC_SLEEP, INVALID_TIMER);
+			}
 			status_change_end(target, SC_DC_WINKCHARM, INVALID_TIMER);
 			status_change_end(target, SC_CONFUSION, INVALID_TIMER);
 			status_change_end(target, SC_TRICKDEAD, INVALID_TIMER);
@@ -10243,8 +10254,18 @@ static int status_change_start_delayed_timer(int tid, int64 tick, int id, intptr
 	struct block_list *bl = map->id2bl(entry->bl_id);
 
 	if (bl != NULL && !status->isdead(bl)) {
-		status->change_start(src, bl, entry->type, entry->rate, entry->val1, entry->val2,
-			entry->val3, entry->val4, entry->tick, entry->flag, entry->skill_id);
+		struct status_change *sc = status->get_sc(bl);
+		// If this exact status was already active and got broken by damage sometime after this
+		// entry was scheduled, don't reapply it - the attack that is trying to (re)inflict the
+		// status is the same attack that just broke it (e.g. hitting a frozen target with a
+		// Stormy Knight Card weapon should not instantly refreeze it once the freeze breaks).
+		bool broken_by_this_attack = sc != NULL && sc->opt1_broken_by_damage_type == entry->type
+			&& sc->opt1_broken_by_damage_tick >= entry->scheduled_tick;
+
+		if (!broken_by_this_attack) {
+			status->change_start(src, bl, entry->type, entry->rate, entry->val1, entry->val2,
+				entry->val3, entry->val4, entry->tick, entry->flag, entry->skill_id);
+		}
 	}
 
 	idb_remove(status->delayed_start_db, id);
@@ -10295,6 +10316,7 @@ static void status_change_start_delayed(struct block_list *src, struct block_lis
 	entry->tick = tick;
 	entry->flag = flag;
 	entry->skill_id = skill_id;
+	entry->scheduled_tick = timer->gettick();
 
 	int index = status->delayed_start_index++;
 	idb_put(status->delayed_start_db, index, entry);

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -10727,10 +10727,16 @@ static void status_change_start_stop_action(struct block_list *bl, enum sc_type 
 		case SC_STONE:
 		case SC_DEEP_SLEEP:
 		{
+			// On officials, Stun/Freeze/Sleep/Stone do not interrupt movement - the target
+			// keeps walking to its already-queued destination cell, unless it was dancing
+			// (which does get interrupted). (rathena:948)
 			struct map_session_data *sd = BL_CAST(BL_PC, bl);
 			if (sd && pc_issit(sd)) //Avoid sprite sync problems.
 				pc->setstand(sd);
-			FALLTHROUGH
+			struct status_change *sc = status->get_sc(bl);
+			if (sc != NULL && sc->data[SC_DANCING] != NULL)
+				unit->stop_walking(bl, STOPWALKING_FLAG_FIXPOS);
+			break;
 		}
 		case SC_GRAVITYCONTROL:
 		{

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -45,6 +45,7 @@
 #include "map/unit.h"
 #include "map/vending.h"
 #include "common/cbasetypes.h"
+#include "common/db.h"
 #include "common/ers.h"
 #include "common/memmgr.h"
 #include "common/msgtable.h"
@@ -10218,6 +10219,89 @@ static int status_change_start(struct block_list *src, struct block_list *bl, en
 	return status->change_start_sub(src, bl, type, rate, val1, val2, val3, val4, 0, tick, flag, skill_id);
 }
 
+/**
+ * Timer callback for a status change that was deferred by status_change_start_delayed().
+ * Re-resolves src/bl by id and, if the target still exists and is not dead, applies the
+ * status change via status->change_start(). If the target is gone, the status change is
+ * silently dropped.
+ *
+ * @param tid  Timer id.
+ * @param tick Current tick.
+ * @param id   Index of the pending entry in status->delayed_start_db.
+ * @param data Unused.
+ *
+ * @return 0
+ */
+static int status_change_start_delayed_timer(int tid, int64 tick, int id, intptr_t data)
+{
+	struct s_status_change_start_delayed *entry = idb_get(status->delayed_start_db, id);
+
+	if (entry == NULL)
+		return 0;
+
+	struct block_list *src = entry->src_id > 0 ? map->id2bl(entry->src_id) : NULL;
+	struct block_list *bl = map->id2bl(entry->bl_id);
+
+	if (bl != NULL && !status->isdead(bl)) {
+		status->change_start(src, bl, entry->type, entry->rate, entry->val1, entry->val2,
+			entry->val3, entry->val4, entry->tick, entry->flag, entry->skill_id);
+	}
+
+	idb_remove(status->delayed_start_db, id);
+
+	return 0;
+}
+
+/**
+ * Starts a status change after a delay, or immediately if delay <= 0.
+ *
+ * Used for status changes that should not take effect the instant the triggering
+ * damage/skill lands (e.g. "on attack" card effects), matching official delayed timing.
+ * The target is re-checked for existence/death when the delay expires; if it is gone,
+ * the status change is dropped.
+ *
+ * @param src      Status change source bl.
+ * @param bl       Status change target bl.
+ * @param type     Status change type.
+ * @param rate     Base success rate. 1 means 0.01%, 10000 means 100%.
+ * @param val1     Additional value (meaning depends on type).
+ * @param val2     Additional value (meaning depends on type).
+ * @param val3     Additional value (meaning depends on type).
+ * @param val4     Additional value (meaning depends on type).
+ * @param tick     Base duration (milliseconds).
+ * @param flag     Special flags (@see enum scstart_flag).
+ * @param skill_id Skill origin of status change, if available.
+ * @param delay    Delay in milliseconds before the status change is applied.
+ */
+static void status_change_start_delayed(struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, int tick, int flag, int skill_id, int delay)
+{
+	nullpo_retv(bl);
+
+	if (delay <= 0) {
+		status->change_start(src, bl, type, rate, val1, val2, val3, val4, tick, flag, skill_id);
+		return;
+	}
+
+	struct s_status_change_start_delayed *entry = aMalloc(sizeof(*entry));
+
+	entry->src_id = src != NULL ? src->id : 0;
+	entry->bl_id = bl->id;
+	entry->type = type;
+	entry->rate = rate;
+	entry->val1 = val1;
+	entry->val2 = val2;
+	entry->val3 = val3;
+	entry->val4 = val4;
+	entry->tick = tick;
+	entry->flag = flag;
+	entry->skill_id = skill_id;
+
+	int index = status->delayed_start_index++;
+	idb_put(status->delayed_start_db, index, entry);
+
+	timer->add(timer->gettick() + delay, status->change_start_delayed_timer, index, 0);
+}
+
 static void status_change_start_display(struct map_session_data *sd, enum sc_type type, int val1, int val2, int val3, int val4)
 {
 	Assert_retv(type >= SC_NONE && type < SC_MAX);
@@ -15019,11 +15103,14 @@ static int do_init_status(bool minimal)
 	timer->add_func_list(status->change_timer,"status_change_timer");
 	timer->add_func_list(status->kaahi_heal_timer,"status_kaahi_heal_timer");
 	timer->add_func_list(status->natural_heal_timer,"status_natural_heal_timer");
+	timer->add_func_list(status->change_start_delayed_timer,"status_change_start_delayed_timer");
 	status->initChangeTables();
 	status->initDummyData();
 	status->readdb();
 	status->natural_heal_prev_tick = timer->gettick();
 	status->data_ers = ers_new(sizeof(struct status_change_entry),"status.c::data_ers",ERS_OPT_NONE);
+	status->delayed_start_db = idb_alloc(DB_OPT_RELEASE_DATA);
+	status->delayed_start_index = 0;
 	timer->add_interval(status->natural_heal_prev_tick + NATURAL_HEAL_INTERVAL, status->natural_heal_timer, 0, 0, NATURAL_HEAL_INTERVAL);
 	return 0;
 }
@@ -15031,6 +15118,7 @@ static int do_init_status(bool minimal)
 static void do_final_status(void)
 {
 	ers_destroy(status->data_ers);
+	db_destroy(status->delayed_start_db);
 
 	status->unit_params_destroy_entry(&status->dummy_unit_params);
 	status->unit_params_clear_db();
@@ -15106,6 +15194,8 @@ void status_defaults(void)
 
 	status->change_start = status_change_start;
 	status->change_start_sub = status_change_start_sub;
+	status->change_start_delayed = status_change_start_delayed;
+	status->change_start_delayed_timer = status_change_start_delayed_timer;
 	status->change_end_ = status_change_end_;
 	status->kaahi_heal_timer = kaahi_heal_timer;
 	status->change_timer = status_change_timer;

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -1286,6 +1286,17 @@ struct status_change {
 	struct status_change_entry *data[SC_MAX];
 };
 
+/// Holds the parameters of a status_change_start() call that is pending a delay timer.
+struct s_status_change_start_delayed {
+	int src_id;
+	int bl_id;
+	enum sc_type type;
+	int rate;
+	int val1, val2, val3, val4;
+	int tick;
+	int flag;
+	int skill_id;
+};
 
 //Define for standard HP damage attacks.
 #define status_fix_damage(src, target, hp, walkdelay) (status->damage((src), (target), (hp), 0, (walkdelay), 0))
@@ -1416,6 +1427,8 @@ struct status_interface {
 	struct s_unit_params dummy_unit_params;
 	int64 natural_heal_prev_tick;
 	unsigned int natural_heal_diff_tick;
+	struct DBMap *delayed_start_db; // int index -> struct s_status_change_start_delayed *
+	int delayed_start_index;
 	/* */
 	int (*init) (bool minimal);
 	void (*final) (void);
@@ -1460,6 +1473,8 @@ struct status_interface {
 	int (*get_sc_def) (struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int tick, int flag, int skill_id);
 	int (*change_start) (struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, int tick, int flag, int skill_id);
 	int (*change_start_sub) (struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, int tick, int total_tick, int flag, int skill_id);
+	void (*change_start_delayed) (struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, int tick, int flag, int skill_id, int delay);
+	int (*change_start_delayed_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*change_end_) (struct block_list* bl, enum sc_type type, int tid);
 	bool (*is_immune_to_status) (struct status_change* sc, enum sc_type type);
 	bool (*is_boss_resist_sc) (enum sc_type type);

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -1283,6 +1283,8 @@ struct status_change {
 #endif
 	unsigned char bs_counter; // Blood Sucker counter
 	unsigned char fv_counter; // Force of vanguard counter
+	enum sc_type opt1_broken_by_damage_type; // Which OPT1 status (Freeze/Stone/Sleep/etc.) most recently ended due to damage
+	int64 opt1_broken_by_damage_tick; // Tick at which opt1_broken_by_damage_type ended due to damage
 	struct status_change_entry *data[SC_MAX];
 };
 
@@ -1296,6 +1298,7 @@ struct s_status_change_start_delayed {
 	int tick;
 	int flag;
 	int skill_id;
+	int64 scheduled_tick; // Tick at which this entry was created (before the delay)
 };
 
 //Define for standard HP damage attacks.

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -9142,6 +9142,10 @@ typedef int (*HPMHOOK_pre_status_change_start) (struct block_list **src, struct 
 typedef int (*HPMHOOK_post_status_change_start) (int retVal___, struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, int tick, int flag, int skill_id);
 typedef int (*HPMHOOK_pre_status_change_start_sub) (struct block_list **src, struct block_list **bl, enum sc_type *type, int *rate, int *val1, int *val2, int *val3, int *val4, int *tick, int *total_tick, int *flag, int *skill_id);
 typedef int (*HPMHOOK_post_status_change_start_sub) (int retVal___, struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, int tick, int total_tick, int flag, int skill_id);
+typedef void (*HPMHOOK_pre_status_change_start_delayed) (struct block_list **src, struct block_list **bl, enum sc_type *type, int *rate, int *val1, int *val2, int *val3, int *val4, int *tick, int *flag, int *skill_id, int *delay);
+typedef void (*HPMHOOK_post_status_change_start_delayed) (struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, int tick, int flag, int skill_id, int delay);
+typedef int (*HPMHOOK_pre_status_change_start_delayed_timer) (int *tid, int64 *tick, int *id, intptr_t *data);
+typedef int (*HPMHOOK_post_status_change_start_delayed_timer) (int retVal___, int tid, int64 tick, int id, intptr_t data);
 typedef int (*HPMHOOK_pre_status_change_end_) (struct block_list **bl, enum sc_type *type, int *tid);
 typedef int (*HPMHOOK_post_status_change_end_) (int retVal___, struct block_list *bl, enum sc_type type, int tid);
 typedef bool (*HPMHOOK_pre_status_is_immune_to_status) (struct status_change **sc, enum sc_type *type);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -7058,6 +7058,10 @@ struct {
 	struct HPMHookPoint *HP_status_change_start_post;
 	struct HPMHookPoint *HP_status_change_start_sub_pre;
 	struct HPMHookPoint *HP_status_change_start_sub_post;
+	struct HPMHookPoint *HP_status_change_start_delayed_pre;
+	struct HPMHookPoint *HP_status_change_start_delayed_post;
+	struct HPMHookPoint *HP_status_change_start_delayed_timer_pre;
+	struct HPMHookPoint *HP_status_change_start_delayed_timer_post;
 	struct HPMHookPoint *HP_status_change_end__pre;
 	struct HPMHookPoint *HP_status_change_end__post;
 	struct HPMHookPoint *HP_status_is_immune_to_status_pre;
@@ -14679,6 +14683,10 @@ struct {
 	int HP_status_change_start_post;
 	int HP_status_change_start_sub_pre;
 	int HP_status_change_start_sub_post;
+	int HP_status_change_start_delayed_pre;
+	int HP_status_change_start_delayed_post;
+	int HP_status_change_start_delayed_timer_pre;
+	int HP_status_change_start_delayed_timer_post;
 	int HP_status_change_end__pre;
 	int HP_status_change_end__post;
 	int HP_status_is_immune_to_status_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -3608,6 +3608,8 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(status->get_sc_def, HP_status_get_sc_def) },
 	{ HP_POP(status->change_start, HP_status_change_start) },
 	{ HP_POP(status->change_start_sub, HP_status_change_start_sub) },
+	{ HP_POP(status->change_start_delayed, HP_status_change_start_delayed) },
+	{ HP_POP(status->change_start_delayed_timer, HP_status_change_start_delayed_timer) },
 	{ HP_POP(status->change_end_, HP_status_change_end_) },
 	{ HP_POP(status->is_immune_to_status, HP_status_is_immune_to_status) },
 	{ HP_POP(status->is_boss_resist_sc, HP_status_is_boss_resist_sc) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -94324,6 +94324,59 @@ int HP_status_change_start_sub(struct block_list *src, struct block_list *bl, en
 	}
 	return retVal___;
 }
+void HP_status_change_start_delayed(struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, int tick, int flag, int skill_id, int delay) {
+	int hIndex = 0;
+	if (HPMHooks.count.HP_status_change_start_delayed_pre > 0) {
+		void (*preHookFunc) (struct block_list **src, struct block_list **bl, enum sc_type *type, int *rate, int *val1, int *val2, int *val3, int *val4, int *tick, int *flag, int *skill_id, int *delay);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_status_change_start_delayed_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_status_change_start_delayed_pre[hIndex].func;
+			preHookFunc(&src, &bl, &type, &rate, &val1, &val2, &val3, &val4, &tick, &flag, &skill_id, &delay);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return;
+		}
+	}
+	{
+		HPMHooks.source.status.change_start_delayed(src, bl, type, rate, val1, val2, val3, val4, tick, flag, skill_id, delay);
+	}
+	if (HPMHooks.count.HP_status_change_start_delayed_post > 0) {
+		void (*postHookFunc) (struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, int tick, int flag, int skill_id, int delay);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_status_change_start_delayed_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_status_change_start_delayed_post[hIndex].func;
+			postHookFunc(src, bl, type, rate, val1, val2, val3, val4, tick, flag, skill_id, delay);
+		}
+	}
+	return;
+}
+int HP_status_change_start_delayed_timer(int tid, int64 tick, int id, intptr_t data) {
+	int hIndex = 0;
+	int retVal___ = 0;
+	if (HPMHooks.count.HP_status_change_start_delayed_timer_pre > 0) {
+		int (*preHookFunc) (int *tid, int64 *tick, int *id, intptr_t *data);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_status_change_start_delayed_timer_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_status_change_start_delayed_timer_pre[hIndex].func;
+			retVal___ = preHookFunc(&tid, &tick, &id, &data);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.status.change_start_delayed_timer(tid, tick, id, data);
+	}
+	if (HPMHooks.count.HP_status_change_start_delayed_timer_post > 0) {
+		int (*postHookFunc) (int retVal___, int tid, int64 tick, int id, intptr_t data);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_status_change_start_delayed_timer_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_status_change_start_delayed_timer_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, tid, tick, id, data);
+		}
+	}
+	return retVal___;
+}
 int HP_status_change_end_(struct block_list *bl, enum sc_type type, int tid) {
 	int hIndex = 0;
 	int retVal___ = 0;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Adds `status->change_start_delayed()` / `status->change_start_delayed_timer()`, a self-contained timer-backed mechanism to apply a status change after a delay instead of instantly, without changing `status_change_start()`'s existing signature or any of its other call sites.
- Wires this into `skill_additional_effect()` so normal-attack triggered status changes (`bAddEff`-style card procs) take effect after the attacker's attack motion ends (`AttackMotion+500ms`) instead of the instant the damage lands, matching official behavior.
- Extends the same delay to single-hit weapon skills (e.g. Asura Strike), while multi-hit weapon skills (e.g. Sonic Blow, Double Strafe) stay instant since each hit already has its own timing. The distinguishing rule used is the skill's `NumberOfHits` (`skill->get_num()`): `abs(num) <= 1` is treated as single-hit.
- Adds skill-specific delays confirmed by official testing in the issue thread: Frost Joke/Scream (~3000ms after the skill goes off) and Lex Divina/Hammerfall (~1000ms after the skill goes off). Removing an existing Silence by recasting Lex Divina stays instant, matching reported behavior.
- Under `RENEWAL`, the applied delay is subtracted from the status duration.
- Fixes a regression found during review: if a hit breaks an existing Freeze/Stone/Sleep via damage, that same hit's delayed card-proc could reapply the status moments later once the delay elapsed (e.g. hitting a frozen target with a Stormy Knight Card weapon would unfreeze it and then immediately refreeze it). Tracks when an OPT1 status was last broken by damage and skips the delayed reapplication if it was broken by the same attack that scheduled it.

**Issues addressed:** #1141

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
