### PR TITLE
Fix truncated skill id (-1 -> 65535) passed to skill_unit_onleft duri…

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -19859,7 +19859,8 @@ static int skill_unit_move_sub(struct block_list *bl, va_list ap)
 		//Non-dualmode unit skills with a timer don't trigger when walking, so just return
 		if (dissonance) {
 			skill->dance_switch(su, 1);
-			skill->unit_onleft(skill->unit_onout(su, target, tick), target, tick); // su was changed to dissonance, trigger songs being terminated
+			skill->unit_onout(su, target, tick);
+			skill->unit_onleft(skill_id, target, tick); // su was changed to dissonance, trigger songs being terminated
 		}
 		return 0;
 	}


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Use the already-captured valid `skill_id` local variable instead of the raw `unit_onout()` return value

<!-- Describe the changes that this pull request makes. -->


**Issues addressed:** #3468<!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
