### PR TITLE
Send guild emblem/minimap updates when a member joins or leaves

### DIFF
--- a/src/map/guild.c
+++ b/src/map/guild.c
@@ -855,7 +855,8 @@ static int guild_reply_invite(struct map_session_data *sd, int guild_id, int fla
 
 		guild->makemember(&g->member[i], sd);
 		intif->guild_addmember(guild_id, &g->member[i]);
-		//TODO: send a minimap update to this player
+		// The minimap/emblem update to this player is sent once the char-server
+		// confirms the join, in guild_member_added() (sd->guild is not set yet here).
 	}
 
 	return 0;
@@ -940,8 +941,7 @@ static int guild_member_added(int guild_id, int account_id, int char_id, int fla
 	//Packets which were sent in the previous 'guild_sent' implementation.
 	clif->guild_belonginfo(sd,g);
 	clif->guild_notice(sd,g);
-
-	//TODO: send new emblem info to others
+	clif->guild_emblem_id_area(&sd->bl);
 
 	if( sd2!=NULL )
 		clif->guild_inviteack(sd2,2);
@@ -1084,7 +1084,7 @@ static int guild_member_withdraw(int guild_id, int account_id, int char_id, int 
 		status_change_end(&sd->bl, SC_GLORYWOUNDS, INVALID_TIMER);
 		status_change_end(&sd->bl, SC_SOULCOLD, INVALID_TIMER);
 		status_change_end(&sd->bl, SC_HAWKEYES, INVALID_TIMER);
-		//TODO: send emblem update to self and people around
+		clif->guild_emblem_id_area(&sd->bl);
 	}
 	return 0;
 }


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- `guild_member_added()`: added the missing `clif->guild_emblem_id_area()`  call once `sd->guild`/`sd->guild_emblem_id` are set, so onlookers see the new guild emblem immediately.
- `guild_member_withdraw()`: added the same call after `sd->guild_emblem_id` is cleared, so onlookers see the emblem disappear immediately.
- `guild_reply_invite()`: removed a stale `TODO` — at that point in the invite-accept flow `sd->guild`/`sd->status.guild_id` are not yet set (the join isn't confirmed by the char-server until `guild_member_added()`), so there was nothing meaningful to broadcast there. Replaced with a comment pointing to where the real update now happens.

**Issues addressed:**

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
