### PR TITLE
Char/login-server: wait for pending acks before completing shutdown

### DIFF
--- a/src/char/char.c
+++ b/src/char/char.c
@@ -183,6 +183,13 @@ static unsigned short skillid2idx[MAX_SKILL_ID];
 //-----------------------------------------------------
 #define AUTH_TIMEOUT 30000
 
+//-----------------------------------------------------
+// Shutdown
+//-----------------------------------------------------
+// Maximum time to wait for the map-server to finish disconnecting/saving
+// all online characters before forcing the shutdown to proceed anyway.
+#define SHUTDOWN_TIMEOUT 30000
+
 static struct DBMap *auth_db; // int account_id -> struct char_auth_node*
 
 //-----------------------------------------------------
@@ -3287,6 +3294,7 @@ static void char_parse_frommap_save_character(int fd)
 		//Flag, set character offline after saving. [Skotlex]
 		chr->set_char_offline(cid, aid);
 		chr->save_character_ack(fd, aid, cid);
+		chr->check_shutdown();
 	}
 	RFIFOSKIP(fd,size);
 }
@@ -6189,6 +6197,46 @@ void set_server_type(void)
 	SERVER_TYPE = SERVER_TYPE_CHAR;
 }
 
+/**
+ * @see DBApply
+ */
+static int char_online_data_count_connected_sub(union DBKey key, struct DBData *data, va_list ap)
+{
+	struct online_char_data *character = (struct online_char_data *)DB->data2ptr(data);
+	nullpo_ret(character);
+	return (character->mapserver_connection == OCS_CONNECTED) ? 1 : 0;
+}
+
+/// Counts characters the map-server may still be disconnecting/saving.
+static int char_online_data_count_connected(void)
+{
+	return chr->online_char_db->foreach(chr->online_char_db, chr->online_data_count_connected_sub);
+}
+
+static int char_shutdown_timeout_timer(int tid, int64 tick, int id, intptr_t data)
+{
+	if (core->runflag != CHARSERVER_ST_SHUTDOWN)
+		return 0;
+	ShowWarning("Shutdown: timed out waiting for %d character(s) to finish saving, forcing shutdown.\n",
+		chr->online_data_count_connected());
+	core->runflag = CORE_ST_STOP;
+	return 0;
+}
+
+/// Checks the conditions for the server to stop.
+/// Finishes the shutdown once the map-server has no more characters left to disconnect/save.
+static void char_check_shutdown(void)
+{
+	if (core->runflag != CHARSERVER_ST_SHUTDOWN)
+		return;
+	if (chr->online_data_count_connected() > 0)
+		return;
+	mapif->server_reset();
+	loginif->check_shutdown();
+	sockt->flush_fifos();
+	core->runflag = CORE_ST_STOP;
+}
+
 /// Called when a terminate signal is received.
 static void do_shutdown(void)
 {
@@ -6196,11 +6244,10 @@ static void do_shutdown(void)
 	{
 		core->runflag = CHARSERVER_ST_SHUTDOWN;
 		ShowStatus("Shutting down...\n");
-		// TODO proper shutdown procedure; wait for acks?, kick all characters, ... [FlavoJS]
-		mapif->server_reset();
-		loginif->check_shutdown();
-		sockt->flush_fifos();
-		core->runflag = CORE_ST_STOP;
+		// Kick every online character so the map-server final-saves them before we tear down.
+		chr->set_all_offline(true);
+		timer->add(timer->gettick() + SHUTDOWN_TIMEOUT, chr->shutdown_timeout_timer, 0, 0);
+		chr->check_shutdown();
 	}
 }
 
@@ -6374,6 +6421,9 @@ int do_init(int argc, char **argv)
 	// Online Data timers (checking if char still connected)
 	timer->add_func_list(chr->online_data_cleanup, "chr->online_data_cleanup");
 	timer->add_interval(timer->gettick() + 1000, chr->online_data_cleanup, 0, 0, 600 * 1000);
+
+	// Shutdown watchdog (only fires once do_shutdown schedules it)
+	timer->add_func_list(chr->shutdown_timeout_timer, "chr->shutdown_timeout_timer");
 
 	//Cleaning the tables for NULL entries @ startup [Sirius]
 	//Chardb clean
