### PR TITLE
Fix critical hit chance underflow with high target LUK

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -5155,7 +5155,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 		skill_id == SN_SHARPSHOOTING || skill_id == MA_SHARPSHOOTING ||
 		skill_id == NJ_KIRIKAGE))
 	{
-		short cri = sstatus->cri;
+		int cri = sstatus->cri;
 		if (sd != NULL) {
 			// Racial crit bonuses are affected by katar's crit bonus.
 			if (battle_config.show_katar_crit_bonus && sd->weapontype == W_KATAR)


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`battle_calc_weapon_attack()` truncated the critical hit chance into a `short` local variable, while the source field (`status_data.cri`) is actually `int32`. When a target's `luk` (a `uint16`, up to 65535) is subtracted with a multiplier of 2 or 3, the result can exceed `short`'s range and wrap around, turning what should be a very low crit chance for a high-LUK target into an incorrectly high one.

This widens the local `cri` variable to `int`, matching the type it's actually assigned from, so the crit-chance calculation stays correct for high-LUK targets.

**Issues addressed:** #2737

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