@@ -6625,6 +6675,10 @@ void char_defaults(void)
 	chr->online_char_destroy_sub = char_online_char_destroy_sub;
 	chr->ensure_online_char_data = char_ensure_online_char_data;
 	chr->clean_online_char_emblem_data = char_clean_online_char_emblem_data;
+	chr->online_data_count_connected_sub = char_online_data_count_connected_sub;
+	chr->online_data_count_connected = char_online_data_count_connected;
+	chr->shutdown_timeout_timer = char_shutdown_timeout_timer;
+	chr->check_shutdown = char_check_shutdown;
 	chr->sql_config_read = char_sql_config_read;
 	chr->sql_config_read_registry = char_sql_config_read_registry;
 	chr->sql_config_read_pc = char_sql_config_read_pc;

--- a/src/char/char.h
+++ b/src/char/char.h
@@ -296,6 +296,10 @@ struct char_interface {
 	int (*online_char_destroy_sub) (union DBKey key, struct DBData *data, va_list ap);
 	void (*ensure_online_char_data) (struct online_char_data *character);
 	void (*clean_online_char_emblem_data) (struct online_char_data *character);
+	int (*online_data_count_connected_sub) (union DBKey key, struct DBData *data, va_list ap);
+	int (*online_data_count_connected) (void);
+	int (*shutdown_timeout_timer) (int tid, int64 tick, int id, intptr_t data);
+	void (*check_shutdown) (void);
 
 	bool (*sql_config_read) (const char *filename, bool imported);
 	bool (*sql_config_read_registry) (const char *filename, const struct config_t *config, bool imported);

--- a/src/char/loginif.c
+++ b/src/char/loginif.c
@@ -49,9 +49,9 @@ static void loginif_reset(void)
 }
 
 
-/// Checks the conditions for the server to stop.
-/// Releases the cookie when all characters are saved.
-/// If all the conditions are met, it stops the core loop.
+/// Finishes the shutdown started by chr->do_shutdown().
+/// Called only once chr->check_shutdown() has confirmed there are no more
+/// characters left for the map-server to disconnect/save.
 static void loginif_check_shutdown(void)
 {
 	if( core->runflag != CHARSERVER_ST_SHUTDOWN )

--- a/src/login/login.c
+++ b/src/login/login.c
@@ -74,6 +74,13 @@ static AccountDB *accounts = NULL;
 //-----------------------------------------------------
 #define AUTH_TIMEOUT 30000
 
+//-----------------------------------------------------
+// Shutdown
+//-----------------------------------------------------
+// Maximum time to wait for char-servers to acknowledge in-flight auth
+// requests before forcing the shutdown to proceed anyway.
+#define SHUTDOWN_TIMEOUT 30000
+
 /**
  * @see DBCreateData
  */
@@ -121,6 +128,7 @@ static int login_waiting_disconnect_timer(int tid, int64 tick, int id, intptr_t 
 		p->waiting_disconnect = INVALID_TIMER;
 		login->remove_online_user(id);
 		idb_remove(login->auth_db, id);
+		login->check_shutdown();
 	}
 	return 0;
 }
@@ -348,7 +356,12 @@ static void login_fromchar_parse_auth(int fd, int id, const char *const ip)
 		nullpo_retv(ip);
 		ShowStatus("Char-server '%s': authentication of the account %d REFUSED (ip: %s).\n", login->dbs->server[id].name, account_id, ip);
 		login->fromchar_auth_ack(fd, account_id, login_id1, login_id2, sex, request_id, NULL);
+		// server is shutting down: this request will never be retried, so stop waiting on it
+		if (core->runflag != LOGINSERVER_ST_RUNNING && node != NULL)
+			idb_remove(login->auth_db, account_id);
 	}
+
+	login->check_shutdown();
 }
 
 static void login_fromchar_parse_update_users(int fd, int id)
@@ -2173,6 +2186,32 @@ void set_server_type(void)
 }
 
 
+static int login_shutdown_timeout_timer(int tid, int64 tick, int id, intptr_t data)
+{
+	if (core->runflag != LOGINSERVER_ST_SHUTDOWN)
+		return 0;
+	ShowWarning("Shutdown: timed out waiting for %d pending auth request(s) to be acknowledged, forcing shutdown.\n",
+		db_size(login->auth_db));
+	core->runflag = CORE_ST_STOP;
+	return 0;
+}
+
+/// Checks the conditions for the server to stop.
+/// Finishes the shutdown once no auth requests are still awaiting a char-server ack.
+static void login_check_shutdown(void)
+{
+	if (core->runflag != LOGINSERVER_ST_SHUTDOWN)
+		return;
+	if (db_size(login->auth_db) > 0)
+		return;
+	for (int id = 0; id < ARRAYLENGTH(login->dbs->server); ++id)
+		lchrif->server_reset(id);
+	for (int id = 0; id < ARRAYLENGTH(login->dbs->api_server); ++id)
+		lapiif->server_reset(id);
+	sockt->flush_fifos();
+	core->runflag = CORE_ST_STOP;
+}
+
 /// Called when a terminate signal is received.
 static void do_shutdown_login(void)
 {
@@ -2180,13 +2219,8 @@ static void do_shutdown_login(void)
 	{
 		core->runflag = LOGINSERVER_ST_SHUTDOWN;
 		ShowStatus("Shutting down...\n");
-		// TODO proper shutdown procedure; kick all characters, wait for acks, ...  [FlavioJS]
-		for (int id = 0; id < ARRAYLENGTH(login->dbs->server); ++id)
-			lchrif->server_reset(id);
-		for (int id = 0; id < ARRAYLENGTH(login->dbs->api_server); ++id)
-			lapiif->server_reset(id);
-		sockt->flush_fifos();
-		core->runflag = CORE_ST_STOP;
+		timer->add(timer->gettick() + SHUTDOWN_TIMEOUT, login->shutdown_timeout_timer, 0, 0);
+		login->check_shutdown();
 	}
 }
 
@@ -2320,6 +2354,7 @@ int do_init(int argc, char **argv)
 
 	// Interserver auth init
 	login->auth_db = idb_alloc(DB_OPT_RELEASE_DATA);
+	timer->add_func_list(login->shutdown_timeout_timer, "login->shutdown_timeout_timer");
 
 	// set default parser as lclif->parse function
 	sockt->set_defaultparse(lclif->parse);
@@ -2380,6 +2415,8 @@ void login_defaults(void)
 	login->mmo_auth = login_mmo_auth;
 	login->mmo_auth_new = login_mmo_auth_new;
 	login->waiting_disconnect_timer = login_waiting_disconnect_timer;
+	login->shutdown_timeout_timer = login_shutdown_timeout_timer;
+	login->check_shutdown = login_check_shutdown;
 	login->create_online_user = login_create_online_user;
 	login->add_online_user = login_add_online_user;
 	login->remove_online_user = login_remove_online_user;

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -183,6 +183,8 @@ struct login_interface {
 	int (*mmo_auth) (struct login_session_data* sd, bool isServer);
 	int (*mmo_auth_new) (const char* userid, const char* pass, const char sex, const char* last_ip);
 	int (*waiting_disconnect_timer) (int tid, int64 tick, int id, intptr_t data);
+	int (*shutdown_timeout_timer) (int tid, int64 tick, int id, intptr_t data);
+	void (*check_shutdown) (void);
 	struct DBData (*create_online_user) (union DBKey key, va_list args);
 	struct online_login_data* (*add_online_user) (int char_server, int account_id);
 	void (*remove_online_user) (int account_id);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`char-server` and `login-server` used to stop immediately on shutdown, with no wait for in-flight saves or auth acks. Unlike `map-server`, which already waits on `chrif->auth_db` draining.

This brings both in line: `char-server` now kicks all characters via the existing (but unused) `chr->set_all_offline(true)` and waits for `online_char_db` to clear before resetting; `login-server` waits on `auth_db` clearing before resetting server links. Both fall back to a 30s watchdog if the wait never completes. Also fixes a bug where `login_fromchar_parse_auth` never cleared its `auth_db` entry during shutdown, which would have made the new wait hang.


**Issues addressed:** 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
